### PR TITLE
🐳(user) use an un-privileged user in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,15 +417,16 @@ jobs:
           command: |
             docker load < docker/images/dev/richie.tar
 
+      # Run commands using CircleCI's user and mount the app volume to have
+      # write permission on it, and thus, being able to create the package.
       - run:
-          name: Build python packages
+          name: Build python package
           command: |
-            docker-compose \
-              -p richie-test \
-              -f docker/compose/ci/docker-compose.yml \
-              --project-directory . \
-              run --rm --no-deps app \
-                python setup.py sdist bdist_wheel
+            docker run --rm \
+              --user="$(id -u)" \
+              --volume "$PWD:/app" \
+              "richie:${CIRCLE_SHA1}-dev" \
+              python setup.py sdist bdist_wheel
 
       # Persist build packages to the workspace
       - persist_to_workspace:

--- a/docker/compose/ci/docker-compose.yml
+++ b/docker/compose/ci/docker-compose.yml
@@ -21,8 +21,7 @@ services:
   app:
     image: "richie:${CIRCLE_SHA1}${IMAGE_SUFFIX}-dev"
     env_file: env.d/ci
-    volumes:
-      - ./dist:/app/dist
     depends_on:
       - "db"
       - "elasticsearch"
+    tmpfs: /data

--- a/docker/compose/test/docker-compose.yml
+++ b/docker/compose/test/docker-compose.yml
@@ -16,3 +16,4 @@ services:
     depends_on:
       - "db"
       - "elasticsearch"
+    tmpfs: /data

--- a/docker/images/dev/Dockerfile
+++ b/docker/images/dev/Dockerfile
@@ -27,3 +27,6 @@ RUN curl -sL \
     https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+# Restore the un-privileged user running the application
+USER 10000


### PR DESCRIPTION
## Purpose

As discussed in #279, running tests in the container using the root user may hide potential issues of the application (e.g. permission-related issues). We need to make our test suite more reliable and trustworthy by running the test suite using a non-privileged user.

## Proposal

- [x] Switch back to an un-privileged user in the dev image
- [x] Use `tmpfs` for the `/data` directory that requires write permission (test + CI)

Fix #282 