### PR TITLE
Fix checking if page extension is published

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ lint-back: ## lint back-end python sources
 
 lint-back-black: ## lint back-end python sources with black
 	@echo 'lint:black started…';
-	@$(COMPOSE_TEST_RUN_APP) black src/richie/apps src/richie/plugins sandbox;
+	@$(COMPOSE_TEST_RUN_APP) black src/richie/apps src/richie/plugins sandbox tests;
 .PHONY: lint-back-black
 
 lint-back-flake8: ## lint back-end python sources with flake8
@@ -92,7 +92,7 @@ lint-back-isort: ## automatically re-arrange python imports in back-end code bas
 
 lint-back-pylint: ## lint back-end python sources with pylint
 	@echo 'lint:pylint started…';
-	@$(COMPOSE_TEST_RUN_APP) pylint src/richie/apps src/richie/plugins sandbox;
+	@$(COMPOSE_TEST_RUN_APP) pylint src/richie/apps src/richie/plugins sandbox tests;
 .PHONY: lint-back-pylint
 
 lint-front: ## lint TypeScript sources

--- a/src/richie/apps/core/models.py
+++ b/src/richie/apps/core/models.py
@@ -1,5 +1,6 @@
 """Define a custom manager for page extensions"""
 from django.db import models
+from django.utils import translation
 
 from cms.extensions import PageExtension
 
@@ -62,3 +63,21 @@ class BasePageExtension(PageExtension):
 
     class Meta:
         abstract = True
