### PR TITLE
Diversify course runs on the demo site

### DIFF
--- a/src/richie/apps/core/management/commands/create_demo_site.py
+++ b/src/richie/apps/core/management/commands/create_demo_site.py
@@ -3,11 +3,12 @@ create_demo_site management command
 """
 import logging
 import random
+from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand, CommandError
-from django.utils import translation
+from django.utils import timezone, translation
 
 from cms import models as cms_models
 
@@ -105,10 +106,10 @@ PAGE_INFOS = {
 
 def get_number_of_course_runs():
     """
-    Returns a random integer between 0 and 5. We make it a convenience method so that it can
+    Returns a random integer between 1 and 5. We make it a convenience method so that it can
     be mocked in tests.
     """
-    return random.randint(0, 5)
+    return random.randint(1, 5)
 
 
 # pylint: disable=no-member
@@ -218,6 +219,15 @@ def create_demo_site():
             in_navigation=True,
         )
         # Add a random number of course runs to the course
+        # 1) Make sure we have one open for enrollment
+        now = timezone.now()
+        CourseRunFactory(
+            course=course,
+            start=now + timedelta(days=1),
+            enrollment_start=now - timedelta(days=5),
+            enrollment_end=now + timedelta(days=5),
+        )
+        # 2) Add more random course runs
         nb_course_runs = get_number_of_course_runs()
         if nb_course_runs > 0:
             CourseRunFactory.create_batch(nb_course_runs, course=course)

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -295,10 +295,10 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         for the course run are chosen randomly in periods that make sense with this start date.
         """
         now = timezone.now()
-        period = timedelta(days=1000)
+        period = timedelta(days=200)
         return pytz.timezone("UTC").localize(
             datetime.fromordinal(
-                random.randrange(now.toordinal(), (now + period).toordinal())
+                random.randrange((now - period).toordinal(), (now + period).toordinal())
             )
         )
 

--- a/tests/apps/courses/test_factories_course_run.py
+++ b/tests/apps/courses/test_factories_course_run.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the CourseRun factory
 """
+from datetime import timedelta
 from unittest import mock
 
 from django.test import TestCase
@@ -22,7 +23,9 @@ class CourseRunFactoriesTestCase(TestCase):
         with mock.patch.object(timezone, "now", return_value=now):
             course_run = CourseRunFactory()
 
-        self.assertTrue(now <= course_run.start)
+        self.assertTrue(
+            now - timedelta(days=500) < course_run.start < now + timedelta(days=500)
+        )
         self.assertTrue(
             course_run.enrollment_start <= course_run.start <= course_run.end
         )

--- a/tests/apps/courses/test_models_course_glimpse_date.py
+++ b/tests/apps/courses/test_models_course_glimpse_date.py
@@ -44,21 +44,25 @@ class CourseRunModelsTestCase(TestCase):
     def create_run_future_not_yet_open(self, course):
         """Create a course run in the future and not yet open for enrollment."""
         return CourseRunFactory(
-            course=course, enrollment_start=self.now + timedelta(hours=1)
+            course=course,
+            start=self.now + timedelta(hours=2),
+            enrollment_start=self.now + timedelta(hours=1),
         )
 
     def create_run_future_closed(self, course):
         """Create a course run in the future and already closed for enrollment."""
         return CourseRunFactory(
             course=course,
-            enrollment_start=self.now + timedelta(hours=2),
-            enrollment_end=self.now + timedelta(hours=1),
+            start=self.now + timedelta(hours=1),
+            enrollment_start=self.now - timedelta(hours=2),
+            enrollment_end=self.now - timedelta(hours=1),
         )
 
     def create_run_future_open(self, course):
         """Create a course run in the future and open for enrollment."""
         return CourseRunFactory(
             course=course,
+            start=self.now + timedelta(hours=1),
             enrollment_start=self.now - timedelta(hours=1),
             enrollment_end=self.now + timedelta(hours=1),
         )


### PR DESCRIPTION
## Purpose

On the demo site, all course runs were created in the future. We want to have course runs in different states: some open, and some future, past, open or closed for enrollment, etc.

## Proposal

I chose the option to loosen the factory and had to fix a few tests as a consequence.
