### PR TITLE
Fix docker user for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,38 @@
-# Docker
+# Richie's Makefile
+#
+# /!\ /!\ /!\ /!\ /!\ /!\ /!\ DISCLAIMER /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+#
+# This Makefile is only meant to be used for DEVELOPMENT purpose as we are
+# changing the user id that will run in the container.
+#
+# PLEASE DO NOT USE IT FOR YOUR CI/PRODUCTION/WHATEVER...
+#
+# /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+
+# -- Docker
+
+# Get the current user ID to use for docker run and docker exec commands
+UID                  = $(shell id -u)
 COMPOSE              = docker-compose
-COMPOSE_RUN          = $(COMPOSE) run --rm
-COMPOSE_EXEC         = $(COMPOSE) exec
+COMPOSE_RUN          = $(COMPOSE) run --rm --user=$(UID)
+COMPOSE_EXEC         = $(COMPOSE) exec --user=$(UID)
 COMPOSE_EXEC_APP     = $(COMPOSE_EXEC) app
-COMPOSE_EXEC_NODE    = $(COMPOSE_EXEC) --user="$(id -u):$(id -g)" node
+COMPOSE_EXEC_NODE    = $(COMPOSE_EXEC) node
 COMPOSE_RUN_APP      = $(COMPOSE_RUN) app
-COMPOSE_RUN_NODE     = $(COMPOSE_RUN) --user="$(id -u):$(id -g)" node
+COMPOSE_RUN_NODE     = $(COMPOSE_RUN) node
 COMPOSE_TEST         = $(COMPOSE) -p richie-test -f docker/compose/test/docker-compose.yml --project-directory .
-COMPOSE_TEST_RUN     = $(COMPOSE_TEST) run --rm
+COMPOSE_TEST_RUN     = $(COMPOSE_TEST) run --rm --user=$(UID)
 COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app
 
-# Node
+# -- Node
+
 YARN                 = $(COMPOSE_RUN_NODE) yarn
 
-# Django
+# -- Django
+
 MANAGE               = $(COMPOSE_RUN_APP) python sandbox/manage.py
+
+# -- Rules
 
 default: help
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Among the features that `Richie` offers out of the box:
 - flexible custom pages for courses, organizations, subjects, teachers (and their inter-relations),
 - Extensible with any third-party `DjangoCMS` plugin or any third-party `Django` application.
 
-
 ## Architecture
 
 `Richie` is a **container-native application** but can also be installed
