### PR TITLE
🐛(circle) fix yarn.lock file update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,7 +433,8 @@ jobs:
 
   # ---- Front-end jobs ----
   # Generate an up-to-date yarn.lock file (sync with package.json) and commit
-  # the new lockfile to the current PR
+  # the new lockfile to the current PR. The new yarn.lock file is persisted to
+  # the workspace.
   lockfile-front:
     docker:
       - image: circleci/node:9-browsers
@@ -444,14 +445,25 @@ jobs:
           keys:
           - v3-front-dependencies-{{ checksum "package.json" }}
           - v3-front-dependencies-
+      # Install Greenkeeper-lockfile (if it is not in the restored cached)
+      # without updating the lockfile; we just need the
+      # greenkeeper-lockfile-update tool installed and prevent any potentially
+      # conflicting updates of the yarn.lock file.
       - run:
           name: Install Greenkeeper-lockfile
-          command: yarn add greenkeeper-lockfile
+          command: |
+            if ! yarn greenkeeper-lockfile-update; then
+              yarn install --no-lockfile
+            fi
       - run:
           name: Update yarn.lock
           command: |
             yarn greenkeeper-lockfile-update && \
               yarn greenkeeper-lockfile-upload
+      - persist_to_workspace:
+          root: ~/richie
+          paths:
+            - yarn.lock
 
   build-front:
     docker:
@@ -463,6 +475,12 @@ jobs:
           keys:
           - v3-front-dependencies-{{ checksum "package.json" }}
           - v3-front-dependencies-
+      # Copy an up-to-date yarn.lock file (if updated, see the lockfile-front
+      # job).
+      - attach_workspace:
+          at: ~/richie
+      # If the yarn.lock file is not up-to-date with the package.json file,
+      # using the --frozen-lockfile should fail.
       - run:
           name: Install front-end dependencies
           command: yarn install --frozen-lockfile


### PR DESCRIPTION
## Purpose

Every greenkeeper PR's CI fails while trying to install project dependencies as the `yarn.lock` file does not match dependencies listed in the `package.json` file.

## Proposal

Only install Greenkeeper-lockfile if it is not already installed. Previous implementation using `yarn add` was updating this dependency (and the lockfile), this was not intended as the resulting lockfile did not match the PR new `package.json` file.

Once the yarn.lock file has been updated by greenkeeper, we need to save this new version in the job's workspace to restore it during the installation job. Using the `--frozen-lockfile` option of `yarn install` ensures that our new lockfile is properly correlated with dependencies definition in the `package.json` file.
