### PR TITLE
🐛(search) fix subjects+organizations terms queries in the same query

### DIFF
--- a/apps/search/tests/test_viewsets_courses.py
+++ b/apps/search/tests/test_viewsets_courses.py
@@ -150,16 +150,22 @@ class CoursesViewsetTestCase(TestCase):
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
             body={
-                "query": {
-                    "multi_match": {
-                        "fields": ["short_description.*", "title.*"],
-                        "query": "some phrase terms",
-                        "type": "cross_fields",
-                    }
-                },
                 "aggs": {
                     "organizations": {"terms": {"field": "organizations"}},
                     "subjects": {"terms": {"field": "subjects"}},
+                },
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "multi_match": {
+                                    "fields": ["short_description.*", "title.*"],
+                                    "query": "some phrase terms",
+                                    "type": "cross_fields",
+                                }
+                            }
+                        ]
+                    }
                 },
             },
             doc_type="course",
@@ -212,11 +218,11 @@ class CoursesViewsetTestCase(TestCase):
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
             body={
-                "query": {"terms": {"organizations": [13, 15]}},
                 "aggs": {
                     "organizations": {"terms": {"field": "organizations"}},
                     "subjects": {"terms": {"field": "subjects"}},
                 },
+                "query": {"bool": {"must": [{"terms": {"organizations": [13, 15]}}]}},
             },
             doc_type="course",
             from_=0,
@@ -259,11 +265,11 @@ class CoursesViewsetTestCase(TestCase):
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
             body={
-                "query": {"terms": {"organizations": [345]}},
                 "aggs": {
                     "organizations": {"terms": {"field": "organizations"}},
                     "subjects": {"terms": {"field": "subjects"}},
                 },
+                "query": {"bool": {"must": [{"terms": {"organizations": [345]}}]}},
             },
             doc_type="course",
             from_=0,
@@ -312,25 +318,37 @@ class CoursesViewsetTestCase(TestCase):
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
             body={
-                "query": {
-                    "range": {
-                        "end_date": {
-                            "gte": datetime.datetime(
-                                2018, 4, 30, 6, 0, tzinfo=pytz.utc
-                            ),
-                            "lte": datetime.datetime(
-                                2018, 6, 30, 6, 0, tzinfo=pytz.utc
-                            ),
-                        },
-                        "start_date": {
-                            "gte": datetime.datetime(2018, 1, 1, 6, 0, tzinfo=pytz.utc),
-                            "lte": None,
-                        },
-                    }
-                },
                 "aggs": {
                     "organizations": {"terms": {"field": "organizations"}},
                     "subjects": {"terms": {"field": "subjects"}},
+                },
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "range": {
+                                    "end_date": {
+                                        "gte": datetime.datetime(
+                                            2018, 4, 30, 6, 0, tzinfo=pytz.utc
+                                        ),
+                                        "lte": datetime.datetime(
+                                            2018, 6, 30, 6, 0, tzinfo=pytz.utc
+                                        ),
+                                    }
+                                }
+                            },
+                            {
+                                "range": {
+                                    "start_date": {
+                                        "gte": datetime.datetime(
+                                            2018, 1, 1, 6, 0, tzinfo=pytz.utc
+                                        ),
+                                        "lte": None,
+                                    }
+                                }
+                            },
+                        ]
+                    }
                 },
             },
             doc_type="course",
@@ -382,31 +400,45 @@ class CoursesViewsetTestCase(TestCase):
         # The ES connector was called with appropriate arguments for the client's request
         mock_search.assert_called_with(
             body={
-                "query": {
-                    "multi_match": {
-                        "fields": ["short_description.*", "title.*"],
-                        "query": "these phrase terms",
-                        "type": "cross_fields",
-                    },
-                    "range": {
-                        "end_date": {
-                            "gte": datetime.datetime(
-                                2018, 4, 30, 6, 0, tzinfo=pytz.utc
-                            ),
-                            "lte": datetime.datetime(
-                                2018, 6, 30, 6, 0, tzinfo=pytz.utc
-                            ),
-                        },
-                        "start_date": {
-                            "gte": datetime.datetime(2018, 1, 1, 6, 0, tzinfo=pytz.utc),
-                            "lte": None,
-                        },
-                    },
-                    "terms": {"subjects": [42, 84]},
-                },
                 "aggs": {
                     "organizations": {"terms": {"field": "organizations"}},
                     "subjects": {"terms": {"field": "subjects"}},
+                },
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "range": {
+                                    "end_date": {
+                                        "gte": datetime.datetime(
+                                            2018, 4, 30, 6, 0, tzinfo=pytz.utc
+                                        ),
+                                        "lte": datetime.datetime(
+                                            2018, 6, 30, 6, 0, tzinfo=pytz.utc
+                                        ),
+                                    }
+                                }
+                            },
+                            {
+                                "multi_match": {
+                                    "fields": ["short_description.*", "title.*"],
+                                    "query": "these phrase terms",
+                                    "type": "cross_fields",
+                                }
+                            },
+                            {
+                                "range": {
+                                    "start_date": {
+                                        "gte": datetime.datetime(
+                                            2018, 1, 1, 6, 0, tzinfo=pytz.utc
+                                        ),
+                                        "lte": None,
+                                    }
+                                }
+                            },
+                            {"terms": {"subjects": [42, 84]}},
+                        ]
+                    }
                 },
             },
             doc_type="course",


### PR DESCRIPTION
## Purpose

The "terms" query does not support multiple different keys on the same query. This is not documented but the issue arose when we attempted it on our live ES instance.

We received a 500 error on the API (400 error from ES) when attempting to filter on orgs & subjects at the same time.

## Proposal

Use a "bool" query that allows us to combine multiple queries (and therefore 2 or more "terms" queries) into one.

It's also structurally cleaner as it allows us to express our constraints as arrays of invididual constraints
with a filter/ranking/necessity marker.

Docs: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html