@@ -46,7 +45,6 @@ consists of 4 services:
 We provide alternative `Docker Compose` configurations for test, CI and production, but the
 application can also be run with your favorite orchestrator. At "France Université Numérique", we
 deploy our applications on `OpenShift` using [`Arnold`](https://github.com/openfun/arnold).
-
 
 ## Getting started
 
@@ -91,7 +89,6 @@ Note that if you don't create the demo site and start from a blank CMS, you will
 requesting you to create some required root pages. So it is easier as a first approach to test the
 CMS with the demo site.
 
-
 ## Contributing
 
 This project is intended to be community-driven, so please, do not hesitate to get in touch if you
@@ -99,7 +96,6 @@ have any question related to our implementation or design decisions.
 
 We try to raise our code quality standards and expect contributors to follow the recommandations
 from our [handbook](https://openfun.gitbooks.io/handbook/content).
-
 
 ### Checking your code
 
@@ -111,7 +107,6 @@ We use strict tslint and prettier to check the validity of our frontend code:
 
     $ make lint-front
 
-
 ### Running tests
 
 On the backend, we use pytest to run our test suite:
@@ -122,7 +117,6 @@ On the frontend, we use karma to run our test suite:
 
     $ make test-front
 
-
 ### Running migrations
 
 The first time you start the project with `make bootstrap`, the `db` container automatically
@@ -131,7 +125,6 @@ creates a fresh database named `richie` and performs database migrations. Each t
 
     $ make migrate
 
-
 ### Handling new dependencies
 
 Each time you add new front-end or back-end dependencies, you will need to rebuild the
@@ -139,15 +132,25 @@ application. We recommend to use:
 
     $ make bootstrap
 
-
 ### To go further
 
 To see all available commands, run:
 
     $ make
 
-See our [tips and tricks](./docs/docker_development.md) for development with Docker
+We also provide shortcuts for docker-compose commands as sugar scripts in the
+`bin/` directory:
 
+```
+bin
+├── exec
+├── pylint
+├── pytest
+└── run
+```
+
+More details and tips & tricks can be found in our [development with Docker
+documentation](./docs/docker_development.md)
 
 ## License
 

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+REPO_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
+UNSET_USER=0
+COMPOSE_FILE="$REPO_DIR/docker-compose.yml"
+COMPOSE_PROJECT="richie"
+
+# _set_user: set (or unset) default user id used to run docker commands
+#
+# usage: _set_user
+#
+# You can override default user ID (the current host user ID), by defining the
+# USER_ID environment variable.
+#
+# To avoid running docker commands with a custom user, please set the
+# $UNSET_USER environment variable to 1.
+function _set_user() {
+
+    if [ $UNSET_USER -eq 1 ]; then
+        USER_ID=""
+        return
+    fi
+
+    # USER_ID = USER_ID or `id -u` if USER_ID is not set
+    USER_ID=${USER_ID:-$(id -u)}
+
+    echo "🙋(user) ID: ${USER_ID}"
+}
+
+# docker_compose: wrap docker-compose command
+#
+# usage: docker_compose [options] [ARGS...]
+#
+# options: docker-compose command options
+# ARGS   : docker-compose command arguments
+function _docker_compose() {
+
+    echo "🐳(compose) project: '${COMPOSE_PROJECT}' file: '${COMPOSE_FILE}'"
+    docker-compose \
+        -p "${COMPOSE_PROJECT}" \
+        -f "${COMPOSE_FILE}" \
+        --project-directory "${REPO_DIR}" \
+        "$@"
+}
+
+# _dc_run: wrap docker-compose run command
+#
+# usage: _dc_run [options] [ARGS...]
+#
+# options: docker-compose run command options
+# ARGS   : docker-compose run command arguments
+function _dc_run() {
+    _set_user
+
+    echo "🐳(compose) run command: '$@'"
+
+    user_args="--user=$USER_ID"
+    if [ -z $USER_ID ]; then
+        user_args=""
+    fi
+
+    _docker_compose run --rm $user_args "$@"
+}
+
+# _dc_exec: wrap docker-compose exec command
+#
+# usage: _dc_exec [options] [ARGS...]
+#
+# options: docker-compose exec command options
+# ARGS   : docker-compose exec command arguments
+function _dc_exec() {
+    _set_user
+
+    echo "🐳(compose) exec command: '$@'"
+
+    user_args="--user=$USER_ID"
+    if [ -z $USER_ID ]; then
+        user_args=""
+    fi
+
+    _docker_compose exec $user_args "$@"
+}

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -24,9 +24,12 @@
 #     docker run --rm --env-file env.d/production richie:latest python sandbox/manage.py migrate
 #
 
+echo "🐳(entrypoint) creating user running in the container..."
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
 fi
+
+echo "🐳(entrypoint) running your command: $@"
 exec "$@"

--- a/bin/exec
+++ b/bin/exec
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+_dc_exec "$@"

--- a/bin/pylint
+++ b/bin/pylint
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-docker-compose \
-    -p richie-test \
-    -f docker/compose/test/docker-compose.yml \
-    --project-directory . \
-    run --rm --no-deps app pylint "$@"
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+COMPOSE_FILE="$REPO_DIR/docker/compose/test/docker-compose.yml"
+COMPOSE_PROJECT="richie-test"
+
+_dc_run --no-deps app pylint "$@"

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-docker-compose \
-    -p richie-test \
-    -f docker/compose/test/docker-compose.yml \
-    --project-directory . \
-    run --rm app pytest "$@"
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+COMPOSE_FILE="$REPO_DIR/docker/compose/test/docker-compose.yml"
+COMPOSE_PROJECT="richie-test"
+
+_dc_run app pytest "$@"

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+_dc_run "$@"

--- a/docs/docker_development.md
+++ b/docs/docker_development.md
@@ -2,23 +2,24 @@
 
 ### Settings
 
-Settings are defined using [Django Configuration]
-(https://django-configurations.readthedocs.io/en/stable/) for different environments:
+Settings are defined using [Django
+Configurations](https://django-configurations.readthedocs.io/en/stable/) for
+different environments:
 
-- Development: settings for development on developpers' local environment,
-- Test: settings used to run our test suite,
-- ContinousIntegration: settings used on the continuous integration platform,
-- Feature: settings for deployment of each developers' feature branches,
-- Staging: settings for deployment to the staging environment,
-- PreProduction: settings for deployment to the pre-production environment,
-- Production: settings for deployment to the production environment.
+- `Development`: settings for development on developers' local environment,
+- `Test`: settings used to run our test suite,
+- `ContinousIntegration`: settings used on the continuous integration platform,
+- `Feature`: settings for deployment of each developers' feature branches,
+- `Staging`: settings for deployment to the staging environment,
+- `PreProduction`: settings for deployment to the pre-production environment,
+- `Production`: settings for deployment to the production environment.
 
 The `Development` environment is defined as the default environment.
 
-
 ### Front-end tools
 
-If you intend to work on the front-end development of the CMS, we also have sweet candies for you! 🤓
+If you intend to work on the front-end development of the CMS, we also have
+sweet candies for you! 🤓
 
 ```bash
 # Start the Sass watcher
@@ -27,7 +28,6 @@ $ make watch-css
 # In a new terminal or session, start the TypeScript watcher
 $ make watch-ts
 ```
-
 
 ### Container control
 
@@ -39,7 +39,6 @@ or stop/start/restart all containers in one command:
 
     $ docker-compose [stop|start|restart]
 
-
 ### Debugging
 
 You can easily see the latest logs for a container:
@@ -48,26 +47,46 @@ You can easily see the latest logs for a container:
 
 Or follow the stream of logs:
 
-    $ docker logs --follow --until=2s
+    $ docker-compose logs --follow [app|db|elasticsearch]
 
-If you need to debug a running container, you can open a Linux shell with the `exec` command:
+If you need to debug a running container, you can open a Linux shell with the
+`docker-compose exec` command (we use a sugar script here, see next section):
 
-    $ docker-compose exec [app|db|nginx] bash
+    $ bin/exec [app|db|nginx] bash
 
-While developing on `Richie`, you will also need to run a `Django shell` and it has to be done in
-the `app` container:
+While developing on `Richie`, you will also need to run a `Django shell` and it
+has to be done in the `app` container (we use a sugar script here, see next
+section):
 
-    $ docker-compose run --rm app python sandbox/manage.py shell
+    $ bin/run app python sandbox/manage.py shell
 
+### Using sugar scripts
+
+While developing using Docker, you will fall into permission issues if you mount
+the code directory as a volume in the container. Indeed, the Docker engine will,
+by default, run the containers using the `root` user. Any file created or
+updated by the app container on your host, as a result of the volume mounts,
+will be owned by the local root user. One way to solve this is to use the
+`--user="$(id -u)"` flag when calling the `docker-compose run` or
+`docker-compose exec` commands. By using the user flag trick, the running
+container user ID will match your local user ID. But, as it's repetitive and
+error-prone, we provide shortcuts that we call our "sugar scripts":
+
+- `bin/run`: is a shortcut for `docker-compose run --rm --user="$(id -u)"`
+- `bin/exec`: is a shortcut for `docker-compose exec --user="$(id -u)"`
+- `bin/pylint`: runs `pylint` in the `app` service using the test docker-compose
+  file
+- `bin/pytest`: runs `pytest` in the `app` service using the test docker-compose
+  file
 
 ### Cleanup
 
-If you work on the Docker configuration and make repeated modifications, remember to periodically
-clean the unused docker images and containers by running:
+If you work on the Docker configuration and make repeated modifications,
+remember to periodically clean the unused docker images and containers by
+running:
 
     $ docker image prune
     $ docker container prune
-
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Purpose

While running Richie locally for development, we use to mount local volumes to running containers. As containers may create files, those last may have inappropriate permissions depending on the user running in the container (_e.g._ root). 

## Proposal

To avoid permission issues we need to map local user with the running container user:

- [x] in the `Makefile`
- [x] by adding sugar scripts to launch `docker run|exec` commands

## Sneak peek

![screenshot from 2018-07-03 17-27-32](https://user-images.githubusercontent.com/956157/42230352-10730c82-7ee9-11e8-9670-f4e2d45c3a40.png)
