### PR TITLE
Rework active filters without facets

### DIFF
--- a/richie/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
+++ b/richie/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
@@ -19,8 +19,8 @@ describe('components/SearchFilterGroup', () => {
     } as FilterDefinitionWithValues;
     const wrapper = shallow(
       <SearchFilterGroup
+        activeFilterValues={[]}
         addFilter={addFilter}
-        currentValue={undefined}
         filter={filter}
         removeFilter={removeFilter}
       />,
@@ -39,8 +39,8 @@ describe('components/SearchFilterGroup', () => {
     } as FilterDefinitionWithValues;
     const wrapper = shallow(
       <SearchFilterGroup
+        activeFilterValues={[]}
         addFilter={addFilter}
-        currentValue={undefined}
         filter={filter}
         removeFilter={removeFilter}
       />,
@@ -49,19 +49,21 @@ describe('components/SearchFilterGroup', () => {
     expect(wrapper.find(SearchFilter).length).toEqual(2);
   });
 
-  it('orders the list by putting active filters at the top', () => {
+  it('renders any active filter values at the top of the list', () => {
+    const activeFilterValues = [
+      { primaryKey: 'value-2', humanName: 'Value Two' },
+    ];
     const filter = {
       humanName: 'Example filter',
       values: [
         { primaryKey: 'value-1', humanName: 'Value One' },
-        { primaryKey: 'value-2', humanName: 'Value Two' },
         { primaryKey: 'value-3', humanName: 'Value Three' },
       ],
     } as FilterDefinitionWithValues;
     const wrapper = shallow(
       <SearchFilterGroup
+        activeFilterValues={activeFilterValues}
         addFilter={addFilter}
-        currentValue={'value-2'}
         filter={filter}
         removeFilter={removeFilter}
       />,
@@ -88,5 +90,49 @@ describe('components/SearchFilterGroup', () => {
         .shallow()
         .text(),
     ).toContain('Value Three');
+  });
+
+  it('deduplicates keys between the filter and the active filter values', () => {
+    const activeFilterValues = [
+      { primaryKey: 'value-2', humanName: 'Value Two' },
+      { primaryKey: 'value-3', humanName: 'Value Three' },
+    ];
+    const filter = {
+      humanName: 'Example filter',
+      values: [
+        { primaryKey: 'value-1', humanName: 'Value One' },
+        { primaryKey: 'value-3', humanName: 'Value Three' },
+      ],
+    } as FilterDefinitionWithValues;
+    const wrapper = shallow(
+      <SearchFilterGroup
+        activeFilterValues={activeFilterValues}
+        addFilter={addFilter}
+        filter={filter}
+        removeFilter={removeFilter}
+      />,
+    );
+
+    expect(
+      wrapper
+        .find(SearchFilter)
+        .at(0)
+        .shallow()
+        .text(),
+    ).toContain('Value Two');
+    expect(
+      wrapper
+        .find(SearchFilter)
+        .at(1)
+        .shallow()
+        .text(),
+    ).toContain('Value Three');
+    expect(
+      wrapper
+        .find(SearchFilter)
+        .at(2)
+        .shallow()
+        .text(),
+    ).toContain('Value One');
   });
 });

--- a/richie/js/components/SearchFilterGroup/SearchFilterGroup.tsx
+++ b/richie/js/components/SearchFilterGroup/SearchFilterGroup.tsx
@@ -1,48 +1,41 @@
-import includes from 'lodash-es/includes';
-import isArray from 'lodash-es/isArray';
-import sortBy from 'lodash-es/sortBy';
+import differenceBy from 'lodash-es/differenceBy';
 import * as React from 'react';
 
 import { FilterDefinitionWithValues, FilterValue } from '../../types/filters';
-import { Maybe, Nullable } from '../../utils/types';
+import { Maybe } from '../../utils/types';
 import { SearchFilter } from '../SearchFilter/SearchFilter';
 
 export interface SearchFilterGroupProps {
+  activeFilterValues: FilterValue[];
   addFilter: (filterKey: string) => void;
-  currentValue: Maybe<string | number | Array<string | number>>;
   filter: FilterDefinitionWithValues;
   removeFilter: (filterKey: string) => void;
 }
 
 export const SearchFilterGroup = (props: SearchFilterGroupProps) => {
   const { humanName, values } = props.filter;
-  // Select currently active filter values (eg. for a given value, if we're filtering on
-  // that dimension by that value).
-  // We'll need to do at least two lookups for each active prop during each render,
-  // which is why we build a hash table for simple/inexpensive lookups below.
-  const valueStates: { [key: string]: boolean } = values.reduce(
-    (acc, fv: FilterValue) =>
-      props.currentValue &&
-      (props.currentValue === fv.primaryKey ||
-        (isArray(props.currentValue) &&
-          includes(props.currentValue, fv.primaryKey)))
-        ? // Key is active
-          { ...acc, [fv.primaryKey]: true }
-        : // Key is inactive
-          { ...acc, [fv.primaryKey]: false },
-    {},
-  );
 
   return (
     <div className="search-filter-group">
       <h3 className="search-filter-group__title">{humanName}</h3>
       <div className="search-filter-group__list">
-        {sortBy(values, val => (valueStates[val.primaryKey] ? 0 : 1)).map(
+        {/* First we render the active filter values */}
+        {props.activeFilterValues.map(value => (
+          <SearchFilter
+            addFilter={props.addFilter}
+            filter={value}
+            isActive={true}
+            key={value.primaryKey}
+            removeFilter={props.removeFilter}
+          />
+        ))}
+        {/* Then we render the default list of facets, minus any active values that might have been in the facets */}
+        {differenceBy(values, props.activeFilterValues, 'primaryKey').map(
           value => (
             <SearchFilter
               addFilter={props.addFilter}
               filter={value}
-              isActive={valueStates[value.primaryKey]}
+              isActive={false}
               key={value.primaryKey}
               removeFilter={props.removeFilter}
             />

--- a/richie/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.spec.tsx
+++ b/richie/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.spec.tsx
@@ -39,7 +39,7 @@ describe('components/SearchFilterGroupContainer/mergeProps', () => {
             params: { limit: 17, offset: 7, organizations: [12, 24] },
           } as ResourceListState<Course>,
         },
-        organizations: {},
+        organizations: { byId: {} },
       },
     } as RootState;
 

--- a/richie/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.tsx
+++ b/richie/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.tsx
@@ -5,7 +5,8 @@ import { Action } from 'redux';
 import { ResourceListStateParams } from '../../data/genericReducers/resourceList/resourceList';
 import { RootState } from '../../data/rootReducer';
 import { API_LIST_DEFAULT_PARAMS as defaultParams } from '../../settings.json';
-import { filterGroupName } from '../../types/filters';
+import { filterGroupName, FilterValue } from '../../types/filters';
+import { getActiveFilterValues } from '../../utils/filters/getActiveFilterValues';
 import { getFilterFromState } from '../../utils/filters/getFilterFromState';
 import { updateFilter } from '../../utils/filters/updateFilter';
 import {
@@ -20,26 +21,38 @@ export interface SearchFilterGroupContainerProps {
 export const mapStateToProps = (
   state: RootState,
   { machineName }: SearchFilterGroupContainerProps,
-) => ({
-  currentParams:
+) => {
+  const currentParams =
     (state.resources.courses &&
       state.resources.courses.currentQuery &&
       state.resources.courses.currentQuery.params) ||
-    defaultParams,
-  filter: getFilterFromState(state, machineName),
-});
+    defaultParams;
+
+  return {
+    activeFilterValues: getActiveFilterValues(
+      state,
+      machineName,
+      currentParams,
+    ),
+    currentParams,
+    filter: getFilterFromState(state, machineName),
+  };
+};
 
 export const mergeProps = (
   {
+    activeFilterValues,
     currentParams,
     filter,
   }: {
+    activeFilterValues: FilterValue[];
     currentParams: ResourceListStateParams;
     filter: SearchFilterGroupProps['filter'];
   },
   { dispatch }: { dispatch: Dispatch<Action> },
   { machineName }: SearchFilterGroupContainerProps,
 ) => ({
+  activeFilterValues,
   addFilter: partial(updateFilter, dispatch, currentParams, 'add', filter),
   currentValue: currentParams[filter.machineName],
   filter,

--- a/richie/js/utils/filters/getActiveFilterValues.spec.ts
+++ b/richie/js/utils/filters/getActiveFilterValues.spec.ts
@@ -1,0 +1,53 @@
+import { RootState } from '../../data/rootReducer';
+import { getActiveFilterValues } from './getActiveFilterValues';
+
+describe('utils/filters/getActiveFilterValues', () => {
+  it('returns an empty array if there are no currently active values', () => {
+    expect(
+      getActiveFilterValues({} as RootState, 'organizations', {
+        limit: 20,
+        offset: 0,
+        organizations: undefined,
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns an array with one FilterValue given a single key', () => {
+    const state = {
+      resources: {
+        organizations: {
+          byId: {
+            42: { id: 42, name: 'Organization #42' },
+          },
+        },
+      },
+    };
+    expect(
+      getActiveFilterValues(state as any, 'organizations', {
+        limit: 20,
+        offset: 0,
+        organizations: 42,
+      }),
+    );
+  });
+
+  it('returns an array of FilterValues givent an array of keys', () => {
+    const state = {
+      resources: {
+        subjects: {
+          byId: {
+            21: { id: 21, name: 'Organization #21' },
+            22: { id: 22, name: 'Organization #21' },
+          },
+        },
+      },
+    };
+    expect(
+      getActiveFilterValues(state as any, 'subjects', {
+        limit: 20,
+        offset: 0,
+        subjects: [21, 22],
+      }),
+    );
+  });
+});

--- a/richie/js/utils/filters/getActiveFilterValues.ts
+++ b/richie/js/utils/filters/getActiveFilterValues.ts
@@ -1,0 +1,50 @@
+import { ResourceListStateParams } from '../../data/genericReducers/resourceList/resourceList';
+import { RootState } from '../../data/rootReducer';
+import { filterGroupName, FilterValue } from '../../types/filters';
+
+// Return the list of *currenly active* filter values for a dimension built from the state & current params
+export const getActiveFilterValues = (
+  state: RootState,
+  machineName: filterGroupName,
+  currentParams: ResourceListStateParams,
+): FilterValue[] => {
+  let currentValues = currentParams[machineName];
+
+  switch (machineName) {
+    case 'organizations':
+    case 'subjects':
+      // There are no active values to return
+      if (!currentValues) {
+        return [];
+      }
+
+      // Wrap base typed values in arrays to make manipulating them easier
+      if (
+        typeof currentValues === 'string' ||
+        typeof currentValues === 'number'
+      ) {
+        currentValues = [currentValues];
+      }
+
+      return (
+        currentValues
+          // Get the value for each our the keys we received
+          .map(
+            key =>
+              state.resources &&
+              state.resources[machineName] &&
+              state.resources[machineName]!.byId[key],
+          )
+          // Drop missing values (avoid throwing)
+          .filter(value => !!value)
+          // Build filter values from the Resource instances
+          .map(value => ({
+            humanName: value!.name,
+            primaryKey: String(value!.id),
+          }))
+      );
+
+    default:
+      return [];
+  }
+};


### PR DESCRIPTION
## Purpose

We used to handle both active filters and facets together, which caused us to display useless counts next to active filters, and more importantly to *not* display active filters that were not part of the facets.

Handling them separately helps us solve both these issues and also gets rid of some awkward code in `SearchFilterGroup`.

## Proposal

Pass active filter values separately from `SearchFilterGroupContainer`.

- [x] improve the filter integration test (which was broken by our other changes where it should not have been due to internal refreshing issues)
- [x] Add a function in `utils/filters` to create this new list of active filter values
- [x] Rewire `SearchFilterGroup` and `SearchFilterGroupContainer` to handle this new list

