### PR TITLE
Update the filters and trigger a request when the user clicks on a filter

### DIFF
--- a/richie/js/bootstrap.ts
+++ b/richie/js/bootstrap.ts
@@ -1,7 +1,10 @@
 import configureStore from './data/configureStore';
+import { initialState as filterDefinitionsInitialState } from './data/filterDefinitions/initialState';
+import { RootState } from './data/rootReducer';
 
 export default function bootstrapStore() {
   return configureStore({
+    filterDefinitions: filterDefinitionsInitialState,
     resources: {},
   });
 }

--- a/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.spec.tsx
@@ -1,3 +1,4 @@
+import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
 import Course from '../../types/Course';
 import { mapStateToProps, mergeProps } from './courseGlimpseContainer';
 
@@ -33,6 +34,7 @@ describe('components/courseGlimpseContainer', () => {
 
   it('mapStateToProps picks in state the organization relevant to the current course', () => {
     const state = {
+      filterDefinitions: {} as FilterDefinitionState,
       resources: {
         organizations: { byId: { 23: org23 } },
       },

--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
@@ -1,3 +1,4 @@
+import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
 import Course from '../../types/Course';
 import { mapStateToProps } from './courseGlimpseListContainer';
 
@@ -44,6 +45,7 @@ describe('components/courseGlimpseListContainer', () => {
     };
 
     const state = {
+      filterDefinitions: {} as FilterDefinitionState,
       resources: {
         courses: {
           byId: { 43: course43, 44: course44 },

--- a/richie/js/components/searchFilter/searchFilter.spec.tsx
+++ b/richie/js/components/searchFilter/searchFilter.spec.tsx
@@ -7,7 +7,9 @@ import SearchFilter from './searchFilter';
 
 describe('components/searchFilter', () => {
   it('renders the name of the filter', () => {
-    const wrapper = shallow(<SearchFilter filter={{ primaryKey: '42', humanName: 'Human name'}} />);
+    const addFilter = jasmine.createSpy('addFilter');
+    const wrapper =
+      shallow(<SearchFilter addFilter={addFilter} filter={{ primaryKey: '42', humanName: 'Human name'}} />);
 
     expect(wrapper.text()).toContain('Human name');
   });

--- a/richie/js/components/searchFilter/searchFilter.tsx
+++ b/richie/js/components/searchFilter/searchFilter.tsx
@@ -3,13 +3,14 @@ import * as React from 'react';
 import { FilterValue } from '../../types/FilterDefinition';
 
 export interface SearchFilterProps {
+  addFilter: (filterValue: string) => void;
   filter: FilterValue;
 }
 
 export const SearchFilter = (props: SearchFilterProps) => {
-  const { filter } = props;
+  const { filter, addFilter } = props;
 
-  return <button className="search-filter">
+  return <button className="search-filter" onClick={() => addFilter(filter.primaryKey)}>
     {filter.humanName}
     {filter.count || filter.count === 0 ?
       <span className="search-filter__count">{filter.count}</span> :

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
@@ -8,13 +8,16 @@ import SearchFilter from '../searchFilter/searchFilter';
 import SearchFilterGroup from './searchFilterGroup';
 
 describe('components/searchFilterGroup', () => {
+  const addFilter = jasmine.createSpy('addFilter');
+  const removeFilter = jasmine.createSpy('removeFilter');
+
   it('renders the name of the filter', () => {
     const filter = {
       humanName: 'Example filter',
       machineName: 'example-filter',
       values: [],
     } as FilterDefinition;
-    const wrapper = shallow(<SearchFilterGroup filter={filter} />);
+    const wrapper = shallow(<SearchFilterGroup addFilter={addFilter} filter={filter} removeFilter={removeFilter} />);
 
     expect(wrapper.text()).toContain('Example filter');
   });
@@ -24,7 +27,7 @@ describe('components/searchFilterGroup', () => {
       humanName: 'Example filter',
       values: [ { primaryKey: 'value-1', humanName: 'Value One' }, { primaryKey: 'value-2', humanName: 'Value Two' } ],
     } as FilterDefinition;
-    const wrapper = shallow(<SearchFilterGroup filter={filter} />);
+    const wrapper = shallow(<SearchFilterGroup addFilter={addFilter} filter={filter} removeFilter={removeFilter} />);
 
     expect(wrapper.find(SearchFilter).length).toEqual(2);
   });

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
@@ -4,7 +4,9 @@ import { FilterDefinition } from '../../types/FilterDefinition';
 import SearchFilter from '../searchFilter/searchFilter';
 
 export interface SearchFilterGroupProps {
+  addFilter: (filterValue: string) => void;
   filter: FilterDefinition;
+  removeFilter: (filterValue: string) => void;
 }
 
 export const SearchFilterGroup = (props: SearchFilterGroupProps) => {
@@ -13,7 +15,7 @@ export const SearchFilterGroup = (props: SearchFilterGroupProps) => {
   return <div className="search-filter-group">
     <h3 className="search-filter-group__title">{humanName}</h3>
     <div className="search-filter-group__list">
-      {values.map((value) => <SearchFilter filter={value} key={value.primaryKey} /> )}
+      {values.map((value) => <SearchFilter filter={value} key={value.primaryKey} addFilter={props.addFilter} /> )}
     </div>
   </div>;
 };

--- a/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.spec.ts
+++ b/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.spec.ts
@@ -1,0 +1,53 @@
+import partial from 'lodash-es/partial';
+
+import { computeNewFilterValue } from './computeNewFilterValue';
+
+describe('components/searchFilterGroupContainer/computeNewFilterValue', () => {
+  describe('add', () => {
+    const addFilter = partial(computeNewFilterValue, 'add');
+
+    it('returns an array with the value when the existing value was null | undefined', () => {
+      expect(addFilter(null, 42)).toEqual([ 42 ]);
+      expect(addFilter(undefined, 'new_value')).toEqual([ 'new_value' ]);
+    });
+
+    it('returns an array with the existing value and the new value when the existing value was a primitive', () => {
+      expect(addFilter(43, 86)).toEqual([ 43, 86 ]);
+      expect(addFilter('existing_value', 'incoming_value')).toEqual([ 'existing_value', 'incoming_value' ]);
+    });
+
+    it('adds the new value at the end of the existing value if the existing value was an array', () => {
+      expect(addFilter([ 44, 88 ], 176)).toEqual([ 44, 88, 176 ]);
+      expect(addFilter([ 'val_A', 'val_B' ], 'val_C')).toEqual([ 'val_A', 'val_B', 'val_C' ]);
+    });
+  });
+
+  describe('remove', () => {
+    const removeFilter = partial(computeNewFilterValue, 'remove');
+
+    it('returns null when the existing value was null | undefined', () => {
+      expect(removeFilter(null, 42)).toEqual(null);
+      expect(removeFilter(null, 'imaginary_value')).toEqual(null);
+    });
+
+    it('returns null when the existing value was the passed value', () => {
+      expect(removeFilter(42, 42)).toEqual(null);
+      expect(removeFilter('existing_value', 'existing_value')).toEqual(null);
+    });
+
+    it('returns the existing value when the existing value was not the passed value', () => {
+      expect(removeFilter(42, 84)).toEqual(42);
+      expect(removeFilter('existing_value', 'imaginary_value')).toEqual('existing_value');
+    });
+
+    it('removes the passed value from the existing value when the existing value was an array', () => {
+      expect(removeFilter([ 42, 84 ], 42)).toEqual([ 84 ]);
+      expect(removeFilter([ 'val_A', 'val_B' ], 'val_B')).toEqual([ 'val_A' ]);
+    });
+
+    it('returns null when the passed value was the only value in the existing value as an array', () => {
+      expect(removeFilter([ 43 ], 43)).toEqual(null);
+      expect(removeFilter([ 'val_B' ], 'val_B')).toEqual(null);
+    });
+  });
+});

--- a/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.ts
+++ b/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.ts
@@ -1,0 +1,41 @@
+import { Maybe, Nullable } from '../../utils/types';
+
+// Compute a new value for a filter to apply to course search, reacting to a user interaction by
+// either adding a new filter or removing one
+export function computeNewFilterValue(
+  action: 'add' | 'remove',
+  existingValue: Maybe<Nullable<string | number | Array<string | number>>>,
+  relevantValue: string | number,
+) {
+  if (!existingValue) {
+    // There is no existing value for this filter
+    return action === 'add' ?
+      // ADD: Make an array with the existing value
+      [ relevantValue ] :
+      // REMOVE: There's nothing that could possibly removed, return null
+      null;
+  } else if (typeof existingValue === 'string' || typeof existingValue === 'number') {
+    // The existing value for this filter is a single primitive type value
+    return action === 'add' ?
+      // ADD: Make an array with the existing value and the new one
+      [ existingValue, relevantValue ] :
+      (existingValue === relevantValue ?
+        // REMOVE: Return nothing if we had to drop the existing value we had
+        null :
+        // REMOVE: Keep the existing value if it's not the one we needed to drop
+        existingValue);
+  } else {
+    // The existing value is an array of strings or numbers
+    const nullEmptyArray = (array: Array<string | number>) => {
+      return array.length === 0 ? null : array;
+    };
+
+    return action === 'add' ?
+      // ADD: Just push the new value into our existing array of values
+      [ ...existingValue, relevantValue ] :
+      // REMOVE: Return the existing array of values without the one we needed to remove
+      nullEmptyArray(existingValue.filter((v) => v !== relevantValue));
+  }
+}
+
+export default computeNewFilterValue;

--- a/richie/js/components/searchFilterGroupContainer/getFilterFromState.spec.ts
+++ b/richie/js/components/searchFilterGroupContainer/getFilterFromState.spec.ts
@@ -1,0 +1,112 @@
+import { CoursesState } from '../../data/courses/reducer';
+import { FilterDefinition } from '../../types/FilterDefinition';
+import Organization from '../../types/Organization';
+import { getFilterFromState } from './getFilterFromState';
+
+describe('components/searchFilterGroupContainer/getFilterFromState', () => {
+  it('returns a FilterDefinition for a hardcoded filter group', () => {
+    const state = {
+      filterDefinitions: {
+        language: {} as FilterDefinition,
+        new: {
+          humanName: 'New courses',
+          machineName: 'status',
+          values: [
+            { primaryKey: 'new', humanName: 'First session'},
+          ],
+        },
+        organizations: {} as FilterDefinition,
+        status: {} as FilterDefinition,
+        subjects: {} as FilterDefinition,
+      },
+      resources: {},
+    };
+    expect(getFilterFromState(state, 'new'))
+    .toEqual({
+      humanName: 'New courses',
+      machineName: 'status',
+      values: [
+        { primaryKey: 'new', humanName: 'First session'},
+      ],
+    });
+  });
+
+  it('builds a filter definition from the facet for a resource-based filter group', () => {
+    const state = {
+      filterDefinitions: {
+        language: {} as FilterDefinition,
+        new: {} as FilterDefinition,
+        organizations: {
+          humanName: 'Organizations',
+          machineName: 'organizations',
+        },
+        status: {} as FilterDefinition,
+        subjects: {} as FilterDefinition,
+      },
+      resources: {
+        courses: {
+          byId: {},
+          currentQuery: {
+            facets: { organizations: { 21: 3, 42: 15, 84: 7 } },
+            items: {},
+            params: { limit: 20, offset: 0 },
+            total_count: 22,
+          },
+        } as CoursesState,
+        organizations: {
+          byId: {
+            21: { id: 21, name: 'Organization #Twenty-One' } as Organization,
+            42: { id: 42, name: 'Organization #Fourty-Two' } as Organization,
+            84: { id: 84, name: 'Organization #Eighty-Four' } as Organization,
+          },
+        },
+      },
+    };
+
+    expect(getFilterFromState(state, 'organizations'))
+    .toEqual({
+      humanName: 'Organizations',
+      machineName: 'organizations',
+      values: [
+        { count: 15, humanName: 'Organization #Fourty-Two', primaryKey: '42' },
+        { count: 7, humanName: 'Organization #Eighty-Four', primaryKey: '84' },
+        { count: 3, humanName: 'Organization #Twenty-One', primaryKey: '21' },
+      ],
+    });
+  });
+
+  it('still builds a default filter group when missing a resource-related facet', () => {
+    const state = {
+      filterDefinitions: {
+        language: {} as FilterDefinition,
+        new: {} as FilterDefinition,
+        organizations: {
+          humanName: 'Organizations',
+          machineName: 'organizations',
+        },
+        status: {} as FilterDefinition,
+        subjects: {} as FilterDefinition,
+      },
+      resources: {
+        organizations: {
+          byId: {
+            21: { id: 21, name: 'Organization #Twenty-One' } as Organization,
+            42: { id: 42, name: 'Organization #Fourty-Two' } as Organization,
+            84: { id: 84, name: 'Organization #Eighty-Four' } as Organization,
+          },
+        },
+      },
+    };
+
+    expect(getFilterFromState(state, 'organizations'))
+    .toEqual({
+      humanName: 'Organizations',
+      machineName: 'organizations',
+      values: [
+        { humanName: 'Organization #Twenty-One', primaryKey: '21' },
+        { humanName: 'Organization #Fourty-Two', primaryKey: '42' },
+        { humanName: 'Organization #Eighty-Four', primaryKey: '84' },
+      ],
+    });
+  });
+});

--- a/richie/js/components/searchFilterGroupContainer/getFilterFromState.ts
+++ b/richie/js/components/searchFilterGroupContainer/getFilterFromState.ts
@@ -1,0 +1,66 @@
+import values from 'lodash-es/values';
+
+import { filterGroupName, resourceBasedFilterGroupName } from '../../data/filterDefinitions/reducer';
+import { RootState } from '../../data/rootReducer';
+import { FilterDefinition } from '../../types/FilterDefinition';
+
+// Get (or build) a complete filter definition for `machineName` from the state, using:
+// - filterDefinitions for hardcoded filters and hardcoded props of resource based filters
+// - organizations & subjects for resource based filters
+export function getFilterFromState(state: RootState, machineName: filterGroupName): FilterDefinition {
+  // Default to empty object as it is the default value for currentQuery.facets
+  const facets = state.resources.courses &&
+                 state.resources.courses.currentQuery &&
+                 state.resources.courses.currentQuery.facets || {};
+
+  switch (machineName) {
+    // Use the facets to build the values for resource based filters
+    case 'organizations':
+    case 'subjects':
+      return {
+        ...state.filterDefinitions[machineName],
+        values: getFacetedValues(state, facets, machineName),
+      };
+
+    // Values from state are usable as-is for hardcoded filters
+    default:
+      return state.filterDefinitions[machineName];
+  }
+
+  /* tslint:disable:variable-name */
+  function getFacetedValues(
+    state_: typeof state,
+    facets_: typeof facets,
+    resourceName: resourceBasedFilterGroupName,
+  ) {
+    if (!state.resources[resourceName]) { return []; }
+
+    // We don't have the facets yet or something broke upstream: provide some filtering
+    // capabilities anyway (without counts, as we can't generate those)
+    if (!facets_[resourceName] || !Object.keys(facets_[resourceName]).length) {
+      return values(state.resources[resourceName]!.byId || {})
+        .map((organization) => ({
+          humanName: organization.name,
+          primaryKey: String(organization.id),
+        }));
+    }
+
+    return Object.keys(facets_[resourceName])
+      .map((resourceId) => ({
+        // Facet current query by this resource id (count)
+        count: facets[resourceName][resourceId],
+        // Get the resource name from the state
+        humanName: state.resources[resourceName]!.byId[resourceId].name,
+        // resourceId is already a string as it was a key on the facets.organization object
+        primaryKey: resourceId,
+      }))
+      // Sort by highest count first
+      .sort((filterValueA, filterValueB) => filterValueA.count > filterValueB.count && -1 ||
+                                            filterValueB.count > filterValueA.count && 1 ||
+                                            0,
+      );
+  }
+  /* tslint:enable */
+}
+
+export default getFilterFromState;

--- a/richie/js/data/filterDefinitions/initialState.ts
+++ b/richie/js/data/filterDefinitions/initialState.ts
@@ -1,0 +1,46 @@
+// Some of our filters are hardcoded and do not rely on any external data
+const hardcodedFilterDefinitions = {
+  language: {
+    humanName: 'Language',
+    machineName: 'language',
+    values: [
+      { primaryKey: 'en', humanName: 'English' },
+      { primaryKey: 'fr', humanName: 'French' },
+    ],
+  },
+
+  new: {
+    humanName: 'New courses',
+    machineName: 'status',
+    values: [
+      { primaryKey: 'new', humanName: 'First session'},
+    ],
+  },
+
+  status: {
+    humanName: 'Availability',
+    isDrilldown: true,
+    machineName: 'availability',
+    values: [
+      { primaryKey: 'coming_soon', humanName: 'Coming soon' },
+      { primaryKey: 'current', humanName: 'Current session' },
+      { primaryKey: 'open', humanName: 'Open, no session' },
+    ],
+  },
+};
+
+const resourceBasedFilterDefinitions = {
+  organizations: {
+    humanName: 'Organizations',
+    machineName: 'organizations',
+  },
+
+  subjects: {
+    humanName: 'Subjects',
+    machineName: 'subjects',
+  },
+};
+
+export const initialState = { ...hardcodedFilterDefinitions, ...resourceBasedFilterDefinitions };
+
+export default initialState;

--- a/richie/js/data/filterDefinitions/reducer.ts
+++ b/richie/js/data/filterDefinitions/reducer.ts
@@ -1,0 +1,28 @@
+import { FilterDefinition } from '../../types/FilterDefinition';
+import initialState from './initialState';
+
+// Hardcoded filter groups have all their data contained in this slice of state
+export type hardcodedFilterGroupName = 'language' | 'new' | 'status';
+type FilterDefinitionStateHardcoded = {
+  [key in hardcodedFilterGroupName]: FilterDefinition;
+};
+
+// Resource based filter groups are partly derived from other slice of states:
+// - the parts that are their own are stored here
+// - the derived parts are computed in mapStateToProps
+export type resourceBasedFilterGroupName = 'organizations' | 'subjects';
+type FilterDefinitionStateResourceBased = {
+  [key in resourceBasedFilterGroupName]: { humanName: string, machineName: string };
+};
+
+// Provide general types for export
+export type filterGroupName = resourceBasedFilterGroupName | hardcodedFilterGroupName;
+export type FilterDefinitionState = FilterDefinitionStateHardcoded & FilterDefinitionStateResourceBased;
+
+// This reducer's only job is to set the initial value.
+// It's also useful to to host the typings for its slice of the data.
+export const filterDefinitions = (state: FilterDefinitionState = initialState, action: { type: '' }) => {
+  return state;
+};
+
+export default filterDefinitions;

--- a/richie/js/data/rootReducer.ts
+++ b/richie/js/data/rootReducer.ts
@@ -1,10 +1,12 @@
 import { Reducer } from 'redux';
 
 import { courses, CoursesState } from './courses/reducer';
+import { filterDefinitions, FilterDefinitionState } from './filterDefinitions/reducer';
 import { organizations, OrganizationsState } from './organizations/reducer';
 import { subjects, SubjectsState } from './subjects/reducer';
 
 export interface RootState {
+  filterDefinitions: FilterDefinitionState;
   resources: {
     courses?: CoursesState;
     organizations?: OrganizationsState;
@@ -14,6 +16,7 @@ export interface RootState {
 
 export const rootReducer: Reducer<RootState> = (state, action) => {
   return {
+    filterDefinitions: filterDefinitions(state.filterDefinitions, action),
     resources: {
       courses: courses(state.resources.courses, action),
       organizations: organizations(state.resources.organizations, action),


### PR DESCRIPTION
## Purpose

This is the most basic form of the expected functionality for our frontend: let users pick a filter in the left sidebar, add it to the current search and get new, relevant search results. 

## Proposal

Build handlers for filter adding and removal in `SearchFilterGroupContainer` as it is the place where all the actionable information is gathered.

We then pass down the handlers through to `SearchFilter` which just uses them as click handlers and passes its own value back upstream.


Note: removal functionality was not included in the UI as this PR was already complicated enough as it is — and it would required us first to manage to show the active filters so they can be deactivated.

The same goes for facet management, which is separate logic: adding/removing should work the same no matter the actual filters we show.