### PR TITLE
⬆️(dependencies) upgrade pylint to 2.0.1

### DIFF
--- a/docker/images/alpine/dev/Dockerfile
+++ b/docker/images/alpine/dev/Dockerfile
@@ -16,6 +16,8 @@ RUN mkdir -p /data/{media,static}
 # Install curl
 RUN apk --no-cache add --update \
         curl \
+        gcc \
+        musl-dev \
         vim
 
 # Install development dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,8 +90,8 @@ dev =
     ipython==6.5.0
     ipython-genutils==0.2.0
     isort==4.3.4
-    pylint==1.9.2
-    pylint-django==0.11.1
+    pylint==2.0.1
+    pylint-django==2.0
     pytest==3.6.4
     pytest-cov==2.5.1
     pytest-django==3.3.3


### PR DESCRIPTION
## Purpose

Upgrade `pylint` to its latest release.

## Proposal

- [x] Upgrade `pylint` to `2.0.1`
- [x] Upgrade `pylint-django` to `2.0`
- [x] Fix `alpine:dev` image build (hat tip to @sampaccoud)
- [ ] Fix new `pylint` weird errors