### PR TITLE
List active filters to let users remove them

### DIFF
--- a/richie/js/components/searchFilter/searchFilter.spec.tsx
+++ b/richie/js/components/searchFilter/searchFilter.spec.tsx
@@ -6,15 +6,54 @@ import * as React from 'react';
 import SearchFilter from './searchFilter';
 
 describe('components/searchFilter', () => {
+  let addFilter: jasmine.Spy;
+  let removeFilter: jasmine.Spy;
+
+  beforeEach(() => {
+    addFilter = jasmine.createSpy('addFilter');
+    removeFilter = jasmine.createSpy('removeFilter');
+  });
+
   it('renders the name of the filter', () => {
-    const addFilter = jasmine.createSpy('addFilter');
     const wrapper = shallow(
       <SearchFilter
         addFilter={addFilter}
         filter={{ primaryKey: '42', humanName: 'Human name' }}
+        isActive={false}
+        removeFilter={removeFilter}
       />,
     );
 
     expect(wrapper.text()).toContain('Human name');
+  });
+
+  it('calls addFilter on button click if it was not active', () => {
+    const wrapper = shallow(
+      <SearchFilter
+        addFilter={addFilter!}
+        filter={{ primaryKey: '42', humanName: 'Human name' }}
+        isActive={false}
+        removeFilter={removeFilter}
+      />,
+    );
+    wrapper.find('button').simulate('click');
+
+    expect(addFilter).toHaveBeenCalledWith('42');
+    expect(removeFilter).not.toHaveBeenCalled();
+  });
+
+  it('calls removeFilter on button click if it was active', () => {
+    const wrapper = shallow(
+      <SearchFilter
+        addFilter={addFilter!}
+        filter={{ primaryKey: '43', humanName: 'Human name' }}
+        isActive={true}
+        removeFilter={removeFilter}
+      />,
+    );
+    wrapper.find('button').simulate('click');
+
+    expect(removeFilter).toHaveBeenCalledWith('43');
+    expect(addFilter).not.toHaveBeenCalled();
   });
 });

