### PR TITLE
🐛(licence) fill Licence with a sample image from fixtures

### DIFF
--- a/src/richie/apps/core/management/commands/create_demo_site.py
+++ b/src/richie/apps/core/management/commands/create_demo_site.py
@@ -20,7 +20,7 @@ from richie.apps.courses.factories import (
     OrganizationFactory,
     SubjectFactory,
 )
-from richie.apps.courses.models import Course, Organization, Subject
+from richie.apps.courses.models import Course, Licence, Organization, Subject
 from richie.apps.persons.factories import PersonFactory
 from richie.apps.persons.models import Person
 
@@ -130,6 +130,7 @@ def clear_cms_data():
     Organization.objects.all().delete()
     Subject.objects.all().delete()
     Person.objects.all().delete()
+    Licence.objects.all().delete()
 
 
 def create_demo_site():

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -375,6 +375,25 @@ class SubjectFactory(BLDPageExtensionDjangoModelFactory):
             self.courses.set(extracted)
 
 
+class LicenceLogoImageFactory(FilerImageFactory):
+    """
+    Image field factory for Licence.
+
+    Randomly get an image from fixtures.
+    """
+
+    # pylint: disable=no-self-use
+    @factory.lazy_attribute
+    def file(self):
+        """
+        Fill image file field with random image.
+        """
+        logo_file = file_getter(os.path.dirname(__file__), "licence")()
+        wrapped_logo = File(logo_file, logo_file.name)
+
+        return wrapped_logo
+
+
 class LicenceFactory(factory.django.DjangoModelFactory):
     """
     A factory to automatically generate random yet meaningful licences.
@@ -384,6 +403,6 @@ class LicenceFactory(factory.django.DjangoModelFactory):
         model = Licence
 
     name = factory.Faker("sentence", nb_words=3)
-    logo = factory.SubFactory(FilerImageFactory)
+    logo = factory.SubFactory(LicenceLogoImageFactory)
     url = factory.Faker("uri")
     content = factory.Faker("text", max_nb_chars=300)


### PR DESCRIPTION
## Purpose

When Licence has been created, their logo image was left to the
'FilerImageFactory' which generate a simple plain color and dummy
image.

## Proposal

Licence factory has been changed to use a new Subfactory for image
file to randomly select a licence logo from fixtures.
