### PR TITLE
Pluralize resource names across back & front code

### DIFF
--- a/apps/search/description.apib
+++ b/apps/search/description.apib
@@ -44,7 +44,7 @@ A single subject as saved in our ElasticSearch index. Includes a small subset of
 # Group Course
 Course-related resources for the richie search API.
 
-## GET /course/{course_id}
+## GET /courses/{course_id}
 A single course object. Access through this API is read-only (and thus GET only) as we're interacting with ElasticSearch and not the underlying model.
 
 See the Course data structure for more information.
@@ -58,7 +58,7 @@ See the Course data structure for more information.
 + Response 200 (application/json)
     + Attributes (Course)
 
-## GET /course?limit&offset&search
+## GET /courses?limit&offset&search
 Collection of all courses indexed in ElasticSearch. Can be filtered and selected through search query parameters.
 
 + Request
@@ -89,7 +89,7 @@ Collection of all courses indexed in ElasticSearch. Can be filtered and selected
 # Group Organization
 Organization-related resources for the richie search API.
 
-## GET /organization/{organization_id}
+## GET /organizations/{organization_id}
 A single organization object. Access through this API is read-only (and thus GET only) as we're interacting with ElasticSearch and not the underlying model.
 
 See the Organization data structure for more information.
@@ -103,7 +103,7 @@ See the Organization data structure for more information.
 + Response 200 (application/json)
     + Attributes (Organization)
 
-## GET /organization?limit&offset&name
+## GET /organizations?limit&offset&name
 Collection of all organizations indexed in ElasticSearch. Can be filtered and selected through search query parameters.
 
 + Request
@@ -127,7 +127,7 @@ Collection of all organizations indexed in ElasticSearch. Can be filtered and se
 # Group Subject
 Subject-related resources for the richie search API.
 
-## GET /subject/{subject_id}
+## GET /subjects/{subject_id}
 A single subject object. Access through this API is read-only (and thus GET only) as we're interacting with ElasticSearch and not the underlying model.
 
 See the Subject data structure for more information.
@@ -141,7 +141,7 @@ See the Subject data structure for more information.
 + Response 200 (application/json)
     + Attributes (Subject)
 
-## GET /subject?limit&offset&name
+## GET /subjects?limit&offset&name
 Collection of all subjects indexed in ElasticSearch. Can be filtered and selected through search query parameters.
 
 + Request

--- a/apps/search/indexers/courses.py
+++ b/apps/search/indexers/courses.py
@@ -9,7 +9,7 @@ from ..utils.api_consumption import walk_api_json_list
 from ..utils.i18n import get_best_field_language
 
 
-class CourseIndexer():
+class CoursesIndexer():
     """
     Makes available the parameters the indexer requires as well as functions to shape
     objects getting into and out of ElasticSearch

--- a/apps/search/indexers/organizations.py
+++ b/apps/search/indexers/organizations.py
@@ -9,7 +9,7 @@ from ..utils.api_consumption import walk_api_json_list
 from ..utils.i18n import get_best_field_language
 
 
-class OrganizationIndexer():
+class OrganizationsIndexer():
     """
     Makes available the parameters the indexer requires as well as a function to shape
     objects into what we want to index in ElasticSearch

--- a/apps/search/indexers/subjects.py
+++ b/apps/search/indexers/subjects.py
@@ -9,7 +9,7 @@ from ..utils.api_consumption import walk_api_json_list
 from ..utils.i18n import get_best_field_language
 
 
-class SubjectIndexer():
+class SubjectsIndexer():
     """
     Makes available the parameters the indexer requires as well as functions to shape
     objects getting into and out of ElasticSearch

--- a/apps/search/routes.py
+++ b/apps/search/routes.py
@@ -3,9 +3,9 @@ API Routes exposed by our Search app
 """
 from rest_framework import routers
 
-from .viewsets.course import CourseViewSet
-from .viewsets.organization import OrganizationViewSet
-from .viewsets.subject import SubjectViewSet
+from .viewsets.courses import CoursesViewSet
+from .viewsets.organizations import OrganizationsViewSet
+from .viewsets.subjects import SubjectsViewSet
 
 
 # For now, we use URLPathVersioning to be consistent with fonzie. Fonzie uses it
@@ -17,9 +17,9 @@ API_PREFIX = r"v(?P<version>[0-9]+\.[0-9]+)"
 ROUTER = routers.SimpleRouter()
 
 # Define our app's routes with the router
-ROUTER.register(r"course", CourseViewSet, "course")
-ROUTER.register(r"organization", OrganizationViewSet, "organization")
-ROUTER.register(r"subject", SubjectViewSet, "subject")
+ROUTER.register(r"courses", CoursesViewSet, "courses")
+ROUTER.register(r"organizations", OrganizationsViewSet, "organizations")
+ROUTER.register(r"subjects", SubjectsViewSet, "subjects")
 
 # Use the standard name for our urlpatterns so urls.py can import it effortlessly
 urlpatterns = ROUTER.urls

--- a/apps/search/tests/test_indexers_courses.py
+++ b/apps/search/tests/test_indexers_courses.py
@@ -6,10 +6,10 @@ from django.test import TestCase
 import responses
 
 from ..exceptions import IndexerDataException
-from ..indexers.course import CourseIndexer
+from ..indexers.courses import CoursesIndexer
 
 
-class CourseIndexerTestCase(TestCase):
+class CoursesIndexerTestCase(TestCase):
     """
     Test the get_data_for_es() function on the course indexer, as well as our mapping,
     and especially dynamic mapping shape in ES
@@ -70,7 +70,7 @@ class CourseIndexerTestCase(TestCase):
             },
         )
 
-        indexer = CourseIndexer()
+        indexer = CoursesIndexer()
 
         # The results were properly formatted and passed to the consumer
         self.assertEqual(
@@ -143,7 +143,7 @@ class CourseIndexerTestCase(TestCase):
             },
         )
 
-        indexer = CourseIndexer()
+        indexer = CoursesIndexer()
 
         with self.assertRaises(IndexerDataException):
             list(indexer.get_data_for_es(index="some_index", action="some_action"))
@@ -171,7 +171,7 @@ class CourseIndexerTestCase(TestCase):
             },
         }
         self.assertEqual(
-            CourseIndexer.format_es_course_for_api(es_course, "en"),
+            CoursesIndexer.format_es_course_for_api(es_course, "en"),
             {
                 "end_date": "2018-02-28T06:00:00Z",
                 "enrollment_end_date": "2018-01-31T06:00:00Z",

--- a/apps/search/tests/test_indexers_organizations.py
+++ b/apps/search/tests/test_indexers_organizations.py
@@ -6,10 +6,10 @@ from django.test import TestCase
 import responses
 
 from ..exceptions import IndexerDataException
-from ..indexers.organization import OrganizationIndexer
+from ..indexers.organizations import OrganizationsIndexer
 
 
-class OrganizationIndexerTestCase(TestCase):
+class OrganizationsIndexerTestCase(TestCase):
     """
     Test the get_data_for_es() function on the organization indexer, as well as our mapping,
     and especially dynamic mapping shape in ES
