### PR TITLE
Prepare to implement default filters on the api

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -10,6 +10,8 @@ import raven
 from configurations import Configuration, values
 from elasticsearch import Elasticsearch
 
+from richie.apps.search.utils.es_indices import IndicesList
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join("/", "data")
 
@@ -61,11 +63,11 @@ class ElasticSearchMixin(object):
         [values.Value("localhost", environ_name="ES_CLIENT", environ_prefix=None)]
     )
     ES_CHUNK_SIZE = 500
-    ES_INDEXES = [
-        "richie.apps.search.indexers.courses.CoursesIndexer",
-        "richie.apps.search.indexers.organizations.OrganizationsIndexer",
-        "richie.apps.search.indexers.subjects.SubjectsIndexer",
-    ]
+    ES_INDICES = IndicesList(
+        courses="richie.apps.search.indexers.courses.CoursesIndexer",
+        organizations="richie.apps.search.indexers.organizations.OrganizationsIndexer",
+        subjects="richie.apps.search.indexers.subjects.SubjectsIndexer",
+    )
 
     ES_DEFAULT_PAGE_SIZE = 10
 

--- a/src/richie/apps/search/exceptions.py
+++ b/src/richie/apps/search/exceptions.py
@@ -3,13 +3,19 @@ Specific exceptions for the search app
 """
 
 
+class ApiConsumingException(Exception):
+    """
+    Exception raised when an exception occurs during API walk using our api_consumption util
+    """
+
+
 class IndexerDataException(Exception):
     """
     Exception raised when an Indexer fails to provide the data required for ES indexing
     """
 
 
-class ApiConsumingException(Exception):
+class QueryFormatException(Exception):
     """
-    Exception raised when an exception occurs during API walk using our api_consumption util
+    Exception raised when the query parameters for a GET list call are invalid
     """

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -75,7 +75,7 @@ def regenerate_indexes(logger):
         existing_indexes = []
 
     # Dynamically import the modules from the config mixin strings
-    indexables = list(map(get_indexable_from_string, settings.ES_INDEXES))
+    indexables = list(map(get_indexable_from_string, settings.ES_INDICES))
 
     # Create a new index for each of those modules
     # NB: we're mapping perform_create_index which produces side-effects

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -15,9 +15,9 @@ from elasticsearch.helpers import bulk
 def get_indexable_from_string(indexable_module_string):
     """
     Load the indexable from the module.Class path in settings
+    NB: we need this level of indirection to enable testing.
     """
-    klass = import_string(indexable_module_string)
-    return klass()
+    return import_string(indexable_module_string)
 
 
 def get_indexes_by_alias(existing_indexes, alias):

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -40,7 +40,8 @@ class CoursesIndexer:
         },
     }
 
-    def get_data_for_es(self, index, action):
+    @classmethod
+    def get_data_for_es(cls, index, action):
         """
         Load all the courses from the API and format them for the ElasticSearch index
         """
@@ -53,7 +54,7 @@ class CoursesIndexer:
                         "_id": course["id"],
                         "_index": index,
                         "_op_type": action,
-                        "_type": self.document_type,
+                        "_type": cls.document_type,
                         "end_date": course["end_date"],
                         "enrollment_end_date": course["enrollment_end_date"],
                         "enrollment_start_date": course["enrollment_start_date"],

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -3,7 +3,8 @@ ElasticSearch organization document management utilities
 """
 from django.conf import settings
 
-from ..exceptions import IndexerDataException
+from ..exceptions import IndexerDataException, QueryFormatException
+from ..forms import OrganizationListForm
 from ..partial_mappings import MULTILINGUAL_TEXT
 from ..utils.api_consumption import walk_api_json_list
 from ..utils.i18n import get_best_field_language
@@ -66,3 +67,40 @@ class OrganizationsIndexer:
                 es_organization["_source"]["name"], best_language
             ),
         }
+
+    @staticmethod
+    def build_es_query(request):
+        """
+        Build an ElasticSearch query and its related aggregations, to be consumed by the ES client
+        in the Organizations ViewSet
+        """
+        # Instantiate a form with the request's query_params to check & sanitize them
+        query_params_form = OrganizationListForm(request.query_params)
+
+        # Raise an exception with error information if the query params are not valid
+        if not query_params_form.is_valid():
+            raise QueryFormatException(query_params_form.errors)
+
+        # Build a query that matches on the organization name field if it was passed by the client
+        # Note: test_elasticsearch_feature.py needs to be updated whenever the search call
+        # is updated and makes use new features.
+        if query_params_form.cleaned_data.get("query"):
+            query = {
+                "query": {
+                    "match": {
+                        "name.fr": {
+                            "query": query_params_form.cleaned_data.get("query"),
+                            "analyzer": "french",
+                        }
+                    }
+                }
+            }
+        # Build a match_all query by default
+        else:
+            query = {"query": {"match_all": {}}}
+
+        return (
+            query_params_form.cleaned_data.get("limit"),
+            query_params_form.cleaned_data.get("offset") or 0,
+            query,
+        )

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -26,7 +26,8 @@ class OrganizationsIndexer:
         },
     }
 
