### PR TITLE
Add cache invalidation mechanism for js/css files

### DIFF
--- a/richie/settings.py
+++ b/richie/settings.py
@@ -377,6 +377,13 @@ class Production(Base):
 
     ALLOWED_HOSTS = values.ListValue(None)
 
+    # For static files in production, we want to use a backend that includes a hash in
+    # the filename, that is calculated from the file content, so that browsers always
+    # get the updated version of each file.
+    STATICFILES_STORAGE = (
+        "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+    )
+
 
 class Feature(Production):
     """


### PR DESCRIPTION
## Purpose

The js/css files are the result of a build done by webpack. Each time they are updated, browsers will get an outdated version from cache on the webserver or CDN which are difficult to invalidate.
By appending as querystring a unique identifier calculated on the content of the file we make sure browsers always get the updated version.

## Proposal

Use Django's `ManifestStaticFilesStorage` to collect static files (only in production settings).