### PR TITLE
💄(layout) push course teaser to aside column and fix responsive

### DIFF
--- a/src/richie/apps/courses/templates/courses/cms/_course_detail.scss
+++ b/src/richie/apps/courses/templates/courses/cms/_course_detail.scss
@@ -1,12 +1,11 @@
 .course-detail {
   @include make-container-max-widths();
-  display: flex;
   margin: 0 auto;
-  padding: 1rem 0 0;
-  flex-direction: column;
-  flex-wrap: wrap;
+  padding: 0;
 
   @include media-breakpoint-up(lg) {
+    display: flex;
+    flex-wrap: wrap;
     flex-direction: row;
   }
 
@@ -15,10 +14,14 @@
     position: relative;
     margin: 0 0 1rem 0;
     padding: 1rem 0;
-    font-size: 3rem;
+    font-size: 2.6rem;
     font-weight: normal;
     line-height: 1.1;
     text-align: center;
+
+    @include media-breakpoint-up(lg) {
+      font-size: 3rem;
+    }
 
     &::after{
       $divider-width: 10rem;
@@ -28,40 +31,6 @@
       left: calc(50% - #{$divider-width / 2});
       bottom: 0;
       border-bottom: 1px solid $gray40;
-    }
-  }
-
-  &__teaser {
-    @include sv-flex-cell-width(100%);
-    margin: 0;
-    padding: 0;
-    /**
-     * Code below replicate .reponsive-embed from Bootstrap with forced 16/9
-     * cause we cannot use object-fit since it is not compatible under IE
-     * Edge 16. For not forced ratio we may use something like flex-video
-     * (which involve some JS)
-     */
-    position: relative;
-    display: block;
-    overflow: hidden;
-
-    &::before {
-      display: block;
-      content: "";
-      padding-top: percentage(9 / 16);
-    }
-
-    iframe,
-    embed,
-    object,
-    video {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      border: 0;
     }
   }
 
@@ -89,7 +58,7 @@
       }
 
       // Automatically alternate bg color on odd/even items
-      &:nth-child(2n+0) {
+      &--even{
         color: $white;
         background: $dodgerblue7;
 
@@ -134,6 +103,40 @@
 
     @include media-breakpoint-up(lg) {
       @include sv-flex-cell-width(30%);
+    }
+
+    &__teaser {
+      @include sv-flex-cell-width(100%);
+      margin: 0;
+      padding: 0;
+      /**
+      * Code below replicate .reponsive-embed from Bootstrap with forced 16/9
+      * cause we cannot use object-fit since it is not compatible under IE
+      * Edge 16. For not forced ratio we may use something like flex-video
+      * (which involve some JS)
+      */
+      position: relative;
+      display: block;
+      overflow: hidden;
+
+      &::before {
+        display: block;
+        content: "";
+        padding-top: percentage(9 / 16);
+      }
+
+      iframe,
+      embed,
+      object,
+      video {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+      }
     }
 
     &__main-org-logo{

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -5,17 +5,19 @@
 <div class="course-detail">
   {% spaceless %}
 
-    <h1 class="course-detail__title">{{ current_page.get_title }}</h1>
-
     {% with course=current_page.course header_level=2 %}
 
-    <div class="course-detail__teaser">
-      {% placeholder "course_teaser" or %}
-      <p>{% trans 'Add a video teaser.' %}</p>
-      {% endplaceholder %}
-    </div>
-
     <div class="course-detail__content">
+
+      <div class="course-detail__content__row">
+        <h1 class="course-detail__title">{{ current_page.get_title }}</h1>
+      </div>
+
+      <div class="course-detail__aside__teaser">
+        {% placeholder "course_teaser" or %}
+        <p>{% trans 'Add a video teaser.' %}</p>
+        {% endplaceholder %}
+      </div>
 
       <div class="course-detail__content__row course-detail__content__syllabus">
         <h2 class="course-detail__content__row__title">{% trans 'About the course' %}</h2>
@@ -47,15 +49,6 @@
         {% endplaceholder %}
       </div>
 
-      <div class="course-detail__content__row course-detail__content__team">
-        <h2 class="course-detail__content__row__title course-detail__content__team__title">{% trans 'Course team' %}</h2>
-        {% with header_level=3 %}
-            {% placeholder "course_team" or %}
-            <p>{% trans 'Who are the teachers in the course team?' %}</p>
-            {% endplaceholder %}
-        {% endwith %}
-      </div>
-
       <div class="course-detail__content__row course-detail__content__subjects">
         <h2 class="course-detail__content__row__title">{% trans 'Subjects' %}</h2>
         <ul class="course-detail__content__subjects__list">
@@ -85,6 +78,19 @@
         </ul>
       </div>
 
+      <div class="course-detail__content__row course-detail__content__information">
+        {% placeholder "course_information" %}
+      </div>
+
+      <div class="course-detail__content__row course-detail__content__team">
+        <h2 class="course-detail__content__row__title course-detail__content__team__title">{% trans 'Course team' %}</h2>
+        {% with header_level=3 %}
+            {% placeholder "course_team" or %}
+            <p>{% trans 'Who are the teachers in the course team?' %}</p>
+            {% endplaceholder %}
+        {% endwith %}
+      </div>
+
       <div class="course-detail__content__row course-detail__content__organizations">
         <h2 class="course-detail__content__row__title">{% trans 'Organizations' %}</h2>
         <ul class="course-detail__content__organizations__list">
@@ -93,10 +99,6 @@
             {% include "courses/cms/fragment_course_organizations.html" %}
           {% endfor %}
         </ul>
-      </div>
-
-      <div class="course-detail__content__row course-detail__content__information">
-        {% placeholder "course_information" %}
       </div>
 
       <div class="course-detail__content__row course-detail__content__license">
@@ -120,16 +122,16 @@
 
     <div class="course-detail__aside">
 
-      <div class="course-detail__aside__main-org-logo">
-        {% include "courses/cms/fragment_organization_main_logo.html" with organization=course.organization_main %}
-      </div>
-
       <div class="course-detail__aside__cover">
         {% if current_page.publisher_is_draft %}
           {% placeholder "course_cover" or %}
           <p>{% trans 'Add an image for course cover on its glimpse.' %}</p>
           {% endplaceholder %}
         {% endif %}
+      </div>
+
+      <div class="course-detail__aside__main-org-logo">
+        {% include "courses/cms/fragment_organization_main_logo.html" with organization=course.organization_main %}
       </div>
 
       <div class="course-detail__aside__run">


### PR DESCRIPTION
## Purpose

Course detail teaser take full width and takes too much place.
Also there is some responsive issues.

## Proposal

Teaser video has been moved to aside column, title placed in main
column, responsive issues has been fixed and some minor color
adjustment on content rows.

![course-detail](https://user-images.githubusercontent.com/1572165/46281898-4afe7800-c570-11e8-9679-de1d875c6633.png)
