### PR TITLE
Use "match" as the params name for basic searches

### DIFF
--- a/apps/search/forms.py
+++ b/apps/search/forms.py
@@ -18,7 +18,7 @@ class CourseListForm(forms.Form):
     organizations = ArrayField(
         required=False, base_type=forms.IntegerField(min_value=0)
     )
-    match = forms.CharField(required=False, min_length=3, max_length=200)
+    query = forms.CharField(required=False, min_length=3, max_length=200)
     offset = forms.IntegerField(required=False, min_value=0, initial=0)
     start_date = DatetimeRangeField(required=False)
     subjects = ArrayField(required=False, base_type=forms.IntegerField(min_value=0))
@@ -29,7 +29,7 @@ class OrganizationListForm(forms.Form):
     Validate the query string params in the organization list request
     """
     limit = forms.IntegerField(required=False, min_value=1, initial=10)
-    name = forms.CharField(required=False, min_length=3, max_length=100)
+    query = forms.CharField(required=False, min_length=3, max_length=100)
     offset = forms.IntegerField(required=False, min_value=0, initial=0)
 
 
@@ -38,5 +38,5 @@ class SubjectListForm(forms.Form):
     Validate the query string params in the subject list request
     """
     limit = forms.IntegerField(required=False, min_value=1, initial=10)
-    name = forms.CharField(required=False, min_length=3, max_length=100)
+    query = forms.CharField(required=False, min_length=3, max_length=100)
     offset = forms.IntegerField(required=False, min_value=0, initial=0)

--- a/apps/search/tests/test_viewsets_courses.py
+++ b/apps/search/tests/test_viewsets_courses.py
@@ -143,7 +143,7 @@ class CoursesViewsetTestCase(TestCase):
         """
         factory = APIRequestFactory()
         request = factory.get(
-            "/api/v1.0/courses?match=some%20phrase%20terms&limit=2&offset=20"
+            "/api/v1.0/courses?query=some%20phrase%20terms&limit=2&offset=20"
         )
 
         mock_search.return_value = {
@@ -483,7 +483,7 @@ class CoursesViewsetTestCase(TestCase):
         end_date = json.dumps(["2018-04-30T06:00:00Z", "2018-06-30T06:00:00Z"])
 
         request = factory.get(
-            "/api/v1.0/courses?subjects=42&subjects=84&match=these%20phrase%20terms&limit=2&"
+            "/api/v1.0/courses?subjects=42&subjects=84&query=these%20phrase%20terms&limit=2&"
             + "start_date={start_date}&end_date={end_date}".format(
                 start_date=start_date, end_date=end_date
             )

--- a/apps/search/tests/test_viewsets_organizations.py
+++ b/apps/search/tests/test_viewsets_organizations.py
@@ -145,7 +145,7 @@ class OrganizationsViewsetTestCase(TestCase):
         Happy path: the consumer is filtering the organizations by name
         """
         factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/organizations?name=Université&limit=2")
+        request = factory.get("/api/v1.0/organizations?query=Université&limit=2")
 
         mock_search.return_value = {
             "hits": {

--- a/apps/search/tests/test_viewsets_subjects.py
+++ b/apps/search/tests/test_viewsets_subjects.py
@@ -129,7 +129,7 @@ class SubjectsViewsetTestCase(TestCase):
         Happy path: the subject is filtering the subjects by name
         """
         factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/subject?name=Science&limit=2")
+        request = factory.get("/api/v1.0/subject?query=Science&limit=2")
 
         mock_search.return_value = {
             "hits": {

--- a/apps/search/viewsets/courses.py
+++ b/apps/search/viewsets/courses.py
@@ -82,7 +82,7 @@ class CoursesViewSet(ViewSet):
                 queries = [*queries, {"terms": {param: value}}]
 
             # Search is a regular (multilingual) match query
-            elif param == "match":
+            elif param == "query":
                 queries = [
                     *queries,
                     {

--- a/apps/search/viewsets/organizations.py
+++ b/apps/search/viewsets/organizations.py
@@ -32,12 +32,12 @@ class OrganizationsViewSet(ViewSet):
         # Build a query that matches on the organization name field if it was passed by the client
         # Note: test_elasticsearch_feature.py needs to be updated whenever the search call
         # is updated and makes use new features.
-        if query_params_form.cleaned_data.get("name"):
+        if query_params_form.cleaned_data.get("query"):
             search_payload = {
                 "query": {
                     "match": {
                         "name.fr": {
-                            "query": query_params_form.cleaned_data.get("name"),
+                            "query": query_params_form.cleaned_data.get("query"),
                             "analyzer": "french",
                         }
                     }

--- a/apps/search/viewsets/subjects.py
+++ b/apps/search/viewsets/subjects.py
@@ -32,12 +32,12 @@ class SubjectsViewSet(ViewSet):
         # Build a query that matches on the name field if it was handed by the client
         # Note: test_elasticsearch_feature.py needs to be updated whenever the search call
         # is updated and makes use new features.
-        if params_form.cleaned_data.get("name"):
+        if params_form.cleaned_data.get("query"):
             search_body = {
                 "query": {
                     "match": {
                         "name.fr": {
-                            "query": params_form.cleaned_data.get("name"),
+                            "query": params_form.cleaned_data.get("query"),
                             "analyzer": "french",
                         }
                     }


### PR DESCRIPTION
## Purpose

Courses use "match" as the param name for searches, whereas Subjects & Organizations use "name". This is unintuitive in the client-side as it would force us to maintain a list matching those param names to model names.

## Proposal

Change those so everyone uses "match".