### PR TITLE
Add a generic error handler shell

### DIFF
--- a/richie/js/utils/errors/handle.ts
+++ b/richie/js/utils/errors/handle.ts
@@ -1,0 +1,6 @@
+// Generic error handler to be called whenever we need to do error reporting throughout the app
+// For now only logs the error but should upload the errors to something like Sentry later on
+// tslint:disable:no-console
+export const handle = (error: Error) => {
+  console.error(error);
+};


### PR DESCRIPTION
## Purpose

We need some error handler to call from our code instead of throwing and calling it a day; that's especially true for async function where it's easy to leave failures uncaught.

## Proposal

Simply add a module with a `handle` export that logs errors to the console so we can start calling it. More comprehensive content such as reporting will be added later on as we work on #112 .