### PR TITLE
🔧(tslint) update tslint rules for prettier & style consistency

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,8 @@
     "member-access": [true, "no-public"],
     "no-console": [true, "log", "error"],
     "no-empty": false,
+    "object-literal-key-quotes": [true, "as-needed"],
+    "one-line": false,
     "quotemark": [true, "single", "avoid-escape", "jsx-double"]
   },
   "rulesDirectory": []


### PR DESCRIPTION
## Purpose

`tslint` recently changed the default (or added a default) for property names in objects. This clashes with the standard way to write JS and with what prettier is enforcing.

We also want to keep the rules consistent between our projects. See [the related PR in marsha](https://github.com/openfun/marsha/pull/38).

## Proposal

 Change it to only allow quotes when they are strictly necessary.

Also remove the one-line rule for if/else clauses, which makes no sense when writing branching logic with comments that can't be coerced easily into a switch.