### PR TITLE
🐛(person) fix Person plugin template escaped html

### DIFF
--- a/src/richie/apps/persons/templates/persons/plugins/person.html
+++ b/src/richie/apps/persons/templates/persons/plugins/person.html
@@ -15,6 +15,6 @@
         {{ page.person.get_full_name }}
       </h{{ header_level|default:2 }}>
     </a>
-    <p class="person-plugin__body__text">{{ related_plugins.resume.0.body }}</p>
+    <p class="person-plugin__body__text">{{ related_plugins.resume.0.body|safe }}</p>
   </div>
 </div>

--- a/src/richie/apps/persons/tests/test_person_plugin.py
+++ b/src/richie/apps/persons/tests/test_person_plugin.py
@@ -49,10 +49,16 @@ class PersonPluginTestCase(TestCase):
         # A resume to related placeholder
         resume_placeholder = person_page.placeholders.get(slot="resume")
         add_plugin(
-            resume_placeholder, PlaintextPlugin, "en", **{"body": "A short resume"}
+            resume_placeholder,
+            PlaintextPlugin,
+            "en",
+            **{"body": "<p>A short resume</p>"}
         )
         add_plugin(
-            resume_placeholder, PlaintextPlugin, "fr", **{"body": "un résumé court"}
+            resume_placeholder,
+            PlaintextPlugin,
+            "fr",
+            **{"body": "<p>un résumé court</p>"}
         )
 
         # Create a page to add the plugin to
@@ -81,7 +87,9 @@ class PersonPluginTestCase(TestCase):
         # pylint: disable=no-member
         self.assertContains(response, image.file.name)
         # Short resume should be present
-        self.assertContains(response, "A short resume")
+        self.assertInHTML(
+            "<p>A short resume</p>", str(response.content, encoding="utf8")
+        )
         # The person's full name should be wrapped in a h2
         self.assertContains(
             response,
@@ -103,4 +111,6 @@ class PersonPluginTestCase(TestCase):
         )
         # pylint: disable=no-member
         self.assertContains(response, image.file.name)
-        self.assertContains(response, "un résumé court", html=True)
+        self.assertInHTML(
+            "<p>un résumé court</p>", str(response.content, encoding="utf8")
+        )


### PR DESCRIPTION
## Purpose

Due to Page extension relation, Person plugin template does not reach
commonly the Person resume attribute value so it is not marked as safe
content, leading to escaped HTML.

## Proposal

This little fix just add the `|safe` filter to the resume variable
usage.
