### PR TITLE
Manage translations through react-intl

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,12 @@
 module.exports = {
+  plugins: [
+    [
+      'react-intl',
+      {
+        messagesDir: './strings/',
+      },
+    ],
+  ],
   presets: [
     [
       '@babel/preset-env',
@@ -7,5 +15,6 @@ module.exports = {
         useBuiltIns: 'usage',
       },
     ],
+    'react',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@types/react-intl": "2.3.8",
     "@types/react-redux": "6.0.3",
     "babel-loader": "8.0.0-beta.4",
+    "babel-plugin-react-intl": "2.4.0",
+    "babel-preset-react": "7.0.0-beta.3",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "fetch-mock": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/react": "16.4.6",
     "@types/react-autosuggest": "9.3.4",
     "@types/react-dom": "16.0.6",
+    "@types/react-intl": "2.3.8",
     "@types/react-redux": "6.0.3",
     "babel-loader": "8.0.0-beta.4",
     "enzyme": "3.3.0",
@@ -72,6 +73,7 @@
     "react": "16.4.1",
     "react-autosuggest": "9.3.4",
     "react-dom": "16.4.1",
+    "react-intl": "2.4.0",
     "react-redux": "5.0.7",
     "redux": "4.0.0",
     "redux-saga": "0.16.0"

--- a/src/richie-front/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
+++ b/src/richie-front/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
@@ -2,6 +2,7 @@ import '../../testSetup.spec';
 
 import { render } from 'enzyme';
 import * as React from 'react';
+import { IntlProvider } from 'react-intl';
 
 import { Course } from '../../types/Course';
 import { Organization } from '../../types/Organization';
@@ -18,12 +19,14 @@ describe('components/CourseGlimpse', () => {
       name: 'Some Organization',
     } as Organization;
     const wrapper = render(
-      <CourseGlimpse course={course} organizationMain={organization} />,
+      <IntlProvider>
+        <CourseGlimpse course={course} organizationMain={organization} />
+      </IntlProvider>,
     );
 
     expect(wrapper.html()).toContain('Course 42');
     expect(wrapper.find('img').attr('src')).toContain('/thumbs/small.png');
-    expect(wrapper.html()).toContain('Starts on Mar 12, 2018');
+    expect(wrapper.html()).toContain('Starts on <span>Mar 12, 2018</span>');
     expect(wrapper.html()).toContain('Some Organization');
   });
 });

--- a/src/richie-front/js/components/CourseGlimpse/CourseGlimpse.tsx
+++ b/src/richie-front/js/components/CourseGlimpse/CourseGlimpse.tsx
@@ -1,5 +1,11 @@
-import moment from 'moment';
 import * as React from 'react';
+import {
+  defineMessages,
+  FormattedDate,
+  FormattedMessage,
+  InjectedIntlProps,
+  injectIntl,
+} from 'react-intl';
 
 import { Course } from '../../types/Course';
 import { Organization } from '../../types/Organization';
@@ -10,8 +16,22 @@ export interface CourseGlimpseProps {
   organizationMain: Nullable<Organization>;
 }
 
