### PR TITLE
➖(requirements)Remove phonenumbers dependecy

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,6 @@ elasticsearch==6.2.0
 gunicorn==19.8.1
 lxml==4.2.1
 pexpect==4.5.0
-phonenumbers==8.9.5
 pickleshare==0.7.4
 Pillow==5.1.0
 prompt-toolkit==1.0.15


### PR DESCRIPTION
This library was forgotten when removing Aldryn Newsblog

