### PR TITLE
💄(courses) lay out & style the organization detail view

### DIFF
--- a/apps/courses/templates/courses/cms/_organization_detail.scss
+++ b/apps/courses/templates/courses/cms/_organization_detail.scss
@@ -1,0 +1,103 @@
+// Overridable & namespaced global variables
+$organization-detail-view-banner-logo-sizing: 15rem !default;
+$organization-detail-view-banner-logo-sizing-md: 20rem !default;
+$organization-detail-view-banner-logo-sizing-xl: 25rem !default;
+
+.organization-detail {
+  $banner-logo-sizing: $organization-detail-view-banner-logo-sizing;
+  $banner-logo-sizing-md: $organization-detail-view-banner-logo-sizing-md;
+  $banner-logo-sizing-xl: $organization-detail-view-banner-logo-sizing-xl;
+
+  @include make-container();
+  @include make-container-max-widths();
+  background: $container-bg;
+
+  &__banner {
+    @include make-row();
+
+    // position & overflow are part of the img hack below
+    position: relative;
+    width: calc(100% + #{$grid-gutter-width});
+    height: $banner-logo-sizing;
+    overflow: hidden;
+
+    @include media-breakpoint-up(md) {
+      height: $banner-logo-sizing-md;
+    }
+
+    @include media-breakpoint-up(xl) {
+      height: $banner-logo-sizing-xl;
+    }
+
+    img {
+      // Hack to center+fill an image we have no control over and can't make into a background image
+      position: absolute;
+      top: -1000%; right: -1000%; bottom: -1000%; left: -1000%;
+      min-width: 100%;
+      min-height: 100%;
+      margin: auto;
+    }
+  }
+
+  &__logo {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid darken($light, 20%);
+
+    width: $banner-logo-sizing * 0.75;
+    height: $banner-logo-sizing * 0.75;
+    margin: (-$banner-logo-sizing * 0.75 / 2) auto $grid-gutter-width;
+
+    @include media-breakpoint-up(md) {
+      float: right;
+      width: $banner-logo-sizing-md * 0.75;
+      height: $banner-logo-sizing-md * 0.75;
+      margin: (-$banner-logo-sizing-md / 2) 3rem $grid-gutter-width;
+    }
+
+    @include media-breakpoint-up(xl) {
+      width: $banner-logo-sizing-xl * 0.75;
+      height: $banner-logo-sizing-xl * 0.75;
+      margin: (-$banner-logo-sizing-xl / 2) 8rem $grid-gutter-width;
+    }
+
+    img {
+      // Hack to center+fill an image we have no control over and can't make into a background image
+      position: absolute;
+      top: -1000%; right: -1000%; bottom: -1000%; left: -1000%;
+      // Make the width fixed so we can never overflow logos - we make the assumption most non-square
+      // logos would be wider as opposed to taller
+      width: 100%;
+      min-height: 100%;
+      margin: auto;
+    }
+  }
+
+  &__title {
+    $h1-calculated-height: $h1-font-size * $headings-line-height;
+    @include media-breakpoint-up(md) {
+      $logo-height: $banner-logo-sizing-md * 0.75;
+      $logo-overflow-height: $logo-height / 3;
+      margin: ($logo-overflow-height - $h1-calculated-height) / 2 $grid-gutter-width;
+    }
+
+    @include media-breakpoint-up(xl) {
+      $logo-height: $banner-logo-sizing-xl * 0.75;
+      $logo-overflow-height: $logo-height / 3;
+      margin: ($logo-overflow-height - $h1-calculated-height) / 2 $grid-gutter-width;
+    }
+  }
+
+  &__content {
+    clear: both;
+    @include make-row();
+    padding-left: $grid-gutter-width;
+    padding-right: $grid-gutter-width;
+
+    &__description,
+    &__courses {
+      @include make-col-ready();
+      @include make-col(12);
+    }
+  }
+}

--- a/apps/courses/templates/courses/cms/organization_detail.html
+++ b/apps/courses/templates/courses/cms/organization_detail.html
@@ -6,6 +6,10 @@
 
   {% with current_page.organization as organization %}
 
+    <div class="organization-detail__banner">
+      {% placeholder "banner" %}
+    </div>
+
     {% if organization.logo %}
       <div class="organization-detail__logo">
         <img
@@ -14,43 +18,42 @@
       </div>
     {% endif %}
 
-    <div class="organization-detail__banner">
-      {% placeholder "banner" %}
-    </div>
-
     <h1 class="organization-detail__title">{{ current_page.get_title }}</h1>
 
-    <div class="organization-detail__description">
-      {% placeholder "description" %}
-    </div>
+    <div class="organization-detail__content">
 
-    <ul class="organization-detail__courses">
-      {% for course in organization.courses.all %}
-        {# If the current page is a draft, show draft courses with a class annotation for styling #}
-        {% if current_page.publisher_is_draft %}
-          {% if course.public_extension %}
-            <li class="organization-detail__courses__item">
+      <div class="organization-detail__content__description">
+        {% placeholder "description" %}
+      </div>
+
+      <ul class="organization-detail__content__courses">
+        {% for course in organization.courses.all %}
+          {# If the current page is a draft, show draft courses with a class annotation for styling #}
+          {% if current_page.publisher_is_draft %}
+            {% if course.public_extension %}
+              <li class="organization-detail__content__courses__item">
+                {{ course.public_extension.extended_object.get_title }}
+              </li>
+            {% else %}
+              <li class="organization-detail__content__courses__item--draft">
+                {{ course.extended_object.get_title }}
+              </li>
+            {% endif %}
+          {# If the current course page is the published version, show only the courses that are published #}
+          {% elif course.public_extension %}
+            <li class="organization-detail__content__courses__item">
               {{ course.public_extension.extended_object.get_title }}
             </li>
-          {% else %}
-            <li class="organization-detail__courses__item--draft">
-              {{ course.extended_object.get_title }}
-            </li>
           {% endif %}
-        {# If the current course page is the published version, show only the courses that are published #}
-        {% elif course.public_extension %}
-          <li class="organization-detail__courses__item">
-            {{ course.public_extension.extended_object.get_title }}
+        {% empty %}
+          <li class="organization-detail__content__courses--empty">
+            {% trans "No associated courses" %}
           </li>
-        {% endif %}
-      {% empty %}
-        <li class="organization-detail__courses--empty">
-          {% trans "No associated courses" %}
-        </li>
-      {% endfor %}
-    </ul>
+        {% endfor %}
+      </ul>
+    </div>
 
-    {% endwith %}
+  {% endwith %}
 
 </div>
 {% endblock content %}

--- a/apps/courses/tests/test_templates_organization_detail.py
+++ b/apps/courses/tests/test_templates_organization_detail.py
@@ -54,7 +54,7 @@ class OrganizationCMSTestCase(TestCase):
         for course in [course1, course2]:
             self.assertContains(
                 response,
-                '<li class="organization-detail__courses__item">{:s}</li>'.format(
+                '<li class="organization-detail__content__courses__item">{:s}</li>'.format(
                     course.extended_object.get_title()
                 ),
                 html=True,
@@ -100,7 +100,7 @@ class OrganizationCMSTestCase(TestCase):
         for course in [course1, course2]:
             self.assertContains(
                 response,
-                '<li class="organization-detail__courses__item">{:s}</li>'.format(
+                '<li class="organization-detail__content__courses__item">{:s}</li>'.format(
                     course.extended_object.get_title()
                 ),
                 html=True,
@@ -108,7 +108,7 @@ class OrganizationCMSTestCase(TestCase):
         # The draft course should also be present on the page with an annotation for styling
         self.assertContains(
             response,
-            '<li class="organization-detail__courses__item--draft">{:s}</li>'.format(
+            '<li class="organization-detail__content__courses__item--draft">{:s}</li>'.format(
                 course3.extended_object.get_title()
             ),
             html=True,

--- a/richie/static/scss/_main.scss
+++ b/richie/static/scss/_main.scss
@@ -31,6 +31,7 @@
 @import "../../js/components/SearchFiltersPane/_SearchFiltersPane";
 
 // Template specific styles
+@import "../../../apps/courses/templates/courses/cms/organization_detail";
 @import "../../../plugins/large_banner/templates/large_banner";
 @import "../../templates/menu/_menu";
 @import "../../templates/search/_search";

--- a/richie/static/scss/_variables.scss
+++ b/richie/static/scss/_variables.scss
@@ -1,2 +1,9 @@
+@import "../../../node_modules/bootstrap/scss/functions";
+@import "../../../node_modules/bootstrap/scss/variables";
+
 // Smaller gutters in grid to increase information density in search results
 $grid-gutter-width: 20px;
+
+// Light gray default background for the body so containers can be enhanced as page structuring elements
+$body-bg: $light;
+/* local */$container-bg: white;


### PR DESCRIPTION
## Purpose

The template for the organization detail view existed but did not include any CSS. 

## Proposal

Do some mobile-first layout work and add some basic styling so the default version of the website without any style override can be shown or used as an example directly.

Part 1/2 of work towards #228.

Part 2 will be to reuse `CourseGlimpse` component styles to have a proper list of related courses as shown in #228 — it just expanded the scope of this PR a little too much.