@@ -56,7 +56,7 @@ class OrganizationIndexerTestCase(TestCase):
             },
         )
 
-        indexer = OrganizationIndexer()
+        indexer = OrganizationsIndexer()
 
         # The results were properly formatted and passed to the consumer
         self.assertEqual(
@@ -108,7 +108,7 @@ class OrganizationIndexerTestCase(TestCase):
             },
         )
 
-        indexer = OrganizationIndexer()
+        indexer = OrganizationsIndexer()
 
         with self.assertRaises(IndexerDataException):
             list(indexer.get_data_for_es(index="some_index", action="some_action"))
@@ -127,7 +127,7 @@ class OrganizationIndexerTestCase(TestCase):
             },
         }
         self.assertEqual(
-            OrganizationIndexer.format_es_organization_for_api(es_organization, "en"),
+            OrganizationsIndexer.format_es_organization_for_api(es_organization, "en"),
             {
                 "banner": "example.com/banner.png",
                 "code": "univ-paris-13",

--- a/apps/search/tests/test_indexers_subjects.py
+++ b/apps/search/tests/test_indexers_subjects.py
@@ -6,10 +6,10 @@ from django.test import TestCase
 import responses
 
 from ..exceptions import IndexerDataException
-from ..indexers.subject import SubjectIndexer
+from ..indexers.subjects import SubjectsIndexer
 
 
-class SubjectIndexerTestCase(TestCase):
+class SubjectsIndexerTestCase(TestCase):
     """
     Test the get_data_for_es() function on the subject indexer, as well as our mapping,
     and especially dynamic mapping shape in ES
@@ -48,7 +48,7 @@ class SubjectIndexerTestCase(TestCase):
             },
         )
 
-        indexer = SubjectIndexer()
+        indexer = SubjectsIndexer()
 
         # The results were properly formatted and passed to the consumer
         self.assertEqual(
@@ -94,7 +94,7 @@ class SubjectIndexerTestCase(TestCase):
             },
         )
 
-        indexer = SubjectIndexer()
+        indexer = SubjectsIndexer()
 
         with self.assertRaises(IndexerDataException):
             list(indexer.get_data_for_es(index="some_index", action="some_action"))
@@ -111,6 +111,6 @@ class SubjectIndexerTestCase(TestCase):
             },
         }
         self.assertEqual(
-            SubjectIndexer.format_es_subject_for_api(es_subject, "en"),
+            SubjectsIndexer.format_es_subject_for_api(es_subject, "en"),
             {"id": 89, "image": "example.com/image.png", "name": "Computer science"},
         )

--- a/apps/search/tests/test_viewsets_organizations.py
+++ b/apps/search/tests/test_viewsets_organizations.py
@@ -8,10 +8,10 @@ from django.test import TestCase
 from elasticsearch.exceptions import NotFoundError
 from rest_framework.test import APIRequestFactory
 
-from ..viewsets.organization import OrganizationViewSet
+from ..viewsets.organizations import OrganizationsViewSet
 
 
-class OrganizationViewsetTestCase(TestCase):
+class OrganizationsViewsetTestCase(TestCase):
     """
     Test the API endpoints for organizations (list and details)
     """
@@ -21,7 +21,7 @@ class OrganizationViewsetTestCase(TestCase):
         Happy path: the client requests an existing organization, gets it back
         """
         factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/organization/42")
+        request = factory.get("/api/v1.0/organizations/42")
 
         with mock.patch.object(
             settings.ES_CLIENT,
@@ -37,7 +37,7 @@ class OrganizationViewsetTestCase(TestCase):
             },
         ):
             # Note: we need to use a separate argument for the ID as that is what the ViewSet uses
-            response = OrganizationViewSet.as_view({"get": "retrieve"})(
+            response = OrganizationsViewSet.as_view({"get": "retrieve"})(
                 request, 42, version="1.0"
             )
 
@@ -59,11 +59,11 @@ class OrganizationViewsetTestCase(TestCase):
         Error case: the client is asking for an organization that does not exist
         """
         factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/organization/43")
+        request = factory.get("/api/v1.0/organizations/43")
 
         # Act like the ES client would when we attempt to get a non-existent document
         with mock.patch.object(settings.ES_CLIENT, "get", side_effect=NotFoundError):
-            response = OrganizationViewSet.as_view({"get": "retrieve"})(
+            response = OrganizationsViewSet.as_view({"get": "retrieve"})(
                 request, 43, version="1.0"
             )
 
@@ -76,7 +76,7 @@ class OrganizationViewsetTestCase(TestCase):
         Happy path: the consumer is not filtering the organizations for anything
         """
         factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/organization?limit=2&offset=10")
+        request = factory.get("/api/v1.0/organizations?limit=2&offset=10")
 
         mock_search.return_value = {
             "hits": {
@@ -104,7 +104,7 @@ class OrganizationViewsetTestCase(TestCase):
             }
         }
 
-        response = OrganizationViewSet.as_view({"get": "list"})(request, version="1.0")
+        response = OrganizationsViewSet.as_view({"get": "list"})(request, version="1.0")
 
         # The client received a properly formatted response
         self.assertEqual(response.status_code, 200)
@@ -145,7 +145,7 @@ class OrganizationViewsetTestCase(TestCase):
         Happy path: the consumer is filtering the organizations by name
         """
         factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/organization?name=Université&limit=2")
+        request = factory.get("/api/v1.0/organizations?name=Université&limit=2")
 
         mock_search.return_value = {
             "hits": {
@@ -173,7 +173,7 @@ class OrganizationViewsetTestCase(TestCase):
             }
         }
 
-        response = OrganizationViewSet.as_view({"get": "list"})(request, version="1.0")
+        response = OrganizationsViewSet.as_view({"get": "list"})(request, version="1.0")
 
         # The client received a properly formatted response
         self.assertEqual(response.status_code, 200)
@@ -218,9 +218,9 @@ class OrganizationViewsetTestCase(TestCase):
         """
         factory = APIRequestFactory()
         # The request contains incorrect params: limit should be a positive integer
-        request = factory.get("/api/v1.0/organization?name=&limit=-2")
+        request = factory.get("/api/v1.0/organizations?name=&limit=-2")
 
-        response = OrganizationViewSet.as_view({"get": "list"})(request, version="1.0")
+        response = OrganizationsViewSet.as_view({"get": "list"})(request, version="1.0")
 
         # The client received a BadRequest response with the relevant data
         self.assertEqual(response.status_code, 400)

--- a/apps/search/tests/test_viewsets_subjects.py
+++ b/apps/search/tests/test_viewsets_subjects.py
@@ -8,10 +8,10 @@ from django.test import TestCase
 from elasticsearch.exceptions import NotFoundError
 from rest_framework.test import APIRequestFactory
 
-from ..viewsets.subject import SubjectViewSet
+from ..viewsets.subjects import SubjectsViewSet
 
 
-class SubjectViewsetTestCase(TestCase):
+class SubjectsViewsetTestCase(TestCase):
     """
     Test the API endpoints for subjects (list and details)
     """
@@ -21,7 +21,7 @@ class SubjectViewsetTestCase(TestCase):
         Happy path: the client requests an existing subject, gets it back
         """
         factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/subject/42")
+        request = factory.get("/api/v1.0/subjects/42")
 
         with mock.patch.object(
             settings.ES_CLIENT,
@@ -34,7 +34,7 @@ class SubjectViewsetTestCase(TestCase):
             },
         ):
             # Note: we need to use a separate argument for the ID as that is what the ViewSet uses
-            response = SubjectViewSet.as_view({"get": "retrieve"})(
+            response = SubjectsViewSet.as_view({"get": "retrieve"})(
                 request, 42, version="1.0"
             )
 
@@ -50,11 +50,11 @@ class SubjectViewsetTestCase(TestCase):
         Error case: the client is asking for a subject that does not exist
         """
         factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/subject/43")
+        request = factory.get("/api/v1.0/subjects/43")
 
         # Act like the ES client would when we attempt to get a non-existent document
         with mock.patch.object(settings.ES_CLIENT, "get", side_effect=NotFoundError):
-            response = SubjectViewSet.as_view({"get": "retrieve"})(
+            response = SubjectsViewSet.as_view({"get": "retrieve"})(
                 request, 43, version="1.0"
             )
 
@@ -91,7 +91,7 @@ class SubjectViewsetTestCase(TestCase):
             }
         }
 
-        response = SubjectViewSet.as_view({"get": "list"})(request, version="1.0")
+        response = SubjectsViewSet.as_view({"get": "list"})(request, version="1.0")
 
         # The client received a properly formatted response
         self.assertEqual(response.status_code, 200)
@@ -152,7 +152,7 @@ class SubjectViewsetTestCase(TestCase):
             }
         }
 
