### PR TITLE
Add prettier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,7 +437,7 @@ jobs:
             - ./node_modules
           key: v3-front-dependencies-{{ checksum "package.json" }}
 
-  lint-front:
+  lint-front-tslint:
     docker:
       - image: circleci/node:9-browsers
     working_directory: ~/richie
@@ -449,6 +449,19 @@ jobs:
       - run:
           name: Lint code with tslint
           command: yarn lint
+
+  lint-front-prettier:
+    docker:
+      - image: circleci/node:9-browsers
+    working_directory: ~/richie
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v3-front-dependencies-{{ checksum "package.json" }}
+      - run:
+          name: Lint code with prettier
+          command: yarn prettier --list-different "richie/js/**/*.+(ts|tsx|json|js|jsx)" "*.+(ts|tsx|json|js|jsx)"
 
   test-front:
     docker:
@@ -481,7 +494,13 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - lint-front:
+      - lint-front-tslint:
+          requires:
+            - build-front
+          filters:
+            tags:
+              only: /.*/
+      - lint-front-prettier:
           requires:
             - build-front
           filters:
@@ -489,7 +508,7 @@ workflows:
               only: /.*/
       - test-front:
           requires:
-            - lint-front
+            - build-front
           filters:
             tags:
               only: /.*/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+singleQuote: true
+trailingComma: all

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,19 +2,19 @@ let fs = require('fs');
 let webpack = require('webpack');
 let webpackConfig = require('./webpack.config');
 
