### PR TITLE
⬆️(django) upgrade Django to 1.11.15

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     cmsplugin-plain-text==0.1.2
     decorator==4.2.1
     dj-database-url==0.5.0
-    Django==1.11.14  # pyup: <2.0
+    Django==1.11.15  # pyup: <2.0
     django-appconf==1.0.2
     django-classy-tags==0.8.0
     django-cms==3.5.2


### PR DESCRIPTION
Django 1.11.14 has a security issue: https://docs.djangoproject.com/en/2.1/releases/1.11.15
and pyup.io/safety-ci will not let us merge any PR until requirements are fixed