### PR TITLE
Update configurations to run Richie on OpenShift

### DIFF
--- a/richie/settings.py
+++ b/richie/settings.py
@@ -261,8 +261,15 @@ class ContinuousIntegration(Test):
 
 
 class Production(Base):
-    """Production environment settings"""
-    pass
+    """Production environment settings
+
+    You must define the DJANGO_ALLOWED_HOSTS environment variable in Production
+    configuration (and derived configurations):
+
+    DJANGO_ALLOWED_HOSTS="foo.com,foo.fr"
+    """
+
+    ALLOWED_HOSTS = values.ListValue(None)
 
 
 class Staging(Production):

--- a/richie/settings.py
+++ b/richie/settings.py
@@ -272,6 +272,15 @@ class Production(Base):
     ALLOWED_HOSTS = values.ListValue(None)
 
 
+class Feature(Production):
+    """
+    Feature environment settings
+
+    nota bene: it should inherit from the Production environment.
+    """
+    pass
+
+
 class Staging(Production):
     """
     Staging environment settings


### PR DESCRIPTION
## Purpose

To run Richie in various environments for various clients on OpenShift, we need to be able the add flexibility in some settings, particularly the `ALLOWED_HOSTS` setting.

## Proposal

We decided to get the `ALLOWED_HOST` value from the environment, because it's easily manageable thanks to Ansible & OpenShift.
