### PR TITLE
Implement custom+default filters on the api

### DIFF
--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -2,9 +2,52 @@
 Import custom settings and set up defaults for values the Search app needs
 """
 from django.conf import settings
+from django.forms import MultipleChoiceField
+
+import arrow
 
 # Define our aggregations names, for our ES query, which will match with the field
 # names on the objects & the facets we return on the API response
 RESOURCE_FACETS = getattr(
     settings, "RICHIE_SEARCH_RESOURCE_FACETS", ["organizations", "subjects"]
+)
+
+FILTERS_HARDCODED_DEFAULT = {
+    "availability": {
+        "field": MultipleChoiceField,
+        "choices": {
+            "coming_soon": [
+                {
+                    "range": {
+                        "start_date": {
+                            "gte": arrow.utcnow().datetime,
+                            "lte": arrow.utcnow().shift(weeks=+12).datetime,
+                        }
+                    }
+                }
+            ],
+            "current": [
+                {"range": {"start_date": {"lte": arrow.utcnow().datetime}}},
+                {"range": {"end_date": {"gte": arrow.utcnow().datetime}}},
+                {"range": {"enrollment_start_date": {"lte": arrow.utcnow().datetime}}},
+                {"range": {"enrollment_end_date": {"gte": arrow.utcnow().datetime}}},
+            ],
+            "open": [
+                {"range": {"start_date": {"lte": arrow.utcnow().datetime}}},
+                {"range": {"end_date": {"gte": arrow.utcnow().datetime}}},
+            ],
+        },
+    },
+    "language": {
+        "field": MultipleChoiceField,
+        "choices": {lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]},
+    },
+    "new": {
+        "field": MultipleChoiceField,
+        "choices": {"new": [{"term": {"session_number": 1}}]},
+    },
+}
+
+FILTERS_HARDCODED = getattr(
+    settings, "RICHIE_SEARCH_FILTERS_HARDCODED", FILTERS_HARDCODED_DEFAULT
 )

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -1,0 +1,10 @@
+"""
+Import custom settings and set up defaults for values the Search app needs
+"""
+from django.conf import settings
+
+# Define our aggregations names, for our ES query, which will match with the field
+# names on the objects & the facets we return on the API response
+RESOURCE_FACETS = getattr(
+    settings, "RICHIE_SEARCH_RESOURCE_FACETS", ["organizations", "subjects"]
+)

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -3,6 +3,7 @@ Validate and clean request parameters for our endpoints using Django forms
 """
 from django import forms
 
+from .defaults import FILTERS_HARDCODED
 from .fields.array import ArrayField
 from .fields.datetimerange import DatetimeRangeField
 
@@ -11,6 +12,17 @@ class CourseListForm(forms.Form):
     """
     Validate the query string params in the course list request
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Add in the fields for the custom filters from defaults/settings
+        for filter_key in FILTERS_HARDCODED:
+            self.fields[filter_key] = FILTERS_HARDCODED[filter_key]["field"](
+                choices=[
+                    (value, value) for value in FILTERS_HARDCODED[filter_key]["choices"]
+                ],
+                required=False,
+            )
 
     end_date = DatetimeRangeField(required=False)
     enrollment_end_date = DatetimeRangeField(required=False)

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -3,6 +3,7 @@ ElasticSearch course document management utilities
 """
 from django.conf import settings
 
+from ..defaults import RESOURCE_FACETS
 from ..exceptions import IndexerDataException, QueryFormatException
 from ..forms import CourseListForm
 from ..partial_mappings import MULTILINGUAL_TEXT
@@ -101,7 +102,7 @@ class CoursesIndexer:
         }
 
     @staticmethod
-    def build_es_query(request, facets):
+    def build_es_query(request):
         """
         Build an ElasticSearch query and its related aggregations, to be consumed by the ES client
         in the Courses ViewSet
@@ -198,7 +199,7 @@ class CoursesIndexer:
                         },
                         "aggregations": {facet: {"terms": {"field": facet}}},
                     }
-                    for facet in facets
+                    for facet in RESOURCE_FACETS
                 },
             }
         }

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -2,8 +2,9 @@
 ElasticSearch course document management utilities
 """
 from django.conf import settings
+from django.forms import ChoiceField, MultipleChoiceField
 
