### PR TITLE
fix(docker) switch to circleci node-browsers image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     depends_on:
       - "app"
   node:
-    image: node:9.4.0
+    image: circleci/node:9-browsers
     working_dir: /app
     volumes:
       - .:/app


### PR DESCRIPTION
## Purpose

As mentioned in #38, we need to fix karma tests execution in a node container.

## Proposal

Use CircleCI `with-browser` docker containers.
