### PR TITLE
🚸(gitlint) Improve UC1 error message

### DIFF
--- a/gitlint/gitlint_emoji.py
+++ b/gitlint/gitlint_emoji.py
@@ -24,7 +24,8 @@ pattern = re.compile(regex, re.UNICODE)
 class GitmojiTitle(LineRule):
     """
     This rule will enforce that each commit title is of the form "<gitmoji>(<scope>) <subject>"
-    where gitmoji is an emoji from the list defined in https://gitmoji.carloscuesta.me
+    where gitmoji is an emoji from the list defined in https://gitmoji.carloscuesta.me and
+    subject should be all lowercase
     """
 
     id = "UC1"
@@ -33,5 +34,5 @@ class GitmojiTitle(LineRule):
 
     def validate(self, title, _commit):
         if not pattern.search(title):
-            violation_msg = "Title does not match regex <gitmoji>(<scope>) <subject>"
+            violation_msg = "Title does not match regex \"<gitmoji>(<scope>) <subject>\""
             return [RuleViolation(self.id, violation_msg, title)]


### PR DESCRIPTION
 Message displayed to when git commit message title did not match regexp could let
user think colon (":") was part of required format

![capture d ecran 2018-06-11 a 18 25 51](https://user-images.githubusercontent.com/89626/41244331-079e3f00-6da5-11e8-9d8d-a359828a1eaf.png)

