### PR TITLE
🔧(gunicorn) redirect logs to stdout

### DIFF
--- a/docker/files/usr/local/etc/gunicorn/richie.py
+++ b/docker/files/usr/local/etc/gunicorn/richie.py
@@ -1,8 +1,16 @@
 # Gunicorn-django settings
-bind = ['0.0.0.0:8000']
+bind = ["0.0.0.0:8000"]
+name = "richie"
+python_path = "/app"
+
+# Run
 graceful_timeout = 90
-loglevel = 'error'
-name = 'richie'
-python_path = '/app'
 timeout = 90
 workers = 3
+
+# Logging
+# Using '-' for the access log file makes gunicorn log accesses to stdout
+accesslog = "-"
+# Using '-' for the error log file makes gunicorn log errors to stderr
+errorlog = "-"
+loglevel = "info"


### PR DESCRIPTION
## Purpose

Current gunicorn configuration hides every log gunicorn might be able to stream. It would be helpful to be make them readable from OpenShift.

## Proposal

Refactor gunicorn configuration file to:

* decrease the log level to `INFO`
* redirect error logs to `stderr`
* redirect access logs to `stdout`

For a logging with Docker reference, see: https://docs.docker.com/config/containers/logging/