-from ..defaults import RESOURCE_FACETS
+from ..defaults import FILTERS_HARDCODED, RESOURCE_FACETS
 from ..exceptions import IndexerDataException, QueryFormatException
 from ..forms import CourseListForm
 from ..partial_mappings import MULTILINGUAL_TEXT
@@ -118,6 +119,10 @@ class CoursesIndexer:
             "organizations"
         )
         params_form_values["subjects"] = request.query_params.getlist("subjects")
+        for param_key in FILTERS_HARDCODED:
+            field = FILTERS_HARDCODED[param_key]["field"]
+            if field is ChoiceField or MultipleChoiceField:
+                params_form_values[param_key] = request.query_params.getlist(param_key)
         # Instantiate the form to allow validation/cleaning
         params_form = CourseListForm(params_form_values)
 

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -9,6 +9,7 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from ..defaults import RESOURCE_FACETS
 from ..exceptions import QueryFormatException
 
 
@@ -28,12 +29,8 @@ class CoursesViewSet(ViewSet):
         it searches its index and returns a list of matching courses
         """
 
-        # Define our aggregations names, for our ES query, which will match with the field
-        # names on the objects & the facets we return on the API response
-        facets = ["organizations", "subjects"]
-
         try:
-            limit, offset, query, aggs = self.indexer.build_es_query(request, facets)
+            limit, offset, query, aggs = self.indexer.build_es_query(request)
         except QueryFormatException as exc:
             # Return a 400 with error information if the query params are not as expected
             return Response(status=400, data={"errors": exc.args[0]})
@@ -71,7 +68,8 @@ class CoursesViewSet(ViewSet):
                 for field, value in course_query_response["aggregations"][
                     "all_courses"
                 ].items()
-                if field in facets
+                # Only build facet counts for relevant resource facets
+                if field in RESOURCE_FACETS
             },
         }
 

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -21,8 +21,6 @@ class CoursesIndexerTestCase(TestCase):
     and especially dynamic mapping shape in ES
     """
 
-    facets = ["organizations", "subjects"]
-
     @responses.activate
     def test_get_data_for_es(self):
         """
@@ -212,7 +210,7 @@ class CoursesIndexerTestCase(TestCase):
             query_params=QueryDict(query_string="limit=2&offset=10")
         )
         self.assertEqual(
-            CoursesIndexer.build_es_query(request, self.facets),
+            CoursesIndexer.build_es_query(request),
             (
                 2,
                 10,
@@ -259,7 +257,7 @@ class CoursesIndexerTestCase(TestCase):
             }
         }
         self.assertEqual(
-            CoursesIndexer.build_es_query(request, self.facets),
+            CoursesIndexer.build_es_query(request),
             (
                 2,
                 20,
@@ -312,7 +310,7 @@ class CoursesIndexerTestCase(TestCase):
         )
         terms_organizations = {"terms": {"organizations": [13, 15]}}
         self.assertEqual(
-            CoursesIndexer.build_es_query(request, self.facets),
+            CoursesIndexer.build_es_query(request),
             (
                 2,
                 0,
@@ -351,7 +349,7 @@ class CoursesIndexerTestCase(TestCase):
         )
         term_organization = {"terms": {"organizations": [345]}}
         self.assertEqual(
-            CoursesIndexer.build_es_query(request, self.facets),
+            CoursesIndexer.build_es_query(request),
             (
                 2,
                 0,
@@ -411,7 +409,7 @@ class CoursesIndexerTestCase(TestCase):
             }
         }
         self.assertEqual(
-            CoursesIndexer.build_es_query(request, self.facets),
+            CoursesIndexer.build_es_query(request),
             (
                 None,
                 0,
@@ -484,7 +482,7 @@ class CoursesIndexerTestCase(TestCase):
         }
         terms_subjects = {"terms": {"subjects": [42, 84]}}
         self.assertEqual(
-            CoursesIndexer.build_es_query(request, self.facets),
+            CoursesIndexer.build_es_query(request),
             (
                 2,
                 0,
@@ -545,6 +543,5 @@ class CoursesIndexerTestCase(TestCase):
         """
         with self.assertRaises(QueryFormatException):
             CoursesIndexer.build_es_query(
-                SimpleNamespace(query_params=QueryDict(query_string="limit=-2")),
-                self.facets,
+                SimpleNamespace(query_params=QueryDict(query_string="limit=-2"))
             )

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -3,8 +3,10 @@ Tests for the course indexer
 """
 import json
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from django.conf import settings
+from django.forms import ChoiceField, MultipleChoiceField
 from django.http.request import QueryDict
 from django.test import TestCase
 
@@ -201,6 +203,17 @@ class CoursesIndexerTestCase(TestCase):
             },
         )
 
+    @patch(
+        "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
+        new={
+            "language": {
+                "choices": {
+                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                },
+                "field": MultipleChoiceField,
+            }
+        },
+    )
     def test_build_es_query_search_all_courses(self):
         """
         Happy path: build a query that does not filter the courses at all