-module.exports = function (config) {
+module.exports = function(config) {
   config.set({
-    frameworks: [ 'jasmine' ],
+    frameworks: ['jasmine'],
 
-    files: [ 'richie/**/*.spec.@(ts|tsx)' ],
+    files: ['richie/**/*.spec.@(ts|tsx)'],
 
     preprocessors: {
-      '**/*.@(ts|tsx)': [ 'webpack', 'sourcemap' ],
+      '**/*.@(ts|tsx)': ['webpack', 'sourcemap'],
     },
 
-    reporters: [ 'mocha' ],
+    reporters: ['mocha'],
 
-    browsers: [ 'Chrome' ],
+    browsers: ['Chrome'],
 
     plugins: [
       'karma-chrome-launcher',
@@ -26,15 +26,15 @@ module.exports = function (config) {
 
     // Absolutely necessary to run typescript tests
     mime: {
-      'text/x-typescript': [ 'ts', 'tsx' ],
+      'text/x-typescript': ['ts', 'tsx'],
     },
 
     webpack: {
       plugins: [
         new webpack.SourceMapDevToolPlugin({
           filename: null, // if no value is provided the sourcemap is inlined
-          test: /\.(ts|tsx|js)($|\?)/i // process .js and .ts files only
-        })
+          test: /\.(ts|tsx|js)($|\?)/i, // process .js and .ts files only
+        }),
       ],
       // Reuse our existing webpack config
       module: webpackConfig.module,
@@ -44,6 +44,6 @@ module.exports = function (config) {
     webpackMiddleware: {
       log: () => {},
       stats: 'errors-only',
-    }
+    },
   });
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "moment": "^2.20.1",
     "node-sass": "^4.7.2",
     "nodemon": "^1.14.12",
+    "prettier": "1.12.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "richie",
   "version": "0.1.0",
-  "description": "This document aims to list all needed steps to have a working `FUN CMS` installation.",
+  "description":
+    "This document aims to list all needed steps to have a working `FUN CMS` installation.",
   "main": "manage.py",
   "scripts": {
     "build": "webpack",
     "lint": "tslint -c tslint.json 'richie/js/**/*.ts'",
-    "sass": "node-sass richie/static/scss/_main.scss richie/static/css/main.css",
+    "sass":
+      "node-sass richie/static/scss/_main.scss richie/static/css/main.css",
     "test": "karma start ./karma.conf.js",
     "watch-sass": "nodemon -e scss -x 'yarn sass'"
   },

--- a/richie/js/components/courseGlimpse/courseGlimpse.spec.tsx
+++ b/richie/js/components/courseGlimpse/courseGlimpse.spec.tsx
@@ -17,7 +17,9 @@ describe('components/courseGlimpse', () => {
     const organization = {
       name: 'Some Organization',
     } as Organization;
-    const wrapper = render(<CourseGlimpse course={course} organization={organization} />);
+    const wrapper = render(
+      <CourseGlimpse course={course} organization={organization} />,
+    );
 
     expect(wrapper.html()).toContain('Course 42');
     expect(wrapper.find('img').attr('src')).toContain('/thumbs/small.png');

--- a/richie/js/components/courseGlimpse/courseGlimpse.tsx
+++ b/richie/js/components/courseGlimpse/courseGlimpse.tsx
@@ -13,16 +13,26 @@ export interface CourseGlimpseProps {
 export const CourseGlimpse = (props: CourseGlimpseProps) => {
   const { course, organization } = props;
 
-  return <div className="course-glimpse-container">
-    <div className="course-glimpse">
-      <img className="course-glimpse__image" src={'https://www.fun-mooc.fr' + course.thumbnails.small} alt=""/>
-      <div className="course-glimpse__body">
-        <div className="course-glimpse__body__title">{course.title}</div>
-        <div className="course-glimpse__body__org">{organization && organization.name || ''}</div>
+  return (
+    <div className="course-glimpse-container">
+      <div className="course-glimpse">
+        <img
+          className="course-glimpse__image"
+          src={'https://www.fun-mooc.fr' + course.thumbnails.small}
+          alt=""
+        />
+        <div className="course-glimpse__body">
+          <div className="course-glimpse__body__title">{course.title}</div>
+          <div className="course-glimpse__body__org">
+            {(organization && organization.name) || ''}
+          </div>
+        </div>
+        <div className="course-glimpse__date">
+          Starts on {moment(course.start_date, moment.ISO_8601).format('ll')}
+        </div>
       </div>
-      <div className="course-glimpse__date">Starts on {moment(course.start_date, moment.ISO_8601).format('ll')}</div>
     </div>
-  </div>;
+  );
 };
 
 export default CourseGlimpse;

--- a/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.spec.tsx
@@ -40,13 +40,18 @@ describe('components/courseGlimpseContainer', () => {
       },
     };
 
-    expect(mapStateToProps(state, { course: course43 })).toEqual({ organization: org23 });
+    expect(mapStateToProps(state, { course: course43 })).toEqual({
+      organization: org23,
+    });
   });
 
   it('mergeProps takes the organization from mapState and the course from ownProps', () => {
     const stateProps = { organization: org23 };
     const ownProps = { course: course43 };
 
-    expect(mergeProps(stateProps, null, ownProps)).toEqual({ course: course43, organization: org23 });
+    expect(mergeProps(stateProps, null, ownProps)).toEqual({
+      course: course43,
+      organization: org23,
+    });
   });
 });

--- a/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.tsx
+++ b/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.tsx
@@ -2,16 +2,24 @@ import { connect } from 'react-redux';
 
 import { RootState } from '../../data/rootReducer';
 import Course from '../../types/Course';
-import { CourseGlimpse, CourseGlimpseProps } from '../courseGlimpse/courseGlimpse';
+import {
+  CourseGlimpse,
+  CourseGlimpseProps,
+} from '../courseGlimpse/courseGlimpse';
 
 export interface CourseGlimpseContainerProps {
   course: Course;
 }
 
-export const mapStateToProps = (state: RootState, ownProps: CourseGlimpseContainerProps) => {
+export const mapStateToProps = (
+  state: RootState,
+  ownProps: CourseGlimpseContainerProps,
+) => {
   return {
-    organization: state.resources.organizations &&
-                  state.resources.organizations.byId[ownProps.course.organizations[0]] || null,
+    organization:
+      (state.resources.organizations &&
+        state.resources.organizations.byId[ownProps.course.organizations[0]]) ||
+      null,
   };
 };
 
@@ -25,6 +33,10 @@ export const mergeProps = (
   return { course, organization };
 };
 
-export const CourseGlimpseContainer = connect(mapStateToProps, null, mergeProps)(CourseGlimpse);
+export const CourseGlimpseContainer = connect(
+  mapStateToProps,
+  null,
+  mergeProps,
+)(CourseGlimpse);
 
 export default CourseGlimpseContainer;

--- a/richie/js/components/courseGlimpseList/courseGlimpseList.spec.tsx
+++ b/richie/js/components/courseGlimpseList/courseGlimpseList.spec.tsx
@@ -9,12 +9,21 @@ import CourseGlimpseList from './courseGlimpseList';
 
 describe('components/courseGlimpseList', () => {
   it('renders a list of Courses into a list of CourseGlimpses', () => {
-    const courses = [ { id: 42, title: 'course-42' }, { id: 42, title: 'course-43' } ] as Course[];
+    const courses = [
+      { id: 42, title: 'course-42' },
+      { id: 42, title: 'course-43' },
+    ] as Course[];
     const requestCourses = jasmine.createSpy('requestCourses');
-    const wrapper = shallow(<CourseGlimpseList courses={courses} requestCourses={requestCourses} />);
+    const wrapper = shallow(
+      <CourseGlimpseList courses={courses} requestCourses={requestCourses} />,
+    );
 
-    const [ course42, course43 ] = courses;
-    expect(wrapper.childAt(0).equals(<CourseGlimpseContainer course={course42} />)).toBeTruthy();
-    expect(wrapper.childAt(1).equals(<CourseGlimpseContainer course={course43} />)).toBeTruthy();
+    const [course42, course43] = courses;
+    expect(
+      wrapper.childAt(0).equals(<CourseGlimpseContainer course={course42} />),
+    ).toBeTruthy();
+    expect(
+      wrapper.childAt(1).equals(<CourseGlimpseContainer course={course43} />),
+    ).toBeTruthy();
   });
 });

--- a/richie/js/components/courseGlimpseList/courseGlimpseList.tsx
+++ b/richie/js/components/courseGlimpseList/courseGlimpseList.tsx
@@ -17,9 +17,13 @@ export class CourseGlimpseList extends React.Component<CourseGlimpseListProps> {
   render() {
     const { courses } = this.props;
 
-    return <div className="course-glimpse-list">
-      {courses.map((course) => <CourseGlimpseContainer course={course} key={course.id} />)}
-    </div>;
+    return (
+      <div className="course-glimpse-list">
+        {courses.map(course => (
+          <CourseGlimpseContainer course={course} key={course.id} />
+        ))}
+      </div>
+    );
   }
 }
 

--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
@@ -12,7 +12,8 @@ describe('components/courseGlimpseListContainer', () => {
       language: 'fr',
       organizations: [23, 31],
       session_number: 1,
-      short_description: 'Lorem ipsum dolor sit amet consectetur adipiscim elit.',
+      short_description:
+        'Lorem ipsum dolor sit amet consectetur adipiscim elit.',
       start_date: '2018-03-01T06:00:00.000Z',
       subjects: [45],
       thumbnails: {
@@ -32,7 +33,8 @@ describe('components/courseGlimpseListContainer', () => {
       language: 'fr',
       organizations: [11],
       session_number: 1,
-      short_description: 'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
+      short_description:
+        'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
       start_date: '2018-03-01T06:00:00.000Z',
       subjects: [7, 128],
       thumbnails: {
@@ -60,7 +62,7 @@ describe('components/courseGlimpseListContainer', () => {
     };
 
     expect(mapStateToProps(state)).toEqual({
-      courses: [ course44, course43 ],
+      courses: [course44, course43],
     });
   });
 });

--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.tsx
@@ -10,21 +10,29 @@ export const mapStateToProps = (state: RootState) => {
   return {
     courses:
       // Get the relevant item indexes for the current query
-      Object.keys(state.resources.courses &&
-                  state.resources.courses.currentQuery &&
-                  state.resources.courses.currentQuery.items || [])
-      // Ensure preservation of order
-      .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
-      // Get the IDs matching the indexes in the current query
-      .map((key) => state.resources.courses &&
-                    state.resources.courses.currentQuery &&
-                    state.resources.courses.currentQuery.items[key])
-      // Get the actual items matching those IDs
-      // -1 will match nothing and get filtered right below
-      .map((id = -1) => state.resources.courses &&
-                        state.resources.courses.byId[id])
-      // Drop unknown indexes or broken keys so we don't pollute the UI
-      .filter((item) => !!item),
+      Object.keys(
+        (state.resources.courses &&
+          state.resources.courses.currentQuery &&
+          state.resources.courses.currentQuery.items) ||
+          [],
+      )
+        // Ensure preservation of order
+        .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
+        // Get the IDs matching the indexes in the current query
+        .map(
+          key =>
+            state.resources.courses &&
+            state.resources.courses.currentQuery &&
+            state.resources.courses.currentQuery.items[key],
+        )
+        // Get the actual items matching those IDs
+        // -1 will match nothing and get filtered right below
+        .map(
+          (id = -1) =>
+            state.resources.courses && state.resources.courses.byId[id],
+        )
+        // Drop unknown indexes or broken keys so we don't pollute the UI
+        .filter(item => !!item),
   };
 };
 

--- a/richie/js/components/search/search.spec.tsx
+++ b/richie/js/components/search/search.spec.tsx
@@ -11,7 +11,9 @@ describe('components/search', () => {
   it('renders the filters pane and the list of courses', () => {
     const orgSpy = jasmine.createSpy('OrganizationSpy');
     const subjSpy = jasmine.createSpy('SubjectsSpy');
-    const wrapper = shallow(<Search requestOrganizations={orgSpy} requestSubjects={subjSpy} />);
+    const wrapper = shallow(
+      <Search requestOrganizations={orgSpy} requestSubjects={subjSpy} />,
+    );
 
     expect(wrapper.find(CourseGlimpseListContainer).length).toEqual(1);
     expect(wrapper.find(SearchFiltersPane).length).toEqual(1);

--- a/richie/js/components/search/search.tsx
+++ b/richie/js/components/search/search.tsx
@@ -21,14 +21,16 @@ export class Search extends React.Component<SearchProps, SearchState> {
   }
 
   render() {
-    return <div className="search">
-      <div className="search__filters">
-        <SearchFiltersPane />
+    return (
+      <div className="search">
+        <div className="search__filters">
+          <SearchFiltersPane />
+        </div>
+        <div className="search__results">
+          <CourseGlimpseListContainer />
+        </div>
       </div>
-      <div className="search__results">
-        <CourseGlimpseListContainer />
-      </div>
-    </div>;
+    );
   }
 }
 

--- a/richie/js/components/searchContainer/searchContainer.tsx
+++ b/richie/js/components/searchContainer/searchContainer.tsx
@@ -5,13 +5,12 @@ import { getResourceList } from '../../data/genericSideEffects/getResourceList/a
 import { Search } from '../search/search';
 
 const mapDispatchToProps = {
-  requestOrganizations: partial(getResourceList, 'organizations', { limit: 999 }),
+  requestOrganizations: partial(getResourceList, 'organizations', {
+    limit: 999,
+  }),
   requestSubjects: partial(getResourceList, 'subjects', { limit: 999 }),
 };
 
-export const SearchContainer = connect(
-  null,
-  mapDispatchToProps,
-)(Search);
+export const SearchContainer = connect(null, mapDispatchToProps)(Search);
 
 export default SearchContainer;

--- a/richie/js/components/searchFilter/searchFilter.spec.tsx
+++ b/richie/js/components/searchFilter/searchFilter.spec.tsx
@@ -8,8 +8,12 @@ import SearchFilter from './searchFilter';
 describe('components/searchFilter', () => {
   it('renders the name of the filter', () => {
     const addFilter = jasmine.createSpy('addFilter');
-    const wrapper =
-      shallow(<SearchFilter addFilter={addFilter} filter={{ primaryKey: '42', humanName: 'Human name'}} />);
+    const wrapper = shallow(
+      <SearchFilter
+        addFilter={addFilter}
+        filter={{ primaryKey: '42', humanName: 'Human name' }}
+      />,
+    );
 
     expect(wrapper.text()).toContain('Human name');
   });

--- a/richie/js/components/searchFilter/searchFilter.tsx
+++ b/richie/js/components/searchFilter/searchFilter.tsx
@@ -10,13 +10,19 @@ export interface SearchFilterProps {
 export const SearchFilter = (props: SearchFilterProps) => {
   const { filter, addFilter } = props;
 
-  return <button className="search-filter" onClick={() => addFilter(filter.primaryKey)}>
-    {filter.humanName}
-    {filter.count || filter.count === 0 ?
-      <span className="search-filter__count">{filter.count}</span> :
-      ''
-    }
-  </button>;
+  return (
+    <button
+      className="search-filter"
+      onClick={() => addFilter(filter.primaryKey)}
+    >
+      {filter.humanName}
+      {filter.count || filter.count === 0 ? (
+        <span className="search-filter__count">{filter.count}</span>
+      ) : (
+        ''
+      )}
+    </button>
+  );
 };
 
 export default SearchFilter;

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
@@ -17,7 +17,13 @@ describe('components/searchFilterGroup', () => {
       machineName: 'example-filter',
       values: [],
     } as FilterDefinition;
-    const wrapper = shallow(<SearchFilterGroup addFilter={addFilter} filter={filter} removeFilter={removeFilter} />);
+    const wrapper = shallow(
+      <SearchFilterGroup
+        addFilter={addFilter}
+        filter={filter}
+        removeFilter={removeFilter}
+      />,
+    );
 
     expect(wrapper.text()).toContain('Example filter');
   });
@@ -25,9 +31,18 @@ describe('components/searchFilterGroup', () => {
   it('renders the list of filter values into a list of SearchFilters', () => {
     const filter = {
       humanName: 'Example filter',
-      values: [ { primaryKey: 'value-1', humanName: 'Value One' }, { primaryKey: 'value-2', humanName: 'Value Two' } ],
+      values: [
+        { primaryKey: 'value-1', humanName: 'Value One' },
+        { primaryKey: 'value-2', humanName: 'Value Two' },
+      ],
     } as FilterDefinition;
-    const wrapper = shallow(<SearchFilterGroup addFilter={addFilter} filter={filter} removeFilter={removeFilter} />);
+    const wrapper = shallow(
+      <SearchFilterGroup
+        addFilter={addFilter}
+        filter={filter}
+        removeFilter={removeFilter}
+      />,
+    );
 
     expect(wrapper.find(SearchFilter).length).toEqual(2);
   });

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
@@ -12,12 +12,20 @@ export interface SearchFilterGroupProps {
 export const SearchFilterGroup = (props: SearchFilterGroupProps) => {
   const { humanName, values } = props.filter;
 
-  return <div className="search-filter-group">
-    <h3 className="search-filter-group__title">{humanName}</h3>
-    <div className="search-filter-group__list">
-      {values.map((value) => <SearchFilter filter={value} key={value.primaryKey} addFilter={props.addFilter} /> )}
+  return (
+    <div className="search-filter-group">
+      <h3 className="search-filter-group__title">{humanName}</h3>
+      <div className="search-filter-group__list">
+        {values.map(value => (
+          <SearchFilter
+            filter={value}
+            key={value.primaryKey}
+            addFilter={props.addFilter}
+          />
+        ))}
+      </div>
     </div>
-  </div>;
+  );
 };
 
 export default SearchFilterGroup;

--- a/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.spec.ts
+++ b/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.spec.ts
@@ -7,18 +7,25 @@ describe('components/searchFilterGroupContainer/computeNewFilterValue', () => {
     const addFilter = partial(computeNewFilterValue, 'add');
 
     it('returns an array with the value when the existing value was null | undefined', () => {
-      expect(addFilter(null, 42)).toEqual([ 42 ]);
-      expect(addFilter(undefined, 'new_value')).toEqual([ 'new_value' ]);
+      expect(addFilter(null, 42)).toEqual([42]);
+      expect(addFilter(undefined, 'new_value')).toEqual(['new_value']);
     });
 
     it('returns an array with the existing value and the new value when the existing value was a primitive', () => {
-      expect(addFilter(43, 86)).toEqual([ 43, 86 ]);
-      expect(addFilter('existing_value', 'incoming_value')).toEqual([ 'existing_value', 'incoming_value' ]);
+      expect(addFilter(43, 86)).toEqual([43, 86]);
+      expect(addFilter('existing_value', 'incoming_value')).toEqual([
+        'existing_value',
+        'incoming_value',
+      ]);
     });
 
     it('adds the new value at the end of the existing value if the existing value was an array', () => {
-      expect(addFilter([ 44, 88 ], 176)).toEqual([ 44, 88, 176 ]);
-      expect(addFilter([ 'val_A', 'val_B' ], 'val_C')).toEqual([ 'val_A', 'val_B', 'val_C' ]);
+      expect(addFilter([44, 88], 176)).toEqual([44, 88, 176]);
+      expect(addFilter(['val_A', 'val_B'], 'val_C')).toEqual([
+        'val_A',
+        'val_B',
+        'val_C',
+      ]);
     });
   });
 
@@ -37,17 +44,19 @@ describe('components/searchFilterGroupContainer/computeNewFilterValue', () => {
 
     it('returns the existing value when the existing value was not the passed value', () => {
       expect(removeFilter(42, 84)).toEqual(42);
-      expect(removeFilter('existing_value', 'imaginary_value')).toEqual('existing_value');
+      expect(removeFilter('existing_value', 'imaginary_value')).toEqual(
+        'existing_value',
+      );
     });
 
     it('removes the passed value from the existing value when the existing value was an array', () => {
-      expect(removeFilter([ 42, 84 ], 42)).toEqual([ 84 ]);
-      expect(removeFilter([ 'val_A', 'val_B' ], 'val_B')).toEqual([ 'val_A' ]);
+      expect(removeFilter([42, 84], 42)).toEqual([84]);
+      expect(removeFilter(['val_A', 'val_B'], 'val_B')).toEqual(['val_A']);
     });
 
     it('returns null when the passed value was the only value in the existing value as an array', () => {
-      expect(removeFilter([ 43 ], 43)).toEqual(null);
-      expect(removeFilter([ 'val_B' ], 'val_B')).toEqual(null);
+      expect(removeFilter([43], 43)).toEqual(null);
+      expect(removeFilter(['val_B'], 'val_B')).toEqual(null);
     });
   });
 });

--- a/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.ts
+++ b/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.ts
@@ -11,7 +11,7 @@ export function computeNewFilterValue(
   if (!existingValue) {
     return {
       // ADD: Make an array with the existing value
-      add: () => [ relevantValue ],
+      add: () => [relevantValue],
       // REMOVE: There's nothing that could possibly removed, return null
       remove: () => null,
     }[action]();
@@ -21,20 +21,25 @@ export function computeNewFilterValue(
   if (typeof existingValue === 'string' || typeof existingValue === 'number') {
     return {
       // ADD: Make an array with the existing value and the new one
-      add: () => [ existingValue, relevantValue ],
+      add: () => [existingValue, relevantValue],
       // REMOVE:
       // - Return nothing if we had to drop the existing value we had
       // - Keep the existing value if it's not the one we needed to drop
-      remove: () => existingValue === relevantValue ? null : existingValue,
+      remove: () => (existingValue === relevantValue ? null : existingValue),
     }[action]();
   }
 
   // The existing value is an array of strings or numbers (see function signature)
   return {
     // ADD: Just push the new value into our existing array of values
-    add: () => [ ...existingValue as Array<string | number>, relevantValue ],
+    add: () => [...(existingValue as Array<string | number>), relevantValue],
     // REMOVE: Return the existing array of values without the one we needed to remove
-    remove: () => nullEmptyArray((existingValue as Array<string | number>).filter((v) => v !== relevantValue)),
+    remove: () =>
+      nullEmptyArray(
+        (existingValue as Array<string | number>).filter(
+          v => v !== relevantValue,
+        ),
+      ),
   }[action]();
 
   function nullEmptyArray(array: Array<string | number>) {

--- a/richie/js/components/searchFilterGroupContainer/getFilterFromState.spec.ts
+++ b/richie/js/components/searchFilterGroupContainer/getFilterFromState.spec.ts
@@ -11,9 +11,7 @@ describe('components/searchFilterGroupContainer/getFilterFromState', () => {
         new: {
           humanName: 'New courses',
           machineName: 'status',
-          values: [
-            { primaryKey: 'new', humanName: 'First session'},
-          ],
+          values: [{ primaryKey: 'new', humanName: 'First session' }],
         },
         organizations: {} as FilterDefinition,
         status: {} as FilterDefinition,
@@ -21,13 +19,10 @@ describe('components/searchFilterGroupContainer/getFilterFromState', () => {
       },
       resources: {},
     };
-    expect(getFilterFromState(state, 'new'))
-    .toEqual({
+    expect(getFilterFromState(state, 'new')).toEqual({
       humanName: 'New courses',
       machineName: 'status',
-      values: [
-        { primaryKey: 'new', humanName: 'First session'},
-      ],
+      values: [{ primaryKey: 'new', humanName: 'First session' }],
     });
   });
 
@@ -63,8 +58,7 @@ describe('components/searchFilterGroupContainer/getFilterFromState', () => {
       },
     };
 
-    expect(getFilterFromState(state, 'organizations'))
-    .toEqual({
+    expect(getFilterFromState(state, 'organizations')).toEqual({
       humanName: 'Organizations',
       machineName: 'organizations',
       values: [
@@ -98,8 +92,7 @@ describe('components/searchFilterGroupContainer/getFilterFromState', () => {
       },
     };
 
-    expect(getFilterFromState(state, 'organizations'))
-    .toEqual({
+    expect(getFilterFromState(state, 'organizations')).toEqual({
       humanName: 'Organizations',
       machineName: 'organizations',
       values: [

--- a/richie/js/components/searchFilterGroupContainer/getFilterFromState.ts
+++ b/richie/js/components/searchFilterGroupContainer/getFilterFromState.ts
@@ -1,17 +1,25 @@
 import values from 'lodash-es/values';
 
-import { filterGroupName, resourceBasedFilterGroupName } from '../../data/filterDefinitions/reducer';
+import {
+  filterGroupName,
+  resourceBasedFilterGroupName,
+} from '../../data/filterDefinitions/reducer';
 import { RootState } from '../../data/rootReducer';
 import { FilterDefinition } from '../../types/FilterDefinition';
 
 // Get (or build) a complete filter definition for `machineName` from the state, using:
 // - filterDefinitions for hardcoded filters and hardcoded props of resource based filters
 // - organizations & subjects for resource based filters
-export function getFilterFromState(state: RootState, machineName: filterGroupName): FilterDefinition {
+export function getFilterFromState(
+  state: RootState,
+  machineName: filterGroupName,
+): FilterDefinition {
   // Default to empty object as it is the default value for currentQuery.facets
-  const facets = state.resources.courses &&
-                 state.resources.courses.currentQuery &&
-                 state.resources.courses.currentQuery.facets || {};
+  const facets =
+    (state.resources.courses &&
+      state.resources.courses.currentQuery &&
+      state.resources.courses.currentQuery.facets) ||
+    {};
 
   switch (machineName) {
     // Use the facets to build the values for resource based filters
@@ -33,32 +41,39 @@ export function getFilterFromState(state: RootState, machineName: filterGroupNam
     facets_: typeof facets,
     resourceName: resourceBasedFilterGroupName,
   ) {
-    if (!state.resources[resourceName]) { return []; }
+    if (!state.resources[resourceName]) {
+      return [];
+    }
 
     // We don't have the facets yet or something broke upstream: provide some filtering
     // capabilities anyway (without counts, as we can't generate those)
     if (!facets_[resourceName] || !Object.keys(facets_[resourceName]).length) {
-      return values(state.resources[resourceName]!.byId || {})
-        .map((organization) => ({
+      return values(state.resources[resourceName]!.byId || {}).map(
+        organization => ({
           humanName: organization.name,
           primaryKey: String(organization.id),
-        }));
+        }),
+      );
     }
 
-    return Object.keys(facets_[resourceName])
-      .map((resourceId) => ({
-        // Facet current query by this resource id (count)
-        count: facets[resourceName][resourceId],
-        // Get the resource name from the state
-        humanName: state.resources[resourceName]!.byId[resourceId].name,
-        // resourceId is already a string as it was a key on the facets.organization object
-        primaryKey: resourceId,
-      }))
-      // Sort by highest count first
-      .sort((filterValueA, filterValueB) => filterValueA.count > filterValueB.count && -1 ||
-                                            filterValueB.count > filterValueA.count && 1 ||
-                                            0,
-      );
+    return (
+      Object.keys(facets_[resourceName])
+        .map(resourceId => ({
+          // Facet current query by this resource id (count)
+          count: facets[resourceName][resourceId],
+          // Get the resource name from the state
+          humanName: state.resources[resourceName]!.byId[resourceId].name,
+          // resourceId is already a string as it was a key on the facets.organization object
+          primaryKey: resourceId,
+        }))
+        // Sort by highest count first
+        .sort(
+          (filterValueA, filterValueB) =>
+            (filterValueA.count > filterValueB.count && -1) ||
+            (filterValueB.count > filterValueA.count && 1) ||
+            0,
+        )
+    );
   }
   /* tslint:enable */
 }

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
@@ -7,14 +7,19 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
 
   beforeEach(() => {
     dispatch = jasmine.createSpy('dispatch');
-    spyOn(filterComputer, 'computeNewFilterValue').and.returnValue('some filter value');
+    spyOn(filterComputer, 'computeNewFilterValue').and.returnValue(
+      'some filter value',
+    );
   });
 
   describe('addFilter', () => {
     describe('when the filter is drilldown', () => {
       it('dispatches the action with params -> the current params with the new filter added on', () => {
         const props = mergeProps(
-          { currentParams: { limit: 20, offset: 0 }, filter: { isDrilldown: true } as FilterDefinition },
+          {
+            currentParams: { limit: 20, offset: 0 },
+            filter: { isDrilldown: true } as FilterDefinition,
+          },
           { dispatch },
           { machineName: 'new' },
         );
@@ -49,7 +54,10 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
     describe('when the filter is not drilldown', () => {
       it('delegates to computeNewFilterValue', () => {
         const props = mergeProps(
-          { currentParams: { limit: 20, offset: 0 }, filter: {} as FilterDefinition },
+          {
+            currentParams: { limit: 20, offset: 0 },
+            filter: {} as FilterDefinition,
+          },
           { dispatch },
           { machineName: 'new' },
         );
@@ -124,7 +132,10 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
     describe('when the filter is not drilldown', () => {
       it('delegates to computeNewFilterValue', () => {
         const props = mergeProps(
-          { currentParams: { limit: 20, offset: 0 }, filter: {} as FilterDefinition },
+          {
+            currentParams: { limit: 20, offset: 0 },
+            filter: {} as FilterDefinition,
+          },
           { dispatch },
           { machineName: 'new' },
         );

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
@@ -1,11 +1,17 @@
 import { connect, Dispatch } from 'react-redux';
 
-import { filterGroupName, resourceBasedFilterGroupName } from '../../data/filterDefinitions/reducer';
+import {
+  filterGroupName,
+  resourceBasedFilterGroupName,
+} from '../../data/filterDefinitions/reducer';
 import { ResourceListStateParams } from '../../data/genericReducers/resourceList/resourceList';
 import { getResourceList } from '../../data/genericSideEffects/getResourceList/actions';
 import { RootState } from '../../data/rootReducer';
 import { API_LIST_DEFAULT_PARAMS as defaultParams } from '../../settings.json';
-import { SearchFilterGroup, SearchFilterGroupProps} from '../searchFilterGroup/searchFilterGroup';
+import {
+  SearchFilterGroup,
+  SearchFilterGroupProps,
+} from '../searchFilterGroup/searchFilterGroup';
 import { computeNewFilterValue } from './computeNewFilterValue';
 import { getFilterFromState } from './getFilterFromState';
 
@@ -13,41 +19,70 @@ export interface SearchFilterGroupContainerProps {
   machineName: filterGroupName;
 }
 
-export const mapStateToProps = (state: RootState, { machineName }: SearchFilterGroupContainerProps) => ({
-  currentParams: state.resources.courses &&
-                 state.resources.courses.currentQuery &&
-                 state.resources.courses.currentQuery.params || defaultParams,
+export const mapStateToProps = (
+  state: RootState,
+  { machineName }: SearchFilterGroupContainerProps,
+) => ({
+  currentParams:
+    (state.resources.courses &&
+      state.resources.courses.currentQuery &&
+      state.resources.courses.currentQuery.params) ||
+    defaultParams,
   filter: getFilterFromState(state, machineName),
 });
 
 export const mergeProps = (
-  { currentParams, filter }: { currentParams: ResourceListStateParams, filter: SearchFilterGroupProps['filter'] },
+  {
+    currentParams,
+    filter,
+  }: {
+    currentParams: ResourceListStateParams;
+    filter: SearchFilterGroupProps['filter'];
+  },
   { dispatch }: { dispatch: Dispatch<RootState> },
   { machineName }: SearchFilterGroupContainerProps,
 ) => ({
-  addFilter: (filterValue: string) => dispatch(getResourceList('courses', {
-    ...currentParams,
-    [machineName]: filter.isDrilldown ?
-      // Drilldown filters only support one value at a time
-      filterValue :
-      // For other filters use the standard computation
-      computeNewFilterValue('add', currentParams[machineName], filterValue),
-  })),
+  addFilter: (filterValue: string) =>
+    dispatch(
+      getResourceList('courses', {
+        ...currentParams,
+        [machineName]: filter.isDrilldown
+          ? // Drilldown filters only support one value at a time
+            filterValue
+          : // For other filters use the standard computation
+            computeNewFilterValue(
+              'add',
+              currentParams[machineName],
+              filterValue,
+            ),
+      }),
+    ),
   filter,
-  removeFilter: (filterValue: string) => dispatch(getResourceList('courses', {
-    ...currentParams,
-    [machineName]: filter.isDrilldown ?
-      // Drilldown filters only support one value at a time
-      (filterValue === currentParams[machineName] ?
-        // Remove the value if it matches current value
-        null :
-        // Don't remove a non matching existing value
-        currentParams[machineName] || null) :
-      // For other filters use the standard computation
-      computeNewFilterValue('remove', currentParams[machineName], filterValue),
-  })),
+  removeFilter: (filterValue: string) =>
+    dispatch(
+      getResourceList('courses', {
+        ...currentParams,
+        [machineName]: filter.isDrilldown
+          ? // Drilldown filters only support one value at a time
+            filterValue === currentParams[machineName]
+            ? // Remove the value if it matches current value
+              null
+            : // Don't remove a non matching existing value
+              currentParams[machineName] || null
+          : // For other filters use the standard computation
+            computeNewFilterValue(
+              'remove',
+              currentParams[machineName],
+              filterValue,
+            ),
+      }),
+    ),
 });
 
-export const SearchFilterGroupContainer = connect(mapStateToProps, null!, mergeProps)(SearchFilterGroup);
+export const SearchFilterGroupContainer = connect(
+  mapStateToProps,
+  null!,
+  mergeProps,
+)(SearchFilterGroup);
 
 export default SearchFilterGroupContainer;

--- a/richie/js/components/searchFiltersPane/searchFiltersPane.tsx
+++ b/richie/js/components/searchFiltersPane/searchFiltersPane.tsx
@@ -3,14 +3,16 @@ import * as React from 'react';
 import SearchFilterGroupContainer from '../searchFilterGroupContainer/searchFilterGroupContainer';
 
 export const SearchFiltersPane = (props: {}) => {
-  return <div className="search-filters-pane">
-    <h2 className="search-filters-pane__title">Filter results</h2>
-    <SearchFilterGroupContainer machineName="new" />
-    <SearchFilterGroupContainer machineName="status" />
-    <SearchFilterGroupContainer machineName="subjects" />
-    <SearchFilterGroupContainer machineName="organizations" />
-    <SearchFilterGroupContainer machineName="language" />
-  </div>;
+  return (
+    <div className="search-filters-pane">
+      <h2 className="search-filters-pane__title">Filter results</h2>
+      <SearchFilterGroupContainer machineName="new" />
+      <SearchFilterGroupContainer machineName="status" />
+      <SearchFilterGroupContainer machineName="subjects" />
+      <SearchFilterGroupContainer machineName="organizations" />
+      <SearchFilterGroupContainer machineName="language" />
+    </div>
+  );
 };
 
 export default SearchFiltersPane;

--- a/richie/js/data/configureStore.ts
+++ b/richie/js/data/configureStore.ts
@@ -10,9 +10,7 @@ export default function configureStore(preloadedState: RootState) {
   const store = createStore(
     rootReducer,
     preloadedState,
-    applyMiddleware(
-      sagaMiddleware,
-    ),
+    applyMiddleware(sagaMiddleware),
   );
 
   sagaMiddleware.run(rootSaga);

--- a/richie/js/data/courses/reducer.spec.ts
+++ b/richie/js/data/courses/reducer.spec.ts
@@ -29,7 +29,8 @@ describe('data/courses reducer', () => {
     language: 'fr',
     organizations: [11],
     session_number: 1,
-    short_description: 'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
+    short_description:
+      'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
     start_date: '2018-03-01T06:00:00.000Z',
     subjects: [7, 128],
     thumbnails: {
@@ -47,30 +48,36 @@ describe('data/courses reducer', () => {
 
   it('returns the state as is when called with an unknown action', () => {
     const previousState = {
-      byId: { 43: course43  },
+      byId: { 43: course43 },
     };
-    expect(coursesReducer(previousState, { type: 'TODO_ADD' })).toEqual(previousState);
+    expect(coursesReducer(previousState, { type: 'TODO_ADD' })).toEqual(
+      previousState,
+    );
   });
 
   describe('resourceById', () => {
     it('drops actions that do not match the resourceName', () => {
-      const previousState = { byId: { 43: course43  } };
+      const previousState = { byId: { 43: course43 } };
 
-      expect(coursesReducer(previousState, {
-        resource: course44,
-        resourceName: 'subjects',
-        type: 'RESOURCE_ADD',
-      })).toEqual(previousState);
+      expect(
+        coursesReducer(previousState, {
+          resource: course44,
+          resourceName: 'subjects',
+          type: 'RESOURCE_ADD',
+        }),
+      ).toEqual(previousState);
     });
 
     it('uses actions that match the resourceName', () => {
-      const previousState = { byId: { 43: course43  } };
+      const previousState = { byId: { 43: course43 } };
 
-      expect(coursesReducer(previousState, {
-        resource: course44,
-        resourceName: 'courses',
-        type: 'RESOURCE_ADD',
-      })).toEqual({ byId: { 43: course43, 44: course44 } });
+      expect(
+        coursesReducer(previousState, {
+          resource: course44,
+          resourceName: 'courses',
+          type: 'RESOURCE_ADD',
+        }),
+      ).toEqual({ byId: { 43: course43, 44: course44 } });
     });
   });
 });

--- a/richie/js/data/courses/reducer.ts
+++ b/richie/js/data/courses/reducer.ts
@@ -11,30 +11,38 @@ import {
   initialState as resourceByIdInit,
   ResourceByIdState,
 } from '../genericReducers/resourceById/resourceById';
-import { currentQuery, ResourceListState } from '../genericReducers/resourceList/resourceList';
+import {
+  currentQuery,
+  ResourceListState,
+} from '../genericReducers/resourceList/resourceList';
 import { ResourceListGetSuccess } from '../genericSideEffects/getResourceList/actions';
 
 const initialState = { ...resourceByIdInit };
 
-export type CoursesState = Maybe<ResourceByIdState<Course> & ResourceListState<Course>>;
+export type CoursesState = Maybe<
+  ResourceByIdState<Course> & ResourceListState<Course>
+>;
 
 export const courses: Reducer<CoursesState> = (
   state: CoursesState = initialState,
   action?: ResourceAdd<Course> | ResourceListGetSuccess<Course> | { type: '' },
 ) => {
-  if (!action) { return state; } // Compiler needs help
+  if (!action) {
+    return state;
+  } // Compiler needs help
 
   // Discriminate resource related actions by resource name
-  if (get(action, 'resourceName') &&
-      get(action, 'resourceName') !== 'courses'
+  if (
+    get(action, 'resourceName') &&
+    get(action, 'resourceName') !== 'courses'
   ) {
     return state;
   }
 
-  return flow([
-    partialRight(byId, action),
-    partialRight(currentQuery, action),
-  ])(state, action);
+  return flow([partialRight(byId, action), partialRight(currentQuery, action)])(
+    state,
+    action,
+  );
 };
 
 export default courses;

--- a/richie/js/data/filterDefinitions/initialState.ts
+++ b/richie/js/data/filterDefinitions/initialState.ts
@@ -12,9 +12,7 @@ const hardcodedFilterDefinitions = {
   new: {
     humanName: 'New courses',
     machineName: 'status',
-    values: [
-      { primaryKey: 'new', humanName: 'First session'},
-    ],
+    values: [{ primaryKey: 'new', humanName: 'First session' }],
   },
 
   status: {
@@ -41,6 +39,9 @@ const resourceBasedFilterDefinitions = {
   },
 };
 
-export const initialState = { ...hardcodedFilterDefinitions, ...resourceBasedFilterDefinitions };
+export const initialState = {
+  ...hardcodedFilterDefinitions,
+  ...resourceBasedFilterDefinitions,
+};
 
 export default initialState;

--- a/richie/js/data/filterDefinitions/reducer.ts
+++ b/richie/js/data/filterDefinitions/reducer.ts
@@ -4,7 +4,7 @@ import initialState from './initialState';
 // Hardcoded filter groups have all their data contained in this slice of state
 export type hardcodedFilterGroupName = 'language' | 'new' | 'status';
 type FilterDefinitionStateHardcoded = {
-  [key in hardcodedFilterGroupName]: FilterDefinition;
+  [key in hardcodedFilterGroupName]: FilterDefinition
 };
 
 // Resource based filter groups are partly derived from other slice of states:
@@ -12,16 +12,25 @@ type FilterDefinitionStateHardcoded = {
 // - the derived parts are computed in mapStateToProps
 export type resourceBasedFilterGroupName = 'organizations' | 'subjects';
 type FilterDefinitionStateResourceBased = {
-  [key in resourceBasedFilterGroupName]: { humanName: string, machineName: string };
+  [key in resourceBasedFilterGroupName]: {
+    humanName: string;
+    machineName: string;
+  }
 };
 
 // Provide general types for export
-export type filterGroupName = resourceBasedFilterGroupName | hardcodedFilterGroupName;
-export type FilterDefinitionState = FilterDefinitionStateHardcoded & FilterDefinitionStateResourceBased;
+export type filterGroupName =
+  | resourceBasedFilterGroupName
+  | hardcodedFilterGroupName;
+export type FilterDefinitionState = FilterDefinitionStateHardcoded &
+  FilterDefinitionStateResourceBased;
 
 // This reducer's only job is to set the initial value.
 // It's also useful to to host the typings for its slice of the data.
-export const filterDefinitions = (state: FilterDefinitionState = initialState, action: { type: '' }) => {
+export const filterDefinitions = (
+  state: FilterDefinitionState = initialState,
+  action: { type: '' },
+) => {
   return state;
 };
 

--- a/richie/js/data/genericReducers/resourceById/actions.ts
+++ b/richie/js/data/genericReducers/resourceById/actions.ts
@@ -8,7 +8,10 @@ export interface ResourceAdd<R extends Resource> {
   resource: R;
 }
 
-export function addResource(resourceName: keyof RootState['resources'], resource: Resource): ResourceAdd<Resource> {
+export function addResource(
+  resourceName: keyof RootState['resources'],
+  resource: Resource,
+): ResourceAdd<Resource> {
   return {
     resource,
     resourceName,

--- a/richie/js/data/genericReducers/resourceById/resourceById.spec.ts
+++ b/richie/js/data/genericReducers/resourceById/resourceById.spec.ts
@@ -20,39 +20,47 @@ describe('data/genericReducers/resourceById reducer', () => {
   };
 
   it('returns an empty state for initialization', () => {
-    expect(resourceByIdReducer({ byId: {} }, { type: '' })).toEqual({ byId: {} });
+    expect(resourceByIdReducer({ byId: {} }, { type: '' })).toEqual({
+      byId: {},
+    });
   });
 
   it('returns the state as is when called with an unknown action', () => {
     const previousState = {
-      byId: { 43: subj43  },
+      byId: { 43: subj43 },
     };
-    expect(resourceByIdReducer(previousState, { type: '' })).toEqual(previousState);
+    expect(resourceByIdReducer(previousState, { type: '' })).toEqual(
+      previousState,
+    );
   });
 
   describe('RESOURCE_ADD', () => {
     it('adds the subject to the state when called with RESOURCE', () => {
       const previousState = {
-        byId: { 43: subj43  },
+        byId: { 43: subj43 },
       };
-      expect(resourceByIdReducer(previousState, {
-        resource: subj44,
-        resourceName: 'subjects',
-        type: 'RESOURCE_ADD',
-      })).toEqual({ byId: { 43: subj43, 44: subj44 } });
+      expect(
+        resourceByIdReducer(previousState, {
+          resource: subj44,
+          resourceName: 'subjects',
+          type: 'RESOURCE_ADD',
+        }),
+      ).toEqual({ byId: { 43: subj43, 44: subj44 } });
     });
   });
 
   describe('RESOURCE_MULTIPLE_ADD', () => {
     it('adds several subjects at once', () => {
       const previousState = {
-        byId: { 43: subj43  },
+        byId: { 43: subj43 },
       };
-      expect(resourceByIdReducer(previousState, {
-        resourceName: 'subjects',
-        resources: [ subj44, subj45 ],
-        type: 'RESOURCE_MULTIPLE_ADD',
-      })).toEqual({ byId: { 43: subj43, 44: subj44, 45: subj45 } });
+      expect(
+        resourceByIdReducer(previousState, {
+          resourceName: 'subjects',
+          resources: [subj44, subj45],
+          type: 'RESOURCE_MULTIPLE_ADD',
+        }),
+      ).toEqual({ byId: { 43: subj43, 44: subj44, 45: subj45 } });
     });
   });
 });

--- a/richie/js/data/genericReducers/resourceById/resourceById.ts
+++ b/richie/js/data/genericReducers/resourceById/resourceById.ts
@@ -18,8 +18,12 @@ export function byId<R extends Resource>(
   action: ResourceAdd<R> | ResourceMultipleAdd<R> | { type: '' },
 ): ResourceByIdState<R> {
   // Initialize the state to an empty version of itself
-  if (!state) { state = initialState; }
-  if (!action) { return state; } // Compiler needs help
+  if (!state) {
+    state = initialState;
+  }
+  if (!action) {
+    return state;
+  } // Compiler needs help
 
   switch (action.type) {
     // Add a single record to our state
@@ -32,14 +36,17 @@ export function byId<R extends Resource>(
         },
       };
 
-      case 'RESOURCE_MULTIPLE_ADD':
-        return {
-          ...state,
-          byId: {
-            ...state.byId,
-            ...action.resources.reduce((acc, resource) => ({ ...acc, [resource.id]: resource }), {}),
-          },
-        };
+    case 'RESOURCE_MULTIPLE_ADD':
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          ...action.resources.reduce(
+            (acc, resource) => ({ ...acc, [resource.id]: resource }),
+            {},
+          ),
+        },
+      };
   }
 
   return state;

--- a/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.spec.ts
@@ -29,7 +29,8 @@ describe('data/genericReducers/resourceList reducer', () => {
     language: 'fr',
     organizations: [11],
     session_number: 1,
-    short_description: 'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
+    short_description:
+      'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
     start_date: '2018-03-01T06:00:00.000Z',
     subjects: [7, 128],
     thumbnails: {
@@ -44,27 +45,26 @@ describe('data/genericReducers/resourceList reducer', () => {
   describe('RESOURCE_LIST_GET_SUCCESS', () => {
     it('creates a new query when there is none', () => {
       const previousState = {};
-      expect(currentQuery(
-        previousState,
-        {
+      expect(
+        currentQuery(previousState, {
           apiResponse: {
             meta: { limit: 12, offset: 2, total_count: 4 },
-            objects: [ course43, course44 ],
+            objects: [course43, course44],
           },
           params: { limit: 12, offset: 2 },
           resourceName: 'courses',
           type: 'RESOURCE_LIST_GET_SUCCESS',
-        },
-      ))
-      // No facets in the apiResponse: we get an empty object in the state
-      .toEqual({
-        currentQuery: {
-          facets: {},
-          items: { 2: 43, 3: 44 },
-          params: { limit: 12, offset: 2 },
-          total_count: 4,
-        },
-      });
+        }),
+      )
+        // No facets in the apiResponse: we get an empty object in the state
+        .toEqual({
+          currentQuery: {
+            facets: {},
+            items: { 2: 43, 3: 44 },
+            params: { limit: 12, offset: 2 },
+            total_count: 4,
+          },
+        });
     });
 
     it('replaces the existing query if the new one has different params', () => {
@@ -76,20 +76,18 @@ describe('data/genericReducers/resourceList reducer', () => {
           total_count: 4,
         },
       };
-      expect(currentQuery(
-        previousState,
-        {
+      expect(
+        currentQuery(previousState, {
           apiResponse: {
             facets: { organizations: { 11: 1, 23: 1, 31: 1 } },
             meta: { limit: 2, offset: 0, total_count: 240 },
-            objects: [ course44, course43 ],
+            objects: [course44, course43],
           },
           params: { limit: 2, match: 'some query', offset: 0 },
           resourceName: 'courses',
           type: 'RESOURCE_LIST_GET_SUCCESS',
-        },
-      ))
-      .toEqual({
+        }),
+      ).toEqual({
         currentQuery: {
           // Facets are copied over on the state as-is
           facets: { organizations: { 11: 1, 23: 1, 31: 1 } },

--- a/richie/js/data/genericReducers/resourceList/resourceList.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.ts
@@ -1,14 +1,21 @@
 import get from 'lodash-es/get';
 
 import { API_LIST_DEFAULT_PARAMS as defaultParams } from '../../../settings.json';
-import { APIListCommonRequestParams, APIResponseListFacets } from '../../../types/api';
+import {
+  APIListCommonRequestParams,
+  APIResponseListFacets,
+} from '../../../types/api';
 import Resource from '../../../types/Resource';
-import { ResourceListGet, ResourceListGetSuccess } from '../../genericSideEffects/getResourceList/actions';
+import {
+  ResourceListGet,
+  ResourceListGetSuccess,
+} from '../../genericSideEffects/getResourceList/actions';
 
 export const initialState = {};
 
-export type ResourceListStateParams = APIListCommonRequestParams &
-  { [key: string]: string | number | null | Array<string | number> };
+export type ResourceListStateParams = APIListCommonRequestParams & {
+  [key: string]: string | number | null | Array<string | number>;
+};
 
 export interface ResourceListState<R extends Resource> {
   currentQuery?: {
@@ -27,15 +34,24 @@ export function currentQuery<R extends Resource>(
   action: ResourceListGetSuccess<R> | { type: '' },
 ): ResourceListState<Resource> {
   // Initialize the state to an empty version of itself
-  if (!state) { state = initialState; }
-  if (!action) { return state; } // Compiler needs help
+  if (!state) {
+    state = initialState;
+  }
+  if (!action) {
+    return state;
+  } // Compiler needs help
 
   switch (action.type) {
     // Create or update the latest resource list we fetched from the server
     case 'RESOURCE_LIST_GET_SUCCESS':
       const { facets = {}, objects, meta } = action.apiResponse;
       // Get the limit/offset from our params, set our defaults
-      const { limit = defaultParams.limit, offset = defaultParams.offset, ...restParams } = action.params;
+      // tslint:disable:trailing-comma // Prettier does not format this syntax properly
+      const {
+        limit = defaultParams.limit,
+        offset = defaultParams.offset,
+        ...restParams
+      } = action.params;
 
       return {
         ...state,
@@ -43,7 +59,8 @@ export function currentQuery<R extends Resource>(
           facets,
           items: objects.reduce(
             // Transform the array into an object with indexes as keys
-            (acc, item, index) => ({ ...acc, [offset + index]: item.id }), {},
+            (acc, item, index) => ({ ...acc, [offset + index]: item.id }),
+            {},
           ),
           // Copy back the params, now with proper defaults on limit/offset
           params: { ...restParams, limit, offset },

--- a/richie/js/data/genericSideEffects/getResourceList/actions.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/actions.ts
@@ -1,9 +1,15 @@
-import { APIListCommonRequestParams, APIResponseListFacets, APIResponseListMeta } from '../../../types/api';
+import {
+  APIListCommonRequestParams,
+  APIResponseListFacets,
+  APIResponseListMeta,
+} from '../../../types/api';
 import Resource from '../../../types/Resource';
 import { RootState } from '../../rootReducer';
 
 export interface ResourceListGet {
-  params?: Partial<APIListCommonRequestParams> & { [key: string]: string | number | null | Array<string | number> };
+  params?: Partial<APIListCommonRequestParams> & {
+    [key: string]: string | number | null | Array<string | number>;
+  };
   resourceName: keyof RootState['resources'];
   type: 'RESOURCE_LIST_GET';
 }
@@ -37,8 +43,14 @@ export function failedToGetResourceList(
 }
 
 export interface ResourceListGetSuccess<R extends Resource> {
-  apiResponse: { facets?: APIResponseListFacets, meta: APIResponseListMeta, objects: R[] };
-  params: Partial<APIListCommonRequestParams> & { [key: string]: string | number | null | Array<string | number> };
+  apiResponse: {
+    facets?: APIResponseListFacets;
+    meta: APIResponseListMeta;
+    objects: R[];
+  };
+  params: Partial<APIListCommonRequestParams> & {
+    [key: string]: string | number | null | Array<string | number>;
+  };
   resourceName: keyof RootState['resources'];
   type: 'RESOURCE_LIST_GET_SUCCESS';
 }

--- a/richie/js/data/genericSideEffects/getResourceList/getResourceList.spec.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/getResourceList.spec.ts
@@ -36,7 +36,8 @@ describe('data/genericSideEffects/getResourceList saga', () => {
     language: 'fr',
     organizations: [11],
     session_number: 1,
-    short_description: 'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
+    short_description:
+      'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
     start_date: '2018-03-01T06:00:00.000Z',
     subjects: [7, 128],
     thumbnails: {
@@ -62,32 +63,36 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       window.fetch = realFetch;
     });
 
-    it('requests the resource list, parses the JSON response and resolves with the results', (done) => {
-      mockFetch.and.returnValue(Promise.resolve({
-        json: () => Promise.resolve({ objects: [ course43, course44 ] }),
-        ok: true,
-      }));
+    it('requests the resource list, parses the JSON response and resolves with the results', done => {
+      mockFetch.and.returnValue(
+        Promise.resolve({
+          json: () => Promise.resolve({ objects: [course43, course44] }),
+          ok: true,
+        }),
+      );
 
-      fetchList('courses', { limit: 2, offset: 43 })
-      .then((response) => {
+      fetchList('courses', { limit: 2, offset: 43 }).then(response => {
         // The correct request given parameters is performed
         expect(mockFetch).toHaveBeenCalledWith(
           '/api/v1.0/courses/?limit=2&offset=43',
-          { headers: { 'Content-Type': 'application/json' },
-        });
+          {
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
         // Our polymorphic response object is properly shaped
         expect(response.error).not.toBeTruthy();
-        expect(response.objects).toEqual([ course43, course44 ]);
+        expect(response.objects).toEqual([course43, course44]);
         done();
       });
     });
 
-    it('returns an { error } object when it fails to get the resource list (local)', (done) => {
-      mockFetch.and.returnValue(Promise.reject(new Error('Could not perform fetch.')));
+    it('returns an { error } object when it fails to get the resource list (local)', done => {
+      mockFetch.and.returnValue(
+        Promise.reject(new Error('Could not perform fetch.')),
+      );
 
       // Don't check params again as it was done in the first test
-      fetchList('courses', { limit: 2, offset: 43 })
-      .then((response) => {
+      fetchList('courses', { limit: 2, offset: 43 }).then(response => {
         // Our polymorphic response object is properly shaped - with an error this time
         expect(response.objects).not.toBeDefined();
         expect(response.error).toEqual(jasmine.any(Error));
@@ -95,12 +100,11 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       });
     });
 
-    it('returns an { error } object when it fails to get the resource list (network)', (done) => {
+    it('returns an { error } object when it fails to get the resource list (network)', done => {
       mockFetch.and.returnValue(Promise.resolve({ ok: false, status: 404 }));
 
       // Don't check params again as it was done in the first test
-      fetchList('courses', { limit: 2, offset: 43 })
-      .then((response) => {
+      fetchList('courses', { limit: 2, offset: 43 }).then(response => {
         // Our polymorphic response object is properly shaped - with an error this time
         expect(response.objects).not.toBeDefined();
         expect(response.error).toEqual(jasmine.any(Error));
@@ -122,15 +126,21 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       // Mock a 'list of courses' response with which to trigger the call to fetchCourses
       const response = {
         meta: { limit: 10, offset: 0, total_count: 120 },
-        objects: [ course43, course44 ],
+        objects: [course43, course44],
       };
 
       // The call to fetch (the actual side-effect) is triggered
-      expect(gen.next().value).toEqual(call(fetchList, 'courses', action.params));
+      expect(gen.next().value).toEqual(
+        call(fetchList, 'courses', action.params),
+      );
       // Both courses are added to the state
-      expect(gen.next(response).value).toEqual(put(addMultipleResources('courses', response.objects)));
+      expect(gen.next(response).value).toEqual(
+        put(addMultipleResources('courses', response.objects)),
+      );
       // The success action is dispatched
-      expect(gen.next().value).toEqual(put(didGetResourceList('courses', response, action.params)));
+      expect(gen.next().value).toEqual(
+        put(didGetResourceList('courses', response, action.params)),
+      );
     });
 
     it('yields a failure action when fetchList fails', () => {
@@ -141,9 +151,13 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       };
 
       // The call to fetch is triggered, but fails for some reason
-      expect(gen.next().value).toEqual(call(fetchList, 'courses', action.params));
+      expect(gen.next().value).toEqual(
+        call(fetchList, 'courses', action.params),
+      );
       // The failure action is dispatched
-      expect(gen.next(response).value).toEqual(put(failedToGetResourceList('courses', response.error)));
+      expect(gen.next(response).value).toEqual(
+        put(failedToGetResourceList('courses', response.error)),
+      );
     });
   });
 });

--- a/richie/js/data/genericSideEffects/getResourceList/getResourceList.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/getResourceList.ts
@@ -40,21 +40,27 @@ export function fetchList(
       'Content-Type': 'application/json',
     },
   })
-  .then((response) => {
-    // Fetch treats remote errors (400, 404, 503...) as successes. The ok flag is the way to discriminate.
-    if (response.ok) {
-      return response;
-    }
-    // Push remote errors to the error channel for consistency
-    throw new Error('Failed to get list from ' + endpoint + ' : ' + response.status);
-  })
-  .then((response) => response.json())
-  .catch((error) => ({ error }));
+    .then(response => {
+      // Fetch treats remote errors (400, 404, 503...) as successes. The ok flag is the way to discriminate.
+      if (response.ok) {
+        return response;
+      }
+      // Push remote errors to the error channel for consistency
+      throw new Error(
+        'Failed to get list from ' + endpoint + ' : ' + response.status,
+      );
+    })
+    .then(response => response.json())
+    .catch(error => ({ error }));
 }
 
 export function* getList(action: ResourceListGet) {
   const { params, resourceName } = action;
-  const { error, meta, objects, ...restProps }: Response = yield call(fetchList, resourceName, params);
+  const { error, meta, objects, ...restProps }: Response = yield call(
+    fetchList,
+    resourceName,
+    params,
+  );
 
   if (error) {
     yield put(failedToGetResourceList(resourceName, error));
@@ -62,7 +68,13 @@ export function* getList(action: ResourceListGet) {
     // Add each individual resource to the state before we put the success action in
     // order to avoid race conditions / incomplete data sets
     yield put(addMultipleResources(resourceName, objects!));
-    yield put(didGetResourceList(resourceName, { meta: meta!, objects: objects!, ...restProps }, params!));
+    yield put(
+      didGetResourceList(
+        resourceName,
+        { meta: meta!, objects: objects!, ...restProps },
+        params!,
+      ),
+    );
   }
 }
 

--- a/richie/js/data/organizations/reducer.spec.ts
+++ b/richie/js/data/organizations/reducer.spec.ts
@@ -21,23 +21,27 @@ describe('data/organizations reducer', () => {
 
   describe('resourceById', () => {
     it('drops actions that do not match the resourceName', () => {
-      const previousState = { byId: { 43: org43  } };
+      const previousState = { byId: { 43: org43 } };
 
-      expect(organizationsReducer(previousState, {
-        resource: org44,
-        resourceName: 'subjects',
-        type: 'RESOURCE_ADD',
-      })).toEqual(previousState);
+      expect(
+        organizationsReducer(previousState, {
+          resource: org44,
+          resourceName: 'subjects',
+          type: 'RESOURCE_ADD',
+        }),
+      ).toEqual(previousState);
     });
 
     it('uses actions that match the resourceName', () => {
-      const previousState = { byId: { 43: org43  } };
+      const previousState = { byId: { 43: org43 } };
 
-      expect(organizationsReducer(previousState, {
-        resource: org44,
-        resourceName: 'organizations',
-        type: 'RESOURCE_ADD',
-      })).toEqual({ byId: { 43: org43, 44: org44 } });
+      expect(
+        organizationsReducer(previousState, {
+          resource: org44,
+          resourceName: 'organizations',
+          type: 'RESOURCE_ADD',
+        }),
+      ).toEqual({ byId: { 43: org43, 44: org44 } });
     });
   });
 });

--- a/richie/js/data/organizations/reducer.ts
+++ b/richie/js/data/organizations/reducer.ts
@@ -11,30 +11,41 @@ import {
   initialState as resourceByIdInit,
   ResourceByIdState,
 } from '../genericReducers/resourceById/resourceById';
-import { currentQuery, ResourceListState } from '../genericReducers/resourceList/resourceList';
+import {
+  currentQuery,
+  ResourceListState,
+} from '../genericReducers/resourceList/resourceList';
 import { ResourceListGetSuccess } from '../genericSideEffects/getResourceList/actions';
 
 const initialState = { ...resourceByIdInit };
 
-export type OrganizationsState = Maybe<ResourceByIdState<Organization> & ResourceListState<Organization>>;
+export type OrganizationsState = Maybe<
+  ResourceByIdState<Organization> & ResourceListState<Organization>
+>;
 
 export const organizations: Reducer<OrganizationsState> = (
   state: OrganizationsState = initialState,
-  action?: ResourceAdd<Organization> | ResourceListGetSuccess<Organization> | { type: '' },
+  action?:
+    | ResourceAdd<Organization>
+    | ResourceListGetSuccess<Organization>
+    | { type: '' },
 ) => {
-  if (!action) { return state; } // Compiler needs help
+  if (!action) {
+    return state;
+  } // Compiler needs help
 
   // Discriminate resource related actions by resource name
-  if (get(action, 'resourceName') &&
-      get(action, 'resourceName') !== 'organizations'
+  if (
+    get(action, 'resourceName') &&
+    get(action, 'resourceName') !== 'organizations'
   ) {
     return state;
   }
 
-  return flow([
-    partialRight(byId, action),
-    partialRight(currentQuery, action),
-  ])(state, action);
+  return flow([partialRight(byId, action), partialRight(currentQuery, action)])(
+    state,
+    action,
+  );
 };
 
 export default organizations;

--- a/richie/js/data/rootReducer.ts
+++ b/richie/js/data/rootReducer.ts
@@ -1,7 +1,10 @@
 import { Reducer } from 'redux';
 
 import { courses, CoursesState } from './courses/reducer';
-import { filterDefinitions, FilterDefinitionState } from './filterDefinitions/reducer';
+import {
+  filterDefinitions,
+  FilterDefinitionState,
+} from './filterDefinitions/reducer';
 import { organizations, OrganizationsState } from './organizations/reducer';
 import { subjects, SubjectsState } from './subjects/reducer';
 

--- a/richie/js/data/rootSaga.ts
+++ b/richie/js/data/rootSaga.ts
@@ -4,7 +4,5 @@ import getResourceListSaga from './genericSideEffects/getResourceList/getResourc
 
 // Aggregate all our sagas through the parallelization effect
 export default function* rootSaga() {
-  yield all([
-    getResourceListSaga(),
-  ]);
+  yield all([getResourceListSaga()]);
 }

--- a/richie/js/data/subjects/reducer.spec.ts
+++ b/richie/js/data/subjects/reducer.spec.ts
@@ -15,23 +15,27 @@ describe('data/subjects reducer', () => {
 
   describe('resourceById', () => {
     it('drops actions that do not match the resourceName', () => {
-      const previousState = { byId: { 43: subj43  } };
+      const previousState = { byId: { 43: subj43 } };
 
-      expect(subjectsReducer(previousState, {
-        resource: subj44,
-        resourceName: 'organizations',
-        type: 'RESOURCE_ADD',
-      })).toEqual(previousState);
+      expect(
+        subjectsReducer(previousState, {
+          resource: subj44,
+          resourceName: 'organizations',
+          type: 'RESOURCE_ADD',
+        }),
+      ).toEqual(previousState);
     });
 
     it('uses actions that match the resourceName', () => {
-      const previousState = { byId: { 43: subj43  } };
+      const previousState = { byId: { 43: subj43 } };
 
-      expect(subjectsReducer(previousState, {
-        resource: subj44,
-        resourceName: 'subjects',
-        type: 'RESOURCE_ADD',
-      })).toEqual({ byId: { 43: subj43, 44: subj44 } });
+      expect(
+        subjectsReducer(previousState, {
+          resource: subj44,
+          resourceName: 'subjects',
+          type: 'RESOURCE_ADD',
+        }),
+      ).toEqual({ byId: { 43: subj43, 44: subj44 } });
     });
   });
 });

--- a/richie/js/data/subjects/reducer.ts
+++ b/richie/js/data/subjects/reducer.ts
@@ -11,30 +11,41 @@ import {
   initialState as resourceByIdInit,
   ResourceByIdState,
 } from '../genericReducers/resourceById/resourceById';
-import { currentQuery, ResourceListState } from '../genericReducers/resourceList/resourceList';
+import {
+  currentQuery,
+  ResourceListState,
+} from '../genericReducers/resourceList/resourceList';
 import { ResourceListGetSuccess } from '../genericSideEffects/getResourceList/actions';
 
 const initialState = { ...resourceByIdInit };
 
-export type SubjectsState = Maybe<ResourceByIdState<Subject> & ResourceListState<Subject>>;
+export type SubjectsState = Maybe<
+  ResourceByIdState<Subject> & ResourceListState<Subject>
+>;
 
 export const subjects: Reducer<SubjectsState> = (
   state = initialState,
-  action?: ResourceAdd<Subject> | ResourceListGetSuccess<Subject> | { type: '' },
+  action?:
+    | ResourceAdd<Subject>
+    | ResourceListGetSuccess<Subject>
+    | { type: '' },
 ) => {
-  if (!action) { return state; } // Compiler needs help
+  if (!action) {
+    return state;
+  } // Compiler needs help
 
   // Discriminate resource related actions by resource name
-  if (get(action, 'resourceName') &&
-      get(action, 'resourceName') !== 'subjects'
+  if (
+    get(action, 'resourceName') &&
+    get(action, 'resourceName') !== 'subjects'
   ) {
     return state;
   }
 
-  return flow([
-    partialRight(byId, action),
-    partialRight(currentQuery, action),
-  ])(state, action);
+  return flow([partialRight(byId, action), partialRight(currentQuery, action)])(
+    state,
+    action,
+  );
 };
 
 export default subjects;

--- a/richie/js/index.tsx
+++ b/richie/js/index.tsx
@@ -29,38 +29,46 @@ const componentLibrary: ComponentLibrary = {
 };
 // Type guard: ensures a given string (candidate) is indeed a proper key of the componentLibrary with a corresponding
 // component. This is a runtime check but it allows TS to check the component prop types at compile time
-function isComponentName(candidate: keyof ComponentLibrary | string): candidate is keyof ComponentLibrary {
+function isComponentName(
+  candidate: keyof ComponentLibrary | string,
+): candidate is keyof ComponentLibrary {
   return includes(Object.keys(componentLibrary), candidate);
 }
 
 // Wait for the DOM to load before we scour it for an element that requires React to be rendered
-document.addEventListener('DOMContentLoaded', (event) => {
+document.addEventListener('DOMContentLoaded', event => {
   // Bootstrap the Redux store using the configureStore function from /data. Can make use of embedded
   // data put there by the Django page.
   const store = bootstrapStore();
 
   // Find all the elements that need React to render a component
-  Array.prototype.forEach.call(document.querySelectorAll('.fun-react'),
-  (element: Element) => {
-    // Generate a component name. It should be a key of the componentLibrary object / ComponentLibrary interface
-    const componentName =
-      startCase(get(element.className.match(/fun-react--([a-zA-Z-]*)/), '[1]') || '')
-      .split(' ')
-      .join('');
-    // Sanity check: only attempt to access and render components for which we do have a valid name
-    if (isComponentName(componentName)) {
-      // Do get the component dynamically. We know this WILL produce a valid component thanks to the type guard
-      const Component = componentLibrary[componentName];
-      // Render the component inside a `react-redux` store Provider so its children can be `connect`ed
-      ReactDOM.render(
-        <Provider store={store}>
-          <Component />
-        </Provider>,
-        element,
-      );
-    } else {
-      // Emit a warning at runtime when we fail to find a matching component for an element that required one
-      console.warn('Failed to load React component: no such component in Library ' + componentName);
-    }
-  });
+  Array.prototype.forEach.call(
+    document.querySelectorAll('.fun-react'),
+    (element: Element) => {
+      // Generate a component name. It should be a key of the componentLibrary object / ComponentLibrary interface
+      const componentName = startCase(
+        get(element.className.match(/fun-react--([a-zA-Z-]*)/), '[1]') || '',
+      )
+        .split(' ')
+        .join('');
+      // Sanity check: only attempt to access and render components for which we do have a valid name
+      if (isComponentName(componentName)) {
+        // Do get the component dynamically. We know this WILL produce a valid component thanks to the type guard
+        const Component = componentLibrary[componentName];
+        // Render the component inside a `react-redux` store Provider so its children can be `connect`ed
+        ReactDOM.render(
+          <Provider store={store}>
+            <Component />
+          </Provider>,
+          element,
+        );
+      } else {
+        // Emit a warning at runtime when we fail to find a matching component for an element that required one
+        console.warn(
+          'Failed to load React component: no such component in Library ' +
+            componentName,
+        );
+      }
+    },
+  );
 });

--- a/richie/js/settings.json
+++ b/richie/js/settings.json
@@ -8,9 +8,5 @@
     "limit": 20,
     "offset": 0
   },
-  "SUPPORTED_LANGUAGES": [
-    "de",
-    "en",
-    "fr"
-  ]
+  "SUPPORTED_LANGUAGES": ["de", "en", "fr"]
 }

--- a/richie/js/utils/http/formatQueryString.spec.ts
+++ b/richie/js/utils/http/formatQueryString.spec.ts
@@ -7,11 +7,15 @@ describe('utils/http - formatQueryString()', () => {
   });
 
   it('returns a query string built from the params', () => {
-    expect(formatQueryString({ foo: 'bar', fizz: 'buzz' })).toEqual('?foo=bar&fizz=buzz');
+    expect(formatQueryString({ foo: 'bar', fizz: 'buzz' })).toEqual(
+      '?foo=bar&fizz=buzz',
+    );
   });
 
   it('supports null as a param value', () => {
-    expect(formatQueryString({ foo: 'bar', fizz: null })).toEqual('?foo=bar&fizz=null');
+    expect(formatQueryString({ foo: 'bar', fizz: null })).toEqual(
+      '?foo=bar&fizz=null',
+    );
   });
 
   it('supports numbers as param values', () => {
@@ -19,6 +23,8 @@ describe('utils/http - formatQueryString()', () => {
   });
 
   it('handles arrays as param values', () => {
-    expect(formatQueryString({ foo: [ 'bar', 'baz' ], fizz: 'buzz' })).toEqual('?foo=bar&foo=baz&fizz=buzz');
+    expect(formatQueryString({ foo: ['bar', 'baz'], fizz: 'buzz' })).toEqual(
+      '?foo=bar&foo=baz&fizz=buzz',
+    );
   });
 });

--- a/richie/js/utils/http/formatQueryString.ts
+++ b/richie/js/utils/http/formatQueryString.ts
@@ -1,17 +1,20 @@
 import toPairs from 'lodash-es/toPairs';
 
 export default function formatQueryString(
-  params: { [key: string]: string | number | null | Array<string | number> } | null = null,
+  params: {
+    [key: string]: string | number | null | Array<string | number>;
+  } | null = null,
 ) {
   if (params) {
     // Build the query string from the params passed to the xhr call
-    return toPairs(params)
-    .reduce((qs, [ key, value ], index, array) => {
+    return toPairs(params).reduce((qs, [key, value], index, array) => {
       // Concatenate '&' unless we're handling the last parameter
       const lastCharIfNecessary = index === array.length - 1 ? '' : '&';
       if (Array.isArray(value)) {
         // For arrays use duplicate keys like { foo: [ 'bar', 'baz' ] } => 'foo=bar&foo=baz'
-        return qs + value.map((v) => key + '=' + v).join('&') + lastCharIfNecessary;
+        return (
+          qs + value.map(v => key + '=' + v).join('&') + lastCharIfNecessary
+        );
       } else {
         // For basic values simply concat them like { foo: 'bar' } => 'foo=bar'
         return qs + key + '=' + value + lastCharIfNecessary;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,11 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "lib": [ "dom", "es5", "scripthost", "es2015.promise", "es2015.iterable" ],
+    "lib": ["dom", "es5", "scripthost", "es2015.promise", "es2015.iterable"],
     "module": "commonjs",
     "strict": true,
     "sourceMap": true,
     "target": "es5"
   },
-  "include": [
-    "./**/*"
-  ]
+  "include": ["./**/*"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,15 +1,14 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended"
-    ],
-    "jsRules": {},
-    "rules": {
-        "interface-name": [ true, "never-prefix" ],
-        "member-access": [ true, "no-public" ],
-        "no-console": [ true, "log", "error" ],
-        "no-empty": false,
-        "quotemark": [ true, "single", "avoid-escape", "jsx-double" ]
-    },
-    "rulesDirectory": []
+  "defaultSeverity": "error",
+  "extends": ["tslint:recommended"],
+  "jsRules": {},
+  "rules": {
+    "arrow-parens": false,
+    "interface-name": [true, "never-prefix"],
+    "member-access": [true, "no-public"],
+    "no-console": [true, "log", "error"],
+    "no-empty": false,
+    "quotemark": [true, "single", "avoid-escape", "jsx-double"]
+  },
+  "rulesDirectory": []
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,10 +9,10 @@ module.exports = {
 
   // Include whatwg fetch as an entry point (and not an import) as it's replacing (when necessary)
   // a globally available browser-provided function
-  entry: [ 'whatwg-fetch', './richie/js/index.tsx' ],
+  entry: ['whatwg-fetch', './richie/js/index.tsx'],
   output: {
     filename: 'index.js',
-    path: __dirname + '/richie/build/js'
+    path: __dirname + '/richie/build/js',
   },
 
   // Enable sourcemaps for debugging webpack's output.
@@ -20,7 +20,7 @@ module.exports = {
 
   resolve: {
     // Add '.ts' and '.tsx' as resolvable extensions.
-    extensions: [ '.ts', '.tsx', '.js', '.json' ]
+    extensions: ['.ts', '.tsx', '.js', '.json'],
   },
 
   module: {
@@ -28,8 +28,8 @@ module.exports = {
       // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
       { test: /\.tsx?$/, loader: 'ts-loader' },
       // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' }
-    ]
+      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+    ],
   },
 
   plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5684,7 +5684,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.5.3:
+prettier@1.12.1, prettier@^1.5.3:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
 


### PR DESCRIPTION
## Purpose

We already use code-formatting on the python side to avoid splitting hair over pointless style differences.
There's no reason not to use black's older brother on the JS side :)

## Proposal

- [x] add prettier to our dependencies
- [x] make a *minimal* config file
- [x] apply prettier to the whole codebase
- [x] add a prettier check step to the CI
- [ ] let each developer integrate prettier into their editor