### PR TITLE
😎(search) index courses in ElasticSearch

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -234,7 +234,7 @@ ignore-on-opaque-inference=yes
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
-ignored-classes=optparse.Values,thread._local,_thread._local
+ignored-classes=optparse.Values,thread._local,_thread._local,responses
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime

--- a/apps/search/exceptions.py
+++ b/apps/search/exceptions.py
@@ -1,0 +1,9 @@
+"""
+Specific exceptions for the search app
+"""
+
+
+class IndexerDataException(Exception):
+    """
+    Exception raised when an Indexer fails to provide the data required for ES indexing
+    """

--- a/apps/search/indexers/course.py
+++ b/apps/search/indexers/course.py
@@ -1,0 +1,100 @@
+"""
+Indexing utility for the ElasticSearch-related regenerate_index command
+"""
+import math
+
+from django.conf import settings
+import requests
+
+from ..partial_mappings import MULTILINGUAL_TEXT
+from ..exceptions import IndexerDataException
+
+
+class CourseIndexer():
+    """
+    Makes available the parameters the indexer requires as well as a function to shape
+    objects into what we want to index in ElasticSearch
+    """
+    document_type = 'course'
+    index_name = 'fun_cms_courses'
+    mapping = {
+        'dynamic_templates': MULTILINGUAL_TEXT,
+        'properties': {
+            'end_date': {'type': 'date'},
+            'enrollment_end_date': {'type': 'date'},
+            'enrollment_start_date': {'type': 'date'},
+            'language': {'type': 'keyword'},
+            'organizations': {'type': 'keyword'},
+            'session_number': {'type': 'integer'},
+            'start_date': {'type': 'date'},
+            'subjects': {'type': 'keyword'},
+            'thumbnails': {
+                'properties': {
+                    'about': {'type': 'text', 'index': False},
+                    'big': {'type': 'text', 'index': False},
+                    'facebook': {'type': 'text', 'index': False},
+                    'small': {'type': 'text', 'index': False},
+                },
+                'type': 'object',
+            },
+        },
+    }
+
+    def get_data_for_es(self, index, action):
+        """
+        Load all the courses from the API and format them for the ElasticSearch index
+        """
+        # Set initial request params. Use math.inf so the first request always fires
+        offset = 0
+        page_length = 50
+        total_count = math.inf
+
+        # Iterate over the API as long as there are results to get
+        while total_count > offset:
+            response = requests.get(
+                settings.COURSE_API_ENDPOINT,
+                params={'page': 1 + offset // page_length, 'rpp': page_length}
+            )
+
+            # Make sure we throw if we received an invalid status code so everything is stopped
+            try:
+                response.raise_for_status()
+            except requests.HTTPError:
+                raise IndexerDataException(
+                    'HTTP Request for ES data failed with code {:n}'.format(response.status_code),
+                )
+
+            # Get the parsed JSON content from the request
+            try:
+                content = response.json()
+            except requests.compat.json.decoder.JSONDecodeError:
+                raise IndexerDataException('Invalid JSON received from remote API')
+
+            try:
+                # Set the params for the next request (or to exit the loop)
+                total_count = content['count']
+
+                # Iterate over the results to put each of them in our index
+                for course in content['results']:
+                    yield {
+                        '_id': course['id'],
+                        '_index': index,
+                        '_op_type': action,
+                        '_type': self.document_type,
+                        'end_date': course['end_date'],
+                        'enrollment_end_date': course['enrollment_end_date'],
+                        'enrollment_start_date': course['enrollment_start_date'],
+                        'language': course['language'],
+                        'organizations': [org['id'] for org in course['universities']],
+                        'session_number': course['session_number'],
+                        'short_description': {course['language']: course['short_description']},
+                        'start_date': course['start_date'],
+                        'subjects': [subject['id'] for subject in course['subjects']],
+                        'thumbnails': course['thumbnails'],
+                        'title': {course['language']: course['title']},
+                    }
+            except KeyError:
+                raise IndexerDataException('Unexpected data shape in courses to index')
+
+            # Prepare the offset for the next request
+            offset = offset + page_length

--- a/apps/search/indexers/organization.py
+++ b/apps/search/indexers/organization.py
@@ -8,11 +8,11 @@ from ...organizations.models import OrganizationPage
 
 class OrganizationIndexer():
     """
-    Makes available the static data the indexer requires as well as a function to shape
+    Makes available the parameters the indexer requires as well as a function to shape
     objects into what we want to index in ElasticSearch
     """
     document_type = 'organization'
-    index_name = 'fun_cms_{:s}s'.format(document_type)
+    index_name = 'fun_cms_organizations'
     mapping = {
         'properties': {
             'code': {'type': 'keyword'},

--- a/apps/search/partial_mappings.py
+++ b/apps/search/partial_mappings.py
@@ -1,0 +1,29 @@
+"""
+Centralize our custom ES mappings for easier reuse and testability
+"""
+
+# Dynamic template to match translated strings with their language analyzer
+# NB: expects objects to follow a conventional form, eg:
+#   {
+#       'title': {
+#           'en': '<english title>',
+#           'fr': '<french title>',
+#       },
+#   }
+# Where all the language keys are optional and dynamically added to the mapping at indexing time
+MULTILINGUAL_TEXT = [
+    {
+        'english_strings': {
+            'match_mapping_type': 'string',
+            'path_match': '*.en',
+            'mapping': {'type': 'text', 'analyzer': 'english'},
+        },
+    },
+    {
+        'french_strings': {
+            'match_mapping_type': 'string',
+            'path_match': '*.fr',
+            'mapping': {'type': 'text', 'analyzer': 'french'},
+        },
+    },
+]

--- a/apps/search/tests/test_course_indexer.py
+++ b/apps/search/tests/test_course_indexer.py
@@ -1,0 +1,183 @@
+"""
+Tests for the course indexer
+"""
+from django.conf import settings
+from django.test import TestCase
+import responses
+
+from ..exceptions import IndexerDataException
+from ..indexers.course import CourseIndexer
+
+
+class CourseIndexerTestCase(TestCase):
+    """
+    Test the get_data_for_es() function on the course indexer, as well as our mapping,
+    and especially dynamic mapping shape in ES
+    """
+
+    @responses.activate
+    def test_get_data_for_es(self):
+        """
+        Happy path: the data is fetched from the API properly formatted
+        """
+        responses.add(
+            method='GET',
+            url=settings.COURSE_API_ENDPOINT + '?page=1&rpp=50',
+            match_querystring=True,
+            json={
+                'count': 51,
+                'results': [
+                    {
+                        'end_date': '2018-02-28T06:00:00Z',
+                        'enrollment_end_date': '2018-01-31T06:00:00Z',
+                        'enrollment_start_date': '2018-01-01T06:00:00Z',
+                        'id': 42,
+                        'language': 'fr',
+                        'session_number': 6,
+                        'short_description':  'Lorem ipsum dolor sit amet',
+                        'start_date': '2018-02-01T06:00:00Z',
+                        'subjects': [{'id': 168}, {'id': 336}],
+                        'thumbnails': {'big': 'whatever.png'},
+                        'title': 'A course in filler text',
+                        'universities': [{'id': 21}, {'id': 84}],
+                    },
+                ],
+            },
+        )
+
+        responses.add(
+            method='GET',
+            url=settings.COURSE_API_ENDPOINT + '?page=2&rpp=50',
+            match_querystring=True,
+            json={
+                'count': 51,
+                'results': [
+                    {
+                        'end_date': '2019-02-28T06:00:00Z',
+                        'enrollment_end_date': '2019-01-31T06:00:00Z',
+                        'enrollment_start_date': '2019-01-01T06:00:00Z',
+                        'id': 44,
+                        'language': 'en',
+                        'session_number': 1,
+                        'short_description':  'Consectetur adipiscim elit',
+                        'start_date': '2019-02-01T06:00:00Z',
+                        'subjects': [{'id': 176}, {'id': 352}],
+                        'thumbnails': {'big': 'whatever_else.png'},
+                        'title': 'Filler text 102',
+                        'universities': [{'id': 22}, {'id': 88}],
+                    },
+                ],
+            },
+        )
+
+        indexer = CourseIndexer()
+
+        # The results were properly formatted and passed to the consumer
+        self.assertEqual(
+            list(indexer.get_data_for_es(index='some_index', action='some_action')),
+            [
+                {
+                    '_id': 42,
+                    '_index': 'some_index',
+                    '_op_type': 'some_action',
+                    '_type': 'course',
+                    'end_date': '2018-02-28T06:00:00Z',
+                    'enrollment_end_date': '2018-01-31T06:00:00Z',
+                    'enrollment_start_date': '2018-01-01T06:00:00Z',
+                    'language': 'fr',
+                    'organizations': [21, 84],
+                    'session_number': 6,
+                    'short_description': {'fr': 'Lorem ipsum dolor sit amet'},
+                    'start_date': '2018-02-01T06:00:00Z',
+                    'subjects': [168, 336],
+                    'thumbnails': {'big': 'whatever.png'},
+                    'title': {'fr': 'A course in filler text'},
+                },
+                {
+                    '_id': 44,
+                    '_index': 'some_index',
+                    '_op_type': 'some_action',
+                    '_type': 'course',
+                    'end_date': '2019-02-28T06:00:00Z',
+                    'enrollment_end_date': '2019-01-31T06:00:00Z',
+                    'enrollment_start_date': '2019-01-01T06:00:00Z',
+                    'language': 'en',
+                    'organizations': [22, 88],
+                    'session_number': 1,
+                    'short_description': {'en': 'Consectetur adipiscim elit'},
+                    'start_date': '2019-02-01T06:00:00Z',
+                    'subjects': [176, 352],
+                    'thumbnails': {'big': 'whatever_else.png'},
+                    'title': {'en': 'Filler text 102'},
+                }
+            ],
+        )
+
+    @responses.activate
+    def test_get_data_for_es_with_error_status(self):
+        """
+        Error case: the API responds with an error status
+        """
+        responses.add(
+            method='GET',
+            url=settings.COURSE_API_ENDPOINT,
+            status=500,
+        )
+
+        indexer = CourseIndexer()
+
+        # The call raised the correct exception
+        with self.assertRaises(IndexerDataException):
+            list(indexer.get_data_for_es(index='some_index', action='some_action'))
+
+    @responses.activate
+    def test_get_data_for_es_with_invalid_json(self):
+        """
+        Error case: the API did not return valid JSON
+        """
+        responses.add(
+            method='GET',
+            url=settings.COURSE_API_ENDPOINT,
+            status=200,
+            body='broken_json',
+        )
+
+        indexer = CourseIndexer()
+
+        with self.assertRaises(IndexerDataException):
+            list(indexer.get_data_for_es(index='some_index', action='some_action'))
+
+    @responses.activate
+    def test_get_data_for_es_with_unexpected_data_shape(self):
+        """
+        Error case: the API returned an object that is not shape like an expected course
+        """
+        responses.add(
+            method='GET',
+            url=settings.COURSE_API_ENDPOINT,
+            status=200,
+            json={
+                'count': 1,
+                'results': [
+                    {
+                        'end_date': '2018-02-28T06:00:00Z',
+                        'enrollment_end_date': '2018-01-31T06:00:00Z',
+                        'enrollment_start_date': '2018-01-01T06:00:00Z',
+                        'id': 42,
+                        # 'language': 'fr', missing language key will trigger the KeyError
+                        'session_number': 6,
+                        'short_description':  'Lorem ipsum dolor sit amet',
+                        'start_date': '2018-02-01T06:00:00Z',
+                        'subjects': [{'id': 168}, {'id': 336}],
+                        'thumbnails': {'big': 'whatever.png'},
+                        'title': 'A course in filler text',
+                        'universities': [{'id': 21}, {'id': 84}],
+                    },
+                ],
+            },
+        )
+
+        indexer = CourseIndexer()
+
+        with self.assertRaises(IndexerDataException):
+            list(indexer.get_data_for_es(index='some_index', action='some_action'))

--- a/apps/search/tests/test_custom_mappings.py
+++ b/apps/search/tests/test_custom_mappings.py
@@ -1,0 +1,97 @@
+"""
+Test for our partial mappings
+"""
+from django.conf import settings
+from django.test import TestCase
+from elasticsearch.client import IndicesClient
+
+from ..partial_mappings import MULTILINGUAL_TEXT
+
+
+class PartialMappingsTestCase(TestCase):
+    """
+    Make sure our mappings (esp. dynamic templates) are correctly understood by ElasticSearch
+    """
+
+    def setUp(self):
+        """
+        Instantiate our ES client and make sure all indexes are deleted before each test
+        """
+        super().setUp()
+        self.indices_client = IndicesClient(client=settings.ES_CLIENT)
+        self.indices_client.delete(index='_all')
+
+    def test_multilingual_text(self):
+        """
+        Make sure our multilingual_text dynamic mapping results in the proper mappings being
+        generated when objects with the expected format are indexed
+        """
+        document_type = 'stub'
+        index_name = 'stub_index'
+        mapping = {'dynamic_templates': MULTILINGUAL_TEXT}
+
+        # Create the index and set a mapping that includes the pattern we want to test
+        self.indices_client.create(index=index_name)
+        self.indices_client.put_mapping(
+            index=index_name,
+            doc_type=document_type,
+            body=mapping,
+        )
+
+        # The stub mapping only contains our dynamic template
+        mapping = self.indices_client.get_mapping(index=index_name, doc_type=document_type)
+        self.assertEqual(
+            mapping[index_name]['mappings'][document_type],
+            {'dynamic_templates': MULTILINGUAL_TEXT},
+        )
+
+        # Index an object that should trigger a match for our dynamic template
+        settings.ES_CLIENT.index(
+            index=index_name,
+            doc_type=document_type,
+            body={
+                'title': {'fr': 'Un titre en français à titre d\'exemple'}
+            },
+        )
+
+        # The stub mapping has been extended with a matching property for 'fr'
+        mapping = self.indices_client.get_mapping(index=index_name, doc_type=document_type)
+        self.assertEqual(
+            mapping[index_name]['mappings'][document_type],
+            {
+                'dynamic_templates': MULTILINGUAL_TEXT,
+                'properties': {
+                    'title': {
+                        'properties': {
+                            'fr': {'type': 'text', 'analyzer': 'french'}
+                        },
+                    },
+                },
+            },
+        )
+
+        # Index an object that should trigger a different match for our dynamic template
+        settings.ES_CLIENT.index(
+            index=index_name,
+            doc_type=document_type,
+            body={
+                'title': {'en': 'An English title as an example'}
+            },
+        )
+
+        # The sub mapping has been extended with a matching property for 'en'
+        mapping = self.indices_client.get_mapping(index=index_name, doc_type=document_type)
+        self.assertEqual(
+            mapping[index_name]['mappings'][document_type],
+            {
+                'dynamic_templates': MULTILINGUAL_TEXT,
+                'properties': {
+                    'title': {
+                        'properties': {
+                            'en': {'type': 'text', 'analyzer': 'english'},
+                            'fr': {'type': 'text', 'analyzer': 'french'},
+                        },
+                    },
+                },
+            },
+        )

--- a/fun_cms/configurations/elasticsearch.py
+++ b/fun_cms/configurations/elasticsearch.py
@@ -21,5 +21,8 @@ class ElasticSearchMixin(object):
     ])
     ES_CHUNK_SIZE = 500
     ES_INDEXES = [
+        'apps.search.indexers.course.CourseIndexer',
         'apps.search.indexers.organization.OrganizationIndexer',
     ]
+
+    COURSE_API_ENDPOINT = 'https://www.fun-mooc.fr/fun/api/courses'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,3 +11,4 @@ pylint-django==0.9.0
 pytest==3.3.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
+responses==0.8.1


### PR DESCRIPTION
Add an indexer for courses. It fetches the courses from the existing fun-apps API (as we don't have the model in fun-cms yet) and adds them in our ES index.