### PR TITLE
🐛(utils) fix broken utility scripts

### DIFF
--- a/bin/pylint
+++ b/bin/pylint
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-docker-compose -p richie-test -f docker-compose.test.yml run --rm --no-deps app pylint "$@"
+docker-compose \
+    -p richie-test \
+    -f docker/compose/test/docker-compose.yml \
+    --project-directory . \
+    run --rm --no-deps app pylint "$@"

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-docker-compose -p richie-test -f docker-compose.test.yml run --rm app pytest "$@"
+docker-compose \
+    -p richie-test \
+    -f docker/compose/test/docker-compose.yml \
+    --project-directory . \
+    run --rm app pytest "$@"


### PR DESCRIPTION
Recent changes in the docker tree broke bin/* utility scripts. This is now fixed, yay!