### PR TITLE
⚡️(front) batchresourceById adds through a list action

### DIFF
--- a/richie/js/data/genericReducers/resourceById/actions.ts
+++ b/richie/js/data/genericReducers/resourceById/actions.ts
@@ -15,3 +15,20 @@ export function addResource(resourceName: keyof RootState['resources'], resource
     type: 'RESOURCE_ADD',
   };
 }
+
+export interface ResourceMultipleAdd<R extends Resource> {
+  type: 'RESOURCE_MULTIPLE_ADD';
+  resourceName: keyof RootState['resources'];
+  resources: R[];
+}
+
+export function addMultipleResources(
+  resourceName: keyof RootState['resources'],
+  resources: Resource[],
+): ResourceMultipleAdd<Resource> {
+  return {
+    resourceName,
+    resources,
+    type: 'RESOURCE_MULTIPLE_ADD',
+  };
+}

--- a/richie/js/data/genericReducers/resourceById/resourceById.ts
+++ b/richie/js/data/genericReducers/resourceById/resourceById.ts
@@ -1,7 +1,7 @@
 import { Reducer } from 'redux';
 
 import Resource from '../../../types/Resource';
-import { ResourceAdd } from './actions';
+import { ResourceAdd, ResourceMultipleAdd } from './actions';
 
 export const initialState = {
   byId: {},
@@ -15,7 +15,7 @@ export interface ResourceByIdState<R extends Resource> {
 
 export function byId<R extends Resource>(
   state: ResourceByIdState<R>,
-  action: ResourceAdd<R> | { type: '' },
+  action: ResourceAdd<R> | ResourceMultipleAdd<R> | { type: '' },
 ): ResourceByIdState<R> {
   // Initialize the state to an empty version of itself
   if (!state) { state = initialState; }
@@ -31,6 +31,15 @@ export function byId<R extends Resource>(
           [action.resource.id]: action.resource,
         },
       };
+
+      case 'RESOURCE_MULTIPLE_ADD':
+        return {
+          ...state,
+          byId: {
+            ...state.byId,
+            ...action.resources.reduce((acc, resource) => ({ ...acc, [resource.id]: resource }), {}),
+          },
+        };
   }
 
   return state;

--- a/richie/js/data/genericSideEffects/getResourceList/getResourceList.spec.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/getResourceList.spec.ts
@@ -1,7 +1,7 @@
 import partial from 'lodash-es/partial';
 import { call, put, takeLatest } from 'redux-saga/effects';
 
-import { addResource } from '../../genericReducers/resourceById/actions';
+import { addMultipleResources } from '../../genericReducers/resourceById/actions';
 import { didGetResourceList, failedToGetResourceList } from './actions';
 import { fetchList, getList, GetListSagaSpecifics } from './getResourceList';
 
@@ -128,8 +128,7 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       // The call to fetch (the actual side-effect) is triggered
       expect(gen.next().value).toEqual(call(fetchList, 'course', action.params));
       // Both courses are added to the state
-      expect(gen.next(response).value).toEqual(put(addResource('course', response.objects[0])));
-      expect(gen.next().value).toEqual(put(addResource('course', response.objects[1])));
+      expect(gen.next(response).value).toEqual(put(addMultipleResources('course', response.objects)));
       // The success action is dispatched
       expect(gen.next().value).toEqual(put(didGetResourceList('course', response, action.params)));
     });

--- a/richie/js/data/genericSideEffects/getResourceList/getResourceList.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/getResourceList.ts
@@ -5,7 +5,7 @@ import { API_ENDPOINTS } from '../../../settings.json';
 import { APIResponseListMeta } from '../../../types/api';
 import Resource from '../../../types/Resource';
 import formatQueryString from '../../../utils/http/formatQueryString';
-import { addResource } from '../../genericReducers/resourceById/actions';
+import { addMultipleResources } from '../../genericReducers/resourceById/actions';
 import { RootState } from '../../rootReducer';
 import {
   didGetResourceList,
@@ -64,9 +64,7 @@ export function* getList(action: ResourceListGet) {
   } else {
     // Add each individual resource to the state before we put the success action in
     // order to avoid race conditions / incomplete data sets
-    for (const resource of objects) {
-      yield put(addResource(resourceName, resource));
-    }
+    yield put(addMultipleResources(resourceName, objects));
     yield put(didGetResourceList(resourceName, { meta, objects, ...restProps }, params));
   }
 }


### PR DESCRIPTION
We encountered performance issues when putting hundreds of RESOURCE_ADD actions at once. Sidestep the issue by adding an action that can add multiple sibling resources at once.