### PR TITLE
🐛(circleci) fix linting of tests directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
               -f docker/compose/ci/docker-compose.yml \
               --project-directory . \
               run --rm --no-deps app \
-                pylint src/richie/apps src/richie/plugins sandbox
+                pylint src/richie/apps src/richie/plugins sandbox tests
 
   lint-back-black:
 
@@ -270,7 +270,7 @@ jobs:
               -f docker/compose/ci/docker-compose.yml \
               --project-directory . \
               run --rm --no-deps app \
-                black src/richie/apps src/richie/plugins sandbox --check
+                black src/richie/apps src/richie/plugins sandbox tests --check
 
   # Restore front & back POT files containing strings to translate and upload them to our
   # translation management tool

--- a/tests/apps/courses/test_templates_subject_detail.py
+++ b/tests/apps/courses/test_templates_subject_detail.py
@@ -17,8 +17,7 @@ class SubjectCMSTestCase(TestCase):
         Validate that the important elements are displayed on a published subject page
         """
         courses = CourseFactory.create_batch(4)
-        subject = SubjectFactory(
-            title="Very interesting subject", with_courses=courses)
+        subject = SubjectFactory(title="Very interesting subject", with_courses=courses)
         page = subject.extended_object
 
         # Publish only 2 out of 3 courses
@@ -60,8 +59,7 @@ class SubjectCMSTestCase(TestCase):
                 html=True,
             )
         for course in courses[-2:]:
-            self.assertNotContains(
-                response, course.extended_object.get_title())
+            self.assertNotContains(response, course.extended_object.get_title())
 
     def test_subject_cms_draft_content(self):
         """
@@ -71,8 +69,7 @@ class SubjectCMSTestCase(TestCase):
         self.client.login(username=user.username, password="password")
 
         courses = CourseFactory.create_batch(4)
-        subject = SubjectFactory(
-            title="Very interesting subject", with_courses=courses)
+        subject = SubjectFactory(title="Very interesting subject", with_courses=courses)
         page = subject.extended_object
 
         # Publish only 2 out of 4 courses

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -150,7 +150,9 @@ class CoursesIndexerTestCase(TestCase):
         )
 
         with self.assertRaises(IndexerDataException):
-            list(CoursesIndexer.get_data_for_es(index="some_index", action="some_action"))
+            list(
+                CoursesIndexer.get_data_for_es(index="some_index", action="some_action")
+            )
 
     def test_format_es_course_for_api(self):
         """

--- a/tests/apps/search/test_indexers_subjects.py
+++ b/tests/apps/search/test_indexers_subjects.py
@@ -139,11 +139,7 @@ class SubjectsIndexerTestCase(TestCase):
         self.assertEqual(
             SubjectsIndexer.build_es_query(
                 SimpleNamespace(
-                    query_params={
-                        "limit": 12,
-                        "offset": 4,
-                        "query": "user search",
-                    }
+                    query_params={"limit": 12, "offset": 4, "query": "user search"}
                 )
             ),
             (
@@ -152,10 +148,7 @@ class SubjectsIndexerTestCase(TestCase):
                 {
                     "query": {
                         "match": {
-                            "name.fr": {
-                                "query": "user search",
-                                "analyzer": "french",
-                            }
+                            "name.fr": {"query": "user search", "analyzer": "french"}
                         }
                     }
                 },

--- a/tests/apps/search/test_viewsets_organizations.py
+++ b/tests/apps/search/test_viewsets_organizations.py
@@ -74,7 +74,7 @@ class OrganizationsViewsetTestCase(TestCase):
 
     @mock.patch(
         "richie.apps.search.indexers.organizations.OrganizationsIndexer.build_es_query",
-        lambda x: (2, 0, {"query": "something"})
+        lambda x: (2, 0, {"query": "something"}),
     )
     @mock.patch.object(settings.ES_CLIENT, "search")
     def test_search_organizations(self, mock_search):
@@ -147,9 +147,9 @@ class OrganizationsViewsetTestCase(TestCase):
 
     @mock.patch(
         "richie.apps.search.indexers.organizations.OrganizationsIndexer.build_es_query",
-        side_effect=QueryFormatException({"limit": "incorrect value"})
+        side_effect=QueryFormatException({"limit": "incorrect value"}),
     )
-    def test_search_organizations_with_invalid_params(self, *args):
+    def test_search_organizations_with_invalid_params(self, _):
         """
         Error case: the client used an incorrectly formatted request
         """

--- a/tests/apps/search/test_viewsets_subjects.py
+++ b/tests/apps/search/test_viewsets_subjects.py
@@ -131,9 +131,9 @@ class SubjectsViewsetTestCase(TestCase):
 
     @mock.patch(
         "richie.apps.search.indexers.subjects.SubjectsIndexer.build_es_query",
-        side_effect=QueryFormatException({"limit": "incorrect value"})
+        side_effect=QueryFormatException({"limit": "incorrect value"}),
     )
-    def test_search_subjects_with_invalid_params(self, *args):
+    def test_search_subjects_with_invalid_params(self, _):
         """
         Error case: the client used an incorrectly formatted request
         """


### PR DESCRIPTION
## Purpose

A recent commit reactivated linting on the tests directory but only in the Makefile. I forgot to reactivate it in the CI configuration so we had discrepancies between what the CI and what our locale linting were saying.

## Proposal

- [x] Reactivate linting on the tests directory in CircleCI
- [x] Fix linting issues that the CI missed because of the bad configuration