--- a/richie/js/components/searchFilter/searchFilter.tsx
+++ b/richie/js/components/searchFilter/searchFilter.tsx
@@ -5,15 +5,21 @@ import { FilterValue } from '../../types/FilterDefinition';
 export interface SearchFilterProps {
   addFilter: (filterValue: string) => void;
   filter: FilterValue;
+  isActive: boolean;
+  removeFilter: (filterValue: string) => void;
 }
 
 export const SearchFilter = (props: SearchFilterProps) => {
-  const { filter, addFilter } = props;
+  const { addFilter, filter, isActive, removeFilter } = props;
 
   return (
     <button
-      className="search-filter"
-      onClick={() => addFilter(filter.primaryKey)}
+      className={`search-filter ${isActive ? 'active' : ''}`}
+      onClick={() =>
+        isActive
+          ? removeFilter(filter.primaryKey)
+          : addFilter(filter.primaryKey)
+      }
     >
       {filter.humanName}
       {filter.count || filter.count === 0 ? (

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
@@ -20,6 +20,7 @@ describe('components/searchFilterGroup', () => {
     const wrapper = shallow(
       <SearchFilterGroup
         addFilter={addFilter}
+        currentValue={undefined}
         filter={filter}
         removeFilter={removeFilter}
       />,
@@ -39,11 +40,53 @@ describe('components/searchFilterGroup', () => {
     const wrapper = shallow(
       <SearchFilterGroup
         addFilter={addFilter}
+        currentValue={undefined}
         filter={filter}
         removeFilter={removeFilter}
       />,
     );
 
     expect(wrapper.find(SearchFilter).length).toEqual(2);
+  });
+
+  it('orders the list by putting active filters at the top', () => {
+    const filter = {
+      humanName: 'Example filter',
+      values: [
+        { primaryKey: 'value-1', humanName: 'Value One' },
+        { primaryKey: 'value-2', humanName: 'Value Two' },
+        { primaryKey: 'value-3', humanName: 'Value Three' },
+      ],
+    } as FilterDefinition;
+    const wrapper = shallow(
+      <SearchFilterGroup
+        addFilter={addFilter}
+        currentValue={'value-2'}
+        filter={filter}
+        removeFilter={removeFilter}
+      />,
+    );
+
+    expect(
+      wrapper
+        .find(SearchFilter)
+        .at(0)
+        .shallow()
+        .text(),
+    ).toContain('Value Two');
+    expect(
+      wrapper
+        .find(SearchFilter)
+        .at(1)
+        .shallow()
+        .text(),
+    ).toContain('Value One');
+    expect(
+      wrapper
+        .find(SearchFilter)
+        .at(2)
+        .shallow()
+        .text(),
+    ).toContain('Value Three');
   });
 });

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
@@ -1,28 +1,53 @@
+import includes from 'lodash-es/includes';
+import isArray from 'lodash-es/isArray';
+import sortBy from 'lodash-es/sortBy';
 import * as React from 'react';
 
-import { FilterDefinition } from '../../types/FilterDefinition';
+import { FilterDefinition, FilterValue } from '../../types/FilterDefinition';
+import { Maybe, Nullable } from '../../utils/types';
 import SearchFilter from '../searchFilter/searchFilter';
 
 export interface SearchFilterGroupProps {
-  addFilter: (filterValue: string) => void;
+  addFilter: (filterKey: string) => void;
+  currentValue: Maybe<string | number | Array<string | number>>;
   filter: FilterDefinition;
-  removeFilter: (filterValue: string) => void;
+  removeFilter: (filterKey: string) => void;
 }
 
 export const SearchFilterGroup = (props: SearchFilterGroupProps) => {
   const { humanName, values } = props.filter;
+  // Select currently active filter values (eg. for a given value, if we're filtering on
+  // that dimension by that value).
+  // We'll need to do at least two lookups for each active prop during each render,
+  // which is why we build a hash table for simple/inexpensive lookups below.
+  const valueStates: { [key: string]: boolean } = values.reduce(
+    (acc, fv: FilterValue) =>
+      props.currentValue &&
+      (props.currentValue === fv.primaryKey ||
+        (isArray(props.currentValue) &&
+          includes(props.currentValue, fv.primaryKey)))
+        ? // Key is active
+          { ...acc, [fv.primaryKey]: true }
+        : // Key is inactive
+          { ...acc, [fv.primaryKey]: false },
+    {},
+  );
 
   return (
     <div className="search-filter-group">
       <h3 className="search-filter-group__title">{humanName}</h3>
       <div className="search-filter-group__list">
-        {values.map(value => (
-          <SearchFilter
-            filter={value}
-            key={value.primaryKey}
-            addFilter={props.addFilter}
-          />
-        ))}
+        {sortBy(values, val => (valueStates[val.primaryKey] ? 0 : 1)).map(
+          value => (
+            <SearchFilter
+              addFilter={props.addFilter}
+              filter={value}
+              isActive={valueStates[value.primaryKey]}
+              key={value.primaryKey}
+              removeFilter={props.removeFilter}
+            />
+          ),
+        )}
       </div>
     </div>
   );

--- a/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.spec.ts
+++ b/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.spec.ts
@@ -6,8 +6,8 @@ describe('components/searchFilterGroupContainer/computeNewFilterValue', () => {
   describe('add', () => {
     const addFilter = partial(computeNewFilterValue, 'add');
 
-    it('returns an array with the value when the existing value was null | undefined', () => {
-      expect(addFilter(null, 42)).toEqual([42]);
+    it('returns an array with the value when the existing value was undefined', () => {
+      expect(addFilter(undefined, 42)).toEqual([42]);
       expect(addFilter(undefined, 'new_value')).toEqual(['new_value']);
     });
 
@@ -32,14 +32,16 @@ describe('components/searchFilterGroupContainer/computeNewFilterValue', () => {
   describe('remove', () => {
     const removeFilter = partial(computeNewFilterValue, 'remove');
 
-    it('returns null when the existing value was null | undefined', () => {
-      expect(removeFilter(null, 42)).toEqual(null);
-      expect(removeFilter(null, 'imaginary_value')).toEqual(null);
+    it('returns undefined when the existing value was undefined', () => {
+      expect(removeFilter(undefined, 42)).toEqual(undefined);
+      expect(removeFilter(undefined, 'imaginary_value')).toEqual(undefined);
     });
 
-    it('returns null when the existing value was the passed value', () => {
-      expect(removeFilter(42, 42)).toEqual(null);
-      expect(removeFilter('existing_value', 'existing_value')).toEqual(null);
+    it('returns undefined when the existing value was the passed value', () => {
+      expect(removeFilter(42, 42)).toEqual(undefined);
+      expect(removeFilter('existing_value', 'existing_value')).toEqual(
+        undefined,
+      );
     });
 
     it('returns the existing value when the existing value was not the passed value', () => {
@@ -54,9 +56,9 @@ describe('components/searchFilterGroupContainer/computeNewFilterValue', () => {
       expect(removeFilter(['val_A', 'val_B'], 'val_B')).toEqual(['val_A']);
     });
 
-    it('returns null when the passed value was the only value in the existing value as an array', () => {
-      expect(removeFilter([43], 43)).toEqual(null);
-      expect(removeFilter(['val_B'], 'val_B')).toEqual(null);
+    it('returns undefined when the passed value was the only value in the existing value as an array', () => {
+      expect(removeFilter([43], 43)).toEqual(undefined);
+      expect(removeFilter(['val_B'], 'val_B')).toEqual(undefined);
     });
   });
 });

--- a/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.ts
+++ b/richie/js/components/searchFilterGroupContainer/computeNewFilterValue.ts
@@ -1,10 +1,10 @@
-import { Maybe, Nullable } from '../../utils/types';
+import { Maybe } from '../../utils/types';
 
 // Compute a new value for a filter to apply to course search, reacting to a user interaction by
 // either adding a new filter or removing one
 export function computeNewFilterValue(
   action: 'add' | 'remove',
-  existingValue: Maybe<Nullable<string | number | Array<string | number>>>,
+  existingValue: Maybe<string | number | Array<string | number>>,
   relevantValue: string | number,
 ) {
   // There is no existing value for this filter
@@ -12,8 +12,8 @@ export function computeNewFilterValue(
     return {
       // ADD: Make an array with the existing value
       add: () => [relevantValue],
-      // REMOVE: There's nothing that could possibly removed, return null
-      remove: () => null,
+      // REMOVE: There's nothing that could possibly removed, return undefined
+      remove: () => undefined,
     }[action]();
   }
 
@@ -25,7 +25,8 @@ export function computeNewFilterValue(
       // REMOVE:
       // - Return nothing if we had to drop the existing value we had
       // - Keep the existing value if it's not the one we needed to drop
-      remove: () => (existingValue === relevantValue ? null : existingValue),
+      remove: () =>
+        existingValue === relevantValue ? undefined : existingValue,
     }[action]();
   }
 
@@ -35,15 +36,15 @@ export function computeNewFilterValue(
     add: () => [...(existingValue as Array<string | number>), relevantValue],
     // REMOVE: Return the existing array of values without the one we needed to remove
     remove: () =>
-      nullEmptyArray(
+      dropEmptyArray(
         (existingValue as Array<string | number>).filter(
           v => v !== relevantValue,
         ),
       ),
   }[action]();
 
-  function nullEmptyArray(array: Array<string | number>) {
-    return array.length === 0 ? null : array;
+  function dropEmptyArray(array: Array<string | number>) {
+    return array.length === 0 ? undefined : array;
   }
 }
 

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
@@ -82,7 +82,7 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
 
   describe('removeFilter', () => {
     describe('when the filter is drilldown', () => {
-      it('nulls the existing filter value when it matches the passed value', () => {
+      it('returns undefined when it matches the passed value', () => {
         const props = mergeProps(
           {
             currentParams: { limit: 20, new: 'value_to_remove', offset: 0 },
@@ -93,7 +93,7 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
         );
         props.removeFilter('value_to_remove');
 
-        expectDispatches(dispatch, { limit: 20, new: null, offset: 0 });
+        expectDispatches(dispatch, { limit: 20, new: undefined, offset: 0 });
       });
 
       it('keeps the existing filter value when it does not match the passed value', () => {
@@ -114,7 +114,7 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
         });
       });
 
-      it('adds a null value and does not throw when there was no existing value', () => {
+      it('returns undefined and does not throw when there was no existing value', () => {
         const props = mergeProps(
           {
             currentParams: { limit: 20, offset: 0 },
@@ -125,7 +125,7 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
         );
         props.removeFilter('where_does_this_come_from');
 
-        expectDispatches(dispatch, { limit: 20, new: null, offset: 0 });
+        expectDispatches(dispatch, { limit: 20, new: undefined, offset: 0 });
       });
     });
 

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
@@ -24,7 +24,7 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
       state: null,
       title: '',
       type: 'HISTORY_PUSH_STATE',
-      url: stringify(expectedParams),
+      url: `?${stringify(expectedParams)}`,
     });
   };
 

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
@@ -55,6 +55,7 @@ export const mergeProps = (
     dispatch(getResourceList('courses', newParams));
     dispatch(pushQueryStringToHistory(newParams));
   },
+  currentValue: currentParams[filter.machineName],
   filter,
   removeFilter: (filterValue: string) => {
     const newParams = {
@@ -63,9 +64,9 @@ export const mergeProps = (
         ? // Drilldown filters only support one value at a time
           filterValue === currentParams[machineName]
           ? // Remove the value if it matches current value
-            null
+            undefined
           : // Don't remove a non matching existing value
-            currentParams[machineName] || null
+            currentParams[machineName] || undefined
         : // For other filters use the standard computation
           computeNewFilterValue(
             'remove',

--- a/richie/js/data/genericReducers/resourceList/resourceList.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.ts
@@ -6,6 +6,7 @@ import {
   APIResponseListFacets,
 } from '../../../types/api';
 import Resource from '../../../types/Resource';
+import { Maybe } from '../../../utils/types';
 import {
   ResourceListGet,
   ResourceListGetSuccess,
@@ -14,7 +15,7 @@ import {
 export const initialState = {};
 
 export type ResourceListStateParams = APIListCommonRequestParams & {
-  [key: string]: string | number | null | Array<string | number>;
+  [key: string]: Maybe<string | number | Array<string | number>>;
 };
 
 export interface ResourceListState<R extends Resource> {

--- a/richie/js/data/genericSideEffects/getResourceList/actions.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/actions.ts
@@ -4,11 +4,12 @@ import {
   APIResponseListMeta,
 } from '../../../types/api';
 import Resource from '../../../types/Resource';
+import { Maybe } from '../../../utils/types';
 import { RootState } from '../../rootReducer';
 
 export interface ResourceListGet {
   params?: Partial<APIListCommonRequestParams> & {
-    [key: string]: string | number | null | Array<string | number>;
+    [key: string]: Maybe<string | number | Array<string | number>>;
   };
   resourceName: keyof RootState['resources'];
   type: 'RESOURCE_LIST_GET';
@@ -49,7 +50,7 @@ export interface ResourceListGetSuccess<R extends Resource> {
     objects: R[];
   };
   params: Partial<APIListCommonRequestParams> & {
-    [key: string]: string | number | null | Array<string | number>;
+    [key: string]: Maybe<string | number | Array<string | number>>;
   };
   resourceName: keyof RootState['resources'];
   type: 'RESOURCE_LIST_GET_SUCCESS';

--- a/richie/js/data/genericSideEffects/pushHistoryState/actions.ts
+++ b/richie/js/data/genericSideEffects/pushHistoryState/actions.ts
@@ -19,6 +19,6 @@ export function pushQueryStringToHistory(
     state: null,
     title: '',
     type: 'HISTORY_PUSH_STATE',
-    url: stringify(queryStringParams),
+    url: `?${stringify(queryStringParams)}`,
   };
 }

--- a/richie/js/data/genericSideEffects/pushHistoryState/actions.ts
+++ b/richie/js/data/genericSideEffects/pushHistoryState/actions.ts
@@ -1,7 +1,7 @@
 import { stringify } from 'query-string';
 
 import { APIListCommonRequestParams } from '../../../types/api';
-import { Nullable } from '../../../utils/types';
+import { Maybe, Nullable } from '../../../utils/types';
 
 export interface HistoryPushState {
   state: Nullable<{}>;
@@ -12,7 +12,7 @@ export interface HistoryPushState {
 
 export function pushQueryStringToHistory(
   queryStringParams: APIListCommonRequestParams & {
-    [key: string]: Nullable<string | number | Array<string | number>>;
+    [key: string]: Maybe<string | number | Array<string | number>>;
   },
 ) {
   return {


### PR DESCRIPTION
## Purpose

Until now active filters were indistinguishable from inactive filters. There was no way to remove them either (apart from editing the URL).

## Proposal

- [x] Add `.active` class to active filters so they stand out
- [x] Put active filters at the top of the list of filters
- [x] Remove an active filter when the user clicks on it
- [x] Fix issues with URL building that caused broken URLs to be pushed to history
