### PR TITLE
Add mention about isort in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ from our [handbook](https://openfun.gitbooks.io/handbook/content).
 
 ### Checking your code
 
-We use strict flake8, pylint and black linters to check the validity of our backend code:
+We use strict flake8, pylint, isort and black linters to check the validity of our backend code:
 
     $ make lint-back
 


### PR DESCRIPTION
## Purpose

The isort linter was added to CircleCI lately but the github issue related to this was missing this documentation step to be completed.

## Proposal

Add mention about isort in readme under the "checking your code" section.
Closes https://github.com/openfun/richie/issues/139