### PR TITLE
Add gitlint to enforce format of commit messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,16 @@ jobs:
           command: |
             ! git log | grep 'fixup!'
 
+      - run:
+          name: Install gitlint
+          command: |
+            pip install gitlint
+
+      - run:
+          name: lint commit messages added to master
+          command: |
+            gitlint --commits origin/master..HEAD
+
   # Docker/back-end jobs
   # Build job
   # Build the Docker image ready for production

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,77 @@
+# All these sections are optional, edit this file as you like.
+[general]
+# Ignore certain rules, you can reference them by their id or by their full name
+# ignore=title-trailing-punctuation, T3
+
+# verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
+# verbosity = 2
+
+# By default gitlint will ignore merge commits. Set to 'false' to disable.
+# ignore-merge-commits=true
+
+# By default gitlint will ignore fixup commits. Set to 'false' to disable.
+# ignore-fixup-commits=true
+
+# By default gitlint will ignore squash commits. Set to 'false' to disable.
+# ignore-squash-commits=true
+
+# Enable debug mode (prints more output). Disabled by default.
+# debug=true
+
+# Set the extra-path where gitlint will search for user defined rules
+# See http://jorisroovers.github.io/gitlint/user_defined_rules for details
+extra-path=gitlint/
+
+# [title-max-length]
+# line-length=80
+
+[title-must-not-contain-word]
+# Comma-separated list of words that should not occur in the title. Matching is case
+# insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
+# will not cause a violation, but "WIP: my title" will.
+words=wip
+
+#[title-match-regex]
+# python like regex (https://docs.python.org/2/library/re.html) that the
+# commit-msg title must be matched to.
+# Note that the regex can contradict with other rules if not used correctly
+# (e.g. title-must-not-contain-word).
+#regex=
+
+# [B1]
+# B1 = body-max-line-length
+# line-length=120
+# [body-min-length]
+# min-length=5
+
+# [body-is-missing]
+# Whether to ignore this rule on merge commits (which typically only have a title)
+# default = True
+# ignore-merge-commits=false
+
+# [body-changed-file-mention]
+# List of files that need to be explicitly mentioned in the body when they are changed
+# This is useful for when developers often erroneously edit certain files or git submodules.
+# By specifying this rule, developers can only change the file when they explicitly reference
+# it in the commit message.
+# files=gitlint/rules.py,README.md
+
+# [author-valid-email]
+# python like regex (https://docs.python.org/2/library/re.html) that the
+# commit author email address should be matched to
+# For example, use the following regex if you only want to allow email addresses from foo.com
+# regex=[^@]+@foo.com
+
+[ignore-by-title]
+# Allow empty body only when upgrading dependendies
+regex=^⬆️.*$
+ignore=B6
+
+# [ignore-by-body]
+# Ignore certain rules for commits of which the body has a line that matches a regex
+# E.g. Match bodies that have a line that that contain "release"
+# regex=(.*)release(.*)
+#
+# Ignore certain rules, you can reference them by their id or by their full name
+# Use 'all' to ignore all rules
+# ignore=T1,body-min-length

--- a/gitlint/gitlint_emoji.py
+++ b/gitlint/gitlint_emoji.py
@@ -1,0 +1,36 @@
+"""
+Gitlint extra rule to validate that the message title is of the form
+"<gitmoji>(<scope>) <subject>"
+"""
+from __future__ import unicode_literals
+import re
+
+from gitlint.rules import CommitMessageTitle, LineRule, RuleViolation
+
+regex = (
+    "^(\U0001f3a8|\u26a1\ufe0f|\U0001f525|\U0001f41b|\U0001f691|\u2728|\U0001f4dd|\U0001f680|"
+    "\U0001f484|\U0001f389|\u2705|\U0001f512|\U0001f34e|\U0001f427|\U0001f3c1|\U0001f916|"
+    "\U0001f34f|\U0001f516|\U0001f6a8|\U0001f6a7|\U0001f49a|\u2b07\ufe0f|\u2b06\ufe0f|\U0001f4cc|"
+    "\U0001f477|\U0001f4c8|\u267b\ufe0f|\u2796|\U0001f433|\u2795|\U0001f527|\U0001f310|\u270f"
+    "\ufe0f|\U0001f4a9|\u23ea|\U0001f500|\U0001f4e6|\U0001f47d|\U0001f69a|\U0001f4c4|\U0001f4a5|"
+    "\U0001f371|\U0001f44c|\u267f\ufe0f|\U0001f4a1|\U0001f37b|\U0001f4ac|\U0001f5c3|\U0001f50a|"
+    "\U0001f507|\U0001f465|\U0001f6b8|\U0001f3d7|\U0001f4f1|\U0001f921|\U0001f95a|\U0001f648|"
+    "\U0001f4f8)\(.*\)\s[a-z].*$"
+)
+pattern = re.compile(regex, re.UNICODE)
+
+
+class GitmojiTitle(LineRule):
+    """
+    This rule will enforce that each commit title is of the form "<gitmoji>(<scope>) <subject>"
+    where gitmoji is an emoji from the list defined in https://gitmoji.carloscuesta.me
+    """
+
+    id = "UC1"
+    name = "title-should-have-gitmoji-and-scope"
+    target = CommitMessageTitle
+
+    def validate(self, title, _commit):
+        if not pattern.search(title):
+            violation_msg = "Title does not match regex <gitmoji>(<scope>) <subject>"
+            return [RuleViolation(self.id, violation_msg, title)]


### PR DESCRIPTION
## Purpose

We want the commit history to be beautiful and normalized.
## Proposal

- [x] Use gitlint to ensure that commit messages are following general good practices (default configuration)
- [x] Add a rule to check that commit titles are matching the pattern: `<gitmoji>(<scope>) <subject>`
- [x] Allow empty body for commit messages related to dependency upgrades (⬆️).
