### PR TITLE
🐳(compose) fix permissions for data directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ MANAGE               = $(COMPOSE_RUN_APP) python sandbox/manage.py
 default: help
 
 bootstrap:  ## install development dependencies
+	@echo 'Preparing data directory...';
+	@mkdir -p data/media data/static
 	@$(COMPOSE) build base;
 	@$(COMPOSE) build app;
 	${MAKE} build-front;


### PR DESCRIPTION
## Purpose

When starting to work on the project (or after a `git clean`), if the `data` directory does not exist, it is created by `docker-compose` and belongs to the `root` user; leading to permission issues while trying to collect statics or upload media.

## Proposal

- [x] Create `data/*` directories while bootstrapping the project (_e.g._ _via_ `make bootstrap`)