### PR TITLE
😎(search)write a saga to manage organization list requests

### DIFF
--- a/fun_cms/js/data/configureStore.ts
+++ b/fun_cms/js/data/configureStore.ts
@@ -2,15 +2,20 @@ import { applyMiddleware, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
 import { rootReducer, RootState } from './rootReducer';
+import rootSaga from './rootSaga';
 
 const sagaMiddleware = createSagaMiddleware();
 
 export default function configureStore(preloadedState: RootState = {}) {
-  return createStore(
+  const store = createStore(
     rootReducer,
     preloadedState,
     applyMiddleware(
       sagaMiddleware,
     ),
   );
+
+  sagaMiddleware.run(rootSaga);
+
+  return store;
 }

--- a/fun_cms/js/data/organization/actions.ts
+++ b/fun_cms/js/data/organization/actions.ts
@@ -11,3 +11,44 @@ export function addOrganization(organization: Organization): OrganizationAdd {
     type: 'ORGANIZATION_ADD',
   };
 }
+
+export interface OrganizationsGet {
+  params?: { keys?: string[] };
+  type: 'ORGANIZATION_LIST_GET';
+}
+
+export function getOrganizations(params: OrganizationsGet['params']): OrganizationsGet {
+  return {
+    params,
+    type: 'ORGANIZATION_LIST_GET',
+  };
+}
+
+export interface OrganizationsGetSuccess {
+  organizations: Organization[];
+  params: OrganizationsGet['params'];
+  type: 'ORGANIZATION_LIST_GET_SUCCESS';
+}
+
+export function didGetOrganizations(
+  organizations: OrganizationsGetSuccess['organizations'],
+  params: OrganizationsGetSuccess['params'],
+): OrganizationsGetSuccess {
+  return {
+    organizations,
+    params,
+    type: 'ORGANIZATION_LIST_GET_SUCCESS',
+  };
+}
+
+export interface OrganizationsGetFailure {
+  error: Error | string;
+  type: 'ORGANIZATION_LIST_GET_FAILURE';
+}
+
+export function failedToGetOrganizations(error: OrganizationsGetFailure['error']): OrganizationsGetFailure {
+  return {
+    error,
+    type: 'ORGANIZATION_LIST_GET_FAILURE',
+  };
+}

--- a/fun_cms/js/data/organization/getOrganizationsSaga.spec.ts
+++ b/fun_cms/js/data/organization/getOrganizationsSaga.spec.ts
@@ -1,0 +1,124 @@
+import { call, put, takeLatest } from 'redux-saga/effects';
+
+import { addOrganization, didGetOrganizations, failedToGetOrganizations } from './actions';
+import { fetchOrganizations, getOrganizations } from './getOrganizationsSaga';
+
+describe('data/organization getOrganizations saga', () => {
+  const org43 = {
+    banner: 'https://example.com/banner43.png',
+    code: 'org-43',
+    detail_page_enabled: false,
+    id: 43,
+    logo: 'https://example.com/logo43.png',
+    name: 'Org 43',
+  };
+  const org44 = {
+    banner: 'https://example.com/banner44.png',
+    code: 'org-44',
+    detail_page_enabled: false,
+    id: 44,
+    logo: 'https://example.com/logo44.png',
+    name: 'Org 44',
+  };
+
+  describe('fetchOrganizations', () => {
+    let realFetch: GlobalFetch['fetch'];
+    let mockFetch: jasmine.Spy;
+
+    beforeEach(() => {
+      realFetch = window.fetch;
+      mockFetch = jasmine.createSpy('fetch');
+      window.fetch = mockFetch;
+    });
+
+    afterEach(() => {
+      window.fetch = realFetch;
+    });
+
+    it('requests the organizations, parses the JSON response and resolves with the results', (done) => {
+      mockFetch.and.returnValue(Promise.resolve({
+        json: () => Promise.resolve({ results: [ org43, org44 ] }),
+        ok: true,
+      }));
+
+      fetchOrganizations({ keys: [ 'org-43', 'org-44' ] })
+      .then((response) => {
+        // The correct request given parameters is performed
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/organizations?keys=org-43&keys=org-44',
+          { headers: { 'Content-Type': 'application/json' },
+        });
+        // Our polymorphic response object is properly shaped
+        expect(response.error).not.toBeTruthy();
+        expect(response.organizations).toEqual([ org43, org44 ]);
+        done();
+      });
+    });
+
+    it('returns an { error } object when it fails to get the organizations (local)', (done) => {
+      mockFetch.and.returnValue(Promise.reject(new Error('Could not perform fetch.')));
+
+      // Don't check params again as it was done in the first test
+      fetchOrganizations({ keys: [ 'org-43', 'org-44' ] })
+      .then((response) => {
+        // Our polymorphic response object is properly shaped - with an error this time
+        expect(response.organizations).not.toBeDefined();
+        expect(response.error).toEqual(jasmine.any(Error));
+        done();
+      });
+    });
+
+    it('returns an { error } object when it fails to get the organizations (network)', (done) => {
+      mockFetch.and.returnValue(Promise.resolve({ ok: false, status: 404 }));
+
+      // Don't check params again as it was done in the first test
+      fetchOrganizations({ keys: [ 'org-43', 'org-44' ] })
+      .then((response) => {
+        // Our polymorphic response object is properly shaped - with an error this time
+        expect(response.organizations).not.toBeDefined();
+        expect(response.error).toEqual(jasmine.any(Error));
+        done();
+      });
+    });
+  });
+
+  describe('getOrganizations', () => {
+    const action = {
+      params: { keys: [ 'param' ] },
+      type: 'ORGANIZATION_LIST_GET' as 'ORGANIZATION_LIST_GET',
+    };
+
+    it('calls fetchOrganizations, puts each org and yields a success action', () => {
+      const gen = getOrganizations(action);
+
+      // Mock a 'list of organizations' response with which to trigger the call to fetchOrganizations
+      const response = {
+        organizations: [ org43, org44 ],
+      };
+
+      // The call to fetch (the actual side-effect) is triggered
+      expect(gen.next().value).toEqual(call(fetchOrganizations, action.params));
+
+      // Both organizations are added to the state
+      expect(gen.next(response).value).toEqual(put(addOrganization(response.organizations[0])));
+      expect(gen.next().value).toEqual(put(addOrganization(response.organizations[1])));
+
+      // The success action is dispatched
+      expect(gen.next().value).toEqual(put(didGetOrganizations(response.organizations, action.params)));
+    });
+
+    it('yields a failure action when fetchOrganization fails', () => {
+      const gen = getOrganizations(action);
+
+      const response = {
+        error: new Error('Failed to fetch organizations for some reason.'),
+      };
+
+      // The call to fetch is triggered, but fails for some reason
+      expect(gen.next().value).toEqual(call(fetchOrganizations, action.params));
+
+      // The failure action is dispatched
+      expect(gen.next(response).value).toEqual(put(failedToGetOrganizations(response.error)));
+    });
+  });
+});