@@ -219,6 +232,16 @@ class CoursesIndexerTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
+                            "language@en": {
+                                "filter": {
+                                    "bool": {"must": [{"term": {"language": "en"}}]}
+                                }
+                            },
+                            "language@fr": {
+                                "filter": {
+                                    "bool": {"must": [{"term": {"language": "fr"}}]}
+                                }
+                            },
                             "organizations": {
                                 "filter": {"bool": {"must": []}},
                                 "aggregations": {
@@ -239,6 +262,17 @@ class CoursesIndexerTestCase(TestCase):
             ),
         )
 
+    @patch(
+        "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
+        new={
+            "language": {
+                "choices": {
+                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                },
+                "field": ChoiceField,
+            }
+        },
+    )
     def test_build_es_query_search_by_match_text(self):
         """
         Happy path: build a query that filters courses by matching text
@@ -278,6 +312,26 @@ class CoursesIndexerTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
+                            "language@en": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "en"}},
+                                            multi_match,
+                                        ]
+                                    }
+                                }
+                            },
+                            "language@fr": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "fr"}},
+                                            multi_match,
+                                        ]
+                                    }
+                                }
+                            },
                             "organizations": {
                                 "filter": {"bool": {"must": [multi_match]}},
                                 "aggregations": {
@@ -298,6 +352,17 @@ class CoursesIndexerTestCase(TestCase):
             ),
         )
 
+    @patch(
+        "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
+        new={
+            "language": {
+                "choices": {
+                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                },
+                "field": MultipleChoiceField,
+            }
+        },
+    )
     def test_build_es_query_search_by_terms_organizations(self):
         """
         Happy path: build a query that filters courses by more than 1 related organizations
@@ -319,6 +384,26 @@ class CoursesIndexerTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
+                            "language@en": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "en"}},
+                                            terms_organizations,
+                                        ]
+                                    }
+                                }
+                            },
+                            "language@fr": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "fr"}},
+                                            terms_organizations,
+                                        ]
+                                    }
+                                }
+                            },
                             "organizations": {
                                 "filter": {"bool": {"must": []}},
                                 "aggregations": {
@@ -339,6 +424,17 @@ class CoursesIndexerTestCase(TestCase):
             ),
         )
 
+    @patch(
+        "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
+        new={
+            "language": {
+                "choices": {
+                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                },
+                "field": ChoiceField,
+            }
+        },
+    )
     def test_build_es_query_search_by_single_term_organizations(self):
         """
         Happy path: build a query that filters courses by exactly 1 related organization
@@ -358,6 +454,26 @@ class CoursesIndexerTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
+                            "language@en": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "en"}},
+                                            term_organization,
+                                        ]
+                                    }
+                                }
+                            },
+                            "language@fr": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "fr"}},
+                                            term_organization,
+                                        ]
+                                    }
+                                }
+                            },
                             "organizations": {
                                 "filter": {"bool": {"must": []}},
                                 "aggregations": {
@@ -378,6 +494,17 @@ class CoursesIndexerTestCase(TestCase):
             ),
         )
 
+    @patch(
+        "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
+        new={
+            "language": {
+                "choices": {
+                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                },
+                "field": MultipleChoiceField,
+            }
+        },
+    )
     def test_build_es_query_search_by_range_datetimes(self):
         """
         Happy path: build a query that filters courses by start & end date datetime ranges
@@ -418,6 +545,28 @@ class CoursesIndexerTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
+                            "language@en": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "en"}},
+                                            range_end_date,
+                                            range_start_date,
+                                        ]
+                                    }
+                                }
+                            },
+                            "language@fr": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "fr"}},
+                                            range_end_date,
+                                            range_start_date,
+                                        ]
+                                    }
+                                }
+                            },
                             "organizations": {
                                 "filter": {
                                     "bool": {"must": [range_end_date, range_start_date]}
@@ -442,9 +591,103 @@ class CoursesIndexerTestCase(TestCase):
             ),
         )
 
