### PR TITLE
Fix an issue on org & subject filters on course search

### DIFF
--- a/apps/search/tests/test_viewsets_course.py
+++ b/apps/search/tests/test_viewsets_course.py
@@ -227,7 +227,7 @@ class CourseViewsetTestCase(TestCase):
         valid, is accepted (added after catching an error during manual testing)
         """
         factory = APIRequestFactory()
-        request = factory.get('/api/v1.0/course?organizations=3&limit=2')
+        request = factory.get('/api/v1.0/course?organizations=345&limit=2')
 
         mock_search.return_value = {
             'hits': {
@@ -256,7 +256,7 @@ class CourseViewsetTestCase(TestCase):
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
             body={
-                'query': {'terms': {'organizations': [3]}},
+                'query': {'terms': {'organizations': [345]}},
                 'aggs': {
                     'organization': {'terms': {'field': 'organizations'}},
                     'subject': {'terms': {'field': 'subjects'}}

--- a/apps/search/viewsets/course.py
+++ b/apps/search/viewsets/course.py
@@ -24,13 +24,15 @@ class CourseViewSet(ViewSet):
         """
         # QueryDict/MultiValueDict breaks lists: we need to normalize them
         # Unpacking does not trigger the broken accessor so we get the proper value
-        params_form = CourseListForm({
+        params_form_values = {
             k: v[0] if len(v) == 1 else v for k, v in request.query_params.lists()
-        })
+        }
         # Use QueryDict/MultiValueDict as a shortcut to make sure we get arrays for these two
         # fields, which should be arrays even if their length is one
-        params_form.organizations = request.query_params.getlist('organizations')
-        params_form.subjects = request.query_params.getlist('subjects')
+        params_form_values['organizations'] = request.query_params.getlist('organizations')
+        params_form_values['subjects'] = request.query_params.getlist('subjects')
+        # Instantiate the form to allow validation/cleaning
+        params_form = CourseListForm(params_form_values)
 
         # Return a 400 with error information if the query params are not as expected
         if not params_form.is_valid():


### PR DESCRIPTION
## Expected Behavior

A call on `/api/v1.0/course?organizations=345` should filter courses to keep those that belong to organization 345.
-> `CourseListForm` should provide the value as `[ '345' ]`

## Actual Behavior

The call filters courses that belong to organizations 3, 4 and 5.
-> `CourseListForm` provides the value as `'345'`

## Explanation and solution

This was due to the way we sidestepped the magic list-eating behavior of QueryValueDict: we patched the values on the form after initializing it with an object that contains values taken from QueryValueDict with `v[0] if len(v) == 1 else v`.

Our own code replaces lists of 1 element with the element when the list is one element long. That is the expected behavior, *except* for `organizations` and `subjects`.
Patching them after the the form is initialized is too late: the form data is already set and we're not updating it.

Simply patch the object we then pass to `CourseListForm`. This way the form receives (and outputs) the expected values.

----

Note: the issue was not showing in our tests as the "filter by a single organization" test was using `3` as a filtering ID. Replacing it with `345` made the issue appear in tests.