### PR TITLE
🐛(pypi) fix package upload from the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,6 +512,8 @@ jobs:
               -f docker/compose/ci/docker-compose.yml \
               --project-directory . \
               run --rm --no-deps \
+                --user="$(id -u)" \
+                --volume="$PWD:/app" \
                 -e TWINE_USERNAME \
                 -e TWINE_PASSWORD \
                 app \


### PR DESCRIPTION
## Purpose

If the current working directory that hosts the workspace with richie's dist packages is not mounted in the container that needs to push them to PyPI, the PyPI job fails.

## Proposal

Mount the working directory in `/app` and work with CircleCI user ID to upload build packages to PyPI.