### PR TITLE
Add an indirection layer for access to window.location

### DIFF
--- a/richie/js/utils/indirection/location.ts
+++ b/richie/js/utils/indirection/location.ts
@@ -1,0 +1,4 @@
+// Layer of indirection to facilitate testing of code that would use location facilities
+export const location = {
+  setHref: (url: string) => (window.location.href = url),
+};


### PR DESCRIPTION
## Purpose

Some native APIs can be hard to test, especially when they cannot be mocked or when they're used through assignment rather than by calling methods.

## Proposal

Add an almost transparent layer of indirection to make testing them a breeze.
