### PR TITLE
🐛(front) fix SearchFilter component prop typing naming

### DIFF
--- a/richie/js/components/searchFilter/searchFilter.tsx
+++ b/richie/js/components/searchFilter/searchFilter.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 
 import { FilterValue } from '../../types/FilterDefinition';
 
-export interface SearchFilterGroupProps {
+export interface SearchFilterProps {
   filter: FilterValue;
 }
 
-export const SearchFilter = (props: SearchFilterGroupProps) => {
+export const SearchFilter = (props: SearchFilterProps) => {
   const { filter } = props;
 
   return <button className="search-filter">


### PR DESCRIPTION
## Purpose

The SearchFilter component's prop type signature was named SearchFilterContainerProps instead of SearchFilterProps by mistake.

## Proposal

Simply rename it.