-        response = SubjectViewSet.as_view({"get": "list"})(request, version="1.0")
+        response = SubjectsViewSet.as_view({"get": "list"})(request, version="1.0")
 
         # The client received a properly formatted response
         self.assertEqual(response.status_code, 200)
@@ -195,7 +195,7 @@ class SubjectViewsetTestCase(TestCase):
         # The request contains incorrect params: limit should be a positive integer
         request = factory.get("/api/v1.0/subject?name=&limit=-2")
 
-        response = SubjectViewSet.as_view({"get": "list"})(request, version="1.0")
+        response = SubjectsViewSet.as_view({"get": "list"})(request, version="1.0")
 
         # The client received a BadRequest response with the relevant data
         self.assertEqual(response.status_code, 400)

--- a/apps/search/viewsets/courses.py
+++ b/apps/search/viewsets/courses.py
@@ -8,10 +8,10 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from ..forms import CourseListForm
-from ..indexers.course import CourseIndexer
+from ..indexers.courses import CoursesIndexer
 
 
-class CourseViewSet(ViewSet):
+class CoursesViewSet(ViewSet):
     """
     A simple viewset with GET endpoints to fetch courses
     See API Blueprint for details on consumer use
@@ -78,13 +78,13 @@ class CourseViewSet(ViewSet):
 
         # Build organizations and subjects terms aggregations for our query
         aggs = {
-            "organization": {"terms": {"field": "organizations"}},
-            "subject": {"terms": {"field": "subjects"}},
+            "organizations": {"terms": {"field": "organizations"}},
+            "subjects": {"terms": {"field": "subjects"}},
         }
 
         course_query_response = settings.ES_CLIENT.search(
-            index=CourseIndexer.index_name,
-            doc_type=CourseIndexer.document_type,
+            index=CoursesIndexer.index_name,
+            doc_type=CoursesIndexer.document_type,
             body={"aggs": aggs, "query": query},
             # Directly pass meta-params through as arguments to the ES client
             from_=params_form.cleaned_data.get("offset") or 0,
@@ -98,7 +98,7 @@ class CourseViewSet(ViewSet):
                 "total_count": course_query_response["hits"]["total"],
             },
             "objects": [
-                CourseIndexer.format_es_course_for_api(
+                CoursesIndexer.format_es_course_for_api(
                     es_course,
                     # Get the best language we can return multilingual fields in
                     get_language_from_request(request),
@@ -128,8 +128,8 @@ class CourseViewSet(ViewSet):
         # raise and end up in a 500 error otherwise
         try:
             query_response = settings.ES_CLIENT.get(
-                index=CourseIndexer.index_name,
-                doc_type=CourseIndexer.document_type,
+                index=CoursesIndexer.index_name,
+                doc_type=CoursesIndexer.document_type,
                 id=pk,
             )
         except NotFoundError:
@@ -137,7 +137,7 @@ class CourseViewSet(ViewSet):
 
         # Format a clean course object as a response
         return Response(
-            CourseIndexer.format_es_course_for_api(
+            CoursesIndexer.format_es_course_for_api(
                 query_response,
                 # Get the best language we can return multilingual fields in
                 get_language_from_request(request),

--- a/apps/search/viewsets/subjects.py
+++ b/apps/search/viewsets/subjects.py
@@ -1,5 +1,5 @@
 """
