### PR TITLE
Update bootstrap version to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -334,9 +334,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.3.tgz",
-      "integrity": "sha512-/Qe1Q2d1muLEZRX2iCteMQHZBBAm6ZIjJ9FcBYK/xLr05+HvDtBOVBN+Cz7mCNZuy0zr+y5artZHM05W7mIz6g=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
+      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
     },
     "brace-expansion": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
-    "bootstrap": "^4.0.0-beta.3",
+    "bootstrap": "4.0.0",
     "lodash-es": "^4.17.4",
     "moment": "^2.20.1",
     "react": "^16.2.0",


### PR DESCRIPTION
Bootstrap4 just went out of beta and released. Simply change the number in package.json.