### PR TITLE
Remove default exports from all our TS modules

### DIFF
--- a/richie/js/bootstrap.ts
+++ b/richie/js/bootstrap.ts
@@ -1,12 +1,12 @@
 import { parse } from 'query-string';
 
-import configureStore from './data/configureStore';
+import { configureStore } from './data/configureStore';
 import { initialState as filterDefinitionsInitialState } from './data/filterDefinitions/initialState';
 import { RootState } from './data/rootReducer';
 
 const params = parse(location.search);
 
-export default function bootstrapStore() {
+export function bootstrapStore() {
   return configureStore({
     filterDefinitions: filterDefinitionsInitialState,
     resources: {

--- a/richie/js/components/courseGlimpse/courseGlimpse.spec.tsx
+++ b/richie/js/components/courseGlimpse/courseGlimpse.spec.tsx
@@ -3,9 +3,9 @@ import '../../testSetup.spec';
 import { render } from 'enzyme';
 import * as React from 'react';
 
-import Course from '../../types/Course';
-import Organization from '../../types/Organization';
-import CourseGlimpse from './courseGlimpse';
+import { Course } from '../../types/Course';
+import { Organization } from '../../types/Organization';
+import { CourseGlimpse } from './courseGlimpse';
 
 describe('components/courseGlimpse', () => {
   it('renders a course glimpse with its data', () => {

--- a/richie/js/components/courseGlimpse/courseGlimpse.tsx
+++ b/richie/js/components/courseGlimpse/courseGlimpse.tsx
@@ -1,8 +1,8 @@
 import * as moment from 'moment';
 import * as React from 'react';
 
-import Course from '../../types/Course';
-import Organization from '../../types/Organization';
+import { Course } from '../../types/Course';
+import { Organization } from '../../types/Organization';
 import { Nullable } from '../../utils/types';
 
 export interface CourseGlimpseProps {
@@ -34,5 +34,3 @@ export const CourseGlimpse = (props: CourseGlimpseProps) => {
     </div>
   );
 };
-
-export default CourseGlimpse;

--- a/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.spec.tsx
@@ -1,5 +1,5 @@
 import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
-import Course from '../../types/Course';
+import { Course } from '../../types/Course';
 import { mapStateToProps, mergeProps } from './courseGlimpseContainer';
 
 describe('components/courseGlimpseContainer', () => {

--- a/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.tsx
+++ b/richie/js/components/courseGlimpseContainer/courseGlimpseContainer.tsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 
 import { RootState } from '../../data/rootReducer';
-import Course from '../../types/Course';
+import { Course } from '../../types/Course';
 import {
   CourseGlimpse,
   CourseGlimpseProps,
@@ -38,5 +38,3 @@ export const CourseGlimpseContainer = connect(
   null,
   mergeProps,
 )(CourseGlimpse);
-
-export default CourseGlimpseContainer;

--- a/richie/js/components/courseGlimpseList/courseGlimpseList.spec.tsx
+++ b/richie/js/components/courseGlimpseList/courseGlimpseList.spec.tsx
@@ -3,9 +3,9 @@ import '../../testSetup.spec';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import Course from '../../types/Course';
-import CourseGlimpseContainer from '../courseGlimpseContainer/courseGlimpseContainer';
-import CourseGlimpseList from './courseGlimpseList';
+import { Course } from '../../types/Course';
+import { CourseGlimpseContainer } from '../courseGlimpseContainer/courseGlimpseContainer';
+import { CourseGlimpseList } from './courseGlimpseList';
 
 describe('components/courseGlimpseList', () => {
   it('renders a list of Courses into a list of CourseGlimpses', () => {

--- a/richie/js/components/courseGlimpseList/courseGlimpseList.tsx
+++ b/richie/js/components/courseGlimpseList/courseGlimpseList.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { ResourceListGet } from '../../data/genericSideEffects/getResourceList/actions';
-import Course from '../../types/Course';
-import CourseGlimpseContainer from '../courseGlimpseContainer/courseGlimpseContainer';
+import { Course } from '../../types/Course';
+import { CourseGlimpseContainer } from '../courseGlimpseContainer/courseGlimpseContainer';
 
 export interface CourseGlimpseListProps {
   courses: Course[];
@@ -26,5 +26,3 @@ export class CourseGlimpseList extends React.Component<CourseGlimpseListProps> {
     );
   }
 }
-
-export default CourseGlimpseList;

--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.spec.tsx
@@ -1,5 +1,5 @@
 import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
-import Course from '../../types/Course';
+import { Course } from '../../types/Course';
 import { mapStateToProps, mergeProps } from './courseGlimpseListContainer';
 
 describe('components/courseGlimpseListContainer', () => {

--- a/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.tsx
+++ b/richie/js/components/courseGlimpseListContainer/courseGlimpseListContainer.tsx
@@ -6,7 +6,7 @@ import { Action } from 'redux';
 import { ResourceListStateParams } from '../../data/genericReducers/resourceList/resourceList';
 import { getResourceList } from '../../data/genericSideEffects/getResourceList/actions';
 import { RootState } from '../../data/rootReducer';
-import Course from '../../types/Course';
+import { Course } from '../../types/Course';
 import { Maybe } from '../../utils/types';
 import { CourseGlimpseList } from '../courseGlimpseList/courseGlimpseList';
 
@@ -69,5 +69,3 @@ export const CourseGlimpseListContainer = connect(
   null!,
   mergeProps,
 )(CourseGlimpseList);
-
-export default CourseGlimpseListContainer;

--- a/richie/js/components/search/search.spec.tsx
+++ b/richie/js/components/search/search.spec.tsx
@@ -3,9 +3,9 @@ import '../../testSetup.spec';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import CourseGlimpseListContainer from '../courseGlimpseListContainer/courseGlimpseListContainer';
-import SearchFiltersPane from '../searchFiltersPane/searchFiltersPane';
-import Search from './search';
+import { CourseGlimpseListContainer } from '../courseGlimpseListContainer/courseGlimpseListContainer';
+import { SearchFiltersPane } from '../searchFiltersPane/searchFiltersPane';
+import { Search } from './search';
 
 describe('components/search', () => {
   it('renders the filters pane and the list of courses', () => {

--- a/richie/js/components/search/search.tsx
+++ b/richie/js/components/search/search.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
 import { ResourceListGet } from '../../data/genericSideEffects/getResourceList/actions';
-import Course from '../../types/Course';
-import CourseGlimpseListContainer from '../courseGlimpseListContainer/courseGlimpseListContainer';
-import SearchFiltersPane from '../searchFiltersPane/searchFiltersPane';
+import { Course } from '../../types/Course';
+import { CourseGlimpseListContainer } from '../courseGlimpseListContainer/courseGlimpseListContainer';
+import { SearchFiltersPane } from '../searchFiltersPane/searchFiltersPane';
 import { SearchSuggestFieldContainer } from '../searchSuggestFieldContainer/searchSuggestFieldContainer';
 
 export interface SearchProps {
@@ -35,5 +35,3 @@ export class Search extends React.Component<SearchProps, SearchState> {
     );
   }
 }
-
-export default Search;

--- a/richie/js/components/searchContainer/searchContainer.tsx
+++ b/richie/js/components/searchContainer/searchContainer.tsx
@@ -12,5 +12,3 @@ const mapDispatchToProps = {
 };
 
 export const SearchContainer = connect(null, mapDispatchToProps)(Search);
-
-export default SearchContainer;

--- a/richie/js/components/searchFilter/searchFilter.spec.tsx
+++ b/richie/js/components/searchFilter/searchFilter.spec.tsx
@@ -3,7 +3,7 @@ import '../../testSetup.spec';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import SearchFilter from './searchFilter';
+import { SearchFilter } from './searchFilter';
 
 describe('components/searchFilter', () => {
   let addFilter: jasmine.Spy;

--- a/richie/js/components/searchFilter/searchFilter.tsx
+++ b/richie/js/components/searchFilter/searchFilter.tsx
@@ -30,5 +30,3 @@ export const SearchFilter = (props: SearchFilterProps) => {
     </button>
   );
 };
-
-export default SearchFilter;

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.spec.tsx
@@ -4,8 +4,8 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { FilterDefinitionWithValues } from '../../types/filters';
-import SearchFilter from '../searchFilter/searchFilter';
-import SearchFilterGroup from './searchFilterGroup';
+import { SearchFilter } from '../searchFilter/searchFilter';
+import { SearchFilterGroup } from './searchFilterGroup';
 
 describe('components/searchFilterGroup', () => {
   const addFilter = jasmine.createSpy('addFilter');

--- a/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
+++ b/richie/js/components/searchFilterGroup/searchFilterGroup.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { FilterDefinitionWithValues, FilterValue } from '../../types/filters';
 import { Maybe, Nullable } from '../../utils/types';
-import SearchFilter from '../searchFilter/searchFilter';
+import { SearchFilter } from '../searchFilter/searchFilter';
 
 export interface SearchFilterGroupProps {
   addFilter: (filterKey: string) => void;
@@ -52,5 +52,3 @@ export const SearchFilterGroup = (props: SearchFilterGroupProps) => {
     </div>
   );
 };
-
-export default SearchFilterGroup;

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.spec.tsx
@@ -3,7 +3,7 @@ import { stringify } from 'query-string';
 import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
 import { ResourceListState } from '../../data/genericReducers/resourceList/resourceList';
 import { RootState } from '../../data/rootReducer';
-import Course from '../../types/Course';
+import { Course } from '../../types/Course';
 import * as filterFromStateGetter from '../../utils/filters/getFilterFromState';
 import * as filterUpdater from '../../utils/filters/updateFilter';
 import { mapStateToProps, mergeProps } from './searchFilterGroupContainer';

--- a/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
+++ b/richie/js/components/searchFilterGroupContainer/searchFilterGroupContainer.tsx
@@ -57,5 +57,3 @@ export const SearchFilterGroupContainer = connect(
   null!,
   mergeProps,
 )(SearchFilterGroup);
-
-export default SearchFilterGroupContainer;

--- a/richie/js/components/searchFiltersPane/searchFiltersPane.spec.tsx
+++ b/richie/js/components/searchFiltersPane/searchFiltersPane.spec.tsx
@@ -3,8 +3,8 @@ import '../../testSetup.spec';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import SearchFilterGroupContainer from '../searchFilterGroupContainer/searchFilterGroupContainer';
-import SearchFiltersPane from './searchFiltersPane';
+import { SearchFilterGroupContainer } from '../searchFilterGroupContainer/searchFilterGroupContainer';
+import { SearchFiltersPane } from './searchFiltersPane';
 
 describe('components/searchFiltersPane', () => {
   it('renders all our search filter group containers', () => {

--- a/richie/js/components/searchFiltersPane/searchFiltersPane.tsx
+++ b/richie/js/components/searchFiltersPane/searchFiltersPane.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import SearchFilterGroupContainer from '../searchFilterGroupContainer/searchFilterGroupContainer';
+import { SearchFilterGroupContainer } from '../searchFilterGroupContainer/searchFilterGroupContainer';
 
 export const SearchFiltersPane = (props: {}) => {
   return (
@@ -14,5 +14,3 @@ export const SearchFiltersPane = (props: {}) => {
     </div>
   );
 };
-
-export default SearchFiltersPane;

--- a/richie/js/components/searchSuggestField/searchSuggestField.spec.tsx
+++ b/richie/js/components/searchSuggestField/searchSuggestField.spec.tsx
@@ -3,7 +3,7 @@ import '../../testSetup.spec';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import Course from '../../types/Course';
+import { Course } from '../../types/Course';
 import { SearchSuggestionSection } from '../../types/searchSuggest';
 import * as errors from '../../utils/errors/handle';
 import { location } from '../../utils/indirection/location';

--- a/richie/js/data/configureStore.ts
+++ b/richie/js/data/configureStore.ts
@@ -2,11 +2,11 @@ import { applyMiddleware, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
 import { rootReducer, RootState } from './rootReducer';
-import rootSaga from './rootSaga';
+import { rootSaga } from './rootSaga';
 
 const sagaMiddleware = createSagaMiddleware();
 
-export default function configureStore(preloadedState: RootState) {
+export function configureStore(preloadedState: RootState) {
   const store = createStore(
     rootReducer,
     preloadedState,

--- a/richie/js/data/courses/reducer.spec.ts
+++ b/richie/js/data/courses/reducer.spec.ts
@@ -1,4 +1,4 @@
-import coursesReducer from './reducer';
+import { courses } from './reducer';
 
 describe('data/courses reducer', () => {
   const course43 = {
@@ -43,16 +43,14 @@ describe('data/courses reducer', () => {
   };
 
   it('returns an empty state for initialization', () => {
-    expect(coursesReducer(undefined, { type: '' })).toEqual({ byId: {} });
+    expect(courses(undefined, { type: '' })).toEqual({ byId: {} });
   });
 
   it('returns the state as is when called with an unknown action', () => {
     const previousState = {
       byId: { 43: course43 },
     };
-    expect(coursesReducer(previousState, { type: 'TODO_ADD' })).toEqual(
-      previousState,
-    );
+    expect(courses(previousState, { type: 'TODO_ADD' })).toEqual(previousState);
   });
 
   describe('resourceById', () => {
@@ -60,7 +58,7 @@ describe('data/courses reducer', () => {
       const previousState = { byId: { 43: course43 } };
 
       expect(
-        coursesReducer(previousState, {
+        courses(previousState, {
           resource: course44,
           resourceName: 'subjects',
           type: 'RESOURCE_ADD',
@@ -72,7 +70,7 @@ describe('data/courses reducer', () => {
       const previousState = { byId: { 43: course43 } };
 
       expect(
-        coursesReducer(previousState, {
+        courses(previousState, {
           resource: course44,
           resourceName: 'courses',
           type: 'RESOURCE_ADD',

--- a/richie/js/data/courses/reducer.ts
+++ b/richie/js/data/courses/reducer.ts
@@ -3,7 +3,7 @@ import get from 'lodash-es/get';
 import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
-import Course from '../../types/Course';
+import { Course } from '../../types/Course';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
 import {
@@ -44,5 +44,3 @@ export const courses: Reducer<CoursesState> = (
     action,
   );
 };
-
-export default courses;

--- a/richie/js/data/filterDefinitions/initialState.ts
+++ b/richie/js/data/filterDefinitions/initialState.ts
@@ -43,5 +43,3 @@ export const initialState = {
   ...hardcodedFilterDefinitions,
   ...resourceBasedFilterDefinitions,
 };
-
-export default initialState;

--- a/richie/js/data/filterDefinitions/reducer.ts
+++ b/richie/js/data/filterDefinitions/reducer.ts
@@ -4,7 +4,7 @@ import {
   hardcodedFilterGroupName,
   resourceBasedFilterGroupName,
 } from '../../types/filters';
-import initialState from './initialState';
+import { initialState } from './initialState';
 
 // Hardcoded filter groups have all their data contained in this slice of state
 type FilterDefinitionStateHardcoded = {
@@ -29,5 +29,3 @@ export const filterDefinitions = (
 ) => {
   return state;
 };
-
-export default filterDefinitions;

--- a/richie/js/data/genericReducers/resourceById/actions.ts
+++ b/richie/js/data/genericReducers/resourceById/actions.ts
@@ -1,6 +1,6 @@
 import { RootState } from '../../rootReducer';
 
-import Resource from '../../../types/Resource';
+import { Resource } from '../../../types/Resource';
 
 export interface ResourceAdd<R extends Resource> {
   type: 'RESOURCE_ADD';

--- a/richie/js/data/genericReducers/resourceById/resourceById.spec.ts
+++ b/richie/js/data/genericReducers/resourceById/resourceById.spec.ts
@@ -1,4 +1,4 @@
-import resourceByIdReducer from './resourceById';
+import { byId } from './resourceById';
 
 describe('data/genericReducers/resourceById reducer', () => {
   const subj43 = {
@@ -20,7 +20,7 @@ describe('data/genericReducers/resourceById reducer', () => {
   };
 
   it('returns an empty state for initialization', () => {
-    expect(resourceByIdReducer({ byId: {} }, { type: '' })).toEqual({
+    expect(byId({ byId: {} }, { type: '' })).toEqual({
       byId: {},
     });
   });
@@ -29,9 +29,7 @@ describe('data/genericReducers/resourceById reducer', () => {
     const previousState = {
       byId: { 43: subj43 },
     };
-    expect(resourceByIdReducer(previousState, { type: '' })).toEqual(
-      previousState,
-    );
+    expect(byId(previousState, { type: '' })).toEqual(previousState);
   });
 
   describe('RESOURCE_ADD', () => {
@@ -40,7 +38,7 @@ describe('data/genericReducers/resourceById reducer', () => {
         byId: { 43: subj43 },
       };
       expect(
-        resourceByIdReducer(previousState, {
+        byId(previousState, {
           resource: subj44,
           resourceName: 'subjects',
           type: 'RESOURCE_ADD',
@@ -55,7 +53,7 @@ describe('data/genericReducers/resourceById reducer', () => {
         byId: { 43: subj43 },
       };
       expect(
-        resourceByIdReducer(previousState, {
+        byId(previousState, {
           resourceName: 'subjects',
           resources: [subj44, subj45],
           type: 'RESOURCE_MULTIPLE_ADD',

--- a/richie/js/data/genericReducers/resourceById/resourceById.ts
+++ b/richie/js/data/genericReducers/resourceById/resourceById.ts
@@ -1,6 +1,6 @@
 import { Reducer } from 'redux';
 
-import Resource from '../../../types/Resource';
+import { Resource } from '../../../types/Resource';
 import { Maybe } from '../../../utils/types';
 import { ResourceAdd, ResourceMultipleAdd } from './actions';
 
@@ -52,5 +52,3 @@ export function byId<R extends Resource>(
 
   return state;
 }
-
-export default byId;

--- a/richie/js/data/genericReducers/resourceList/resourceList.ts
+++ b/richie/js/data/genericReducers/resourceList/resourceList.ts
@@ -5,7 +5,7 @@ import {
   APIListCommonRequestParams,
   APIResponseListFacets,
 } from '../../../types/api';
-import Resource from '../../../types/Resource';
+import { Resource } from '../../../types/Resource';
 import { Maybe } from '../../../utils/types';
 import {
   ResourceListGet,
@@ -71,5 +71,3 @@ export function currentQuery<R extends Resource>(
   }
   return state;
 }
-
-export default currentQuery;

--- a/richie/js/data/genericSideEffects/getResourceList/actions.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/actions.ts
@@ -3,7 +3,7 @@ import {
   APIResponseListFacets,
   APIResponseListMeta,
 } from '../../../types/api';
-import Resource from '../../../types/Resource';
+import { Resource } from '../../../types/Resource';
 import { Maybe } from '../../../utils/types';
 import { RootState } from '../../rootReducer';
 

--- a/richie/js/data/genericSideEffects/getResourceList/getResourceList.ts
+++ b/richie/js/data/genericSideEffects/getResourceList/getResourceList.ts
@@ -4,7 +4,7 @@ import { call, put, takeEvery } from 'redux-saga/effects';
 
 import { API_ENDPOINTS, API_LIST_DEFAULT_PARAMS } from '../../../settings.json';
 import { APIResponseListFacets, APIResponseListMeta } from '../../../types/api';
-import Resource from '../../../types/Resource';
+import { Resource } from '../../../types/Resource';
 import { addMultipleResources } from '../../genericReducers/resourceById/actions';
 import { RootState } from '../../rootReducer';
 import {
@@ -78,7 +78,7 @@ export function* getList(action: ResourceListGet) {
   }
 }
 
-export default function* watch() {
+export function* getResourceListSaga() {
   // We can cancel ongoing requests whenever there's a new one: the user will not request several different sets
   // of filters of the same kind at the same time.
   yield takeEvery('RESOURCE_LIST_GET', getList);

--- a/richie/js/data/genericSideEffects/pushHistoryState/pushHistoryState.ts
+++ b/richie/js/data/genericSideEffects/pushHistoryState/pushHistoryState.ts
@@ -1,11 +1,12 @@
 import partial from 'lodash-es/partial';
 import { takeEvery } from 'redux-saga/effects';
+
 import { HistoryPushState } from './actions';
 
 export function pushState(w: Window, action: HistoryPushState) {
   w.history.pushState(action.state, action.title, action.url);
 }
 
-export default function* watch() {
+export function* pushHistoryState() {
   yield takeEvery('HISTORY_PUSH_STATE', partial(pushState, window));
 }

--- a/richie/js/data/organizations/reducer.spec.ts
+++ b/richie/js/data/organizations/reducer.spec.ts
@@ -1,4 +1,4 @@
-import organizationsReducer from './reducer';
+import { organizations } from './reducer';
 
 describe('data/organizations reducer', () => {
   const org43 = {
@@ -24,7 +24,7 @@ describe('data/organizations reducer', () => {
       const previousState = { byId: { 43: org43 } };
 
       expect(
-        organizationsReducer(previousState, {
+        organizations(previousState, {
           resource: org44,
           resourceName: 'subjects',
           type: 'RESOURCE_ADD',
@@ -36,7 +36,7 @@ describe('data/organizations reducer', () => {
       const previousState = { byId: { 43: org43 } };
 
       expect(
-        organizationsReducer(previousState, {
+        organizations(previousState, {
           resource: org44,
           resourceName: 'organizations',
           type: 'RESOURCE_ADD',

--- a/richie/js/data/organizations/reducer.ts
+++ b/richie/js/data/organizations/reducer.ts
@@ -3,7 +3,7 @@ import get from 'lodash-es/get';
 import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
-import Organization from '../../types/Organization';
+import { Organization } from '../../types/Organization';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
 import {
@@ -47,5 +47,3 @@ export const organizations: Reducer<OrganizationsState> = (
     action,
   );
 };
-
-export default organizations;

--- a/richie/js/data/rootReducer.ts
+++ b/richie/js/data/rootReducer.ts
@@ -36,5 +36,3 @@ export const rootReducer: Reducer<RootState> = (state, action) => {
     },
   };
 };
-
-export default rootReducer;

--- a/richie/js/data/rootSaga.ts
+++ b/richie/js/data/rootSaga.ts
@@ -1,9 +1,9 @@
 import { all } from 'redux-saga/effects';
 
-import getResourceListSaga from './genericSideEffects/getResourceList/getResourceList';
-import pushHistoryState from './genericSideEffects/pushHistoryState/pushHistoryState';
+import { getResourceListSaga } from './genericSideEffects/getResourceList/getResourceList';
+import { pushHistoryState } from './genericSideEffects/pushHistoryState/pushHistoryState';
 
 // Aggregate all our sagas through the parallelization effect
-export default function* rootSaga() {
+export function* rootSaga() {
   yield all([getResourceListSaga(), pushHistoryState()]);
 }

--- a/richie/js/data/subjects/reducer.spec.ts
+++ b/richie/js/data/subjects/reducer.spec.ts
@@ -1,4 +1,4 @@
-import subjectsReducer from './reducer';
+import { subjects } from './reducer';
 
 describe('data/subjects reducer', () => {
   const subj43 = {
@@ -18,7 +18,7 @@ describe('data/subjects reducer', () => {
       const previousState = { byId: { 43: subj43 } };
 
       expect(
-        subjectsReducer(previousState, {
+        subjects(previousState, {
           resource: subj44,
           resourceName: 'organizations',
           type: 'RESOURCE_ADD',
@@ -30,7 +30,7 @@ describe('data/subjects reducer', () => {
       const previousState = { byId: { 43: subj43 } };
 
       expect(
-        subjectsReducer(previousState, {
+        subjects(previousState, {
           resource: subj44,
           resourceName: 'subjects',
           type: 'RESOURCE_ADD',

--- a/richie/js/data/subjects/reducer.ts
+++ b/richie/js/data/subjects/reducer.ts
@@ -3,7 +3,7 @@ import get from 'lodash-es/get';
 import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
-import Subject from '../../types/Subject';
+import { Subject } from '../../types/Subject';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
 import {
@@ -47,5 +47,3 @@ export const subjects: Reducer<SubjectsState> = (
     action,
   );
 };
-
-export default subjects;

--- a/richie/js/index.tsx
+++ b/richie/js/index.tsx
@@ -14,7 +14,7 @@ import get from 'lodash-es/get';
 import includes from 'lodash-es/includes';
 import startCase from 'lodash-es/startCase';
 
-import bootstrapStore from './bootstrap';
+import { bootstrapStore } from './bootstrap';
 
 // Import the top-level components that can be directly called from the CMS
 import { SearchContainer } from './components/searchContainer/searchContainer';

--- a/richie/js/integration_tests/filters.spec.tsx
+++ b/richie/js/integration_tests/filters.spec.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider, Store } from 'react-redux';
 
-import bootstrapStore from '../bootstrap';
+import { bootstrapStore } from '../bootstrap';
 import { SearchFilter } from '../components/searchFilter/searchFilter';
 import { SearchFilterGroupContainer } from '../components/searchFilterGroupContainer/searchFilterGroupContainer';
 import { SearchFiltersPane } from '../components/searchFiltersPane/searchFiltersPane';

--- a/richie/js/types/Course.ts
+++ b/richie/js/types/Course.ts
@@ -1,8 +1,8 @@
-import Organization from './Organization';
-import Resource from './Resource';
-import Subject from './Subject';
+import { Organization } from './Organization';
+import { Resource } from './Resource';
+import { Subject } from './Subject';
 
-export default interface Course extends Resource {
+export interface Course extends Resource {
   end_date: string;
   enrollment_end_date: string;
   enrollment_start_date: string;

--- a/richie/js/types/Organization.ts
+++ b/richie/js/types/Organization.ts
@@ -1,6 +1,6 @@
-import Resource from './Resource';
+import { Resource } from './Resource';
 
-export default interface Organization extends Resource {
+export interface Organization extends Resource {
   banner: string | null;
   code: string;
   logo: string | null;

--- a/richie/js/types/Resource.ts
+++ b/richie/js/types/Resource.ts
@@ -1,3 +1,3 @@
-export default interface Resource {
+export interface Resource {
   id: number;
 }

--- a/richie/js/types/Subject.ts
+++ b/richie/js/types/Subject.ts
@@ -1,6 +1,6 @@
-import Resource from './Resource';
+import { Resource } from './Resource';
 
-export default interface Subject extends Resource {
+export interface Subject extends Resource {
   image: string | null;
   name: string;
 }

--- a/richie/js/types/api.ts
+++ b/richie/js/types/api.ts
@@ -1,4 +1,4 @@
-import Resource from './Resource';
+import { Resource } from './Resource';
 
 export interface APIResponseListMeta {
   limit: number;

--- a/richie/js/types/searchSuggest.ts
+++ b/richie/js/types/searchSuggest.ts
@@ -1,8 +1,8 @@
-import Course from './Course';
+import { Course } from './Course';
 import { modelNameList } from './models';
-import Organization from './Organization';
-import Resource from './Resource';
-import Subject from './Subject';
+import { Organization } from './Organization';
+import { Resource } from './Resource';
+import { Subject } from './Subject';
 
 interface ResourceSuggestion<M extends modelNameList, T extends Resource> {
   model: M;

--- a/richie/js/utils/filters/computeNewFilterValue.ts
+++ b/richie/js/utils/filters/computeNewFilterValue.ts
@@ -66,5 +66,3 @@ export function computeNewFilterValue(
     return array.length === 0 ? undefined : array;
   }
 }
-
-export default computeNewFilterValue;

--- a/richie/js/utils/filters/getFilterFromState.spec.ts
+++ b/richie/js/utils/filters/getFilterFromState.spec.ts
@@ -4,7 +4,7 @@ import {
   FilterDefinition,
   FilterDefinitionWithValues,
 } from '../../types/filters';
-import Organization from '../../types/Organization';
+import { Organization } from '../../types/Organization';
 import { getFilterFromState } from './getFilterFromState';
 
 describe('utils/filters/getFilterFromState', () => {

--- a/richie/js/utils/filters/getFilterFromState.ts
+++ b/richie/js/utils/filters/getFilterFromState.ts
@@ -84,5 +84,3 @@ export function getFilterFromState(
   }
   /* tslint:enable */
 }
-
-export default getFilterFromState;

--- a/richie/js/utils/searchSuggest/getSuggestionsSection.ts
+++ b/richie/js/utils/searchSuggest/getSuggestionsSection.ts
@@ -6,7 +6,7 @@ import {
   API_ENDPOINTS_KEYS,
   API_LIST_DEFAULT_PARAMS,
 } from '../../settings.json';
-import Resource from '../../types/Resource';
+import { Resource } from '../../types/Resource';
 import {
   SearchSuggestion,
   SearchSuggestionSection,

--- a/richie/js/utils/searchSuggest/getSuggestionsSections.spec.ts
+++ b/richie/js/utils/searchSuggest/getSuggestionsSections.spec.ts
@@ -1,6 +1,6 @@
 import * as fetchMock from 'fetch-mock';
 
-import Course from '../../types/Course';
+import { Course } from '../../types/Course';
 import * as errors from '../../utils/errors/handle';
 import { getSuggestionsSection } from './getSuggestionsSection';
 

--- a/richie/js/utils/searchSuggest/suggestionHumanName.spec.ts
+++ b/richie/js/utils/searchSuggest/suggestionHumanName.spec.ts
@@ -1,6 +1,6 @@
-import Course from '../../types/Course';
-import Organization from '../../types/Organization';
-import Subject from '../../types/Subject';
+import { Course } from '../../types/Course';
+import { Organization } from '../../types/Organization';
+import { Subject } from '../../types/Subject';
 import { suggestionHumanName } from './suggestionHumanName';
 
 describe('utils/searchSuggest/suggestionHumanName', () => {

--- a/richie/js/utils/searchSuggest/suggestionsFromSection.spec.ts
+++ b/richie/js/utils/searchSuggest/suggestionsFromSection.spec.ts
@@ -1,6 +1,6 @@
-import Course from '../../types/Course';
-import Organization from '../../types/Organization';
-import Subject from '../../types/Subject';
+import { Course } from '../../types/Course';
+import { Organization } from '../../types/Organization';
+import { Subject } from '../../types/Subject';
 import { suggestionsFromSection } from './suggestionsFromSection';
 
 describe('utils/searchSuggest/suggestionsFromSection', () => {

--- a/richie/js/utils/searchSuggest/suggestionsFromSection.ts
+++ b/richie/js/utils/searchSuggest/suggestionsFromSection.ts
@@ -1,5 +1,5 @@
-import Course from '../../types/Course';
-import Organization from '../../types/Organization';
+import { Course } from '../../types/Course';
+import { Organization } from '../../types/Organization';
 import {
   CourseSuggestion,
   CourseSuggestionSection,
@@ -10,7 +10,7 @@ import {
   SubjectSuggestion,
   SubjectSuggestionSection,
 } from '../../types/searchSuggest';
-import Subject from '../../types/Subject';
+import { Subject } from '../../types/Subject';
 
 export function suggestionsFromSection(
   coursesSection: CourseSuggestionSection,


### PR DESCRIPTION
## Purpose

In our opinion default exports inside app code are a bad practice as it decouples the names of imported functions from the names of the exports, which is not real decoupling as the underlying functionality is still very much linked.

Using default exports has no benefit we can see but makes it easy to transparently import the wrong module.

## Proposal

Just remove them and use only named exports/imports.