-API endpoints to access organizations through ElasticSearch
+API endpoints to access subjects through ElasticSearch
 """
 from django.conf import settings
 from django.utils.translation import get_language_from_request
@@ -7,37 +7,37 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
-from ..forms import OrganizationListForm
-from ..indexers.organization import OrganizationIndexer
+from ..forms import SubjectListForm
+from ..indexers.subjects import SubjectsIndexer
 
 
-class OrganizationViewSet(ViewSet):
+class SubjectsViewSet(ViewSet):
     """
-    A simple viewset with GET endpoints to fetch organizations
+    A simple viewset with GET endpoints to fetch subjects
     See API Blueprint for details on consumer use.
     """
     # pylint: disable=no-self-use,unused-argument
     def list(self, request, version):
         """
-        Organization search endpoint: pass query params to ElasticSearch so it filters
-        organizations and returns a list of matching items
+        Subject search endpoint: pass query params to ElasticSearch so it filters subjects
+        and returns a list of matching items
         """
         # Instantiate a form with our query_params to check & sanitize them
-        query_params_form = OrganizationListForm(request.query_params)
+        params_form = SubjectListForm(request.query_params)
 
         # Return a 400 with error information if the query params are not as expected
-        if not query_params_form.is_valid():
-            return Response(status=400, data={"errors": query_params_form.errors})
+        if not params_form.is_valid():
+            return Response(status=400, data={"errors": params_form.errors})
 
-        # Build a query that matches on the organization name field if it was passed by the client
+        # Build a query that matches on the name field if it was handed by the client
         # Note: test_elasticsearch_feature.py needs to be updated whenever the search call
         # is updated and makes use new features.
-        if query_params_form.cleaned_data.get("name"):
-            search_payload = {
+        if params_form.cleaned_data.get("name"):
+            search_body = {
                 "query": {
                     "match": {
                         "name.fr": {
-                            "query": query_params_form.cleaned_data.get("name"),
+                            "query": params_form.cleaned_data.get("name"),
                             "analyzer": "french",
                         }
                     }
@@ -45,16 +45,15 @@ class OrganizationViewSet(ViewSet):
             }
         # Build a match_all query by default
         else:
-            search_payload = {"query": {"match_all": {}}}
+            search_body = {"query": {"match_all": {}}}
 
         query_response = settings.ES_CLIENT.search(
-            index=OrganizationIndexer.index_name,
-            doc_type=OrganizationIndexer.document_type,
-            body=search_payload,
+            index=SubjectsIndexer.index_name,
+            doc_type=SubjectsIndexer.document_type,
+            body=search_body,
             # Directly pass meta-params through as arguments to the ES client
-            from_=query_params_form.cleaned_data.get("offset") or 0,
-            size=query_params_form.cleaned_data.get("limit")
-            or settings.ES_DEFAULT_PAGE_SIZE,
+            from_=params_form.cleaned_data.get("offset") or 0,
+            size=params_form.cleaned_data.get("limit") or settings.ES_DEFAULT_PAGE_SIZE,
         )
 
         # Format the response in a consumer-friendly way
@@ -63,16 +62,16 @@ class OrganizationViewSet(ViewSet):
         response_object = {
             "meta": {
                 "count": len(query_response["hits"]["hits"]),
-                "offset": query_params_form.cleaned_data.get("offset") or 0,
+                "offset": params_form.cleaned_data.get("offset") or 0,
                 "total_count": query_response["hits"]["total"],
             },
             "objects": [
-                OrganizationIndexer.format_es_organization_for_api(
-                    organization,
-                    # Get the best language to return multilingual fields
+                SubjectsIndexer.format_es_subject_for_api(
+                    subject,
+                    # Get the best language we can return multilingual fields in
                     get_language_from_request(request),
                 )
-                for organization in query_response["hits"]["hits"]
+                for subject in query_response["hits"]["hits"]
             ],
         }
 
@@ -81,22 +80,22 @@ class OrganizationViewSet(ViewSet):
     # pylint: disable=no-self-use,invalid-name,unused-argument
     def retrieve(self, request, pk, version):
         """
