### PR TITLE
🐛(circle) force lockfile-front as the first job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,17 +549,14 @@ workflows:
 
   richie:
     jobs:
-      # Git jobs
-      #
-      # Check validity of git history
-      - lint-git:
-          filters:
-            tags:
-              only: /.*/
-
       # Front-end jobs
       #
       # Build, lint and test the front-end apps
+      #
+      # NOTA BENE: the lockfile-front job SHOULD be the first job to run in the
+      # CI or else it will refuse to update the yarn.lock file. As a
+      # consequence, every first job of a workflow MUST require the
+      # "lockfile-front" job.
       - lockfile-front:
           filters:
             tags:
@@ -589,11 +586,23 @@ workflows:
             tags:
               only: /.*/
 
+      # Git jobs
+      #
+      # Check validity of git history
+      - lint-git:
+          requires:
+            - lockfile-front
+          filters:
+            tags:
+              only: /.*/
+
       # Docker jobs
       #
       # Build, lint and test production and development Docker images
       # (debian-based)
       - build:
+          requires:
+            - lockfile-front
           filters:
             tags:
               only: /.*/
@@ -632,6 +641,8 @@ workflows:
       #
       # Build and run tests in alpine based images
       - build-alpine:
+          requires:
+            - lockfile-front
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
## Purpose

Most of the time, the `lockfile-front` CI job refuses to update the `yarn.lock` file, but sometimes it works. When the `yarn.lock` file is not updated, the front-end workflow fails as we install dependencies using a frozen lockfile (it cannot be updated and dependencies listed in `package.json` should match those listed in the `yarn.lock` file).

## Proposal

As mentionned in `greenkeeper-lockfile` documentation [1], the `lockfile-front` job SHOULD be the FIRST job to run. I misunderstood this rule and thought that the first job of the front-end workflow would be sufficient. This was a mistake: as we have multiple parallel workflows, all other workflows' first job SHOULD require the `lockfile-front` job to ensure that it will always be the first job to run.

[1] https://github.com/greenkeeperio/greenkeeper-lockfile#circleci-workflows
