### PR TITLE
Bugfix/174 fix issues in filters update display

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/enzyme": "^3.1.9",
     "@types/enzyme-adapter-react-16": "^1.0.2",
+    "@types/fetch-mock": "^6.0.1",
     "@types/jasmine": "^2.8.6",
     "@types/lodash-es": "^4.17.0",
     "@types/query-string": "^5.1.0",
@@ -33,6 +34,7 @@
     "@types/react-redux": "^6.0.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
+    "fetch-mock": "^6.4.2",
     "jasmine": "^2.9.0",
     "karma": "^2.0.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
@@ -52,7 +52,17 @@ describe('components/searchFilterGroupContainer/mergeProps', () => {
 
     expect(currentValue).toEqual([12, 24]);
     expect(filter).toEqual(exampleFilter);
-    expect(addFilter()).toEqual([dispatch, 'add', filter]);
-    expect(removeFilter()).toEqual([dispatch, 'remove', filter]);
+    expect(addFilter()).toEqual([
+      dispatch,
+      { limit: 17, offset: 7, organizations: [12, 24] },
+      'add',
+      filter,
+    ]);
+    expect(removeFilter()).toEqual([
+      dispatch,
+      { limit: 17, offset: 7, organizations: [12, 24] },
+      'remove',
+      filter,
+    ]);
   });
 });

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
@@ -40,10 +40,16 @@ export const mergeProps = (
   { dispatch }: { dispatch: Dispatch<Action> },
   { machineName }: SearchFilterGroupContainerProps,
 ) => ({
-  addFilter: partial(updateFilter, dispatch, 'add', filter),
+  addFilter: partial(updateFilter, dispatch, currentParams, 'add', filter),
   currentValue: currentParams[filter.machineName],
   filter,
-  removeFilter: partial(updateFilter, dispatch, 'remove', filter),
+  removeFilter: partial(
+    updateFilter,
+    dispatch,
+    currentParams,
+    'remove',
+    filter,
+  ),
 });
 
 export const SearchFilterGroupContainer = connect(

--- a/richie/js/data/genericReducers/resourceById/actions.ts
+++ b/richie/js/data/genericReducers/resourceById/actions.ts
@@ -8,10 +8,10 @@ export interface ResourceAdd<R extends Resource> {
   resource: R;
 }
 
-export function addResource(
+export function addResource<R extends Resource>(
   resourceName: keyof RootState['resources'],
-  resource: Resource,
-): ResourceAdd<Resource> {
+  resource: R,
+): ResourceAdd<R> {
   return {
     resource,
     resourceName,
@@ -25,10 +25,10 @@ export interface ResourceMultipleAdd<R extends Resource> {
   resources: R[];
 }
 
-export function addMultipleResources(
+export function addMultipleResources<R extends Resource>(
   resourceName: keyof RootState['resources'],
-  resources: Resource[],
-): ResourceMultipleAdd<Resource> {
+  resources: R[],
+): ResourceMultipleAdd<R> {
   return {
     resourceName,
     resources,

--- a/richie/js/data/genericReducers/resourceById/resourceById.ts
+++ b/richie/js/data/genericReducers/resourceById/resourceById.ts
@@ -1,6 +1,7 @@
 import { Reducer } from 'redux';
 
 import Resource from '../../../types/Resource';
+import { Maybe } from '../../../utils/types';
 import { ResourceAdd, ResourceMultipleAdd } from './actions';
 
 export const initialState = {
@@ -9,7 +10,7 @@ export const initialState = {
 
 export interface ResourceByIdState<R extends Resource> {
   byId: {
-    [id: string]: R;
+    [id: string]: Maybe<R>;
   };
 }
 

--- a/richie/js/data/genericSideEffects/getResourceList/actions.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/actions.ts
@@ -56,11 +56,11 @@ export interface ResourceListGetSuccess<R extends Resource> {
   type: 'RESOURCE_LIST_GET_SUCCESS';
 }
 
-export function didGetResourceList(
+export function didGetResourceList<R extends Resource>(
   resourceName: keyof RootState['resources'],
-  apiResponse: ResourceListGetSuccess<Resource>['apiResponse'],
-  params: ResourceListGetSuccess<Resource>['params'],
-): ResourceListGetSuccess<Resource> {
+  apiResponse: ResourceListGetSuccess<R>['apiResponse'],
+  params: ResourceListGetSuccess<R>['params'],
+): ResourceListGetSuccess<R> {
   return {
     apiResponse,
     params,

--- a/richie/js/integration_tests/filters.spec.tsx
+++ b/richie/js/integration_tests/filters.spec.tsx
@@ -1,0 +1,251 @@
+import '../testSetup.spec';
+
+import { mount, ReactWrapper } from 'enzyme';
+import * as fetchMock from 'fetch-mock';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Provider, Store } from 'react-redux';
+
+import bootstrapStore from '../bootstrap';
+import { SearchFilter } from '../components/searchFilter/searchFilter';
+import { SearchFilterGroupContainer } from '../components/searchFilterGroupContainer/searchFilterGroupContainer';
+import { SearchFiltersPane } from '../components/searchFiltersPane/searchFiltersPane';
+import { addMultipleResources } from '../data/genericReducers/resourceById/actions';
+import { didGetResourceList } from '../data/genericSideEffects/getResourceList/actions';
+import { RootState } from '../data/rootReducer';
+
+describe('Integration tests - filters', () => {
+  let store: Store<RootState>;
+  let searchFiltersPane: ReactWrapper;
+
+  beforeEach(() => {
+    spyOn(window.history, 'pushState');
+
+    // Create the store with the same initial state as in-app
+    store = bootstrapStore();
+    // Create some organizations, subjects and courses facets and put them in our store so we can
+    // use them to test the filters
+    const orgs = [
+      {
+        banner: null,
+        code: 'org-3',
+        id: 3,
+        logo: null,
+        name: 'Organization Three',
+      },
+      {
+        banner: null,
+        code: 'org-4',
+        id: 4,
+        logo: null,
+        name: 'Organization Four',
+      },
+      {
+        banner: null,
+        code: 'org-5',
+        id: 5,
+        logo: null,
+        name: 'Organization Five',
+      },
+    ];
+    store.dispatch(addMultipleResources('organizations', orgs));
+    store.dispatch(
+      didGetResourceList(
+        'organizations',
+        {
+          meta: { limit: 3, offset: 0, total_count: 3 },
+          objects: orgs,
+        },
+        { limit: 0, offset: 3 },
+      ),
+    );
+    const subjects = [
+      { id: 31, image: null, name: 'Subject Thirty-One' },
+      { id: 41, image: null, name: 'Subject Forty-One' },
+      { id: 51, image: null, name: 'Subject Fifty-One' },
+    ];
+    store.dispatch(addMultipleResources('subjects', subjects));
+    store.dispatch(
+      didGetResourceList(
+        'subjects',
+        {
+          meta: { limit: 3, offset: 0, total_count: 3 },
+          objects: subjects,
+        },
+        { limit: 0, offset: 3 },
+      ),
+    );
+    store.dispatch(
+      didGetResourceList(
+        'courses',
+        {
+          facets: {
+            organizations: { 3: 12, 4: 87, 5: 56 },
+            subjects: { 31: 1, 41: 3, 51: 9 },
+          },
+          meta: { limit: 0, offset: 0, total_count: 400 },
+          objects: [],
+        },
+        { limit: 0, offset: 0 },
+      ),
+    );
+    // Render and mount our whole filters pane
+    searchFiltersPane = mount(
+      <Provider store={store}>
+        <SearchFiltersPane />
+      </Provider>,
+    );
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('shows the values for the hardcoded filters in their groups', () => {
+    const filterGroupNew = searchFiltersPane
+      .find(SearchFilterGroupContainer)
+      .filterWhere(wrapper => wrapper.prop('machineName') === 'new');
+    expect(
+      filterGroupNew.containsMatchingElement(
+        <button className="search-filter ">First session</button>,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('shows the values for the resource-based filters in their groups, ordered by facet count', () => {
+    const filtersOrganizations = searchFiltersPane
+      .find(SearchFilterGroupContainer)
+      .filterWhere(wrapper => wrapper.prop('machineName') === 'organizations')
+      .find(SearchFilter);
+    expect(filtersOrganizations.at(0).html()).toContain(
+      'Organization Four',
+      '87',
+    );
+    expect(filtersOrganizations.at(1).html()).toContain(
+      'Organization Five',
+      '56',
+    );
+    expect(filtersOrganizations.at(2).html()).toContain(
+      'Organization Three',
+      '12',
+    );
+  });
+
+  it('adds the value to the relevant filter when the user clicks on a filter value', async () => {
+    // Return the same thing as what's already in state, we don't intend to modify the state
+    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&organizations=5', {
+      facets: {
+        organizations: { 3: 12, 4: 87, 5: 56 },
+        subjects: { 31: 1, 41: 3, 51: 9 },
+      },
+      meta: { limit: 0, offset: 0, total_count: 400 },
+      objects: [],
+    });
+
+    // Simulate a click on the filter we wish to add
+    searchFiltersPane
+      .find(SearchFilter)
+      .filterWhere(
+        wrapper => wrapper.html().indexOf('Organization Five') !== -1,
+      )
+      .simulate('click');
+
+    // Flush all promises (let data from our fetchMock reach the store)
+    await new Promise(resolve => setImmediate(resolve));
+
+    // Our newly active filter should be at the top
+    const topOrgsFilter = searchFiltersPane
+      .find(SearchFilterGroupContainer)
+      .filterWhere(wrapper => wrapper.prop('machineName') === 'organizations')
+      .render()
+      .find('.search-filter')
+      .first();
+
+    // The correct filter is at the top and marked as active
+    expect(topOrgsFilter.html()).toContain('Organization Five');
+    expect(topOrgsFilter.hasClass('active')).toBeTruthy();
+
+    // URL has been updated with the filter
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      null,
+      '',
+      '?limit=0&offset=0&organizations=5',
+    );
+  });
+
+  it('removes the filter value when the user clicks on an active filter', async () => {
+    // Return the same thing as what's already in state, we don't intend to modify the state
+    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0', {
+      facets: {
+        organizations: { 3: 12, 4: 87, 5: 56 },
+        subjects: { 31: 1, 41: 3, 51: 9 },
+      },
+      meta: { limit: 0, offset: 0, total_count: 400 },
+      objects: [],
+    });
+
+    // Set the subjects filter to '41'
+    store.dispatch(
+      didGetResourceList(
+        'courses',
+        {
+          facets: {
+            organizations: { 3: 12, 4: 87, 5: 56 },
+            subjects: { 31: 1, 41: 3, 51: 9 },
+          },
+          meta: { limit: 0, offset: 0, total_count: 400 },
+          objects: [],
+        },
+        { limit: 0, offset: 0, subjects: '41' },
+      ),
+    );
+
+    // Ensure the value is active before we go on to disable it
+    expect(
+      searchFiltersPane
+        .render()
+        .find('.search-filter.active')
+        .html(),
+    ).toContain('Subject Forty-One');
+
+    // Simulate a click on the filter we want to disable
+    searchFiltersPane
+      .find(SearchFilter)
+      .filterWhere(
+        wrapper => wrapper.html().indexOf('Subject Forty-One') !== -1,
+      )
+      .simulate('click');
+
+    // Flush all promises (let data from our fetchMock reach the store)
+    await new Promise(resolve => setImmediate(resolve));
+
+    // Our previously active filter is not at the top, instead it is the filter with the highest facet count
+    expect(
+      searchFiltersPane
+        .find(SearchFilterGroupContainer)
+        .filterWhere(wrapper => wrapper.prop('machineName') === 'subjects')
+        .render()
+        .find('.search-filter')
+        .first()
+        .html(),
+    ).toContain('Subject Fifty-One');
+
+    // Our previously active filter is not marked as active any more
+    expect(
+      searchFiltersPane
+        .find(SearchFilter)
+        .filterWhere(
+          wrapper => wrapper.html().indexOf('Subject Forty-One') !== -1,
+        )
+        .render()
+        .hasClass('active'),
+    ).not.toBeTruthy();
+
+    // URL has been updated to remove the filter
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      null,
+      '',
+      '?limit=0&offset=0',
+    );
+  });
+});

--- a/richie/js/utils/filters/getFilterFromState.ts
+++ b/richie/js/utils/filters/getFilterFromState.ts
@@ -48,12 +48,12 @@ export function getFilterFromState(
     // We don't have the facets yet or something broke upstream: provide some filtering
     // capabilities anyway (without counts, as we can't generate those)
     if (!facets_[resourceName] || !Object.keys(facets_[resourceName]).length) {
-      return values(state.resources[resourceName]!.byId || {}).map(
-        organization => ({
-          humanName: organization.name,
-          primaryKey: String(organization.id),
-        }),
-      );
+      return values(state.resources[resourceName]!.byId)
+        .filter(organization => !!organization)
+        .map(organization => ({
+          humanName: organization!.name,
+          primaryKey: String(organization!.id),
+        }));
     }
 
     return (
@@ -62,10 +62,17 @@ export function getFilterFromState(
           // Facet current query by this resource id (count)
           count: facets[resourceName][resourceId],
           // Get the resource name from the state
-          humanName: state.resources[resourceName]!.byId[resourceId].name,
+          humanName:
+            (state.resources[resourceName]!.byId[resourceId] &&
+              state.resources[resourceName]!.byId[resourceId]!.name) ||
+            '',
           // resourceId is already a string as it was a key on the facets.organization object
           primaryKey: resourceId,
         }))
+        .filter(
+          ({ count, humanName, primaryKey }) =>
+            !!count && !!humanName && !!primaryKey,
+        )
         // Sort by highest count first
         .sort(
           (filterValueA, filterValueB) =>

--- a/richie/js/utils/filters/updateFilter.spec.ts
+++ b/richie/js/utils/filters/updateFilter.spec.ts
@@ -17,10 +17,10 @@ describe('utils/filters/updateFilter', () => {
   it('dispatches relevant actions with the updated params', () => {
     updateFilter(
       dispatch,
+      { limit: 13, offset: 3, organizations: [42, 84] },
       'add',
       { isDrilldown: true, machineName: 'status' } as FilterDefinition,
       'some filter value',
-      { limit: 13, offset: 3, organizations: [42, 84] },
     );
 
     expect(dispatch).toHaveBeenCalledWith({

--- a/richie/js/utils/filters/updateFilter.ts
+++ b/richie/js/utils/filters/updateFilter.ts
@@ -14,10 +14,10 @@ import { computeNewFilterValue } from './computeNewFilterValue';
 // have it duplicated in several connected components, and once in each component for each action it supports.
 export const updateFilter = (
   dispatch: Dispatch<Action>,
+  currentParams: ResourceListStateParams,
   action: 'add' | 'remove',
   filter: FilterDefinition,
   filterValue: string,
-  currentParams: ResourceListStateParams,
 ) => {
   // Use our other utils to build the new params from the existing state and filter information,
   // and the incoming filter value & definition

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,10 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
+"@types/fetch-mock@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-6.0.1.tgz#df4e9f3a12fc81fae173f018ea17ad79441c10ba"
+
 "@types/jasmine@^2.8.6":
   version "2.8.6"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.6.tgz#14445b6a1613cf4e05dd61c3c3256d0e95c0421e"
@@ -888,6 +892,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
+
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
 
 babel-preset-es2015@^6.9.0:
   version "6.24.1"
@@ -2720,6 +2732,14 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fetch-mock@^6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-6.4.2.tgz#cb0ff7dc3baf5d3bc8628f73fca73bf862fbaa43"
+  dependencies:
+    babel-polyfill "^6.26.0"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3055,6 +3075,10 @@ glob-parent@^3.1.0:
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
 
 glob@^6.0.4:
   version "6.0.4"
@@ -5610,6 +5634,10 @@ path-proxy@~1.0.0:
   dependencies:
     inflection "~1.3.0"
 
+path-to-regexp@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -6114,6 +6142,10 @@ redux@^4.0.0:
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
## Purpose

There were two separate issues in the filters management:
1. an empty filter was be impossible to update
2. race conditions caused failures to display the filters when the facets arrived before the records for the related resource

## Proposal

- [x] Fix both issues in the code
- [x] Make the record reducer state type more robust to avoid running into 2 again
- [x] Add an integration test that would have caught those bugs for us (hopefully the first of many others 🚀)
- [x] improve our generic reducer action creator types (was necessary to write that integration test)