+    @patch(
+        "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
+        new={
+            "language": {
+                "choices": {
+                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                },
+                "field": ChoiceField,
+            },
+            "new": {
+                "choices": {"new": [{"term": {"session_number": 1}}]},
+                "field": MultipleChoiceField,
+            },
+        },
+    )
+    def test_build_es_query_search_by_custom_filter(self):
+        """
+        Happy path: build a query using custom filters
+        Note: we're keeping fields from defaults.py instead of mocking for simplicity
+        """
+        # Build a request stub
+        request = SimpleNamespace(
+            query_params=QueryDict(query_string="limit=2&offset=10&language=fr")
+        )
+        self.assertEqual(
+            CoursesIndexer.build_es_query(request),
+            (
+                2,
+                10,
+                {"bool": {"must": [{"term": {"language": "fr"}}]}},
+                {
+                    "all_courses": {
+                        "global": {},
+                        "aggregations": {
+                            "language@en": {
+                                "filter": {
+                                    "bool": {"must": [{"term": {"language": "en"}}]}
+                                }
+                            },
+                            "language@fr": {
+                                "filter": {
+                                    "bool": {"must": [{"term": {"language": "fr"}}]}
+                                }
+                            },
+                            "new@new": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"session_number": 1}},
+                                            {"term": {"language": "fr"}},
+                                        ]
+                                    }
+                                }
+                            },
+                            "organizations": {
+                                "filter": {
+                                    "bool": {"must": [{"term": {"language": "fr"}}]}
+                                },
+                                "aggregations": {
+                                    "organizations": {
+                                        "terms": {"field": "organizations"}
+                                    }
+                                },
+                            },
+                            "subjects": {
+                                "filter": {
+                                    "bool": {"must": [{"term": {"language": "fr"}}]}
+                                },
+                                "aggregations": {
+                                    "subjects": {"terms": {"field": "subjects"}}
+                                },
+                            },
+                        },
+                    }
+                },
+            ),
+        )
+
+    @patch(
+        "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
+        new={
+            "language": {
+                "choices": {
+                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                },
+                "field": MultipleChoiceField,
+            },
+            "new": {
+                "choices": {"new": [{"term": {"session_number": 1}}]},
+                "field": ChoiceField,
+            },
+        },
+    )
     def test_build_es_query_combined_search(self):
         """
-        Happy path: build a query that filters courses by multiple filters
+        Happy path: build a query that filters courses by multiple filters, including a custom
+        filter; make all aggs using all of those along with another custom filter
         """
         # Build a request stub
         start_date = json.dumps(["2018-01-01T06:00:00Z", None])
@@ -452,6 +695,7 @@ class CoursesIndexerTestCase(TestCase):
         request = SimpleNamespace(
             query_params=QueryDict(
                 query_string="subjects=42&subjects=84&query=these%20phrase%20terms&limit=2&"
+                + "language=fr&"
                 + "start_date={start_date}&end_date={end_date}".format(
                     start_date=start_date, end_date=end_date
                 )
@@ -481,6 +725,7 @@ class CoursesIndexerTestCase(TestCase):
             }
         }
         terms_subjects = {"terms": {"subjects": [42, 84]}}
+        term_language_fr = {"term": {"language": "fr"}}
         self.assertEqual(
             CoursesIndexer.build_es_query(request),
             (
@@ -493,6 +738,7 @@ class CoursesIndexerTestCase(TestCase):
                             multi_match,
                             range_start_date,
                             terms_subjects,
+                            term_language_fr,
                         ]
                     }
                 },
@@ -500,6 +746,46 @@ class CoursesIndexerTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
+                            "language@en": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"language": "en"}},
+                                            range_end_date,
+                                            multi_match,
+                                            range_start_date,
+                                            terms_subjects,
+                                        ]
+                                    }
+                                }
+                            },
+                            "language@fr": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            term_language_fr,
+                                            range_end_date,
+                                            multi_match,
+                                            range_start_date,
+                                            terms_subjects,
+                                        ]
+                                    }
+                                }
+                            },
+                            "new@new": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"session_number": 1}},
+                                            range_end_date,
+                                            multi_match,
+                                            range_start_date,
+                                            terms_subjects,
+                                            term_language_fr,
+                                        ]
+                                    }
+                                }
+                            },
                             "organizations": {
                                 "filter": {
                                     "bool": {
@@ -508,6 +794,7 @@ class CoursesIndexerTestCase(TestCase):
                                             multi_match,
                                             range_start_date,
                                             terms_subjects,
+                                            term_language_fr,
                                         ]
                                     }
                                 },
