### PR TITLE
🐛(settings) fix ES_INDEXES paths

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -62,9 +62,9 @@ class ElasticSearchMixin(object):
     )
     ES_CHUNK_SIZE = 500
     ES_INDEXES = [
-        "apps.search.indexers.courses.CoursesIndexer",
-        "apps.search.indexers.organizations.OrganizationsIndexer",
-        "apps.search.indexers.subjects.SubjectsIndexer",
+        "richie.apps.search.indexers.courses.CoursesIndexer",
+        "richie.apps.search.indexers.organizations.OrganizationsIndexer",
+        "richie.apps.search.indexers.subjects.SubjectsIndexer",
     ]
 
     ES_DEFAULT_PAGE_SIZE = 10


### PR DESCRIPTION
## Purpose

Recent changes in the project tree moved indexers path, and we did not report new paths to the sandbox's `ES_INDEXES` setting.

## Proposal

- [x] fix path to indexers in sandbox's settings
- [x] ~~add integration tests (?)~~