### PR TITLE
Display facet results in filter pane

### DIFF
--- a/apps/search/tests/test_viewsets_course.py
+++ b/apps/search/tests/test_viewsets_course.py
@@ -77,7 +77,7 @@ class CourseViewsetTestCase(TestCase):
                 'total': 90,
             },
             'aggregations': {
-                'organizations': {
+                'organization': {
                     'buckets': [
                         {'key': '1', 'doc_count': 7},
                         {'key': '2', 'doc_count': 9},
@@ -93,15 +93,15 @@ class CourseViewsetTestCase(TestCase):
         self.assertEqual(response.data, {
             'meta': {'count': 2, 'offset': 10, 'total_count': 90},
             'objects': ['Course #89', 'Course #94'],
-            'facets': {'organizations': {'1': 7, '2': 9}},
+            'facets': {'organization': {'1': 7, '2': 9}},
         })
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
             body={
                 'query': {'match_all': {}},
                 'aggs': {
-                    'organizations': {'terms': {'field': 'organizations'}},
-                    'subjects': {'terms': {'field': 'subjects'}}
+                    'organization': {'terms': {'field': 'organizations'}},
+                    'subject': {'terms': {'field': 'subjects'}}
                 },
             },
             doc_type='course',
@@ -124,7 +124,7 @@ class CourseViewsetTestCase(TestCase):
                 'total': 35,
             },
             'aggregations': {
-                'subjects': {
+                'subject': {
                     'buckets': [
                         {'key': '11', 'doc_count': 17},
                         {'key': '21', 'doc_count': 19},
@@ -140,7 +140,7 @@ class CourseViewsetTestCase(TestCase):
         self.assertEqual(response.data, {
             'meta': {'count': 2, 'offset': 20, 'total_count': 35},
             'objects': ['Course #523', 'Course #861'],
-            'facets': {'subjects': {'11': 17, '21': 19}},
+            'facets': {'subject': {'11': 17, '21': 19}},
         })
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
@@ -153,8 +153,8 @@ class CourseViewsetTestCase(TestCase):
                     }
                 },
                 'aggs': {
-                    'organizations': {'terms': {'field': 'organizations'}},
-                    'subjects': {'terms': {'field': 'subjects'}}
+                    'organization': {'terms': {'field': 'organizations'}},
+                    'subject': {'terms': {'field': 'subjects'}}
                 },
 
             },
@@ -178,13 +178,13 @@ class CourseViewsetTestCase(TestCase):
                 'total': 29,
             },
             'aggregations': {
-                'organizations': {
+                'organization': {
                     'buckets': [
                         {'key': '13', 'doc_count': 21},
                         {'key': '15', 'doc_count': 13},
                     ],
                 },
-                'subjects': {
+                'subject': {
                     'buckets': [
                         {'key': '12', 'doc_count': 3},
                         {'key': '22', 'doc_count': 5},
@@ -201,8 +201,8 @@ class CourseViewsetTestCase(TestCase):
             'meta': {'count': 2, 'offset': 0, 'total_count': 29},
             'objects': ['Course #221', 'Course #42'],
             'facets': {
-                'organizations': {'13': 21, '15': 13},
-                'subjects': {'12': 3, '22': 5},
+                'organization': {'13': 21, '15': 13},
+                'subject': {'12': 3, '22': 5},
             },
         })
         # The ES connector was called with appropriate arguments for the client's request
@@ -210,8 +210,8 @@ class CourseViewsetTestCase(TestCase):
             body={
                 'query': {'terms': {'organizations': [13, 15]}},
                 'aggs': {
-                    'organizations': {'terms': {'field': 'organizations'}},
-                    'subjects': {'terms': {'field': 'subjects'}}
+                    'organization': {'terms': {'field': 'organizations'}},
+                    'subject': {'terms': {'field': 'subjects'}}
                 },
             },
             doc_type='course',
@@ -235,7 +235,7 @@ class CourseViewsetTestCase(TestCase):
                 'total': 12,
             },
             'aggregations': {
-                'organizations': {
+                'organization': {
                     'buckets': [
                         {'key': '3', 'doc_count': 6},
                         {'key': '14', 'doc_count': 7},
@@ -251,15 +251,15 @@ class CourseViewsetTestCase(TestCase):
         self.assertEqual(response.data, {
             'meta': {'count': 2, 'offset': 0, 'total_count': 12},
             'objects': ['Course #37', 'Course #98'],
-            'facets': {'organizations': {'3': 6, '14': 7}},
+            'facets': {'organization': {'3': 6, '14': 7}},
         })
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
             body={
                 'query': {'terms': {'organizations': [3]}},
                 'aggs': {
-                    'organizations': {'terms': {'field': 'organizations'}},
-                    'subjects': {'terms': {'field': 'subjects'}}
+                    'organization': {'terms': {'field': 'organizations'}},
+                    'subject': {'terms': {'field': 'subjects'}}
                 },
             },
             doc_type='course',
@@ -288,7 +288,7 @@ class CourseViewsetTestCase(TestCase):
                 'total': 7,
             },
             'aggregations': {
-                'subjects': {
+                'subject': {
                     'buckets': [
                         {'key': '61', 'doc_count': 4},
                         {'key': '122', 'doc_count': 5},
@@ -304,7 +304,7 @@ class CourseViewsetTestCase(TestCase):
         self.assertEqual(response.data, {
             'meta': {'count': 2, 'offset': 0, 'total_count': 7},
             'objects': ['Course #13', 'Course #15'],
-            'facets': {'subjects': {'61': 4, '122': 5}},
+            'facets': {'subject': {'61': 4, '122': 5}},
         })
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
@@ -322,8 +322,8 @@ class CourseViewsetTestCase(TestCase):
                     }
                 },
                 'aggs': {
-                    'organizations': {'terms': {'field': 'organizations'}},
-                    'subjects': {'terms': {'field': 'subjects'}}
+                    'organization': {'terms': {'field': 'organizations'}},
+                    'subject': {'terms': {'field': 'subjects'}}
                 },
             },
             doc_type='course',
@@ -354,7 +354,7 @@ class CourseViewsetTestCase(TestCase):
                 'total': 3,
             },
             'aggregations': {
-                'subjects': {
+                'subject': {
                     'buckets': [
                         {'key': '42', 'doc_count': 3},
                         {'key': '84', 'doc_count': 1},
@@ -370,7 +370,7 @@ class CourseViewsetTestCase(TestCase):
         self.assertEqual(response.data, {
             'meta': {'count': 2, 'offset': 0, 'total_count': 3},
             'objects': ['Course #999', 'Course #888'],
-            'facets': {'subjects': {'42': 3, '84': 1}},
+            'facets': {'subject': {'42': 3, '84': 1}},
         })
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
@@ -394,8 +394,8 @@ class CourseViewsetTestCase(TestCase):
                     'terms': {'subjects': [42, 84]}
                 },
                 'aggs': {
-                    'organizations': {'terms': {'field': 'organizations'}},
-                    'subjects': {'terms': {'field': 'subjects'}}
+                    'organization': {'terms': {'field': 'organizations'}},
+                    'subject': {'terms': {'field': 'subjects'}}
                 },
             },
             doc_type='course',

--- a/apps/search/viewsets/course.py
+++ b/apps/search/viewsets/course.py
@@ -72,10 +72,10 @@ class CourseViewSet(ViewSet):
 
         # Build organizations and subjects terms aggregations for our query
         aggs = {
-            'organizations': {
+            'organization': {
                 'terms': {'field': 'organizations'},
             },
-            'subjects': {
+            'subject': {
                 'terms': {'field': 'subjects'},
             },
         }

--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
@@ -48,6 +48,7 @@ describe('components/courseGlimpseListContainer', () => {
         course: {
           byId: { 43: course43, 44: course44 },
           currentQuery: {
+            facets: {},
             items: { 0: 44, 1: 43 },
             queryKey: '{}',
             total_count: 2,

--- a/richie/js/components/searchFilter/searchFilter.spec.tsx
+++ b/richie/js/components/searchFilter/searchFilter.spec.tsx
@@ -7,7 +7,7 @@ import SearchFilter from './searchFilter';
 
 describe('components/searchFilter', () => {
   it('renders the name of the filter', () => {
-    const wrapper = shallow(<SearchFilter filter={[ '42', 'Human name' ]} />);
+    const wrapper = shallow(<SearchFilter filter={{ primaryKey: '42', humanName: 'Human name'}} />);
 
     expect(wrapper.text()).toContain('Human name');
   });

--- a/richie/js/components/searchFilter/searchFilter.tsx
+++ b/richie/js/components/searchFilter/searchFilter.tsx
@@ -1,15 +1,20 @@
 import * as React from 'react';
 
+import { FilterValue } from '../../types/FilterDefinition';
+
 export interface SearchFilterGroupProps {
-  filter: string[];
+  filter: FilterValue;
 }
 
 export const SearchFilter = (props: SearchFilterGroupProps) => {
   const { filter } = props;
 
   return <button className="search-filter">
-    {filter[1]}
-    <span className="search-filter__count">358</span>
+    {filter.humanName}
+    {filter.count || filter.count === 0 ?
+      <span className="search-filter__count">{filter.count}</span> :
+      ''
+    }
   </button>;
 };
 

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
@@ -3,7 +3,7 @@ import '../../testSetup.spec';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import FilterDefinition from '../../types/FilterDefinition';
+import { FilterDefinition } from '../../types/FilterDefinition';
 import SearchFilter from '../searchFilter/searchFilter';
 import SearchFilterGroup from './searchFilterGroup';
 
@@ -21,7 +21,7 @@ describe('components/searchFilterGroup', () => {
   it('renders the list of filter values into a list of SearchFilters', () => {
     const filter = {
       humanName: 'Example filter',
-      values: [ [ 'value-1' ], [ 'value-2' ] ],
+      values: [ { primaryKey: 'value-1', humanName: 'Value One' }, { primaryKey: 'value-2', humanName: 'Value Two' } ],
     } as FilterDefinition;
     const wrapper = shallow(<SearchFilterGroup filter={filter} />);
 

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import FilterDefinition from '../../types/FilterDefinition';
+import { FilterDefinition } from '../../types/FilterDefinition';
 import SearchFilter from '../searchFilter/searchFilter';
 
 export interface SearchFilterGroupProps {
@@ -13,7 +13,7 @@ export const SearchFilterGroup = (props: SearchFilterGroupProps) => {
   return <div className="search-filter-group">
     <h3 className="search-filter-group__title">{humanName}</h3>
     <div className="search-filter-group__list">
-      {values.map((value) => <SearchFilter filter={value} key={value[0]} /> )}
+      {values.map((value) => <SearchFilter filter={value} key={value.primaryKey} /> )}
     </div>
   </div>;
 };

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
@@ -1,0 +1,81 @@
+import { CourseState } from '../../data/course/reducer';
+import Organization from '../../types/Organization';
+import { mapStateToProps } from './searchFilterGroupContainer';
+
+describe('components/searchFilterGroupContainer', () => {
+  it('mapStateToProps returns a FilterDefinition for a hardcoded filter group', () => {
+    expect(mapStateToProps({}, { machineName: 'new' }))
+    .toEqual({
+      filter: {
+        humanName: 'New courses',
+        machineName: 'status',
+        values: [
+          { primaryKey: 'new', humanName: 'First session'},
+        ],
+      },
+    });
+  });
+
+  it('mapStateToProps builds a filter definition from the facet for a resource-based filter group', () => {
+    const state = {
+      resources: {
+        course: {
+          byId: {},
+          currentQuery: {
+            facets: { organization: { 21: 3, 42: 15, 84: 7 } },
+            items: {},
+            queryKey: '',
+            total_count: 22,
+          },
+        } as CourseState,
+        organization: {
+          byId: {
+            21: { id: 21, name: 'Organization #Twenty-One' } as Organization,
+            42: { id: 42, name: 'Organization #Fourty-Two' } as Organization,
+            84: { id: 84, name: 'Organization #Eighty-Four' } as Organization,
+          },
+        },
+      },
+    };
+
+    expect(mapStateToProps(state, { machineName: 'organization' }))
+    .toEqual({
+      filter: {
+        humanName: 'Organizations',
+        machineName: 'organization',
+        values: [
+          { count: 15, humanName: 'Organization #Fourty-Two', primaryKey: '42' },
+          { count: 7, humanName: 'Organization #Eighty-Four', primaryKey: '84' },
+          { count: 3, humanName: 'Organization #Twenty-One', primaryKey: '21' },
+        ],
+      },
+    });
+  });
+
+  it('mapStateToProps still builds a default filter group when missing a resource-related facet', () => {
+    const state = {
+      resources: {
+        organization: {
+          byId: {
+            21: { id: 21, name: 'Organization #Twenty-One' } as Organization,
+            42: { id: 42, name: 'Organization #Fourty-Two' } as Organization,
+            84: { id: 84, name: 'Organization #Eighty-Four' } as Organization,
+          },
+        },
+      },
+    };
+
+    expect(mapStateToProps(state, { machineName: 'organization' }))
+    .toEqual({
+      filter: {
+        humanName: 'Organizations',
+        machineName: 'organization',
+        values: [
+          { humanName: 'Organization #Twenty-One', primaryKey: '21' },
+          { humanName: 'Organization #Fourty-Two', primaryKey: '42' },
+          { humanName: 'Organization #Eighty-Four', primaryKey: '84' },
+        ],
+      },
+    });
+  });
+});

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
@@ -2,7 +2,7 @@ import values from 'lodash-es/values';
 import { connect } from 'react-redux';
 
 import { RootState } from '../../data/rootReducer';
-import FilterDefinition from '../../types/FilterDefinition';
+import { FilterDefinition } from '../../types/FilterDefinition';
 import SearchFilterGroup from '../searchFilterGroup/searchFilterGroup';
 
 export interface SearchFilterGroupContainerProps {
@@ -15,8 +15,8 @@ const hardcodedFilters: { [machineName: string]: FilterDefinition; } = {
     humanName: 'Language',
     machineName: 'language',
     values: [
-      [ 'en', 'English' ],
-      [ 'fr', 'French' ],
+      { primaryKey: 'en', humanName: 'English' },
+      { primaryKey: 'fr', humanName: 'French' },
     ],
   },
 
@@ -24,7 +24,7 @@ const hardcodedFilters: { [machineName: string]: FilterDefinition; } = {
     humanName: 'New courses',
     machineName: 'status',
     values: [
-      [ 'new', 'First session' ],
+      { primaryKey: 'new', humanName: 'First session'},
     ],
   },
 
@@ -33,41 +33,72 @@ const hardcodedFilters: { [machineName: string]: FilterDefinition; } = {
     isDrilldown: true,
     machineName: 'availability',
     values: [
-      [ 'coming_soon', 'Coming soon' ],
-      [ 'current', 'Current session' ],
-      [ 'open', 'Open, no session' ],
+      { primaryKey: 'coming_soon', humanName: 'Coming soon' },
+      { primaryKey: 'current', humanName: 'Current session' },
+      { primaryKey: 'open', humanName: 'Open, no session' },
     ],
   },
 };
 
 // Some filters need to be derived from the data
-const getFilterFromData = (state: RootState, machineName: string) => {
+function getFilterFromData(state: RootState, machineName: string): FilterDefinition {
+  // Default to empty object as it is the default value for currentQuery.facets
+  const facets = state.resources.course &&
+                 state.resources.course.currentQuery &&
+                 state.resources.course.currentQuery.facets || {};
+
+  /* tslint:disable:variable-name */
+  function getFacetedValues(
+    state_: typeof state,
+    facets_: typeof facets,
+    resourceName: 'organization' | 'subject',
+  ) {
+    // We don't have the facets yet or something broke upstream: provide some filtering
+    // capabilities anyway (without counts, as we can't generate those)
+    if (!facets_[resourceName] || !Object.keys(facets_[resourceName]).length) {
+      return values(state.resources[resourceName] &&
+                    state.resources[resourceName].byId || {})
+        .map((organization) => ({
+          humanName: organization.name,
+          primaryKey: String(organization.id),
+        }));
+    }
+
+    return Object.keys(facets_[resourceName])
+      .map((resourceId) => ({
+        // Facet current query by this resource id (count)
+        count: facets[resourceName][resourceId],
+        // Get the resource name from the state
+        humanName: state.resources[resourceName].byId[resourceId].name,
+        // resourceId is already a string as it was a key on the facets.organization object
+        primaryKey: resourceId,
+      }))
+      // Sort by highest count first
+      .sort((filterValueA, filterValueB) => filterValueA.count > filterValueB.count && -1 ||
+                                            filterValueB.count > filterValueA.count && 1 ||
+                                            0,
+      );
+  }
+  /* tslint:enable */
+
   switch (machineName) {
     case 'organization':
       return {
         humanName: 'Organizations',
         machineName,
-        values:
-          values(state.resources &&
-                 state.resources[machineName] &&
-                 state.resources[machineName].byId || {})
-          .map((organization) => [ String(organization.id), organization.name ]),
+        values: getFacetedValues(state, facets, machineName),
       };
 
     case 'subject':
       return {
         humanName: 'Subjects',
         machineName,
-        values:
-          values(state.resources &&
-                 state.resources[machineName] &&
-                 state.resources[machineName].byId || {})
-          .map((subject) => [ String(subject.id), subject.name ]),
+        values: getFacetedValues(state, facets, machineName),
       };
   }
-};
+}
 
-const mapStateToProps = (state: RootState, { machineName }: SearchFilterGroupContainerProps) => {
+export const mapStateToProps = (state: RootState, { machineName }: SearchFilterGroupContainerProps) => {
   return { filter: hardcodedFilters[machineName] || getFilterFromData(state, machineName) };
 };
 

--- a/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
@@ -55,9 +55,8 @@ describe('data/genericReducers/resourceList reducer', () => {
           resourceName: 'course',
           type: 'RESOURCE_LIST_GET_SUCCESS',
         },
-      )).toEqual({
-        currentQuery: { items: { 2: 43, 3: 44 }, queryKey: '{}', total_count: 4 },
-      });
+      ))
+      .toEqual({ currentQuery: { items: { 2: 43, 3: 44 }, queryKey: '{}', total_count: 4 } });
     });
 
     it('replaces the existing query if the new one has different params', () => {
@@ -75,49 +74,13 @@ describe('data/genericReducers/resourceList reducer', () => {
           resourceName: 'course',
           type: 'RESOURCE_LIST_GET_SUCCESS',
         },
-      )).toEqual({
-        currentQuery: { items: { 0: 44, 1: 43 }, queryKey: '{"match":"some query"}', total_count: 240 },
-      });
-    });
-
-    it('completes the existing query if the new one shares the same params', () => {
-      const course45 = {
-        end_date: '2018-04-30T06:00:00.000Z',
-        enrollment_end_date: '2018-02-28T06:00:00.000Z',
-        enrollment_start_date: '2018-02-01T06:00:00.000Z',
-        id: 45,
-        language: 'de',
-        organizations: [98],
-        session_number: 1,
-        short_description: 'Nunc a risus faucibus, pretium ante et, convallis neque.',
-        start_date: '2018-03-01T06:00:00.000Z',
-        subjects: [44, 29],
-        thumbnails: {
-          about: 'https://example.com/about_45.png',
-          big: 'https://example.com/big_45.png',
-          facebook: 'https://example.com/facebook_45.png',
-          small: 'https://example.com/small_45.png',
+      ))
+      .toEqual({
+        currentQuery: {
+          items: { 0: 44, 1: 43 },
+          queryKey: '{"match":"some query"}',
+          total_count: 240,
         },
-        title: 'Datenstrukturen und algorithmen in Python',
-      };
-
-      const previousState = {
-        currentQuery: { items: { 0: 44, 1: 43 }, queryKey: '{"match":"some query"}', total_count: 240 },
-      };
-
-      expect(currentQuery(
-        previousState,
-        {
-          apiResponse: {
-            meta: { limit: 1, offset: 2, total_count: 240 },
-            objects: [ course45 ],
-          },
-          params: { limit: 1, match: 'some query', offset: 2 },
-          resourceName: 'course',
-          type: 'RESOURCE_LIST_GET_SUCCESS',
-        },
-      )).toEqual({
-        currentQuery: { items: { 0: 44, 1: 43, 2: 45 }, queryKey: '{"match":"some query"}', total_count: 240 },
       });
     });
   });

--- a/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
@@ -56,17 +56,19 @@ describe('data/genericReducers/resourceList reducer', () => {
           type: 'RESOURCE_LIST_GET_SUCCESS',
         },
       ))
-      .toEqual({ currentQuery: { items: { 2: 43, 3: 44 }, queryKey: '{}', total_count: 4 } });
+      // No facets in the apiResponse: we get an empty object in the state
+      .toEqual({ currentQuery: { facets: {}, items: { 2: 43, 3: 44 }, queryKey: '{}', total_count: 4 } });
     });
 
     it('replaces the existing query if the new one has different params', () => {
       const previousState = {
-        currentQuery: { items: { 2: 43, 3: 44 }, queryKey: '{}', total_count: 4 },
+        currentQuery: { facets: {}, items: { 2: 43, 3: 44 }, queryKey: '{}', total_count: 4 },
       };
       expect(currentQuery(
         previousState,
         {
           apiResponse: {
+            facets: { organizations: { 11: 1, 23: 1, 31: 1 } },
             meta: { limit: 2, offset: 0, total_count: 240 },
             objects: [ course44, course43 ],
           },
@@ -77,6 +79,8 @@ describe('data/genericReducers/resourceList reducer', () => {
       ))
       .toEqual({
         currentQuery: {
+          // Facets are copied over on the state as-is
+          facets: { organizations: { 11: 1, 23: 1, 31: 1 } },
           items: { 0: 44, 1: 43 },
           queryKey: '{"match":"some query"}',
           total_count: 240,

--- a/richie/js/data/genericReducers/resourceList/resourceList.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.ts
@@ -37,10 +37,7 @@ export function currentQuery<R extends Resource>(
         currentQuery: {
           items: objects.reduce(
             // Transform the array into an object with indexes as keys
-            (acc, item, index) => ({ ...acc, [offset + index]: item.id }),
-            // Extend the items list if we're receiving more items for the query we have in memory
-            // (e.g. for pagination), replace it otherwise
-            queryKey === get(state, 'currentQuery.queryKey') ? { ...state.currentQuery.items } : {},
+            (acc, item, index) => ({ ...acc, [offset + index]: item.id }), {},
           ),
           queryKey,
           total_count: meta.total_count,

--- a/richie/js/data/genericReducers/resourceList/resourceList.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.ts
@@ -1,5 +1,6 @@
 import get from 'lodash-es/get';
 
+import { APIResponseListFacets } from '../../../types/api';
 import Resource from '../../../types/Resource';
 import { ResourceListGetSuccess } from '../../genericSideEffects/getResourceList/actions';
 
@@ -7,6 +8,7 @@ export const initialState = {};
 
 export interface ResourceListState<R extends Resource> {
   currentQuery?: {
+    facets: APIResponseListFacets;
     // A number-keyed object is more stable than an array to keep a list with a moving starting
     // index and potential gaps throughout.
     // NB: we still use string as the index type as keys of an objects are always converted to strings
@@ -19,7 +21,7 @@ export interface ResourceListState<R extends Resource> {
 export function currentQuery<R extends Resource>(
   state: ResourceListState<R>,
   action: ResourceListGetSuccess<R> | { type: '' },
-) {
+): ResourceListState<Resource> {
   // Initialize the state to an empty version of itself
   if (!state) { state = initialState; }
   if (!action) { return state; } // Compiler needs help
@@ -27,7 +29,7 @@ export function currentQuery<R extends Resource>(
   switch (action.type) {
     // Create or update the latest resource list we fetched from the server
     case 'RESOURCE_LIST_GET_SUCCESS':
-      const { objects, meta } = action.apiResponse;
+      const { facets = {}, objects, meta } = action.apiResponse;
       // Generate a generic representation of our query as a string with pagination params removed
       const { limit, offset = 0, ...cleanQuery } = action.params;
       const queryKey = JSON.stringify(cleanQuery);
@@ -35,6 +37,7 @@ export function currentQuery<R extends Resource>(
       return {
         ...state,
         currentQuery: {
+          facets,
           items: objects.reduce(
             // Transform the array into an object with indexes as keys
             (acc, item, index) => ({ ...acc, [offset + index]: item.id }), {},

--- a/richie/js/data/genericSideEffects/getResourceList/actions.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/actions.ts
@@ -1,4 +1,4 @@
-import { APIListCommonRequestParams, APIResponseListMeta } from '../../../types/api';
+import { APIListCommonRequestParams, APIResponseListFacets, APIResponseListMeta } from '../../../types/api';
 import Resource from '../../../types/Resource';
 import { RootState } from '../../rootReducer';
 
@@ -37,7 +37,7 @@ export function failedToGetResourceList(
 }
 
 export interface ResourceListGetSuccess<R extends Resource> {
-  apiResponse: { meta: APIResponseListMeta, objects: R[] };
+  apiResponse: { facets?: APIResponseListFacets, meta: APIResponseListMeta, objects: R[] };
   params: APIListCommonRequestParams & { [key: string]: string | number | null | Array<string | number> };
   resourceName: keyof RootState['resources'];
   type: 'RESOURCE_LIST_GET_SUCCESS';

--- a/richie/js/data/genericSideEffects/getResourceList/getResourceList.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/getResourceList.ts
@@ -2,7 +2,7 @@ import partial from 'lodash-es/partial';
 import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { API_ENDPOINTS } from '../../../settings.json';
-import { APIResponseListMeta } from '../../../types/api';
+import { APIResponseListFacets, APIResponseListMeta } from '../../../types/api';
 import Resource from '../../../types/Resource';
 import formatQueryString from '../../../utils/http/formatQueryString';
 import { addMultipleResources } from '../../genericReducers/resourceById/actions';
@@ -18,11 +18,8 @@ import {
 // Use a polymorphic response object so it can be elegantly consumed through destructuration
 export interface Response {
   error?: string;
-  meta?: {
-    limit: number;
-    offset: number;
-    total_count: number;
-  };
+  facets?: APIResponseListFacets;
+  meta?: APIResponseListMeta;
   objects?: Resource[];
 }
 

--- a/richie/js/types/FilterDefinition.ts
+++ b/richie/js/types/FilterDefinition.ts
@@ -1,6 +1,11 @@
-export default interface FilterDefinition {
+export interface FilterValue {
+  primaryKey: string; // Either a machine name or a stringified ID
+  humanName: string;
+  count?: number; // TODO: Replace Maybe<number> with number when all the facets are available
+}
+export interface FilterDefinition {
   humanName: string;
   machineName: string;
   isDrilldown?: boolean;
-  values: string[][];
+  values: FilterValue[];
 }

--- a/richie/js/types/api.ts
+++ b/richie/js/types/api.ts
@@ -1,7 +1,15 @@
+import Resource from './Resource';
+
 export interface APIResponseListMeta {
   limit: number;
   offset: number;
   total_count: number;
+}
+
+export interface APIResponseListFacets {
+  [resourcePropName: string]: {
+    [resourcePropValue: string]: number;
+  };
 }
 
 export interface APIListCommonRequestParams {


### PR DESCRIPTION
Simply take the orgs & subjects from facets we received from the server and display them along with the proper count (if available) in the left sidebar.

NB: this required a slight API change to avoid overcomplicating things on the client side.