-    def get_data_for_es(self, index, action):
+    @classmethod
+    def get_data_for_es(cls, index, action):
         """
         Load all the organizations from the API and format them for the ElasticSearch index
         """
@@ -39,7 +40,7 @@ class OrganizationsIndexer:
                         "_id": organization["id"],
                         "_index": index,
                         "_op_type": action,
-                        "_type": self.document_type,
+                        "_type": cls.document_type,
                         "banner": organization["banner"],
                         "code": organization["code"],
                         "logo": organization["logo"],

--- a/src/richie/apps/search/indexers/subjects.py
+++ b/src/richie/apps/search/indexers/subjects.py
@@ -22,7 +22,8 @@ class SubjectsIndexer:
         "properties": {"image": {"type": "text", "index": False}},
     }
 
-    def get_data_for_es(self, index, action):
+    @classmethod
+    def get_data_for_es(cls, index, action):
         """
         Load all the subjects from the API and format them for the ElasticSearch index
         """
@@ -35,7 +36,7 @@ class SubjectsIndexer:
                         "_id": subject["id"],
                         "_index": index,
                         "_op_type": action,
-                        "_type": self.document_type,
+                        "_type": cls.document_type,
                         "image": subject["image"],
                         "name": {"fr": subject["name"]},
                     }

--- a/src/richie/apps/search/utils/es_indices.py
+++ b/src/richie/apps/search/utils/es_indices.py
@@ -1,0 +1,7 @@
+"""
+Define a named tuple type that will enforce the necessary keys for our ES_INDICES setting
+(and also make iteration, both with and without keys, trivial)
+"""
+from collections import namedtuple
+
+IndicesList = namedtuple("IndicesList", ["courses", "organizations", "subjects"])

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -17,6 +17,7 @@ from richie.apps.search.index_manager import (
     perform_create_index,
     regenerate_indexes,
 )
+from richie.apps.search.utils.es_indices import IndicesList
 
 
 class IndexManagerTestCase(TestCase):
@@ -155,7 +156,13 @@ class IndexManagerTestCase(TestCase):
         mock_logger.info.assert_called()
 
     # pylint: disable=no-member,unused-argument
-    @override_settings(ES_INDEXES=["example.ExOneIndexable", "example.ExTwoIndexable"])
+    @override_settings(
+        ES_INDICES=IndicesList(
+            "example.ExOneIndexable",
+            "example.ExTwoIndexable",
+            "example.ExThreeIndexable",
+        )
+    )
     @mock.patch(
         "richie.apps.search.index_manager.get_indexable_from_string",
         lambda name: ExOneIndexable
@@ -204,6 +211,12 @@ class IndexManagerTestCase(TestCase):
                         }
                     },
                     {
+                        "add": {
+                            "index": "richie_stub_created_index",
+                            "alias": "richie_stub",
+                        }
+                    },
+                    {
                         "remove": {
                             "index": "richie_example_forgotten",
                             "alias": "richie_example",
@@ -227,6 +240,18 @@ class IndexManagerTestCase(TestCase):
                             "alias": "richie_stub",
                         }
                     },
+                    {
+                        "remove": {
+                            "index": "richie_stub_forgotten",
+                            "alias": "richie_stub",
+                        }
+                    },
+                    {
+                        "remove": {
+                            "index": "richie_stub_previous",
+                            "alias": "richie_stub",
+                        }
+                    },
                 ]
             }
         )
@@ -234,7 +259,13 @@ class IndexManagerTestCase(TestCase):
             ignore=[400, 404], index="richie_orphan"
         )
 
