### PR TITLE
🐛(docker) fix issues with docker bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ MANAGE               = $(COMPOSE_RUN_APP) python manage.py
 default: help
 
 bootstrap:  ## install development dependencies
+	@$(COMPOSE) build base;
 	@$(COMPOSE) build app;
 	${MAKE} build-front;
 	@echo 'Waiting until database is up…';


### PR DESCRIPTION
There were 2 issues that were preventing docker-compose from running our app properly:
- the name "base" in the dockerfile was conflicting with the name  "base" in docker-compose.yml
- "make bootstrap" was missing a call to build the base image before   it builds app.