### PR TITLE
🐛(docker) use local user ID in the dev image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ bootstrap:  ## install development dependencies
 	@echo 'Preparing data directory...';
 	@mkdir -p data/media data/static
 	@$(COMPOSE) build base;
-	@$(COMPOSE) build app;
+	@$(COMPOSE) build --build-arg UID=$(UID) app;
 	${MAKE} build-front;
 	@echo 'Waiting until database is up…';
 	$(COMPOSE_RUN_APP) dockerize -wait tcp://db:5432 -timeout 60s

--- a/docker/images/dev/Dockerfile
+++ b/docker/images/dev/Dockerfile
@@ -1,7 +1,12 @@
 # The base image we inherit from is richie:latest, but you can override this by
-# passing a build argument to your build command, e.g.:
+# passing the BASE_TAG build argument to your build command. You can also
+# override the default container running user ID (e.g. 1000) thanks to the UID
+# build argument (we recommend using yours). An example follows:
 #
-# docker build --build-arg BASE_TAG=${CIRCLE_SHA1} .
+# docker build \
+#   --build-arg BASE_TAG=${CIRCLE_SHA1}\
+#   --build-arg UID=$(id -u) \
+#   .
 #
 ARG BASE_TAG=latest
 
@@ -29,4 +34,5 @@ RUN curl -sL \
     rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 # Restore the un-privileged user running the application
-USER 10000
+ARG UID=1000
+USER ${UID}


### PR DESCRIPTION
# Purpose

When starting the development stack using the `docker-compose up` command, compose uses the image default `USER` to run defined command (_e.g._ `10000` in the "dev" Dockerfile). Hence the Django development server runs using this user ID. This is an issue when developing with local volumes mounted in this container, because, the server may want to create new files in these volumes and unfortunately the running user (with UID `10000`) has no permission to write in the aforementioned volumes.

## Proposal

- [x] Add a `UID` build `ARG` to be able to customize the default user ID in the "dev" docker image

Fix #305