### PR TITLE
Make the sass build automatic from a docker container

### DIFF
--- a/app/fun_cms/templates/base.html
+++ b/app/fun_cms/templates/base.html
@@ -7,7 +7,7 @@
 
         {% render_block "css" %}
 
-        <link rel="stylesheet" type="text/css" href="../static/css/main.css">
+        <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}">
         <script type="text/javascript" src="{% static 'js/index.js' %}"></script>
     </head>
     <body>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,13 @@ services:
       - ./:/fun-cms
     entrypoint: >
       bash -c "npm install && webpack --watch"
+  sass:
+    build: './sass'
+    image: fun_cms-sass
+    volumes:
+      - ./:/fun-cms
+    entrypoint: >
+      bash -c "mkdir -p /fun-cms/data/static/css &&
+      sass --watch /fun-cms/app/fun_cms/static/scss/main.scss:/fun-cms/data/static/css/main.css -E \"UTF-8\"";
+    depends_on:
+      - "js"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -10,7 +10,8 @@ The project is defined using a [docker-compose file](../docker-compose.yml) and 
 - **nginx:** the front end web server configured to serve static/media files and proxy other requests to Django,
 - **db:** the SQL database,
 - **app:** the actual Django CMS project with all our application code,
-- **typescript:** a webpack process that transpiles our sources and bundles them into a JS package.
+- **typescript:** a webpack process that transpiles our sources and bundles them into a JS package,
+- **sass:** builds the output CSS file from `app/` to `static/`.
 
 This default `docker-compose` configuration is intended for development, so we are:
 

--- a/sass/Dockerfile
+++ b/sass/Dockerfile
@@ -1,0 +1,3 @@
+FROM ruby:2.4
+
+RUN gem install sass


### PR DESCRIPTION
Running the initial `docker-compose` command now starts a long-running container running `sass` that will keep static/css/main.css up-to-date whenever the source files are changed.