### PR TITLE
Upload frontend strings to crowdin

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,7 +3,7 @@ module.exports = {
     [
       'react-intl',
       {
-        messagesDir: './strings/',
+        messagesDir: './src/richie-front/i18n',
       },
     ],
   ],

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,20 @@ jobs:
           paths:
             - ~/fun/docker/images/dev/
           key: docker-debian-images-dev-{{ .Revision }}
+      # Generate and persist the translations base file
+      - run:
+          name: Generate a POT file from strings extracted from the project
+          command: |
+            docker run --rm \
+              --user="$(id -u)" \
+              --volume "$PWD:/app" \
+              --workdir /app/src/richie \
+              "richie:${CIRCLE_SHA1}-dev" \
+                  python /app/sandbox/manage.py makemessages --keep-pot
+      - persist_to_workspace:
+          root: ~/fun/src/richie/locale
+          paths:
+            - django.pot
 
   lint-back-isort:
 
@@ -257,6 +271,28 @@ jobs:
               --project-directory . \
               run --rm --no-deps app \
                 black src/richie/apps src/richie/plugins sandbox --check
+
+  # Restore front & back POT files containing strings to translate and upload them to our
+  # translation management tool
+  upload-i18n-strings:
+    docker:
+      - image: circleci/node:9-browsers
+    working_directory: ~/richie
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v3-front-dependencies-{{ checksum "package.json" }}
+      - attach_workspace:
+          at: ~/fun/src/richie/locale
+      - run:
+          name: Use our node script to upload i18n backend strings file
+          command: node i18n/scripts/upload.js 'richie-back.pot' '/../../../fun/src/richie/locale/django.pot'
+      - attach_workspace:
+          at: ~/richie/src/richie-front/i18n
+      - run:
+          name: Use our node script to upload i18n frontend strings file
+          command: node i18n/scripts/upload.js 'richie-front.pot' '/../../src/richie-front/i18n/richie-front.pot'
 
   test-back:
 
@@ -574,6 +610,16 @@ jobs:
       - run:
           name: Build application styles
           command: yarn sass
+      - run:
+          name: Use react-intl-po to generate our richie-front.pot file
+          command: yarn generate-l10n-template
+      - persist_to_workspace:
+          root: ~/richie/src/richie-front/i18n
+          paths:
+            - richie-front.pot
+      - store_artifacts:
+          path: src/richie-front/i18n/richie-front.pot
+          destination: richie-front.pot
       - save_cache:
           paths:
             - ./node_modules
@@ -701,6 +747,17 @@ workflows:
           filters:
             tags:
               only: /.*/
+
+      # i18n jobs
+      #
+      # Extract strings and upload them to our translation management SaaS
+      - upload-i18n-strings:
+          requires:
+            - build-front
+            - build-dev
+          filters:
+            branches:
+              only: master
 
       # Docker alpine jobs
       #

--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,6 @@ htmlcov/
 nosetests.xml
 coverage.xml
 
-# Translations
-*.mo
-
 # Vagrant
 .vagrant
 
@@ -81,3 +78,7 @@ node_modules
 
 # logs
 yarn-error.log
+
+# Exported strings & generated translation templates
+src/richie-front/i18n/src
+*.pot

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,12 @@ RUN yarn install && \
 # ---- final application image ----
 FROM base
 
+# Install gettext
+RUN apt-get update && \
+    apt-get install -y \
+    gettext && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy installed python dependencies
 COPY --from=back-builder /install /usr/local
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ build-ts: ## build TypeScript application
 	@$(YARN) build
 .PHONY: build-ts
 
+compilemessages: ## compile the gettext files
+	@$(COMPOSE_RUN) -w /app/src/richie app python /app/sandbox/manage.py compilemessages
+
 demo-site:  ## create a demo site
 	@$(MANAGE) create_demo_site
 .PHONY: demo-site
@@ -99,6 +102,9 @@ lint-front: ## lint TypeScript sources
 logs: ## get development logs
 	@$(COMPOSE) logs -f
 .PHONY: logs
+
+messages: ## create the .po files used for i18n
+	@$(COMPOSE_RUN) -w /app/src/richie app python /app/sandbox/manage.py makemessages --keep-pot
 
 migrate:  ## perform database migrations
 	@$(MANAGE) migrate

