### PR TITLE
Clean up resource list params in reducer

### DIFF
--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
@@ -50,7 +50,7 @@ describe('components/courseGlimpseListContainer', () => {
           currentQuery: {
             facets: {},
             items: { 0: 44, 1: 43 },
-            queryKey: '{}',
+            params: { limit: 2, offset: 0 },
             total_count: 2,
           },
         },

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
@@ -24,7 +24,7 @@ describe('components/searchFilterGroupContainer', () => {
           currentQuery: {
             facets: { organizations: { 21: 3, 42: 15, 84: 7 } },
             items: {},
-            queryKey: '',
+            params: { limit: 20, offset: 0 },
             total_count: 22,
           },
         } as CoursesState,

--- a/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
@@ -57,12 +57,24 @@ describe('data/genericReducers/resourceList reducer', () => {
         },
       ))
       // No facets in the apiResponse: we get an empty object in the state
-      .toEqual({ currentQuery: { facets: {}, items: { 2: 43, 3: 44 }, queryKey: '{}', total_count: 4 } });
+      .toEqual({
+        currentQuery: {
+          facets: {},
+          items: { 2: 43, 3: 44 },
+          params: { limit: 12, offset: 2 },
+          total_count: 4,
+        },
+      });
     });
 
     it('replaces the existing query if the new one has different params', () => {
       const previousState = {
-        currentQuery: { facets: {}, items: { 2: 43, 3: 44 }, queryKey: '{}', total_count: 4 },
+        currentQuery: {
+          facets: {},
+          items: { 2: 43, 3: 44 },
+          params: { limit: 20, offset: 20 },
+          total_count: 4,
+        },
       };
       expect(currentQuery(
         previousState,
@@ -82,7 +94,7 @@ describe('data/genericReducers/resourceList reducer', () => {
           // Facets are copied over on the state as-is
           facets: { organizations: { 11: 1, 23: 1, 31: 1 } },
           items: { 0: 44, 1: 43 },
-          queryKey: '{"match":"some query"}',
+          params: { limit: 2, match: 'some query', offset: 0 },
           total_count: 240,
         },
       });

--- a/richie/js/data/genericSideEffects/getResourceList/actions.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/actions.ts
@@ -3,7 +3,7 @@ import Resource from '../../../types/Resource';
 import { RootState } from '../../rootReducer';
 
 export interface ResourceListGet {
-  params?: APIListCommonRequestParams & { [key: string]: string | number | null | Array<string | number> };
+  params?: Partial<APIListCommonRequestParams> & { [key: string]: string | number | null | Array<string | number> };
   resourceName: keyof RootState['resources'];
   type: 'RESOURCE_LIST_GET';
 }
@@ -38,7 +38,7 @@ export function failedToGetResourceList(
 
 export interface ResourceListGetSuccess<R extends Resource> {
   apiResponse: { facets?: APIResponseListFacets, meta: APIResponseListMeta, objects: R[] };
-  params: APIListCommonRequestParams & { [key: string]: string | number | null | Array<string | number> };
+  params: Partial<APIListCommonRequestParams> & { [key: string]: string | number | null | Array<string | number> };
   resourceName: keyof RootState['resources'];
   type: 'RESOURCE_LIST_GET_SUCCESS';
 }

--- a/richie/js/settings.d.ts
+++ b/richie/js/settings.d.ts
@@ -5,5 +5,10 @@ declare module '*settings.json' {
     subjects: string;
   };
 
+  export const API_LIST_DEFAULT_PARAMS: {
+    limit: number;
+    offset: number;
+  };
+
   export const SUPPORTED_LANGUAGES: string[];
 }

--- a/richie/js/settings.json
+++ b/richie/js/settings.json
@@ -4,6 +4,10 @@
     "organizations": "/api/v1.0/organizations/",
     "subjects": "/api/v1.0/subjects/"
   },
+  "API_LIST_DEFAULT_PARAMS": {
+    "limit": 20,
+    "offset": 0
+  },
   "SUPPORTED_LANGUAGES": [
     "de",
     "en",

--- a/richie/js/types/api.ts
+++ b/richie/js/types/api.ts
@@ -13,6 +13,6 @@ export interface APIResponseListFacets {
 }
 
 export interface APIListCommonRequestParams {
-  limit?: number;
-  offset?: number;
+  limit: number;
+  offset: number;
 }


### PR DESCRIPTION
## Purpose

As we're not caching list responses anymore, we don't need the query key. On the other hand, we do need the current params to modify them as users interact with the filters.

## Proposal

Set defaults and clean up APIListCommonRequestParams.

It makes more sense to have them specified and then use Partial<> when we accept incomplete subsets.