### PR TITLE
📌(pyup) restore dependency contraints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,14 +29,14 @@ install_requires =
     cmsplugin-plain-text==0.1.2
     decorator==4.2.1
     dj-database-url==0.5.0
-    Django==1.11.13
+    Django==1.11.13  # pyup: <2.0
     django-appconf==1.0.2
     django-classy-tags==0.8.0
     django-cms==3.5.2
     django-configurations==2.0
     django-formtools==2.1
     django-mptt==0.9.0
-    django-reversion==1.10.2
+    django-reversion==1.10.2  # pyup: >=1.8.2,<1.11
     django-sekizai==0.10.0
     djangocms-admin-style==1.2.8
     djangocms-attributes-field==0.3.0


### PR DESCRIPTION
## Purpose

During Richie's packaging, we removed requirements files in favor of a setup.cfg configuration. During this step, pyup contraints on dependencies have been dropped.

## Proposal

As pyup seems to support `setup.cfg` format, let's try to use the same syntax as for requirements, _e.g._ `... # pyup: <2.0` (this is an undocumented feature).