-    @override_settings(ES_INDEXES=["example.ExOneIndexable", "example.ExTwoIndexable"])
+    @override_settings(
+        ES_INDICES=IndicesList(
+            "example.ExOneIndexable",
+            "example.ExTwoIndexable",
+            "example.ExThreeIndexable",
+        )
+    )
     @mock.patch(
         "richie.apps.search.index_manager.get_indexable_from_string",
         lambda name: ExOneIndexable
@@ -266,6 +297,12 @@ class IndexManagerTestCase(TestCase):
                         "add": {
                             "index": "richie_example_created_index",
                             "alias": "richie_example",
+                        }
+                    },
+                    {
+                        "add": {
+                            "index": "richie_stub_created_index",
+                            "alias": "richie_stub",
                         }
                     },
                     {

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -158,9 +158,9 @@ class IndexManagerTestCase(TestCase):
     @override_settings(ES_INDEXES=["example.ExOneIndexable", "example.ExTwoIndexable"])
     @mock.patch(
         "richie.apps.search.index_manager.get_indexable_from_string",
-        lambda name: ExOneIndexable()
+        lambda name: ExOneIndexable
         if name == "example.ExOneIndexable"
-        else ExTwoIndexable(),
+        else ExTwoIndexable,
     )
     @mock.patch(
         "richie.apps.search.index_manager.get_indexes_by_alias",
@@ -237,9 +237,9 @@ class IndexManagerTestCase(TestCase):
     @override_settings(ES_INDEXES=["example.ExOneIndexable", "example.ExTwoIndexable"])
     @mock.patch(
         "richie.apps.search.index_manager.get_indexable_from_string",
-        lambda name: ExOneIndexable()
+        lambda name: ExOneIndexable
         if name == "example.ExOneIndexable"
-        else ExTwoIndexable(),
+        else ExTwoIndexable,
     )
     @mock.patch(
         "richie.apps.search.index_manager.get_indexes_by_alias",

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -73,11 +73,11 @@ class CoursesIndexerTestCase(TestCase):
             },
         )
 
-        indexer = CoursesIndexer()
-
         # The results were properly formatted and passed to the consumer
         self.assertEqual(
-            list(indexer.get_data_for_es(index="some_index", action="some_action")),
+            list(
+                CoursesIndexer.get_data_for_es(index="some_index", action="some_action")
+            ),
             [
                 {
                     "_id": 42,
@@ -149,10 +149,8 @@ class CoursesIndexerTestCase(TestCase):
             },
         )
 
-        indexer = CoursesIndexer()
-
         with self.assertRaises(IndexerDataException):
-            list(indexer.get_data_for_es(index="some_index", action="some_action"))
+            list(CoursesIndexer.get_data_for_es(index="some_index", action="some_action"))
 
     def test_format_es_course_for_api(self):
         """

--- a/tests/apps/search/test_indexers_organizations.py
+++ b/tests/apps/search/test_indexers_organizations.py
@@ -57,11 +57,13 @@ class OrganizationsIndexerTestCase(TestCase):
             },
         )
 
-        indexer = OrganizationsIndexer()
-
         # The results were properly formatted and passed to the consumer
         self.assertEqual(
-            list(indexer.get_data_for_es(index="some_index", action="some_action")),
+            list(
+                OrganizationsIndexer.get_data_for_es(
+                    index="some_index", action="some_action"
+                )
+            ),
             [
                 {
                     "_id": 1,
@@ -109,10 +111,12 @@ class OrganizationsIndexerTestCase(TestCase):
             },
         )
 
-        indexer = OrganizationsIndexer()
-
         with self.assertRaises(IndexerDataException):
-            list(indexer.get_data_for_es(index="some_index", action="some_action"))
+            list(
+                OrganizationsIndexer.get_data_for_es(
+                    index="some_index", action="some_action"
+                )
+            )
 
     def test_format_es_organization_for_api(self):
         """

--- a/tests/apps/search/test_indexers_subjects.py
+++ b/tests/apps/search/test_indexers_subjects.py
@@ -49,11 +49,13 @@ class SubjectsIndexerTestCase(TestCase):
             },
         )
 
-        indexer = SubjectsIndexer()
-
         # The results were properly formatted and passed to the consumer
         self.assertEqual(
-            list(indexer.get_data_for_es(index="some_index", action="some_action")),
+            list(
+                SubjectsIndexer.get_data_for_es(
+                    index="some_index", action="some_action"
+                )
+            ),
             [
                 {
                     "_id": 62,
@@ -95,10 +97,12 @@ class SubjectsIndexerTestCase(TestCase):
             },
         )
 
-        indexer = SubjectsIndexer()
-
         with self.assertRaises(IndexerDataException):
-            list(indexer.get_data_for_es(index="some_index", action="some_action"))
+            list(
+                SubjectsIndexer.get_data_for_es(
+                    index="some_index", action="some_action"
+                )
+            )
 
     def test_format_es_subject_for_api(self):
         """


### PR DESCRIPTION
## Purpose

As we were working on #292, we noticed some necessary improvements we should undertake before getting to the heart of the matter.

## Proposal

- [x] simplify indexers by using `@staticmethod` & `@classmethod` instead of instantiating them
- [x] make `ES_INDEXES` a named tuple instead of an array: we're going to need the names, it ensures validity for downstream devs, and it remains easy to consume
- [x] import indexers in viewsets through settings
- [x] break in our new viewset/list design with the simple orgs & subjects viewsets