### PR TITLE
Install JS deps from the lockfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           - v2-front-dependencies-
       - run:
           name: Install front-end dependencies
-          command: yarn install
+          command: yarn install --frozen-lockfile
       - run:
           name: Build front-end application
           command: yarn build


### PR DESCRIPTION
The --frozen-lockfile flag installs from the lockfile *if* it is compliant with package.json requirements, and fails otherwise. This ensures reproducible builds by avoiding silent updates occurring on the CI at an uncontrolled time (instead of on a developer's machine when they decide to upgrade dependencies).