### PR TITLE
Add package.json/makefile commands to run prettier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,18 @@ lint-back-pylint: ## lint back-end python sources with pylint
 	@$(COMPOSE_TEST_RUN_APP) pylint src/richie/apps src/richie/plugins sandbox tests;
 .PHONY: lint-back-pylint
 
-lint-front: ## lint TypeScript sources
-	@$(YARN) lint
+lint-front: ## run both front-end "linters" prettier & tslint
+	${MAKE} lint-front-tslint;
+	${MAKE} lint-front-prettier;
 .PHONY: lint-front
+
+lint-front-tslint: ## lint TypeScript sources
+	@$(YARN) lint
+.PHONY: lint-front-tslint
+
+lint-front-prettier: ## run prettier over js/jsx/json/ts/tsx files -- beware! overwrites files
+	@$(YARN) prettier
+.PHONY: lint-front-prettier
 
 logs: ## get development logs
 	@$(COMPOSE) logs -f

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "webpack",
     "generate-l10n-template": "rip json2pot 'src/richie-front/i18n/src/**/*.json' -o src/richie-front/i18n/richie-front.pot",
     "lint": "tslint -c tslint.json 'src/richie-front/js/**/*.ts?(x)'",
+    "prettier": "prettier --write 'src/richie-front/js/**/*.+(ts|tsx|json|js|jsx)' '*.+(ts|tsx|json|js|jsx)'",
     "sass": "node-sass src/richie-front/scss/_main.scss src/richie/static/richie/css/main.css",
     "test": "karma start ./karma.conf.js",
     "watch-sass": "nodemon -e scss -x 'yarn sass'"


### PR DESCRIPTION
## Purpose

Right now we don't have easy-to-use commands to run prettier in write mode on the codebase (the CI just runs it in list-different mode).

## Proposal

Add a "yarn prettier" command that can be run directly by end-users with local installs of yarn & dependencies, and a corresponding lint-front-prettier in Makefile to enable users to run the same
from the container.