+
+    def check_publication(self, language=None):
+        """
+        Allow checking if a page extension is published without passing any language (unlike the
+        "is_published" method on the page object): if not explicitly passed as argument, the
+        language is retrieved from the context.
+
+        The actual check is subcontracted to the "is_published" method on the related Django CMS
+        Page object.
+
+        Note: We choose not to name our method "is_published" like Django CMS, because it is a
+        bad practice. Indeed, someone may think it is a property and use it without invocating it
+        and the returned value (a bound method) will always be truthy... This issue happened a lot
+        with the "is_authenticated" method on Django's User model before they converted it to a
+        property.
+        """
+        language = language or translation.get_language()
+        return self.extended_object.is_published(language)

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -58,7 +58,7 @@
           {% for subject in course.subjects.drafts %}
             {# If the current page is a draft, show draft subjects with a class annotation for styling #}
             {% if current_page.publisher_is_draft %}
-              {% if subject.public_extension %}
+              {% if subject.check_publication is True %}
                 <li class="course-detail__content__subjects__item">
                   {{ subject.public_extension.extended_object.get_title }}
                 </li>
@@ -68,7 +68,7 @@
                 </li>
               {% endif %}
             {# If the current course page is the published version, show only the subjects that are published #}
-            {% elif subject.public_extension %}
+            {% elif subject.check_publication is True %}
               <li class="course-detail__content__subjects__item">
                 {{ subject.public_extension.extended_object.get_title }}
               </li>
@@ -85,29 +85,12 @@
         <h2>{% trans 'Organizations' %}</h2>
         <ul class="course-detail__content__organizations__list">
           {% if course.organization_main %}
-          <li class="course-detail__content__organizations__item course-detail__content__organizations__item--main">
-            {{ course.organization_main.extended_object.get_title }}
-          </li>
+            {% include "courses/cms/organization_fragment.html" with organization=course.organization_main is_main=True %}
           {% endif %}
           {% for organization in course.organizations.drafts %}
             {# If the current page is a draft, show draft organizations with a class annotation for styling #}
             {% if organization.id != course.organization_main.id %}
-              {% if current_page.publisher_is_draft %}
-                {% if organization.public_extension %}
-                  <li class="course-detail__content__organizations__item">
-                    {{ organization.public_extension.extended_object.get_title }}
-                  </li>
-                {% else %}
-                  <li class="course-detail__content__organizations__item--draft">
-                    {{ organization.extended_object.get_title }}
-                  </li>
-                {% endif %}
-              {# If the current page is the published version, show only the organizations that are published #}
-              {% elif organization.public_extension %}
-                <li class="course-detail__content__organizations__item">
-                  {{ organization.public_extension.extended_object.get_title }}
-                </li>
-              {% endif %}
+              {% include "courses/cms/organization_fragment.html" %}
             {% endif %}
           {% endfor %}
         </ul>

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -63,7 +63,7 @@
                   {{ subject.public_extension.extended_object.get_title }}
                 </li>
               {% else %}
-                <li class="course-detail__content__subjects__item--draft">
+                <li class="course-detail__content__subjects__item course-detail__content__subjects__item--draft">
                   {{ subject.extended_object.get_title }}
                 </li>
               {% endif %}
@@ -74,7 +74,7 @@
               </li>
             {% endif %}
           {% empty %}
-            <li class="course-detail__content__subjects--empty">
+            <li class="course-detail__content__subjects course-detail__content__subjects--empty">
               {% trans "No associated subjects" %}
             </li>
           {% endfor %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -30,7 +30,7 @@
         {% for course in organization.courses.drafts %}
           {# If the current page is a draft, show draft courses with a class annotation for styling #}
           {% if current_page.publisher_is_draft %}
-            {% if course.public_extension %}
+            {% if course.check_publication is True %}
               <li class="organization-detail__content__courses__item">
                 {{ course.public_extension.extended_object.get_title }}
               </li>
@@ -40,7 +40,7 @@
               </li>
             {% endif %}
           {# If the current course page is the published version, show only the courses that are published #}
-          {% elif course.public_extension %}
+          {% elif course.check_publication is True %}
             <li class="organization-detail__content__courses__item">
               {{ course.public_extension.extended_object.get_title }}
             </li>

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -35,7 +35,7 @@
                 {{ course.public_extension.extended_object.get_title }}
               </li>
             {% else %}
-              <li class="organization-detail__content__courses__item--draft">
+              <li class="organization-detail__content__courses__item organization-detail__content__courses__item--draft">
                 {{ course.extended_object.get_title }}
               </li>
             {% endif %}
@@ -46,7 +46,7 @@
             </li>
           {% endif %}
         {% empty %}
-          <li class="organization-detail__content__courses--empty">
+          <li class="organization-detail__content__courses organization-detail__content__courses--empty">
             {% trans "No associated courses" %}
           </li>
         {% endfor %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_fragment.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_fragment.html
@@ -1,16 +1,16 @@
 {% if current_page.publisher_is_draft %}
     {% if organization.check_publication is True %}
-        <li class="course-detail__content__organizations__item{% if is_main %}--main{% endif %}">
+        <li class="course-detail__content__organizations__item{% if is_main %} course-detail__content__organizations__item--main{% endif %}">
             {{ organization.public_extension.extended_object.get_title }}
         </li>
     {% else %}
-        <li class="course-detail__content__organizations__item--draft{% if is_main %} course-detail__content__organizations__item--main{% endif %}">
+        <li class="course-detail__content__organizations__item course-detail__content__organizations__item--draft{% if is_main %} course-detail__content__organizations__item--main{% endif %}">
             {{ organization.extended_object.get_title }}
         </li>
     {% endif %}
     {# If the current page is the published version, show only the organizations that are published #}
 {% elif organization.check_publication is True %}
-    <li class="course-detail__content__organizations__item{% if is_main %}--main{% endif %}">
+    <li class="course-detail__content__organizations__item{% if is_main %} course-detail__content__organizations__item--main{% endif %}">
     {{ organization.public_extension.extended_object.get_title }}
     </li>
 {% endif %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_fragment.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_fragment.html
@@ -1,0 +1,16 @@
+{% if current_page.publisher_is_draft %}
+    {% if organization.check_publication is True %}
+        <li class="course-detail__content__organizations__item{% if is_main %}--main{% endif %}">
+            {{ organization.public_extension.extended_object.get_title }}
+        </li>
+    {% else %}
+        <li class="course-detail__content__organizations__item--draft{% if is_main %} course-detail__content__organizations__item--main{% endif %}">
+            {{ organization.extended_object.get_title }}
+        </li>
+    {% endif %}
+    {# If the current page is the published version, show only the organizations that are published #}
+{% elif organization.check_publication is True %}
+    <li class="course-detail__content__organizations__item{% if is_main %}--main{% endif %}">
+    {{ organization.public_extension.extended_object.get_title }}
+    </li>
+{% endif %}

--- a/src/richie/apps/courses/templates/courses/cms/subject_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/subject_detail.html
@@ -26,7 +26,7 @@
       {% for course in subject.courses.drafts %}
         {# If the current page is a draft, show draft courses with a class annotation for styling #}
         {% if current_page.publisher_is_draft %}
-          {% if course.public_extension %}
+          {% if course.check_publication is True %}
             <li class="subject-detail__courses__item">
               {{ course.public_extension.extended_object.get_title }}
             </li>
@@ -36,7 +36,7 @@
             </li>
           {% endif %}
         {# If the current course page is the published version, show only the courses that are published #}
-        {% elif course.public_extension %}
+        {% elif course.check_publication is True %}
           <li class="subject-detail__courses__item">
             {{ course.public_extension.extended_object.get_title }}
           </li>

--- a/src/richie/apps/courses/templates/courses/cms/subject_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/subject_detail.html
@@ -31,7 +31,7 @@
               {{ course.public_extension.extended_object.get_title }}
             </li>
           {% else %}
-            <li class="subject-detail__courses__item--draft">
+            <li class="subject-detail__courses__item subject-detail__courses__item--draft">
               {{ course.extended_object.get_title }}
             </li>
           {% endif %}
@@ -42,7 +42,7 @@
           </li>
         {% endif %}
       {% empty %}
-        <li class="subject-detail__courses--empty">
+        <li class="subject-detail__courses subject-detail__courses--empty">
           {% trans "No associated courses" %}
         </li>
       {% endfor %}

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -87,9 +87,10 @@ class CourseCMSTestCase(CMSTestCase):
         # organization 1 is marked as main organization
         self.assertContains(
             response,
-            (
-                '<li class="course-detail__content__organizations__item--main">{:s}</li>'
-            ).format(organizations[0].extended_object.get_title()),
+            '<li class="{element:s} {element:s}--main">{title:s}</li>'.format(
+                element="course-detail__content__organizations__item",
+                title=organizations[0].extended_object.get_title(),
+            ),
             html=True,
         )
         # organization 2 is the only "common" org in listing since
@@ -162,9 +163,10 @@ class CourseCMSTestCase(CMSTestCase):
         # organization 1 is marked as main and not duplicated
         self.assertContains(
             response,
-            (
-                '<li class="course-detail__content__organizations__item--main">{:s}</li>'
-            ).format(organizations[0].extended_object.get_title()),
+            '<li class="{element:s} {element:s}--main">{title:s}</li>'.format(
+                element="course-detail__content__organizations__item",
+                title=organizations[0].extended_object.get_title(),
+            ),
             html=True,
         )
         self.assertNotContains(
@@ -186,9 +188,10 @@ class CourseCMSTestCase(CMSTestCase):
         for organization in organizations[:2]:
             self.assertNotContains(
                 response,
-                (
-                    '<li class="course-detail__content__organizations__item--draft">{:s}</li>'
-                ).format(organization.extended_object.get_title()),
+                '<li class="{element:s} {element:s}--draft">{title:s}</li>'.format(
+                    element="course - detail__content__organizations__item",
+                    title=organization.extended_object.get_title(),
+                ),
                 html=True,
             )
 
@@ -205,8 +208,9 @@ class CourseCMSTestCase(CMSTestCase):
         for subject in subjects[-2:]:
             self.assertContains(
                 response,
-                '<li class="course-detail__content__subjects__item--draft">{:s}</li>'.format(
-                    subject.extended_object.get_title()
+                '<li class="{element:s} {element:s}--draft">{title:s}</li>'.format(
+                    element="course-detail__content__subjects__item",
+                    title=subject.extended_object.get_title(),
                 ),
                 html=True,
             )
@@ -228,17 +232,18 @@ class CourseCMSTestCase(CMSTestCase):
         # The main organization is only listed separately and also marked as draft
         self.assertContains(
             response,
-            (
-                '<li class="course-detail__content__organizations__item--draft '
-                'course-detail__content__organizations__item--main">{:s}</li>'
-            ).format(course.organization_main.extended_object.get_title()),
+            '<li class="{element:s} {element:s}--draft {element:s}--main">{title:s}</li>'.format(
+                element="course-detail__content__organizations__item",
+                title=course.organization_main.extended_object.get_title(),
+            ),
             html=True,
         )
         self.assertNotContains(
             response,
-            (
-                '<li class="course-detail__content__organizations__item--draft">{:s}</li>'
-            ).format(course.organization_main.extended_object.get_title()),
+            '<li class="{element:s} {element:s}--draft">{title:s}</li>'.format(
+                element="course-detail__content__organizations__item",
+                title=course.organization_main.extended_object.get_title(),
+            ),
             html=True,
         )
 

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -16,17 +16,21 @@ class OrganizationCMSTestCase(TestCase):
         """
         Validate that the important elements are displayed on a published organization page
         """
-        course1, course2, course3 = CourseFactory.create_batch(3)
+        courses = CourseFactory.create_batch(4)
         organization = OrganizationFactory(
-            title="La Sorbonne",
-            logo="my_logo.jpg",
-            with_courses=[course1, course2, course3],
+            title="La Sorbonne", logo="my_logo.jpg", with_courses=courses
         )
         page = organization.extended_object
 
-        # Publish only 2 out of 3 courses
-        course1.extended_object.publish("en")
-        course2.extended_object.publish("en")
+        # Publish only 2 out of 4 courses
+        courses[0].extended_object.publish("en")
+        courses[1].extended_object.publish("en")
+
+        # The unpublished objects may have been published and unpublished which puts them in a
+        # status different from objects that have never been published.
+        # We want to test both cases.
+        courses[2].extended_object.publish("en")
+        courses[2].extended_object.unpublish("en")
 
         # The page should not be visible before it is published
         url = page.get_absolute_url()
@@ -49,7 +53,7 @@ class OrganizationCMSTestCase(TestCase):
         )
 
         # Only published courses should be present on the page
-        for course in [course1, course2]:
+        for course in courses[:2]:
             self.assertContains(
                 response,
                 '<li class="organization-detail__content__courses__item">{:s}</li>'.format(
@@ -57,7 +61,8 @@ class OrganizationCMSTestCase(TestCase):
                 ),
                 html=True,
             )
-        self.assertNotContains(response, course3.extended_object.get_title())
+        for course in courses[-2:]:
+            self.assertNotContains(response, course.extended_object.get_title())
 
     def test_organization_cms_draft_content(self):
         """
@@ -67,17 +72,21 @@ class OrganizationCMSTestCase(TestCase):
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
-        course1, course2, course3 = CourseFactory.create_batch(3)
+        courses = CourseFactory.create_batch(4)
         organization = OrganizationFactory(
-            title="La Sorbonne",
-            logo="my_logo.jpg",
-            with_courses=[course1, course2, course3],
+            title="La Sorbonne", logo="my_logo.jpg", with_courses=courses
         )
         page = organization.extended_object
 
-        # Publish only 2 out of 3 courses
-        course1.extended_object.publish("en")
-        course2.extended_object.publish("en")
+        # Publish only 2 out of 4 courses
+        courses[0].extended_object.publish("en")
+        courses[1].extended_object.publish("en")
+
+        # The unpublished objects may have been published and unpublished which puts them in a
+        # status different from objects that have never been published.
+        # We want to test both cases.
+        courses[2].extended_object.publish("en")
+        courses[2].extended_object.unpublish("en")
 
         # The page should be visible as draft to the staff user
         url = page.get_absolute_url()
@@ -95,7 +104,7 @@ class OrganizationCMSTestCase(TestCase):
         )
 
         # The published courses should be present on the page
-        for course in [course1, course2]:
+        for course in courses[:2]:
             self.assertContains(
                 response,
                 '<li class="organization-detail__content__courses__item">{:s}</li>'.format(
@@ -103,11 +112,12 @@ class OrganizationCMSTestCase(TestCase):
                 ),
                 html=True,
             )
-        # The draft course should also be present on the page with an annotation for styling
-        self.assertContains(
-            response,
-            '<li class="organization-detail__content__courses__item--draft">{:s}</li>'.format(
-                course3.extended_object.get_title()
-            ),
-            html=True,
-        )
+        # Draft courses should also be present on the page with an annotation for styling
+        for course in courses[-2:]:
+            self.assertContains(
+                response,
+                '<li class="organization-detail__content__courses__item--draft">{:s}</li>'.format(
+                    course.extended_object.get_title()
+                ),
+                html=True,
+            )

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -116,8 +116,9 @@ class OrganizationCMSTestCase(TestCase):
         for course in courses[-2:]:
             self.assertContains(
                 response,
-                '<li class="organization-detail__content__courses__item--draft">{:s}</li>'.format(
-                    course.extended_object.get_title()
+                '<li class="{element:s} {element:s}--draft">{title:s}</li>'.format(
+                    element="organization-detail__content__courses__item",
+                    title=course.extended_object.get_title(),
                 ),
                 html=True,
             )

--- a/tests/apps/courses/test_templates_subject_detail.py
+++ b/tests/apps/courses/test_templates_subject_detail.py
@@ -109,8 +109,9 @@ class SubjectCMSTestCase(TestCase):
         for course in courses[-2:]:
             self.assertContains(
                 response,
-                '<li class="subject-detail__courses__item--draft">{:s}</li>'.format(
-                    course.extended_object.get_title()
+                '<li class="{element:s} {element:s}--draft">{title:s}</li>'.format(
+                    element="subject-detail__courses__item",
+                    title=course.extended_object.get_title(),
                 ),
                 html=True,
             )

--- a/tests/apps/persons/test_person_plugin.py
+++ b/tests/apps/persons/test_person_plugin.py
@@ -28,6 +28,8 @@ class PersonPluginTestCase(TestCase):
         """
 
         class PersonPluginModelForm(forms.ModelForm):
+            """A form for testing the choices in the select box"""
+
             class Meta:
                 model = PersonPluginModel
                 exclude = ()


### PR DESCRIPTION
## Purpose

When checking if a page is published, we were just checking the existence of a public version of the page. It turns out that pages can be published and later unpublished... so the public version of a page may exist but not be in a "published" status. 

Furthermore, the publication of a page is handled language by language.

## Proposal

- [x] Improve tests to surface the problem for all existing templates ;
- [x] Add a method "check_publication" on all page extension models to check the publication status of a page for a specific language or for the current language ;
- [x] Use the new "check_publication" method to check the publication status of a page extension in all our templates ;
- [x] Fix BEM structure of list items in templates (organizations, courses, subjects) ;
- [x] Related bug fix: reactivate linting on the "tests" directory.