@@ -524,9 +811,49 @@ class CoursesIndexerTestCase(TestCase):
                                             range_end_date,
                                             multi_match,
                                             range_start_date,
+                                            term_language_fr,
                                         ]
                                     }
                                 },
+                                "aggregations": {
+                                    "subjects": {"terms": {"field": "subjects"}}
+                                },
+                            },
+                        },
+                    }
+                },
+            ),
+        )
+
+    @patch("richie.apps.search.indexers.courses.FILTERS_HARDCODED", new={})
+    def test_build_es_query_search_with_empty_filters(self):
+        """
+        Edge case: custom filters have been removed entirely through settings
+        """
+        # Build a request stub
+        request = SimpleNamespace(
+            query_params=QueryDict(query_string="limit=20&offset=40")
+        )
+        self.assertEqual(
+            CoursesIndexer.build_es_query(request),
+            (
+                20,
+                40,
+                {"match_all": {}},
+                {
+                    "all_courses": {
+                        "global": {},
+                        "aggregations": {
+                            "organizations": {
+                                "filter": {"bool": {"must": []}},
+                                "aggregations": {
+                                    "organizations": {
+                                        "terms": {"field": "organizations"}
+                                    }
+                                },
+                            },
+                            "subjects": {
+                                "filter": {"bool": {"must": []}},
                                 "aggregations": {
                                     "subjects": {"terms": {"field": "subjects"}}
                                 },

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -86,6 +86,11 @@ class CoursesViewsetTestCase(TestCase):
             "hits": {"hits": [{"_id": 523}, {"_id": 861}], "total": 35},
             "aggregations": {
                 "all_courses": {
+                    "availability@coming_soon": {"doc_count": 8},
+                    "availability@current": {"doc_count": 42},
+                    "availability@open": {"doc_count": 59},
+                    "language@en": {"doc_count": 81},
+                    "language@fr": {"doc_count": 23},
                     "subjects": {
                         "subjects": {
                             "buckets": [
@@ -93,7 +98,7 @@ class CoursesViewsetTestCase(TestCase):
                                 {"key": "21", "doc_count": 19},
                             ]
                         }
-                    }
+                    },
                 }
             },
         }
@@ -107,7 +112,11 @@ class CoursesViewsetTestCase(TestCase):
             {
                 "meta": {"count": 2, "offset": 77, "total_count": 35},
                 "objects": ["Course #523", "Course #861"],
-                "facets": {"subjects": {"11": 17, "21": 19}},
+                "facets": {
+                    "availability": {"coming_soon": 8, "current": 42, "open": 59},
+                    "language": {"en": 81, "fr": 23},
+                    "subjects": {"11": 17, "21": 19},
+                },
             },
         )
         # The ES connector was called with appropriate arguments for the client's request


### PR DESCRIPTION
## Purpose

We need to implement some default filters for development in the sandbox and to enable providers to quickly have an up-and-running search experience when they start working with Richie.

We wanted these default filters to be easy to extend/replace without having to re-do or copy/pasta the whole query building logic which can be daunting for people unfamiliar with ES.

## Proposal

Provide a way to add filters through settings (and some useful defaults for them) by specifying key/value pairs along with form fields to validate them and actual ES query fragments to use them.

- [x] Set up default filters in our `defaults.py`, overridable through settings
- [x] Extend the courses list request params form with fields from defaults/settings
- [x] Use the custom filters as we build the main query & aggregations in the courses indexer
- [x] Structure consistent facets out of these filters for the API response

Note: we still have some work to complete this PR:
- [x] Update tests for the courses viewset
- [x] Enable multiple choices for custom filters (`ChoiceField` => `MultipleChoiceField` in defaults + support when we build the main query in the indexer)
- [ ] Support drilldown filters [this may be done in a separate PR] 

## Refs

Closes #292.
Follows #302 & #307.