### PR TITLE
fix(docker) force container/local user mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 # Docker
 COMPOSE              = docker-compose
 COMPOSE_RUN          = $(COMPOSE) run --rm
+COMPOSE_EXEC         = $(COMPOSE) exec
+COMPOSE_EXEC_APP     = $(COMPOSE_EXEC) app
+COMPOSE_EXEC_NODE    = $(COMPOSE_EXEC) --user="$(id -u):$(id -g)" node
 COMPOSE_RUN_APP      = $(COMPOSE_RUN) app
-COMPOSE_RUN_NODE     = $(COMPOSE_RUN) node
+COMPOSE_RUN_NODE     = $(COMPOSE_RUN) --user="$(id -u):$(id -g)" node
 COMPOSE_TEST         = $(COMPOSE) -p fun-cms-test -f docker-compose.test.yml
 COMPOSE_TEST_RUN     = $(COMPOSE_TEST) run --rm
 COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app


### PR DESCRIPTION
It is often considered as a good practice to define a USER in your
Dockerfile to prevent privilege escalation in a Docker context. This can
be an issue if you mount host volumes that must have write permission
for the container's user.

In this case, it is a good idea to force the mapping with local users
thanks to the --user option of docker(-compose) run. In our particular
case, we use this option in the Makefile only for the node service
commands. By doing so, we have access to current  user ids ($(id
-u):$(id -g)) and this trick will hopefully work on most systems.