--- a/fun_cms/js/data/organization/getOrganizationsSaga.ts
+++ b/fun_cms/js/data/organization/getOrganizationsSaga.ts
@@ -1,0 +1,54 @@
+import { call, put, takeLatest } from 'redux-saga/effects';
+
+import Organization from '../../types/Organization';
+import formatQueryString from '../../utils/http/formatQueryString';
+import { addOrganization, didGetOrganizations, failedToGetOrganizations, OrganizationsGet } from './actions';
+
+// Use a polymorphic response object so it can be elegantly consumed through destructuration
+interface Response {
+  error?: string | Error;
+  organizations?: Organization[];
+}
+
+// Wrap fetch to handle params, headers, parsing & sane response handling
+// NB: some of this logic should be move in a separate module when we reuse it elsewhere
+export function fetchOrganizations(params?: OrganizationsGet['params']): Promise<Response> {
+  return fetch('/organizations' + formatQueryString(params), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  .then((response) => {
+    // Fetch treats remote errors (400, 404, 503...) as successes. The ok flag is the way to discriminate.
+    if (response.ok) {
+      return response;
+    }
+    // Push remote errors to the error channel for consistency
+    throw new Error('Failed to get the organizations: ' + response.status);
+  })
+  .then((response) => response.json())
+  .then((response: { results: Organization[] }) => ({ organizations: response.results }))
+  .catch((error) => ({ error }));
+}
+
+export function* getOrganizations(action: OrganizationsGet) {
+  const { params } = action;
+  const { error, organizations }: Response = yield call(fetchOrganizations, params);
+
+  if (error) {
+    yield put(failedToGetOrganizations(error));
+  } else {
+    // Add each individual organization to the state before we put the success action in
+    // order to avoid race conditions / incomplete data sets
+    for (const organization of organizations) {
+      yield put(addOrganization(organization));
+    }
+    yield put(didGetOrganizations(organizations, params));
+  }
+}
+
+export default function* watch() {
+  // We can cancel ongoing requests whenever there's a new one: the user will not request several different sets
+  // of filters of the same kind at the same time.
+  yield takeLatest('ORGANIZATION_LIST_GET', getOrganizations);
+}

--- a/fun_cms/js/data/rootSaga.ts
+++ b/fun_cms/js/data/rootSaga.ts
@@ -1,0 +1,10 @@
+import { all } from 'redux-saga/effects';
+
+import getOrganizationsSaga from './organization/getOrganizationsSaga';
+
+// Aggregate all our sagas through the parallelization effect
+export default function* rootSaga() {
+  yield all([
+    getOrganizationsSaga(),
+  ]);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "lib": [ "dom", "es5", "scripthost", "es2015.promise" ],
+    "lib": [ "dom", "es5", "scripthost", "es2015.promise", "es2015.iterable" ],
     "module": "commonjs",
     "noImplicitAny": true,
     "sourceMap": true,


### PR DESCRIPTION
In our filters list, organizations will be taken from the facets of ElasticSearch query responses. 

However, we'll still need to get the human names from the server through a list request on an organization endpoint.

This saga provides the facilities to handle that use case: the relevant component (or whatever part of the code handles filter update notifications) will just need to dispatch an action with the necessary keys and any consumer that needs them will have the human names ready as soon as they're loaded from the server.

NB: nothing is relying on this just yet but as far as I can tell it is functional right now (if rudimentary when it comes to error handling).