--- a/i18n/scripts/upload.js
+++ b/i18n/scripts/upload.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+const request = require('request-promise');
+
+// Get file to upload from command line arguments
+const [_, __, fileName, filePath] = process.argv;
+if (!fileName || !filePath) {
+  console.log('⚠️  missing file to upload, aborting.');
+  process.exit(1);
+}
+
+// Get project ID & key from environment variables
+const { CROWDIN_API_KEY, CROWDIN_PROJECT_IDENTIFIER } = process.env;
+if (!CROWDIN_API_KEY || !CROWDIN_PROJECT_IDENTIFIER) {
+  console.log(
+    '⚠️  missing necessary environment variables (CROWDIN_API_KEY, CROWDIN_PROJECT_IDENTIFIER), aborting.',
+  );
+  process.exit(1);
+}
+
+// Run the uploader for the passed file
+createOrUpdateFile(fileName, filePath);
+
+// Attempt to update the file (most common operation), default to creating it
+// if it does not exist (initial setup)
+function createOrUpdateFile(fileName, filePath, shouldCreateFile) {
+  console.log(
+    `🙈 uploading ${fileName} [${shouldCreateFile ? 'CREATE' : 'UPDATE'}]...`,
+  );
+
+  // Crowdin expects the POST request to contain the files in form data format
+  const formData = {
+    [`files[${fileName}]`]: fs.createReadStream(
+      path.join(__dirname + filePath),
+    ),
+    json: JSON.stringify(true),
+  };
+
+  // Crowdin API action keywords/routes
+  const keyword = shouldCreateFile ? 'add-file' : 'update-file';
+
+  request
+    .post({
+      formData,
+      url: `https://api.crowdin.com/api/project/${CROWDIN_PROJECT_IDENTIFIER}/${keyword}?key=${CROWDIN_API_KEY}`,
+    })
+    .then(
+      () => console.log(`🚀 uploaded ${fileName}.`),
+      response => {
+        const error =
+          typeof response.error === 'string'
+            ? JSON.parse(response.error)
+            : response.error;
+        if (error && error.error && error.error.code === 8) {
+          console.log(
+            `🙉 cannot update ${fileName}, attempting to create instead...`,
+          );
+          return createOrUpdateFile(fileName, filePath, true);
+        } else if (error && error.code && error.code === 'ENOENT') {
+          console.log(`👻 cannot find ${path.join(__dirname + filePath)}, aborting.`);
+          process.exit(1);
+        }
+
+        console.log(`💥 failed to upload ${fileName}, aborting.`);
+        process.exit(1);
+      },
+    );
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "nodemon": "1.17.5",
     "prettier": "1.13.7",
     "react-intl-po": "2.2.2",
+    "request": "2.87.0",
+    "request-promise": "4.2.2",
     "source-map-loader": "0.2.3",
     "ts-loader": "4.4.2",
     "tslint": "5.10.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "sandbox/manage.py",
   "scripts": {
     "build": "webpack",
+    "generate-l10n-template": "rip json2pot 'src/richie-front/i18n/src/**/*.json' -o src/richie-front/i18n/richie-front.pot",
     "lint": "tslint -c tslint.json 'src/richie-front/js/**/*.ts'",
     "sass": "node-sass src/richie-front/scss/_main.scss src/richie/static/richie/css/main.css",
     "test": "karma start ./karma.conf.js",
@@ -59,6 +60,7 @@
     "node-sass": "4.9.2",
     "nodemon": "1.17.5",
     "prettier": "1.13.7",
+    "react-intl-po": "2.2.2",
     "source-map-loader": "0.2.3",
     "ts-loader": "4.4.2",
     "tslint": "5.10.0",

--- a/src/richie-front/js/settings.ts
+++ b/src/richie-front/js/settings.ts
@@ -7,6 +7,7 @@ import {
   hardcodedFilterGroupName,
   resourceBasedFilterGroupName,
 } from './types/filters';
+import { commonMessages } from './utils/commonMessages';
 
 export const API_ENDPOINTS = {
   courses: '/api/v1.0/courses/',
@@ -138,23 +139,11 @@ export const FILTERS_RESOURCES: {
   [key in resourceBasedFilterGroupName]: FilterDefinition
 } = {
   organizations: {
-    humanName: defineMessages({
-      message: {
-        defaultMessage: 'Organizations',
-        description: 'Title for the "Organizations" section of course filters',
-        id: 'settings.filters.organizations.title',
-      },
-    }).message,
+    humanName: commonMessages.organizationsHumanName,
     machineName: 'organizations',
   },
   subjects: {
-    humanName: defineMessages({
-      message: {
-        defaultMessage: 'Subjects',
-        description: 'Title for the "Subjects" section of course filters',
-        id: 'settings.filters.subjects.title',
-      },
-    }).message,
+    humanName: commonMessages.subjectsHumanName,
     machineName: 'subjects',
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,7 +1149,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.3.0, bluebird@^3.4.6, bluebird@^3.5.1:
+bluebird@^3.3.0, bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -3634,7 +3634,7 @@ lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -4698,6 +4698,10 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+psl@^1.1.24:
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
+
 pstree.remy@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.0.tgz#f2af27265bd3e5b32bbfcc10e80bac55ba78688b"
@@ -5093,6 +5097,21 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.2.tgz#d1ea46d654a6ee4f8ee6a4fea1018c22911904b4"
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
 
 request@2, request@2.87.0, request@^2.0.0, request@^2.74.0:
   version "2.87.0"
@@ -5588,6 +5607,10 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
@@ -5818,6 +5841,13 @@ touch@^3.1.0:
   resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
   dependencies:
     nopt "~1.0.10"
+
+tough-cookie@>=2.3.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
 
 tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,6 +841,10 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
+
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -1410,13 +1414,21 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 chardet@^0.5.0:
   version "0.5.0"
@@ -1563,6 +1575,10 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@^2.12.1, commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+commander@^2.15.1:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
 
 commander@~2.13.0:
   version "2.13.0"
@@ -2651,6 +2667,12 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gettext-parser@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-1.1.0.tgz#2c5a6638d893934b9b55037d0ad82cb7004b2679"
+  dependencies:
+    encoding "^0.1.11"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -2763,6 +2785,10 @@ has-binary2@~1.0.2:
   resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.3.tgz#7776ac627f3ea77250cfc332dab7ddf5e4f5d11d"
   dependencies:
     isarray "2.0.1"
+
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
 has-cors@1.1.0:
   version "1.1.0"
@@ -4133,6 +4159,13 @@ nodemon@1.17.5:
     undefsafe "^2.0.2"
     update-notifier "^2.3.0"
 
+nomnom@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
+
 nomnom@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
@@ -4567,6 +4600,13 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+po2json@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/po2json/-/po2json-0.4.5.tgz#47bb2952da32d58a1be2f256a598eebc0b745118"
+  dependencies:
+    gettext-parser "1.1.0"
+    nomnom "1.8.1"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -4738,6 +4778,10 @@ railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
 
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+
 randexp@0.4.6:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
@@ -4804,6 +4848,17 @@ react-dom@16.4.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-intl-po@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-intl-po/-/react-intl-po-2.2.2.tgz#ca5b5d8cefe1a693b0c316cb5f6dd4caf8b0141c"
+  dependencies:
+    chalk "^2.3.2"
+    commander "^2.15.1"
+    glob "^7.1.2"
+    mkdirp "^0.5.1"
+    po2json "^0.4.5"
+    ramda "^0.25.0"
 
 react-intl@2.4.0:
   version "2.4.0"
@@ -5621,6 +5676,10 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -5901,6 +5960,10 @@ undefsafe@^2.0.2:
 underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 underscore@~1.7.0:
   version "1.7.0"


### PR DESCRIPTION
## Purpose

Generate a POT file from our strings and upload strings to our SaaS translation manager.

## Proposal

- [x] tidy up our folder structure
- [x] use `react-intl-po` to generate a standard POT from our JSON files with message descriptors
- [x] write a small node script to handle string uploading
- [x] add a Circle CI job to upload strings when running on master

🚫 install & configure the Crowdin CLI tool (abandoned because it introduced a dependency to java in the project and that's not something we're ready for)

Note: penultimate step towards #89 