-export const CourseGlimpse = (props: CourseGlimpseProps) => {
-  const { course, organizationMain } = props;
+const messages = defineMessages({
+  altText: {
+    defaultMessage: 'Logo for {courseTitle} course.',
+    description: 'Alternate text for the course logo in a course glimpse.',
+    id: 'components.CourseGlimpse.logoAltText',
+  },
+  date: {
+    defaultMessage: 'Starts on {date}',
+    description:
+      "Shows the start date for a course in a course glimpse in a short format such as Sep 4, '1986'",
+    id: 'components.CourseGlimpse.startsOn',
+  },
+});
+
+export const CourseGlimpse = injectIntl((props: CourseGlimpseProps & InjectedIntlProps) => {
+  const { course, intl, organizationMain } = props;
 
   return (
     <div className="course-glimpse-container">
@@ -19,7 +39,9 @@ export const CourseGlimpse = (props: CourseGlimpseProps) => {
         <img
           className="course-glimpse__image"
           src={'https://www.fun-mooc.fr' + course.thumbnails.small}
-          alt=""
+          alt={intl.formatMessage(messages.altText, {
+            courseTitle: course.title,
+          })}
         />
         <div className="course-glimpse__body">
           <div className="course-glimpse__body__title">{course.title}</div>
@@ -28,9 +50,21 @@ export const CourseGlimpse = (props: CourseGlimpseProps) => {
           </div>
         </div>
         <div className="course-glimpse__date">
-          Starts on {moment(course.start_date, moment.ISO_8601).format('ll')}
+          <FormattedMessage
+            {...messages.date}
+            values={{
+              date: (
+                <FormattedDate
+                  value={new Date(course.start_date)}
+                  year="numeric"
+                  month="short"
+                  day="numeric"
+                />
+              ),
+            }}
+          />
         </div>
       </div>
     </div>
   );
-};
+});

--- a/src/richie-front/js/components/SearchFilter/SearchFilter.spec.tsx
+++ b/src/richie-front/js/components/SearchFilter/SearchFilter.spec.tsx
@@ -1,7 +1,8 @@
 import '../../testSetup.spec';
 
-import { shallow } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import * as React from 'react';
+import { IntlProvider } from 'react-intl';
 
 import { SearchFilter } from './SearchFilter';
 
@@ -14,24 +15,49 @@ describe('components/SearchFilter', () => {
     removeFilter = jasmine.createSpy('removeFilter');
   });
 
-  it('renders the name of the filter', () => {
-    const wrapper = shallow(
-      <SearchFilter
-        addFilter={addFilter}
-        filter={{ primaryKey: '42', humanName: 'Human name' }}
-        isActive={false}
-        removeFilter={removeFilter}
-      />,
+  it('renders the name of the filter (passed as a message)', () => {
+    const wrapper = render(
+      <IntlProvider>
+        <SearchFilter
+          addFilter={addFilter}
+          filter={{
+            humanName: { defaultMessage: 'Human name', id: 'humanName' },
+            primaryKey: '42',
+          }}
+          isActive={false}
+          removeFilter={removeFilter}
+        />
+      </IntlProvider>,
     );
 
     expect(wrapper.text()).toContain('Human name');
   });
 
+  it('renders the name of the filter (passed as a string)', () => {
+    const wrapper = render(
+      <IntlProvider>
+        <SearchFilter
+          addFilter={addFilter}
+          filter={{
+            humanName: 'Hooman name',
+            primaryKey: '42',
+          }}
+          isActive={false}
+          removeFilter={removeFilter}
+        />
+      </IntlProvider>,
+    );
+
+    expect(wrapper.text()).toContain('Hooman name');
+  });
   it('calls addFilter on button click if it was not active', () => {
     const wrapper = shallow(
       <SearchFilter
         addFilter={addFilter!}
-        filter={{ primaryKey: '42', humanName: 'Human name' }}
+        filter={{
+          humanName: { defaultMessage: 'Human name', id: 'humanName' },
+          primaryKey: '42',
+        }}
         isActive={false}
         removeFilter={removeFilter}
       />,
@@ -46,7 +72,10 @@ describe('components/SearchFilter', () => {
     const wrapper = shallow(
       <SearchFilter
         addFilter={addFilter!}
-        filter={{ primaryKey: '43', humanName: 'Human name' }}
+        filter={{
+          humanName: { defaultMessage: 'Human name', id: 'humanName' },
+          primaryKey: '43',
+        }}
         isActive={true}
         removeFilter={removeFilter}
       />,

--- a/src/richie-front/js/components/SearchFilter/SearchFilter.tsx
+++ b/src/richie-front/js/components/SearchFilter/SearchFilter.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
 
 import { FilterValue } from '../../types/filters';
 
@@ -21,7 +22,11 @@ export const SearchFilter = (props: SearchFilterProps) => {
           : addFilter(filter.primaryKey)
       }
     >
-      {filter.humanName}
+      {typeof filter.humanName === 'string' ? (
+        <span>{filter.humanName}</span>
+      ) : (
+        <FormattedMessage {...filter.humanName} />
+      )}
       {filter.count || filter.count === 0 ? (
         <span className="search-filter__count">{filter.count}</span>
       ) : (

--- a/src/richie-front/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
+++ b/src/richie-front/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
@@ -1,7 +1,8 @@
 import '../../testSetup.spec';
 
-import { shallow } from 'enzyme';
+import { mount, ReactWrapper, shallow } from 'enzyme';
 import * as React from 'react';
+import { IntlProvider } from 'react-intl';
 
 import { FilterDefinitionWithValues } from '../../types/filters';
 import { SearchFilter } from '../SearchFilter/SearchFilter';
@@ -10,128 +11,164 @@ import { SearchFilterGroup } from './SearchFilterGroup';
 describe('components/SearchFilterGroup', () => {
   const addFilter = jasmine.createSpy('addFilter');
   const removeFilter = jasmine.createSpy('removeFilter');
+  let makeSearchFilterGroup: (element: JSX.Element) => ReactWrapper;
+
+  beforeEach(() => {
+    // Mount our whole filters group whenever we need it.
+    makeSearchFilterGroup = element =>
+      mount(<IntlProvider>{element}</IntlProvider>);
+  });
 
   it('renders the name of the filter', () => {
     const filter = {
-      humanName: 'Organizations',
+      humanName: { defaultMessage: 'Organizations', id: 'organizations' },
       machineName: 'organizations',
       values: [],
     } as FilterDefinitionWithValues;
-    const wrapper = shallow(
+    const element = (
       <SearchFilterGroup
         activeFilterValues={[]}
         addFilter={addFilter}
         filter={filter}
         removeFilter={removeFilter}
-      />,
+      />
     );
 
-    expect(wrapper.text()).toContain('Organizations');
+    expect(makeSearchFilterGroup(element).text()).toContain('Organizations');
   });
 
   it('renders the list of filter values into a list of SearchFilters', () => {
     const filter = {
-      humanName: 'Example filter',
+      humanName: { defaultMessage: 'Example filter', id: 'exampleFilter' },
       values: [
-        { primaryKey: 'value-1', humanName: 'Value One' },
-        { primaryKey: 'value-2', humanName: 'Value Two' },
+        {
+          humanName: { defaultMessage: 'Value One', id: 'valueOne' },
+          primaryKey: 'value-1',
+        },
+        {
+          humanName: { defaultMessage: 'Value Two', id: 'valueTwo' },
+          primaryKey: 'value-2',
+        },
       ],
     } as FilterDefinitionWithValues;
-    const wrapper = shallow(
+    const element = (
       <SearchFilterGroup
         activeFilterValues={[]}
         addFilter={addFilter}
         filter={filter}
         removeFilter={removeFilter}
-      />,
+      />
     );
 
-    expect(wrapper.find(SearchFilter).length).toEqual(2);
+    expect(makeSearchFilterGroup(element).find(SearchFilter).length).toEqual(2);
   });
 
   it('renders any active filter values at the top of the list', () => {
     const activeFilterValues = [
-      { primaryKey: 'value-2', humanName: 'Value Two' },
+      {
+        humanName: { defaultMessage: 'Value Two', id: 'valueTwo' },
+        primaryKey: 'value-2',
+      },
     ];
     const filter = {
-      humanName: 'Example filter',
+      humanName: { defaultMessage: 'Example filter', id: 'exampleFilter' },
       values: [
-        { primaryKey: 'value-1', humanName: 'Value One' },
-        { primaryKey: 'value-3', humanName: 'Value Three' },
+        {
+          humanName: { defaultMessage: 'Value One', id: 'valueOne' },
+          primaryKey: 'value-1',
+        },
+        {
+          humanName: { defaultMessage: 'Value Three', id: 'valueThree' },
+          primaryKey: 'value-3',
+        },
       ],
     } as FilterDefinitionWithValues;
-    const wrapper = shallow(
+    const element = (
       <SearchFilterGroup
         activeFilterValues={activeFilterValues}
         addFilter={addFilter}
         filter={filter}
         removeFilter={removeFilter}
-      />,
+      />
     );
 
     expect(
-      wrapper
+      makeSearchFilterGroup(element)
         .find(SearchFilter)
         .at(0)
-        .shallow()
+        .render()
         .text(),
     ).toContain('Value Two');
     expect(
-      wrapper
+      makeSearchFilterGroup(element)
         .find(SearchFilter)
         .at(1)
-        .shallow()
+        .render()
         .text(),
     ).toContain('Value One');
     expect(
-      wrapper
+      makeSearchFilterGroup(element)
         .find(SearchFilter)
         .at(2)
-        .shallow()
+        .render()
         .text(),
     ).toContain('Value Three');
   });
 
   it('deduplicates keys between the filter and the active filter values', () => {
     const activeFilterValues = [
-      { primaryKey: 'value-2', humanName: 'Value Two' },
-      { primaryKey: 'value-3', humanName: 'Value Three' },
+      {
+        humanName: { defaultMessage: 'Value Two', id: 'valueTwo' },
+        primaryKey: 'value-2',
+      },
+      {
+        humanName: { defaultMessage: 'Value Three', id: 'valueThree' },
+        primaryKey: 'value-3',
+      },
     ];
     const filter = {
-      humanName: 'Example filter',
+      humanName: { defaultMessage: 'Example filter', id: 'exampleFilter' },
       values: [
-        { primaryKey: 'value-1', humanName: 'Value One' },
-        { primaryKey: 'value-3', humanName: 'Value Three' },
+        {
+          humanName: { defaultMessage: 'Value One', id: 'valueOne' },
+          primaryKey: 'value-1',
+        },
+        {
+          humanName: { defaultMessage: 'Value Three', id: 'valueThree' },
+          primaryKey: 'value-3',
+        },
       ],
     } as FilterDefinitionWithValues;
-    const wrapper = shallow(
-      <SearchFilterGroup
-        activeFilterValues={activeFilterValues}
-        addFilter={addFilter}
-        filter={filter}
-        removeFilter={removeFilter}
-      />,
+    const element = (
+      <IntlProvider>
+        <SearchFilterGroup
+          activeFilterValues={activeFilterValues}
+          addFilter={addFilter}
+          filter={filter}
+          removeFilter={removeFilter}
+        />
+      </IntlProvider>
     );
 
     expect(
-      wrapper
+      makeSearchFilterGroup(element)
         .find(SearchFilter)
         .at(0)
-        .shallow()
+        .render()
         .text(),
     ).toContain('Value Two');
     expect(
-      wrapper
+      makeSearchFilterGroup(element)
         .find(SearchFilter)
         .at(1)
-        .shallow()
+        .render()
         .text(),
     ).toContain('Value Three');
     expect(
-      wrapper
+      makeSearchFilterGroup(element)
         .find(SearchFilter)
         .at(2)
-        .shallow()
+        .render()
         .text(),
     ).toContain('Value One');
   });

--- a/src/richie-front/js/components/SearchFilterGroup/SearchFilterGroup.tsx
+++ b/src/richie-front/js/components/SearchFilterGroup/SearchFilterGroup.tsx
@@ -1,5 +1,6 @@
 import differenceBy from 'lodash-es/differenceBy';
 import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
 
 import { FilterDefinitionWithValues, FilterValue } from '../../types/filters';
 import { Maybe } from '../../utils/types';
@@ -17,7 +18,7 @@ export const SearchFilterGroup = (props: SearchFilterGroupProps) => {
 
   return (
     <div className="search-filter-group">
-      <h3 className="search-filter-group__title">{humanName}</h3>
+      <h3 className="search-filter-group__title"><FormattedMessage {...humanName} /></h3>
       <div className="search-filter-group__list">
         {/* First we render the active filter values */}
         {props.activeFilterValues.map(value => (

--- a/src/richie-front/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.spec.tsx
+++ b/src/richie-front/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.spec.tsx
@@ -10,11 +10,19 @@ import { mapStateToProps, mergeProps } from './SearchFilterGroupContainer';
 
 describe('components/SearchFilterGroupContainer/mergeProps', () => {
   const exampleFilter = {
-    humanName: 'Organizations',
+    humanName: { defaultMessage: 'Organizations', id: 'organizations' },
     machineName: 'organizations' as 'organizations',
     values: [
-      { count: 3, humanName: 'Organization #31', primaryKey: '31' },
-      { count: 5, humanName: 'Organization #41', primaryKey: '41' },
+      {
+        count: 3,
+        humanName: { defaultMessage: 'Organization #31', id: 'org31' },
+        primaryKey: '31',
+      },
+      {
+        count: 5,
+        humanName: { defaultMessage: 'Organization #41', id: 'org41' },
+        primaryKey: '41',
+      },
     ],
   };
 

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -2,6 +2,7 @@ import '../../testSetup.spec';
 
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IntlProvider } from 'react-intl';
 
 import { Course } from '../../types/Course';
 import { SearchSuggestionSection } from '../../types/searchSuggest';
@@ -23,8 +24,13 @@ describe('components/SearchSuggestField', () => {
   });
 
   it('renders', () => {
-    const { SearchSuggestField } = searchSuggestField;
-    const wrapper = shallow(<SearchSuggestField addFilter={addFilter} />);
+    const { SearchSuggestFieldBase } = searchSuggestField;
+    const wrapper = shallow(
+      <SearchSuggestFieldBase
+        addFilter={addFilter}
+        intl={{ formatMessage: (message: any) => message.defaultMessage } as any}
+      />,
+    );
     expect(wrapper.html()).toContain(
       'Search for courses, organizations, subjects',
     );
@@ -44,9 +50,15 @@ describe('components/SearchSuggestField', () => {
   describe('renderSectionTitle()', () => {
     it('renders a section title', () => {
       expect(
-        searchSuggestField.renderSectionTitle({
-          title: 'Some section title',
-        } as SearchSuggestionSection),
+        searchSuggestField.renderSectionTitle(
+          { formatMessage: ({ defaultMessage }: any) => defaultMessage } as any,
+          {
+            message: {
+              defaultMessage: 'Some section title',
+              id: 'someMessage',
+            },
+          } as SearchSuggestionSection,
+        ),
       ).toEqual(<span>Some section title</span>);
     });
   });

--- a/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
@@ -12,7 +12,7 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
     const state = {
       filterDefinitions: {
         organizations: {
-          humanName: 'Organizations',
+          humanName: { defaultMessage: 'Organizations', id: 'organizations' },
           machineName: 'organizations',
         },
       } as FilterDefinitionState,
@@ -37,7 +37,7 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
       { limit: 20, offset: 0 },
       'add',
       {
-        humanName: 'Organizations',
+        humanName: { defaultMessage: 'Organizations', id: 'organizations' },
         machineName: 'organizations',
       },
       '84',

--- a/src/richie-front/js/index.tsx
+++ b/src/richie-front/js/index.tsx
@@ -7,6 +7,7 @@
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
 
 // Import submodules so we don't get the whole of lodash in the bundle
@@ -57,9 +58,11 @@ document.addEventListener('DOMContentLoaded', event => {
         const Component = componentLibrary[componentName];
         // Render the component inside a `react-redux` store Provider so its children can be `connect`ed
         ReactDOM.render(
-          <Provider store={store}>
-            <Component />
-          </Provider>,
+          <IntlProvider>
+            <Provider store={store}>
+              <Component />
+            </Provider>
+          </IntlProvider>,
           element,
         );
       } else {

--- a/src/richie-front/js/integration_tests/filters.spec.tsx
+++ b/src/richie-front/js/integration_tests/filters.spec.tsx
@@ -4,6 +4,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import fetchMock from 'fetch-mock';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
 import { Store } from 'redux';
 
@@ -93,9 +94,11 @@ describe('Integration tests - filters', () => {
     // Mount our whole filters pane whhenever we need it.
     makeSearchFilterPane = () =>
       mount(
-        <Provider store={store}>
-          <SearchFiltersPane />
-        </Provider>,
+        <IntlProvider>
+          <Provider store={store}>
+            <SearchFiltersPane />
+          </Provider>
+        </IntlProvider>,
       );
   });
 
@@ -107,11 +110,7 @@ describe('Integration tests - filters', () => {
     const filterGroupNew = makeSearchFilterPane()
       .find(SearchFilterGroupContainer)
       .filterWhere(wrapper => wrapper.prop('machineName') === 'new');
-    expect(
-      filterGroupNew.containsMatchingElement(
-        <button className="search-filter ">First session</button>,
-      ),
-    ).toBeTruthy();
+    expect(filterGroupNew.html()).toContain('search-filter', 'First session');
   });
 
   it('shows the values for the resource-based filters in their groups, ordered by facet count', () => {

--- a/src/richie-front/js/settings.ts
+++ b/src/richie-front/js/settings.ts
@@ -1,3 +1,5 @@
+import { defineMessages } from 'react-intl';
+
 import {
   FilterDefinition,
   FilterDefinitionWithValues,
@@ -29,27 +31,106 @@ export const FILTERS_HARDCODED: {
   [key in hardcodedFilterGroupName]: FilterDefinitionWithValues
 } = {
   availability: {
-    humanName: 'Availability',
+    humanName: defineMessages({
+      message: {
+        defaultMessage: 'Availability',
+        description:
+          'Title for the "Availability" section of course filters (eg. Coming soon / Current session etc.)',
+        id: 'settings.filters.availability.title',
+      },
+    }).message,
     isDrilldown: true,
     machineName: 'availability',
     values: [
-      { primaryKey: 'coming_soon', humanName: 'Coming soon' },
-      { primaryKey: 'current', humanName: 'Current session' },
-      { primaryKey: 'open', humanName: 'Open, no session' },
+      {
+        humanName: defineMessages({
+          message: {
+            defaultMessage: 'Coming soon',
+            description:
+              'Possible value for the "Availability" filter for courses',
+            id: 'settings.filters.availability.values.coming_soon',
+          },
+        }).message,
+        primaryKey: 'coming_soon',
+      },
+      {
+        humanName: defineMessages({
+          message: {
+            defaultMessage: 'Current session',
+            description:
+              'Possible value for the "Availability" filter for courses',
+            id: 'settings.filters.availability.values.current',
+          },
+        }).message,
+        primaryKey: 'current',
+      },
+      {
+        humanName: defineMessages({
+          message: {
+            defaultMessage: 'Current session',
+            description:
+              'Possible value for the "Availability" filter for courses',
+            id: 'settings.filters.availability.values.current',
+          },
+        }).message,
+        primaryKey: 'open',
+      },
     ],
   },
   language: {
-    humanName: 'Language',
+    humanName: defineMessages({
+      message: {
+        defaultMessage: 'Language',
+        description:
+          'Title for the "Language" section of course filters (eg. FR / EN etc.)',
+        id: 'settings.filters.language.title',
+      },
+    }).message,
     machineName: 'language',
     values: [
-      { primaryKey: 'en', humanName: 'English' },
-      { primaryKey: 'fr', humanName: 'French' },
+      {
+        humanName: defineMessages({
+          message: {
+            defaultMessage: 'English',
+            description: 'Language',
+            id: 'settings.filters.language.en',
+          },
+        }).message,
+        primaryKey: 'en',
+      },
+      {
+        humanName: defineMessages({
+          message: {
+            defaultMessage: 'French',
+            description: 'Language',
+            id: 'settings.filters.language.fr',
+          },
+        }).message,
+        primaryKey: 'fr',
+      },
     ],
   },
   new: {
-    humanName: 'New courses',
+    humanName: defineMessages({
+      message: {
+        defaultMessage: 'New courses',
+        description: 'Title for the "New" section of course filters',
+        id: 'settings.filters.new.title',
+      },
+    }).message,
     machineName: 'new',
-    values: [{ primaryKey: 'new', humanName: 'First session' }],
+    values: [
+      {
+        humanName: defineMessages({
+          message: {
+            defaultMessage: 'First session',
+            description: 'Possible balue for the "New" filter for courses',
+            id: 'settings.filters.new.new',
+          },
+        }).message,
+        primaryKey: 'new',
+      },
+    ],
   },
 };
 
@@ -57,11 +138,23 @@ export const FILTERS_RESOURCES: {
   [key in resourceBasedFilterGroupName]: FilterDefinition
 } = {
   organizations: {
-    humanName: 'Organizations',
+    humanName: defineMessages({
+      message: {
+        defaultMessage: 'Organizations',
+        description: 'Title for the "Organizations" section of course filters',
+        id: 'settings.filters.organizations.title',
+      },
+    }).message,
     machineName: 'organizations',
   },
   subjects: {
-    humanName: 'Subjects',
+    humanName: defineMessages({
+      message: {
+        defaultMessage: 'Subjects',
+        description: 'Title for the "Subjects" section of course filters',
+        id: 'settings.filters.subjects.title',
+      },
+    }).message,
     machineName: 'subjects',
   },
 };

--- a/src/richie-front/js/types/filters.ts
+++ b/src/richie-front/js/types/filters.ts
@@ -1,3 +1,5 @@
+import { FormattedMessage } from 'react-intl';
+
 export type hardcodedFilterGroupName = 'availability' | 'language' | 'new';
 
 export type resourceBasedFilterGroupName = 'organizations' | 'subjects';
@@ -8,12 +10,12 @@ export type filterGroupName =
 
 export interface FilterValue {
   primaryKey: string; // Either a machine name or a stringified ID
-  humanName: string;
+  humanName: FormattedMessage.MessageDescriptor | string;
   count?: number; // TODO: Replace Maybe<number> with number when all the facets are available
 }
 
 export interface FilterDefinition {
-  humanName: string;
+  humanName: FormattedMessage.MessageDescriptor;
   machineName: filterGroupName;
   isDrilldown?: boolean;
 }

--- a/src/richie-front/js/types/searchSuggest.ts
+++ b/src/richie-front/js/types/searchSuggest.ts
@@ -1,3 +1,5 @@
+import { FormattedMessage } from 'react-intl';
+
 import { Course } from './Course';
 import { modelNameList } from './models';
 import { Organization } from './Organization';
@@ -25,8 +27,8 @@ interface ResourceSuggestionSection<
   M extends modelNameList,
   T extends Resource
 > {
+  message: FormattedMessage.MessageDescriptor;
   model: M;
-  title: string;
   values: T[];
 }
 

--- a/src/richie-front/js/utils/commonMessages.ts
+++ b/src/richie-front/js/utils/commonMessages.ts
@@ -1,0 +1,19 @@
+import { defineMessages } from 'react-intl';
+
+export const commonMessages = defineMessages({
+  coursesHumanName: {
+    defaultMessage: 'Courses',
+    description: 'Title/name to use when we display a list of courses',
+    id: 'common.coursesHumanName',
+  },
+  organizationsHumanName: {
+    defaultMessage: 'Organizations',
+    description: 'Title/name to use when we display a list of organizations',
+    id: 'common.organizationsHumanName',
+  },
+  subjectsHumanName: {
+    defaultMessage: 'Subjects',
+    description: 'Title/name to use when we display a list of subjects',
+    id: 'common.subjectsHumanName',
+  },
+});

--- a/src/richie-front/js/utils/filters/getFilterFromState.spec.ts
+++ b/src/richie-front/js/utils/filters/getFilterFromState.spec.ts
@@ -14,7 +14,7 @@ describe('utils/filters/getFilterFromState', () => {
         availability: {} as FilterDefinitionWithValues,
         language: {} as FilterDefinitionWithValues,
         new: {
-          humanName: 'New courses',
+          humanName: { defaultMessage: 'New courses', id: 'newCourses' },
           machineName: 'new' as 'new',
           values: [{ primaryKey: 'new', humanName: 'First session' }],
         },
@@ -24,7 +24,7 @@ describe('utils/filters/getFilterFromState', () => {
       resources: {},
     } as RootState;
     expect(getFilterFromState(state, 'new')).toEqual({
-      humanName: 'New courses',
+      humanName: { defaultMessage: 'New courses', id: 'newCourses' },
       machineName: 'new',
       values: [{ primaryKey: 'new', humanName: 'First session' }],
     });
@@ -37,7 +37,7 @@ describe('utils/filters/getFilterFromState', () => {
         language: {} as FilterDefinitionWithValues,
         new: {} as FilterDefinitionWithValues,
         organizations: {
-          humanName: 'Organizations',
+          humanName: { defaultMessage: 'Organizations', id: 'organizations' },
           machineName: 'organizations',
           values: [],
         },
@@ -64,7 +64,7 @@ describe('utils/filters/getFilterFromState', () => {
     };
 
     expect(getFilterFromState(state as RootState, 'organizations')).toEqual({
-      humanName: 'Organizations',
+      humanName: { defaultMessage: 'Organizations', id: 'organizations' },
       machineName: 'organizations',
       values: [
         { count: 15, humanName: 'Organization #Fourty-Two', primaryKey: '42' },
@@ -81,7 +81,7 @@ describe('utils/filters/getFilterFromState', () => {
         language: {} as FilterDefinitionWithValues,
         new: {} as FilterDefinitionWithValues,
         organizations: {
-          humanName: 'Organizations',
+          humanName: { defaultMessage: 'Organizations', id: 'organizations' },
           machineName: 'organizations',
           values: [],
         },
@@ -99,7 +99,7 @@ describe('utils/filters/getFilterFromState', () => {
     };
 
     expect(getFilterFromState(state as RootState, 'organizations')).toEqual({
-      humanName: 'Organizations',
+      humanName: { defaultMessage: 'Organizations', id: 'organizations' },
       machineName: 'organizations',
       values: [
         { humanName: 'Organization #Twenty-One', primaryKey: '21' },

--- a/src/richie-front/js/utils/filters/updateFilter.spec.ts
+++ b/src/richie-front/js/utils/filters/updateFilter.spec.ts
@@ -20,7 +20,7 @@ describe('utils/filters/updateFilter', () => {
       { limit: 13, offset: 3, organizations: [42, 84] },
       'add',
       {
-        humanName: 'Availability',
+        humanName: { defaultMessage: 'Availability', id: 'availability' },
         isDrilldown: true,
         machineName: 'availability',
       } as FilterDefinition,

--- a/src/richie-front/js/utils/searchSuggest/getSuggestionsSection.ts
+++ b/src/richie-front/js/utils/searchSuggest/getSuggestionsSection.ts
@@ -1,5 +1,6 @@
 import take from 'lodash-es/take';
 import { stringify } from 'query-string';
+import { FormattedMessage } from 'react-intl';
 
 import { API_ENDPOINTS } from '../../settings';
 import { Resource } from '../../types/Resource';
@@ -13,7 +14,7 @@ import { handle } from '../../utils/errors/handle';
 // values to populate it from the API
 export const getSuggestionsSection = async (
   sectionModel: SearchSuggestionSection['model'],
-  sectionTitle: string,
+  sectionTitleMessage: FormattedMessage.MessageDescriptor,
   query: string,
 ) => {
   // Run the search for the section on the API
@@ -52,8 +53,8 @@ export const getSuggestionsSection = async (
 
   // Build out the section. Compiler needs help as it is unable to infer model name matches
   return {
+    message: sectionTitleMessage,
     model: sectionModel,
-    title: sectionTitle,
     values: take(data.objects, 3),
   } as SearchSuggestionSection;
 };

--- a/src/richie-front/js/utils/searchSuggest/getSuggestionsSections.spec.ts
+++ b/src/richie-front/js/utils/searchSuggest/getSuggestionsSections.spec.ts
@@ -22,7 +22,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
     try {
       suggestionsSection = await getSuggestionsSection(
         'courses',
-        'Courses',
+        { defaultMessage: 'Courses', id: 'coursesHumanName' },
         'some search',
       );
     } catch (error) {
@@ -30,8 +30,8 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
     }
 
     expect(suggestionsSection).toEqual({
+      message: { defaultMessage: 'Courses', id: 'coursesHumanName' },
       model: 'courses',
-      title: 'Courses',
       values: [
         { title: 'Course #1' } as Course,
         { title: 'Course #2' } as Course,
@@ -43,7 +43,11 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
     fetchMock.get('/api/v1.0/courses/?query=some%20search', {
       throws: 'Failed to send API request',
     });
-    await getSuggestionsSection('courses', 'Courses', 'some search');
+    await getSuggestionsSection(
+      'courses',
+      { defaultMessage: 'Courses', id: 'coursesHumanName' },
+      'some search',
+    );
     expect(errors.handle).toHaveBeenCalledWith(
       new Error('Failed to send API request'),
     );
@@ -54,7 +58,11 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
       body: {},
       status: 403,
     });
-    await getSuggestionsSection('courses', 'Courses', 'some search');
+    await getSuggestionsSection(
+      'courses',
+      { defaultMessage: 'Courses', id: 'coursesHumanName' },
+      'some search',
+    );
     expect(errors.handle).toHaveBeenCalledWith(
       new Error('Failed to get list from /api/v1.0/courses/ : 403'),
     );
@@ -65,7 +73,11 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
       '/api/v1.0/courses/?query=some%20search',
       new Response('not json'),
     );
-    await getSuggestionsSection('courses', 'Courses', 'some search');
+    await getSuggestionsSection(
+      'courses',
+      { defaultMessage: 'Courses', id: 'coursesHumanName' },
+      'some search',
+    );
     expect(errors.handle).toHaveBeenCalledWith(
       new Error(
         'Failed to decode JSON in getSuggestionSection SyntaxError: Unexpected token o in JSON at position 1',

--- a/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.spec.ts
+++ b/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.spec.ts
@@ -7,8 +7,8 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
   it('turns a course suggestion section into a list of individual course suggestions', () => {
     expect(
       suggestionsFromSection({
+        message: { defaultMessage: 'Courses', id: 'coursesHumanName' },
         model: 'courses',
-        title: 'Courses',
         values: [
           { title: 'Example course #1' } as Course,
           { title: 'Example course #2' } as Course,
@@ -29,8 +29,8 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
   it('turns an organization suggestion section into a list of individual organization suggestions', () => {
     expect(
       suggestionsFromSection({
+        message: { defaultMessage: 'Organizations', id: 'organizationsHumanName' },
         model: 'organizations',
-        title: 'Organizations',
         values: [
           { name: 'Example organization #1' } as Organization,
           { name: 'Example organization #2' } as Organization,
@@ -51,8 +51,8 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
   it('turns a subject suggestion section into a list of individual subject suggestions', () => {
     expect(
       suggestionsFromSection({
+        message: { defaultMessage: 'Subjects', id: 'subjectsHumanName' },
         model: 'subjects',
-        title: 'Subjects',
         values: [
           { name: 'Example subject #1' } as Subject,
           { name: 'Example subject #2' } as Subject,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "jsx": "react",
+    "jsx": "preserve",
     "lib": [
       "dom",
       "dom.iterable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,13 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
+babel-helper-builder-react-jsx@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-7.0.0-beta.3.tgz#a3ff5d2427c4aec5af6b4376e7a5103c67508f8e"
+  dependencies:
+    babel-types "7.0.0-beta.3"
+    esutils "^2.0.0"
+
 babel-loader@8.0.0-beta.4:
   version "8.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.0-beta.4.tgz#c3fab00696c385c70c04dbe486391f0eb996f345"
@@ -996,6 +1003,41 @@ babel-loader@8.0.0-beta.4:
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
 
+babel-plugin-react-intl@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-intl/-/babel-plugin-react-intl-2.4.0.tgz#292fca8030603a9e0476973290836aa0c7da17e2"
+  dependencies:
+    babel-runtime "^6.2.0"
+    intl-messageformat-parser "^1.2.0"
+    mkdirp "^0.5.1"
+
+babel-plugin-syntax-jsx@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-7.0.0-beta.3.tgz#e45983c652a50d3647dfa4acd9db5567c0c2b701"
+
+babel-plugin-transform-react-display-name@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-7.0.0-beta.3.tgz#9bec4984d868bf37e5184ed22bb66c44db61d612"
+
+babel-plugin-transform-react-jsx-self@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-7.0.0-beta.3.tgz#33bc0b66b090661409d308e6020d6835f8cfe611"
+  dependencies:
+    babel-plugin-syntax-jsx "7.0.0-beta.3"
+
+babel-plugin-transform-react-jsx-source@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-7.0.0-beta.3.tgz#e5b1015a8eb107e51d64aace7677b2621c87f2ed"
+  dependencies:
+    babel-plugin-syntax-jsx "7.0.0-beta.3"
+
+babel-plugin-transform-react-jsx@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-7.0.0-beta.3.tgz#61af93962a3e6938ae8aeca10bb544f8b231ee7b"
+  dependencies:
+    babel-helper-builder-react-jsx "7.0.0-beta.3"
+    babel-plugin-syntax-jsx "7.0.0-beta.3"
+
 babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
@@ -1004,12 +1046,30 @@ babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-runtime@^6.0.0, babel-runtime@^6.26.0:
+babel-preset-react@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-7.0.0-beta.3.tgz#3a6453e0a5e6156d9528590b629a70ecd9d50226"
+  dependencies:
+    babel-plugin-syntax-jsx "7.0.0-beta.3"
+    babel-plugin-transform-react-display-name "7.0.0-beta.3"
+    babel-plugin-transform-react-jsx "7.0.0-beta.3"
+    babel-plugin-transform-react-jsx-self "7.0.0-beta.3"
+    babel-plugin-transform-react-jsx-source "7.0.0-beta.3"
+
+babel-runtime@^6.0.0, babel-runtime@^6.2.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-types@7.0.0-beta.3:
+  version "7.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-7.0.0-beta.3.tgz#cd927ca70e0ae8ab05f4aab83778cfb3e6eb20b4"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -2201,7 +2261,7 @@ estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-esutils@^2.0.2:
+esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -2994,7 +3054,7 @@ intl-format-cache@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"
 
-intl-messageformat-parser@1.4.0:
+intl-messageformat-parser@1.4.0, intl-messageformat-parser@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
 
@@ -3560,7 +3620,7 @@ lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,6 +579,10 @@
     "@types/node" "*"
     "@types/react" "*"
 
+"@types/react-intl@2.3.8":
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.8.tgz#de56b21b67e39df24bc0fc7e67b437976b666919"
+
 "@types/react-redux@6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.3.tgz#7e8a86cce1c453166056bce9d4eb5cab5a2cfe13"
@@ -2986,7 +2990,27 @@ interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.2:
+intl-format-cache@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-2.1.0.tgz#04a369fecbfad6da6005bae1f14333332dcf9316"
+
+intl-messageformat-parser@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
+
+intl-messageformat@^2.0.0, intl-messageformat@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.2.0.tgz#345bcd46de630b7683330c2e52177ff5eab484fc"
+  dependencies:
+    intl-messageformat-parser "1.4.0"
+
+intl-relativeformat@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz#010f1105802251f40ac47d0e3e1a201348a255df"
+  dependencies:
+    intl-messageformat "^2.0.0"
+
+invariant@^2.0.0, invariant@^2.1.1, invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -4736,6 +4760,15 @@ react-dom@16.4.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-intl@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.4.0.tgz#66c14dc9df9a73b2fbbfbd6021726e80a613eb15"
+  dependencies:
+    intl-format-cache "^2.0.5"
+    intl-messageformat "^2.1.0"
+    intl-relativeformat "^2.0.0"
+    invariant "^2.1.1"
 
 react-is@^16.4.0:
   version "16.4.0"


### PR DESCRIPTION
## Purpose

This is step 3 & 4 of #89. We need to manage strings inside the JS app and to collect them for translation.

## Proposal

- [x] Add a dependency (`react-intl`) to manage i18n for us
- [x] Mark all strings and replace them with full message descriptors
- [x] Automatically extract them during `yarn build` through a babel plugin