### PR TITLE
💚(gitlint) ignore bots git message lint

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -63,9 +63,10 @@ words=wip
 # regex=[^@]+@foo.com
 
 [ignore-by-title]
-# Allow empty body only when upgrading dependendies
-regex=^⬆️.*$
-ignore=B6
+# Allow empty body & wrong title pattern only when bots (pyup/greenkeeper)
+# upgrade dependencies
+regex=^(⬆️.*|Update (.*) from (.*) to (.*)|chore\(package\): update .*)$
+ignore=B6,UC1
 
 # [ignore-by-body]
 # Ignore certain rules for commits of which the body has a line that matches a regex


### PR DESCRIPTION
## Purpose

Pyup and Greenkeeper bots git commit title does not comply with our imposed pattern :cry: thus blocking each PR that the bot makes.

## Proposal

We choose to add a `git-lint` rule to ignore the linting of these commits to be able to reformat them using the "squash and merge" strategy while merging the PR.