-        Return a single organization by ID
+        Return a single item by ID
         """
-        # Wrap the ES get in a try/catch so we control the exception we emit — it would
+        # Wrap the ES get in a try/catch to we control the exception we emit — it would
         # raise and end up in a 500 error otherwise
         try:
             query_response = settings.ES_CLIENT.get(
-                index=OrganizationIndexer.index_name,
-                doc_type=OrganizationIndexer.document_type,
+                index=SubjectsIndexer.index_name,
+                doc_type=SubjectsIndexer.document_type,
                 id=pk,
             )
         except NotFoundError:
             return Response(status=404)
 
-        # Format a clean organization object as a response
+        # Format a clean subject object as a response
         return Response(
-            OrganizationIndexer.format_es_organization_for_api(
+            SubjectsIndexer.format_es_subject_for_api(
                 query_response,
                 # Get the best language we can return multilingual fields in
                 get_language_from_request(request),

--- a/richie/configurations/elasticsearch.py
+++ b/richie/configurations/elasticsearch.py
@@ -21,9 +21,9 @@ class ElasticSearchMixin(object):
     )
     ES_CHUNK_SIZE = 500
     ES_INDEXES = [
-        "apps.search.indexers.course.CourseIndexer",
-        "apps.search.indexers.organization.OrganizationIndexer",
-        "apps.search.indexers.subject.SubjectIndexer",
+        "apps.search.indexers.courses.CoursesIndexer",
+        "apps.search.indexers.organizations.OrganizationsIndexer",
+        "apps.search.indexers.subjects.SubjectsIndexer",
     ]
 
     ES_DEFAULT_PAGE_SIZE = 10

--- a/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.spec.tsx
@@ -34,7 +34,7 @@ describe('components/courseGlimpseContainer', () => {
   it('mapStateToProps picks in state the organization relevant to the current course', () => {
     const state = {
       resources: {
-        organization: { byId: { 23: org23 } },
+        organizations: { byId: { 23: org23 } },
       },
     };
 

--- a/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.tsx
+++ b/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.tsx
@@ -10,8 +10,8 @@ export interface CourseGlimpseContainerProps {
 
 export const mapStateToProps = (state: RootState, ownProps: CourseGlimpseContainerProps) => {
   return {
-    organization: state.resources.organization &&
-                  state.resources.organization.byId[ownProps.course.organizations[0]] || null,
+    organization: state.resources.organizations &&
+                  state.resources.organizations.byId[ownProps.course.organizations[0]] || null,
   };
 };
 

--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
@@ -45,7 +45,7 @@ describe('components/courseGlimpseListContainer', () => {
 
     const state = {
       resources: {
-        course: {
+        courses: {
           byId: { 43: course43, 44: course44 },
           currentQuery: {
             facets: {},

--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.tsx
@@ -10,26 +10,26 @@ export const mapStateToProps = (state: RootState) => {
   return {
     courses:
       // Get the relevant item indexes for the current query
-      Object.keys(state.resources.course &&
-                  state.resources.course.currentQuery &&
-                  state.resources.course.currentQuery.items || [])
+      Object.keys(state.resources.courses &&
+                  state.resources.courses.currentQuery &&
+                  state.resources.courses.currentQuery.items || [])
       // Ensure preservation of order
       .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
       // Get the IDs matching the indexes in the current query
-      .map((key) => state.resources.course &&
-                    state.resources.course.currentQuery &&
-                    state.resources.course.currentQuery.items[key])
+      .map((key) => state.resources.courses &&
+                    state.resources.courses.currentQuery &&
+                    state.resources.courses.currentQuery.items[key])
       // Get the actual items matching those IDs
       // -1 will match nothing and get filtered right below
-      .map((id = -1) => state.resources.course &&
-                        state.resources.course.byId[id])
+      .map((id = -1) => state.resources.courses &&
+                        state.resources.courses.byId[id])
       // Drop unknown indexes or broken keys so we don't pollute the UI
       .filter((item) => !!item),
   };
 };
 
 const mapDispatchToProps = {
-  requestCourses: partial(getResourceList, 'course', { limit: 999 }),
+  requestCourses: partial(getResourceList, 'courses', { limit: 999 }),
 };
 
 export const CourseGlimpseListContainer = connect(

--- a/richie/js/components/searchContainer/searchContainer.tsx
+++ b/richie/js/components/searchContainer/searchContainer.tsx
@@ -5,8 +5,8 @@ import { getResourceList } from '../../data/genericSideEffects/getResourceList/a
 import { Search } from '../search/search';
 
 const mapDispatchToProps = {
-  requestOrganizations: partial(getResourceList, 'organization', { limit: 999 }),
-  requestSubjects: partial(getResourceList, 'subject', { limit: 999 }),
+  requestOrganizations: partial(getResourceList, 'organizations', { limit: 999 }),
+  requestSubjects: partial(getResourceList, 'subjects', { limit: 999 }),
 };
 
 export const SearchContainer = connect(

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
@@ -1,4 +1,4 @@
-import { CourseState } from '../../data/course/reducer';
+import { CoursesState } from '../../data/courses/reducer';
 import Organization from '../../types/Organization';
 import { mapStateToProps } from './searchFilterGroupContainer';
 
@@ -19,16 +19,16 @@ describe('components/searchFilterGroupContainer', () => {
   it('mapStateToProps builds a filter definition from the facet for a resource-based filter group', () => {
     const state = {
       resources: {
-        course: {
+        courses: {
           byId: {},
           currentQuery: {
-            facets: { organization: { 21: 3, 42: 15, 84: 7 } },
+            facets: { organizations: { 21: 3, 42: 15, 84: 7 } },
             items: {},
             queryKey: '',
             total_count: 22,
           },
-        } as CourseState,
-        organization: {
+        } as CoursesState,
+        organizations: {
           byId: {
             21: { id: 21, name: 'Organization #Twenty-One' } as Organization,
             42: { id: 42, name: 'Organization #Fourty-Two' } as Organization,
@@ -38,11 +38,11 @@ describe('components/searchFilterGroupContainer', () => {
       },
     };
 
-    expect(mapStateToProps(state, { machineName: 'organization' }))
+    expect(mapStateToProps(state, { machineName: 'organizations' }))
     .toEqual({
       filter: {
         humanName: 'Organizations',
-        machineName: 'organization',
+        machineName: 'organizations',
         values: [
           { count: 15, humanName: 'Organization #Fourty-Two', primaryKey: '42' },
           { count: 7, humanName: 'Organization #Eighty-Four', primaryKey: '84' },
@@ -55,7 +55,7 @@ describe('components/searchFilterGroupContainer', () => {
   it('mapStateToProps still builds a default filter group when missing a resource-related facet', () => {
     const state = {
       resources: {
-        organization: {
+        organizations: {
           byId: {
             21: { id: 21, name: 'Organization #Twenty-One' } as Organization,
             42: { id: 42, name: 'Organization #Fourty-Two' } as Organization,
@@ -65,11 +65,11 @@ describe('components/searchFilterGroupContainer', () => {
       },
     };
 
-    expect(mapStateToProps(state, { machineName: 'organization' }))
+    expect(mapStateToProps(state, { machineName: 'organizations' }))
     .toEqual({
       filter: {
         humanName: 'Organizations',
-        machineName: 'organization',
+        machineName: 'organizations',
         values: [
           { humanName: 'Organization #Twenty-One', primaryKey: '21' },
           { humanName: 'Organization #Fourty-Two', primaryKey: '42' },

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
@@ -9,7 +9,7 @@ export interface SearchFilterGroupContainerProps {
   machineName: filterGroups;
 }
 
-type resourceBasedFilterGroups = 'organization' | 'subject';
+type resourceBasedFilterGroups = 'organizations' | 'subjects';
 type hardcodedFilterGroups = 'language' | 'new' | 'status';
 export type filterGroups = resourceBasedFilterGroups | hardcodedFilterGroups;
 
@@ -47,19 +47,19 @@ const hardcodedFilters: { [machineName in hardcodedFilterGroups]: FilterDefiniti
 // Some filters need to be derived from the data
 function getFilterFromData(state: RootState, machineName: filterGroups): FilterDefinition {
   // Default to empty object as it is the default value for currentQuery.facets
-  const facets = state.resources.course &&
-                 state.resources.course.currentQuery &&
-                 state.resources.course.currentQuery.facets || {};
+  const facets = state.resources.courses &&
+                 state.resources.courses.currentQuery &&
+                 state.resources.courses.currentQuery.facets || {};
 
   switch (machineName) {
-    case 'organization':
+    case 'organizations':
       return {
         humanName: 'Organizations',
         machineName,
         values: getFacetedValues(state, facets, machineName),
       };
 
-    case 'subject':
+    case 'subjects':
       return {
         humanName: 'Subjects',
         machineName,

--- a/richie/js/components/searchFiltersPane/searchFiltersPane.tsx
+++ b/richie/js/components/searchFiltersPane/searchFiltersPane.tsx
@@ -7,8 +7,8 @@ export const SearchFiltersPane = (props: {}) => {
     <h2 className="search-filters-pane__title">Filter results</h2>
     <SearchFilterGroupContainer machineName="new" />
     <SearchFilterGroupContainer machineName="status" />
-    <SearchFilterGroupContainer machineName="subject" />
-    <SearchFilterGroupContainer machineName="organization" />
+    <SearchFilterGroupContainer machineName="subjects" />
+    <SearchFilterGroupContainer machineName="organizations" />
     <SearchFilterGroupContainer machineName="language" />
   </div>;
 };

--- a/richie/js/data/courses/reducer.spec.ts
+++ b/richie/js/data/courses/reducer.spec.ts
@@ -1,6 +1,6 @@
-import courseReducer from './reducer';
+import coursesReducer from './reducer';
 
-describe('data/course reducer', () => {
+describe('data/courses reducer', () => {
   const course43 = {
     end_date: '2018-05-31T06:00:00.000Z',
     enrollment_end_date: '2018-03-15T06:00:00.000Z',
@@ -42,23 +42,23 @@ describe('data/course reducer', () => {
   };
 
   it('returns an empty state for initialization', () => {
-    expect(courseReducer(undefined, { type: '' })).toEqual({ byId: {} });
+    expect(coursesReducer(undefined, { type: '' })).toEqual({ byId: {} });
   });
 
   it('returns the state as is when called with an unknown action', () => {
     const previousState = {
       byId: { 43: course43  },
     };
-    expect(courseReducer(previousState, { type: 'TODO_ADD' })).toEqual(previousState);
+    expect(coursesReducer(previousState, { type: 'TODO_ADD' })).toEqual(previousState);
   });
 
   describe('resourceById', () => {
     it('drops actions that do not match the resourceName', () => {
       const previousState = { byId: { 43: course43  } };
 
-      expect(courseReducer(previousState, {
+      expect(coursesReducer(previousState, {
         resource: course44,
-        resourceName: 'subject',
+        resourceName: 'subjects',
         type: 'RESOURCE_ADD',
       })).toEqual(previousState);
     });
@@ -66,9 +66,9 @@ describe('data/course reducer', () => {
     it('uses actions that match the resourceName', () => {
       const previousState = { byId: { 43: course43  } };
 
-      expect(courseReducer(previousState, {
+      expect(coursesReducer(previousState, {
         resource: course44,
-        resourceName: 'course',
+        resourceName: 'courses',
         type: 'RESOURCE_ADD',
       })).toEqual({ byId: { 43: course43, 44: course44 } });
     });

--- a/richie/js/data/courses/reducer.ts
+++ b/richie/js/data/courses/reducer.ts
@@ -3,7 +3,7 @@ import get from 'lodash-es/get';
 import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
-import Organization from '../../types/Organization';
+import Course from '../../types/Course';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
 import {
@@ -16,17 +16,17 @@ import { ResourceListGetSuccess } from '../genericSideEffects/getResourceList/ac
 
 const initialState = { ...resourceByIdInit };
 
-export type OrganizationState = Maybe<ResourceByIdState<Organization> & ResourceListState<Organization>>;
+export type CoursesState = Maybe<ResourceByIdState<Course> & ResourceListState<Course>>;
 
-export const organization: Reducer<OrganizationState> = (
-  state: OrganizationState = initialState,
-  action?: ResourceAdd<Organization> | ResourceListGetSuccess<Organization> | { type: '' },
+export const courses: Reducer<CoursesState> = (
+  state: CoursesState = initialState,
+  action?: ResourceAdd<Course> | ResourceListGetSuccess<Course> | { type: '' },
 ) => {
   if (!action) { return state; } // Compiler needs help
 
   // Discriminate resource related actions by resource name
   if (get(action, 'resourceName') &&
-      get(action, 'resourceName') !== 'organization'
+      get(action, 'resourceName') !== 'courses'
   ) {
     return state;
   }
@@ -37,4 +37,4 @@ export const organization: Reducer<OrganizationState> = (
   ])(state, action);
 };
 
-export default organization;
+export default courses;

--- a/richie/js/data/genericReducers/resourceById/resourceById.spec.ts
+++ b/richie/js/data/genericReducers/resourceById/resourceById.spec.ts
@@ -37,7 +37,7 @@ describe('data/genericReducers/resourceById reducer', () => {
       };
       expect(resourceByIdReducer(previousState, {
         resource: subj44,
-        resourceName: 'subject',
+        resourceName: 'subjects',
         type: 'RESOURCE_ADD',
       })).toEqual({ byId: { 43: subj43, 44: subj44 } });
     });
@@ -49,7 +49,7 @@ describe('data/genericReducers/resourceById reducer', () => {
         byId: { 43: subj43  },
       };
       expect(resourceByIdReducer(previousState, {
-        resourceName: 'subject',
+        resourceName: 'subjects',
         resources: [ subj44, subj45 ],
         type: 'RESOURCE_MULTIPLE_ADD',
       })).toEqual({ byId: { 43: subj43, 44: subj44, 45: subj45 } });

--- a/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
@@ -52,7 +52,7 @@ describe('data/genericReducers/resourceList reducer', () => {
             objects: [ course43, course44 ],
           },
           params: { limit: 12, offset: 2 },
-          resourceName: 'course',
+          resourceName: 'courses',
           type: 'RESOURCE_LIST_GET_SUCCESS',
         },
       ))
@@ -73,7 +73,7 @@ describe('data/genericReducers/resourceList reducer', () => {
             objects: [ course44, course43 ],
           },
           params: { limit: 2, match: 'some query', offset: 0 },
-          resourceName: 'course',
+          resourceName: 'courses',
           type: 'RESOURCE_LIST_GET_SUCCESS',
         },
       ))

--- a/richie/js/data/genericSideEffects/getResourceList/getResourceList.spec.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/getResourceList.spec.ts
@@ -68,11 +68,11 @@ describe('data/genericSideEffects/getResourceList saga', () => {
         ok: true,
       }));
 
-      fetchList('course', { limit: 2, offset: 43 })
+      fetchList('courses', { limit: 2, offset: 43 })
       .then((response) => {
         // The correct request given parameters is performed
         expect(mockFetch).toHaveBeenCalledWith(
-          '/api/v1.0/course/?limit=2&offset=43',
+          '/api/v1.0/courses/?limit=2&offset=43',
           { headers: { 'Content-Type': 'application/json' },
         });
         // Our polymorphic response object is properly shaped
@@ -86,7 +86,7 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       mockFetch.and.returnValue(Promise.reject(new Error('Could not perform fetch.')));
 
       // Don't check params again as it was done in the first test
-      fetchList('course', { limit: 2, offset: 43 })
+      fetchList('courses', { limit: 2, offset: 43 })
       .then((response) => {
         // Our polymorphic response object is properly shaped - with an error this time
         expect(response.objects).not.toBeDefined();
@@ -99,7 +99,7 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       mockFetch.and.returnValue(Promise.resolve({ ok: false, status: 404 }));
 
       // Don't check params again as it was done in the first test
-      fetchList('course', { limit: 2, offset: 43 })
+      fetchList('courses', { limit: 2, offset: 43 })
       .then((response) => {
         // Our polymorphic response object is properly shaped - with an error this time
         expect(response.objects).not.toBeDefined();
@@ -112,7 +112,7 @@ describe('data/genericSideEffects/getResourceList saga', () => {
   describe('getList', () => {
     const action = {
       params: { limit: 10, name: 'python', offset: 0 },
-      resourceName: 'course' as 'course',
+      resourceName: 'courses' as 'courses',
       type: 'RESOURCE_LIST_GET' as 'RESOURCE_LIST_GET',
     };
 
@@ -126,11 +126,11 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       };
 
       // The call to fetch (the actual side-effect) is triggered
-      expect(gen.next().value).toEqual(call(fetchList, 'course', action.params));
+      expect(gen.next().value).toEqual(call(fetchList, 'courses', action.params));
       // Both courses are added to the state
-      expect(gen.next(response).value).toEqual(put(addMultipleResources('course', response.objects)));
+      expect(gen.next(response).value).toEqual(put(addMultipleResources('courses', response.objects)));
       // The success action is dispatched
-      expect(gen.next().value).toEqual(put(didGetResourceList('course', response, action.params)));
+      expect(gen.next().value).toEqual(put(didGetResourceList('courses', response, action.params)));
     });
 
     it('yields a failure action when fetchList fails', () => {
@@ -141,9 +141,9 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       };
 
       // The call to fetch is triggered, but fails for some reason
-      expect(gen.next().value).toEqual(call(fetchList, 'course', action.params));
+      expect(gen.next().value).toEqual(call(fetchList, 'courses', action.params));
       // The failure action is dispatched
-      expect(gen.next(response).value).toEqual(put(failedToGetResourceList('course', response.error)));
+      expect(gen.next(response).value).toEqual(put(failedToGetResourceList('courses', response.error)));
     });
   });
 });

--- a/richie/js/data/organizations/reducer.spec.ts
+++ b/richie/js/data/organizations/reducer.spec.ts
@@ -1,6 +1,6 @@
-import organizationReducer from './reducer';
+import organizationsReducer from './reducer';
 
-describe('data/organization reducer', () => {
+describe('data/organizations reducer', () => {
   const org43 = {
     banner: 'https://example.com/banner43.png',
     code: 'org-43',
@@ -23,9 +23,9 @@ describe('data/organization reducer', () => {
     it('drops actions that do not match the resourceName', () => {
       const previousState = { byId: { 43: org43  } };
 
-      expect(organizationReducer(previousState, {
+      expect(organizationsReducer(previousState, {
         resource: org44,
-        resourceName: 'subject',
+        resourceName: 'subjects',
         type: 'RESOURCE_ADD',
       })).toEqual(previousState);
     });
@@ -33,9 +33,9 @@ describe('data/organization reducer', () => {
     it('uses actions that match the resourceName', () => {
       const previousState = { byId: { 43: org43  } };
 
-      expect(organizationReducer(previousState, {
+      expect(organizationsReducer(previousState, {
         resource: org44,
-        resourceName: 'organization',
+        resourceName: 'organizations',
         type: 'RESOURCE_ADD',
       })).toEqual({ byId: { 43: org43, 44: org44 } });
     });

--- a/richie/js/data/organizations/reducer.ts
+++ b/richie/js/data/organizations/reducer.ts
@@ -3,7 +3,7 @@ import get from 'lodash-es/get';
 import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
-import Subject from '../../types/Subject';
+import Organization from '../../types/Organization';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
 import {
@@ -16,17 +16,17 @@ import { ResourceListGetSuccess } from '../genericSideEffects/getResourceList/ac
 
 const initialState = { ...resourceByIdInit };
 
-export type SubjectState = Maybe<ResourceByIdState<Subject> & ResourceListState<Subject>>;
+export type OrganizationsState = Maybe<ResourceByIdState<Organization> & ResourceListState<Organization>>;
 
-export const subject: Reducer<SubjectState> = (
-  state = initialState,
-  action?: ResourceAdd<Subject> | ResourceListGetSuccess<Subject> | { type: '' },
+export const organizations: Reducer<OrganizationsState> = (
+  state: OrganizationsState = initialState,
+  action?: ResourceAdd<Organization> | ResourceListGetSuccess<Organization> | { type: '' },
 ) => {
   if (!action) { return state; } // Compiler needs help
 
   // Discriminate resource related actions by resource name
   if (get(action, 'resourceName') &&
-      get(action, 'resourceName') !== 'subject'
+      get(action, 'resourceName') !== 'organizations'
   ) {
     return state;
   }
@@ -37,4 +37,4 @@ export const subject: Reducer<SubjectState> = (
   ])(state, action);
 };
 
-export default subject;
+export default organizations;

--- a/richie/js/data/rootReducer.ts
+++ b/richie/js/data/rootReducer.ts
@@ -1,23 +1,23 @@
 import { Reducer } from 'redux';
 
-import { course, CourseState } from './course/reducer';
-import { organization, OrganizationState } from './organization/reducer';
-import { subject, SubjectState } from './subject/reducer';
+import { courses, CoursesState } from './courses/reducer';
+import { organizations, OrganizationsState } from './organizations/reducer';
+import { subjects, SubjectsState } from './subjects/reducer';
 
 export interface RootState {
   resources: {
-    course?: CourseState;
-    organization?: OrganizationState;
-    subject?: SubjectState;
+    courses?: CoursesState;
+    organizations?: OrganizationsState;
+    subjects?: SubjectsState;
   };
 }
 
 export const rootReducer: Reducer<RootState> = (state, action) => {
   return {
     resources: {
-      course: course(state.resources.course, action),
-      organization: organization(state.resources.organization, action),
-      subject: subject(state.resources.subject, action),
+      courses: courses(state.resources.courses, action),
+      organizations: organizations(state.resources.organizations, action),
+      subjects: subjects(state.resources.subjects, action),
     },
   };
 };

--- a/richie/js/data/subjects/reducer.spec.ts
+++ b/richie/js/data/subjects/reducer.spec.ts
@@ -1,6 +1,6 @@
-import subjectReducer from './reducer';
+import subjectsReducer from './reducer';
 
-describe('data/subject reducer', () => {
+describe('data/subjects reducer', () => {
   const subj43 = {
     id: 43,
     image: 'https://example.com/subject_43.png',
@@ -17,9 +17,9 @@ describe('data/subject reducer', () => {
     it('drops actions that do not match the resourceName', () => {
       const previousState = { byId: { 43: subj43  } };
 
-      expect(subjectReducer(previousState, {
+      expect(subjectsReducer(previousState, {
         resource: subj44,
-        resourceName: 'organization',
+        resourceName: 'organizations',
         type: 'RESOURCE_ADD',
       })).toEqual(previousState);
     });
@@ -27,9 +27,9 @@ describe('data/subject reducer', () => {
     it('uses actions that match the resourceName', () => {
       const previousState = { byId: { 43: subj43  } };
 
-      expect(subjectReducer(previousState, {
+      expect(subjectsReducer(previousState, {
         resource: subj44,
-        resourceName: 'subject',
+        resourceName: 'subjects',
         type: 'RESOURCE_ADD',
       })).toEqual({ byId: { 43: subj43, 44: subj44 } });
     });

--- a/richie/js/data/subjects/reducer.ts
+++ b/richie/js/data/subjects/reducer.ts
@@ -3,7 +3,7 @@ import get from 'lodash-es/get';
 import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
-import Course from '../../types/Course';
+import Subject from '../../types/Subject';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
 import {
@@ -16,17 +16,17 @@ import { ResourceListGetSuccess } from '../genericSideEffects/getResourceList/ac
 
 const initialState = { ...resourceByIdInit };
 
-export type CourseState = Maybe<ResourceByIdState<Course> & ResourceListState<Course>>;
+export type SubjectsState = Maybe<ResourceByIdState<Subject> & ResourceListState<Subject>>;
 
-export const course: Reducer<CourseState> = (
-  state: CourseState = initialState,
-  action?: ResourceAdd<Course> | ResourceListGetSuccess<Course> | { type: '' },
+export const subjects: Reducer<SubjectsState> = (
+  state = initialState,
+  action?: ResourceAdd<Subject> | ResourceListGetSuccess<Subject> | { type: '' },
 ) => {
   if (!action) { return state; } // Compiler needs help
 
   // Discriminate resource related actions by resource name
   if (get(action, 'resourceName') &&
-      get(action, 'resourceName') !== 'course'
+      get(action, 'resourceName') !== 'subjects'
   ) {
     return state;
   }
@@ -37,4 +37,4 @@ export const course: Reducer<CourseState> = (
   ])(state, action);
 };
 
-export default course;
+export default subjects;

--- a/richie/js/settings.d.ts
+++ b/richie/js/settings.d.ts
@@ -1,8 +1,8 @@
 declare module '*settings.json' {
   export const API_ENDPOINTS: {
-    course: string;
-    organization: string;
-    subject: string;
+    courses: string;
+    organizations: string;
+    subjects: string;
   };
 
   export const SUPPORTED_LANGUAGES: string[];

--- a/richie/js/settings.json
+++ b/richie/js/settings.json
@@ -1,8 +1,8 @@
 {
   "API_ENDPOINTS": {
-    "course": "/api/v1.0/course/",
-    "organization": "/api/v1.0/organization/",
-    "subject": "/api/v1.0/subject/"
+    "courses": "/api/v1.0/courses/",
+    "organizations": "/api/v1.0/organizations/",
+    "subjects": "/api/v1.0/subjects/"
   },
   "SUPPORTED_LANGUAGES": [
     "de",


### PR DESCRIPTION
## Purpose

As discussed in #95, we need to make resource names consistent across the project so we don't have to convert between singular/plural form.

## Proposal

Pluralize resource names across the board so everything fits together nicely. We've only left out case when it makes no sense to pluralize, for exemple a single record type names or a single record passed through a prop

- [x] Pluralize resource names throughout backend code...
- [x] ... and throughout frontend code


Fixes #95 