### PR TITLE
⚡️(gitlint) allow greenkeeper fix commits

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -65,7 +65,7 @@ words=wip
 [ignore-by-title]
 # Allow empty body & wrong title pattern only when bots (pyup/greenkeeper)
 # upgrade dependencies
-regex=^(⬆️.*|Update (.*) from (.*) to (.*)|chore\(package\): update .*)$
+regex=^(⬆️.*|Update (.*) from (.*) to (.*)|(chore|fix)\(package\): update .*)$
 ignore=B6,UC1
 
 # [ignore-by-body]


### PR DESCRIPTION
## Purpose

Following the semver convention, when greenkeeper upgrades the patch version, its git commit title starts with fix (and not chore), thus breaking the built at the `git-lint` step.

## Proposal

- [x] Update git-lint regex to allow such pattern