### PR TITLE
Fix getting linked page extensions via many-to-many

### DIFF
--- a/src/richie/apps/core/models.py
+++ b/src/richie/apps/core/models.py
@@ -1,0 +1,64 @@
+"""Define a custom manager for page extensions"""
+from django.db import models
+
+from cms.extensions import PageExtension
+
+
+class PageExtensionQuerySet(models.QuerySet):
+    """
+    Add custom filters to the default Django queryset for page extensions.
+    """
+
+    def drafts(self):
+        """
+        Custom filter to get only the draft page extension instances based on the status of the
+        linked DjangoCMS page.
+        """
+        return self.filter(extended_object__publisher_is_draft=True)
+
+    def published(self):
+        """
+        Custom filter to get only the published page extension instances based on the status of the
+        linked DjangoCMS page.
+        """
+        return self.filter(extended_object__publisher_is_draft=False)
+
+
+class PageExtensionManager(models.Manager):
+    """
+    Add custom filters to the default Django manager for page extensions.
+    """
+
+    def get_queryset(self):
+        """
+        Use our custom queryset for page extensions.
+        """
+        return PageExtensionQuerySet(self.model, using=self._db)
+
+    def drafts(self):
+        """
+        Make our custom filter "drafts" available on the page extension manager.
+        """
+        return self.get_queryset().drafts()
+
+    def published(self):
+        """
+        Make our custom filter "published" available on the page extension manager.
+        """
+        return self.get_queryset().published()
+
+
+class BasePageExtension(PageExtension):
+    """
+    The organization page extension represents and records entities that manage courses.
+    It could be a university or a training company for example.
+
+    This model should be used to record structured data about the organization whereas the
+    associated page object is where we record the less structured information to display on the
+    page to present the organization.
+    """
+
+    objects = PageExtensionManager()
+
+    class Meta:
+        abstract = True

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -42,6 +42,7 @@ class CourseWizardForm(BaseWizardForm):
 
         if (
             self.cleaned_data.get("active_session")
+            # pylint: disable=no-member
             and Course.objects.filter(
                 active_session=self.cleaned_data["active_session"]
             ).exists()

--- a/src/richie/apps/courses/models.py
+++ b/src/richie/apps/courses/models.py
@@ -6,11 +6,12 @@ from django.db import models
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 
-from cms.extensions import PageExtension
 from cms.extensions.extension_pool import extension_pool
 
+from ..core.models import BasePageExtension
 
-class Organization(PageExtension):
+
+class Organization(BasePageExtension):
     """
     The organization page extension represents and records entities that manage courses.
     It could be a university or a training company for example.
@@ -49,7 +50,7 @@ class Organization(PageExtension):
         We must manually copy the many-to-many relations from the "draft" instance of
         to the "published" instance.
         """
-        self.courses.set(oldinstance.courses.all())
+        self.courses.set(oldinstance.courses.drafts())
 
     def clean(self):
         """
@@ -74,6 +75,7 @@ class Organization(PageExtension):
 
             # If the page is being updated, we should exclude it while looking for duplicates
             if self.pk:
+                # pylint: disable=no-member
                 uniqueness_query = uniqueness_query.exclude(pk=self.pk)
 
             # Raise a ValidationError if the code already exists
@@ -91,7 +93,7 @@ class Organization(PageExtension):
         super().save(*args, **kwargs)
 
 
-class Course(PageExtension):
+class Course(BasePageExtension):
     """
     The course page extension represents and records a course in the catalog.
 
@@ -147,8 +149,8 @@ class Course(PageExtension):
         to the "published" instance.
         """
         # pylint: disable=no-member
-        self.organizations.set(oldinstance.organizations.all())
-        self.subjects.set(oldinstance.subjects.all())
+        self.organizations.set(oldinstance.organizations.drafts())
+        self.subjects.set(oldinstance.subjects.drafts())
 
     def validate_unique(self, exclude=None):
         """
@@ -165,6 +167,7 @@ class Course(PageExtension):
 
             # If the page is being updated, we should exclude it while looking for duplicates
             if self.pk:
+                # pylint: disable=no-member
                 uniqueness_query = uniqueness_query.exclude(pk=self.pk)
 
             # Raise a ValidationError if the active session already exists
@@ -191,7 +194,7 @@ class Course(PageExtension):
             self.organizations.add(self.organization_main)
 
 
-class Subject(PageExtension):
+class Subject(BasePageExtension):
     """
     The subject page extension represents and records a thematic in the catalog.
 
@@ -218,7 +221,7 @@ class Subject(PageExtension):
         We must manually copy the many-to-many relations from the "draft" instance
         to the "published" instance.
         """
-        self.courses.set(oldinstance.courses.all())
+        self.courses.set(oldinstance.courses.drafts())
 
 
 extension_pool.register(Course)

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -55,7 +55,7 @@
       <div class="course-detail__content__subjects">
         <h2>{% trans 'Subjects' %}</h2>
         <ul class="course-detail__content__subjects__list">
-          {% for subject in course.subjects.all %}
+          {% for subject in course.subjects.drafts %}
             {# If the current page is a draft, show draft subjects with a class annotation for styling #}
             {% if current_page.publisher_is_draft %}
               {% if subject.public_extension %}
@@ -89,7 +89,7 @@
             {{ course.organization_main.extended_object.get_title }}
           </li>
           {% endif %}
-          {% for organization in course.organizations.all %}
+          {% for organization in course.organizations.drafts %}
             {# If the current page is a draft, show draft organizations with a class annotation for styling #}
             {% if organization.id != course.organization_main.id %}
               {% if current_page.publisher_is_draft %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -27,7 +27,7 @@
       </div>
 
       <ul class="organization-detail__content__courses">
-        {% for course in organization.courses.all %}
+        {% for course in organization.courses.drafts %}
           {# If the current page is a draft, show draft courses with a class annotation for styling #}
           {% if current_page.publisher_is_draft %}
             {% if course.public_extension %}

--- a/src/richie/apps/courses/templates/courses/cms/subject_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/subject_detail.html
@@ -23,7 +23,7 @@
     </div>
 
     <ul class="subject-detail__courses">
-      {% for course in subject.courses.all %}
+      {% for course in subject.courses.drafts %}
         {# If the current page is a draft, show draft courses with a class annotation for styling #}
         {% if current_page.publisher_is_draft %}
           {% if course.public_extension %}

--- a/tests/apps/courses/test_models_organization.py
+++ b/tests/apps/courses/test_models_organization.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 
 from cms.api import create_page
 
-from richie.apps.courses.factories import OrganizationFactory
+from richie.apps.courses.factories import CourseFactory, OrganizationFactory
 from richie.apps.courses.models import Organization
 
 
@@ -78,3 +78,43 @@ class OrganizationTestCase(TestCase):
         organization = Organization(code="SOR", extended_object=page)
         with self.assertNumQueries(1):
             self.assertEqual(str(organization), "Organization: La Sorbonne (SOR)")
+
+    def test_organization_courses_copied_when_publishing(self):
+        """
+        When publishing a organization, the links to draft courses on the draft version of the
+        organization should be copied (clear then add) to the published version.
+        Links to published courses should not be copied as they are redundant and not
+        up-to-date.
+        """
+        # Create draft courses
+        course1, course2 = CourseFactory.create_batch(2)
+
+        # Create a draft organization
+        draft_organization = OrganizationFactory(with_courses=[course1, course2])
+
+        # Publish course1
+        course1.extended_object.publish("en")
+        course1.refresh_from_db()
+
+        # The draft organization should see all courses and propose a custom filter to easily
+        # access the draft versions
+        self.assertEqual(
+            set(draft_organization.courses.all()),
+            {course1, course1.public_extension, course2},
+        )
+        self.assertEqual(set(draft_organization.courses.drafts()), {course1, course2})
+
+        # Publish the organization and check that the courses are copied
+        draft_organization.extended_object.publish("en")
+        published_organization = Organization.objects.get(
+            extended_object__publisher_is_draft=False
+        )
+        self.assertEqual(set(published_organization.courses.all()), {course1, course2})
+
+        # When publishing, the courses that are obsolete should be cleared
+        draft_organization.courses.remove(course2)
+        self.assertEqual(set(published_organization.courses.all()), {course1, course2})
+
+        # courses on the published organization are only cleared after publishing the draft page
+        draft_organization.extended_object.publish("en")
+        self.assertEqual(set(published_organization.courses.all()), {course1})

--- a/tests/apps/courses/test_models_subject.py
+++ b/tests/apps/courses/test_models_subject.py
@@ -26,11 +26,28 @@ class SubjectTestCase(TestCase):
 
     def test_subject_courses_copied_when_publishing(self):
         """
-        When publishing a subject, the courses on the draft version of the subject
-        should be copied (clear then add) to the published version.
+        When publishing a subject, the links to draft courses on the draft version of the
+        subject should be copied (clear then add) to the published version.
+        Links to published courses should not be copied as they are redundant and not
+        up-to-date.
         """
+        # Create draft courses
         course1, course2 = CourseFactory.create_batch(2)
+
+        # Create a draft subject
         draft_subject = SubjectFactory(with_courses=[course1, course2])
+
+        # Publish course1
+        course1.extended_object.publish("en")
+        course1.refresh_from_db()
+
+        # The draft subject should see all courses and propose a custom filter to easily access
+        # the draft versions
+        self.assertEqual(
+            set(draft_subject.courses.all()),
+            {course1, course1.public_extension, course2},
+        )
+        self.assertEqual(set(draft_subject.courses.drafts()), {course1, course2})
 
         # Publish the subject and check that the courses are copied
         draft_subject.extended_object.publish("en")
@@ -42,6 +59,7 @@ class SubjectTestCase(TestCase):
         # When publishing, the courses that are obsolete should be cleared
         draft_subject.courses.remove(course2)
         self.assertEqual(set(published_subject.courses.all()), {course1, course2})
-        # Courses on the published subject are only cleared after publishing the draft page
+
+        # courses on the published subject are only cleared after publishing the draft page
         draft_subject.extended_object.publish("en")
         self.assertEqual(set(published_subject.courses.all()), {course1})

--- a/tests/apps/persons/test_person_plugin.py
+++ b/tests/apps/persons/test_person_plugin.py
@@ -36,7 +36,6 @@ class PersonPluginTestCase(TestCase):
         other_page_title = "other page"
         create_page(other_page_title, "richie/fullwidth.html", settings.LANGUAGE_CODE)
         plugin_form = PersonPluginModelForm()
-        print(plugin_form)
         self.assertIn(person.get_full_name(), plugin_form.as_table())
         self.assertNotIn(other_page_title, plugin_form.as_table())
 


### PR DESCRIPTION
## Purpose

Many to many relations between page extenions are copied when a page is published. We end up with links between draft and published versions of the page extension but the draft version should serve as the reference. I added tests to evidence the bug and then fixed it.

## Proposal

- [x] Improve tests to surface the issue
- [x] Add a custom "drafts" filter to easily access the relevant linked page extensions 

TODO: improving tests on the html generated by our templates will be done in https://github.com/openfun/richie/pull/288