### PR TITLE
💄(layout) improve licence plugin look and course detail teaser

### DIFF
--- a/src/richie-front/scss/_main.scss
+++ b/src/richie-front/scss/_main.scss
@@ -41,6 +41,7 @@
 @import "../../../sandbox/templates/menu/_menu";
 @import "./objects/course_glimpses";
 @import "../../richie/apps/persons/templates/persons/plugins/person_plugin";
+@import "../../richie/apps/courses/templates/courses/plugins/licence_plugin";
 @import "../../richie/apps/courses/templates/courses/cms/organization_detail";
 @import "../../richie/apps/courses/templates/courses/cms/subject_detail";
 @import "../../richie/apps/courses/templates/courses/cms/course_detail";

--- a/src/richie-front/scss/_variables.scss
+++ b/src/richie-front/scss/_variables.scss
@@ -180,6 +180,17 @@ $richie-course-glimpse-foot-cta-background-hover: $firebrick6;
 
 
 ///
+/// Course Licence plugin
+/// -----
+///
+$richie-licence-plugin-breakpoint: sm;
+$richie-licence-plugin-logo-width: 100px;
+$richie-licence-plugin-title-fontsize: 1.4rem;
+$richie-licence-plugin-title-fontcolor: $dodgerblue5;
+$richie-licence-plugin-description-fontcolor: $gray40;
+
+
+///
 /// Search objects
 /// -----
 ///

--- a/src/richie/apps/courses/templates/courses/cms/_course_detail.scss
+++ b/src/richie/apps/courses/templates/courses/cms/_course_detail.scss
@@ -1,3 +1,5 @@
+$richie-course-detail-row-fontsize: 0.95rem;
+
 .course-detail {
   @include make-container-max-widths();
   margin: 0 auto;
@@ -54,7 +56,7 @@
       }
 
       p, li{
-        font-size: 0.95rem;
+        font-size: $richie-course-detail-row-fontsize;
       }
 
       // Automatically alternate bg color on odd/even items
@@ -65,6 +67,41 @@
         #{$row-selector}__title{
           color: inherit;
         }
+      }
+    }
+
+    &__teaser {
+      @include sv-flex-cell-width(100%);
+      margin: 0;
+      padding: 0;
+      /**
+      * Code below replicate .reponsive-embed from Bootstrap with forced 16/9
+      * cause we cannot use object-fit since it is not compatible under IE
+      * Edge 16. For not forced ratio we may use something like flex-video
+      * (which involve some JS)
+      */
+      position: relative;
+      display: block;
+      overflow: hidden;
+
+      &::before {
+        display: block;
+        content: "";
+        padding-top: percentage(9 / 16);
+      }
+
+      iframe,
+      embed,
+      object,
+      video {
+        position: absolute;
+        top: 1.5rem;
+        bottom: 1.5rem;
+        left: 1rem;
+        right: 1rem;
+        width: calc(100% - 2rem);
+        height: calc(100% - 3rem);
+        border: 0;
       }
     }
 
@@ -94,6 +131,18 @@
         }
       }
     }
+
+    &__license{
+      &__item{
+        margin-top: 1rem;
+        font-size: $richie-course-detail-row-fontsize;
+
+        &__title{
+          margin-bottom: 0.75rem;
+          color: $dodgerblue3;
+        }
+      }
+    }
   }
 
   &__aside {
@@ -103,40 +152,6 @@
 
     @include media-breakpoint-up(lg) {
       @include sv-flex-cell-width(30%);
-    }
-
-    &__teaser {
-      @include sv-flex-cell-width(100%);
-      margin: 0;
-      padding: 0;
-      /**
-      * Code below replicate .reponsive-embed from Bootstrap with forced 16/9
-      * cause we cannot use object-fit since it is not compatible under IE
-      * Edge 16. For not forced ratio we may use something like flex-video
-      * (which involve some JS)
-      */
-      position: relative;
-      display: block;
-      overflow: hidden;
-
-      &::before {
-        display: block;
-        content: "";
-        padding-top: percentage(9 / 16);
-      }
-
-      iframe,
-      embed,
-      object,
-      video {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        border: 0;
-      }
     }
 
     &__main-org-logo{

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -13,7 +13,7 @@
         <h1 class="course-detail__title">{{ current_page.get_title }}</h1>
       </div>
 
-      <div class="course-detail__aside__teaser">
+      <div class="course-detail__content__row course-detail__content__teaser">
         {% placeholder "course_teaser" or %}
         <p>{% trans 'Add a video teaser.' %}</p>
         {% endplaceholder %}
@@ -102,21 +102,25 @@
       </div>
 
       <div class="course-detail__content__row course-detail__content__license">
-        <h2 class="course-detail__content__row__title">{% trans 'License' %}</h2>
+        <h2 class="course-detail__content__row__title course-detail__content__license__title">{% trans 'License' %}</h2>
 
-        <h3>{% trans 'License for the course content' %}</h3>
-        {% with header_level=4 %}
-            {% placeholder "course_license_content" or %}
-            <p>{% trans 'What is the license for the course content?' %}</p>
+        <div class="course-detail__content__license__item">
+          <h3 class="course-detail__content__license__item__title">{% trans 'License for the course content' %}</h3>
+          {% with header_level=4 %}
+              {% placeholder "course_license_content" or %}
+              <p>{% trans 'What is the license for the course content?' %}</p>
+              {% endplaceholder %}
+          {% endwith %}
+        </div>
+
+        <div class="course-detail__content__license__item">
+          <h3 class="course-detail__content__license__item__title">{% trans 'License for the content created by course participants' %}</h3>
+          {% with header_level=4 %}
+            {% placeholder "course_license_participation" or %}
+              <p>{% trans 'What is the license for the content created by course participants?' %}</p>
             {% endplaceholder %}
-        {% endwith %}
-
-        <h3>{% trans 'License for the content created by course participants' %}</h3>
-        {% with header_level=4 %}
-          {% placeholder "course_license_participation" or %}
-            <p>{% trans 'What is the license for the content created by course participants?' %}</p>
-          {% endplaceholder %}
-        {% endwith %}
+          {% endwith %}
+        </div>
       </div>
     </div>
 

--- a/src/richie/apps/courses/templates/courses/plugins/_licence_plugin.scss
+++ b/src/richie/apps/courses/templates/courses/plugins/_licence_plugin.scss
@@ -1,0 +1,46 @@
+$richie-licence-plugin-breakpoint: sm !default;
+$richie-licence-plugin-logo-width: 100px !default;
+$richie-licence-plugin-title-fontsize: null !default;
+$richie-licence-plugin-title-fontcolor: null !default;
+$richie-licence-plugin-description-fontcolor: null !default;
+
+.licence-plugin{
+    @include media-breakpoint-up($richie-licence-plugin-breakpoint) {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    &__logo{
+        text-align: center;
+
+        @include media-breakpoint-up($richie-licence-plugin-breakpoint) {
+            @include sv-flex(1, 0, #{$richie-licence-plugin-logo-width});
+        }
+    }
+
+    &__wrapper{
+        @include media-breakpoint-up($richie-licence-plugin-breakpoint) {
+            @include sv-flex(1, 0, calc(100% - #{$richie-licence-plugin-logo-width}));
+        }
+
+        &__title{
+            font-size: $richie-licence-plugin-title-fontsize;
+            color: $richie-licence-plugin-title-fontcolor;
+            text-align: center;
+
+            @include media-breakpoint-up($richie-licence-plugin-breakpoint) {
+                text-align: left;
+            }
+
+            a{
+                color: inherit;
+                text-decoration: none;
+            }
+        }
+
+        &__description{
+            color: $richie-licence-plugin-description-fontcolor;
+        }
+    }
+}

--- a/src/richie/apps/courses/templates/courses/plugins/licence_plugin.html
+++ b/src/richie/apps/courses/templates/courses/plugins/licence_plugin.html
@@ -1,18 +1,22 @@
 {% load thumbnail %}{% spaceless %}
 <div class="licence-plugin">
-  <h{{ header_level|default:2 }} class="licence-plugin__title">
-    {% if instance.licence.url %}<a href="{{ instance.licence.url }}">{% endif %}
-    {{ instance.licence.name }}
-    {% if instance.licence.url %}</a>{% endif %}
-  </h{{ header_level|default:2 }}>
   <p class="licence-plugin__logo">
     <img src="{% thumbnail instance.licence.logo 100x50 crop='smart' %}" alt="">
   </p>
-  <div class="licence-plugin__content">
-    {{ instance.licence.content|safe }}
+  <div class="licence-plugin__wrapper">
+    <h{{ header_level|default:2 }} class="licence-plugin__wrapper__title">
+        {% if instance.licence.url %}<a href="{{ instance.licence.url }}">{% endif %}
+        {{ instance.licence.name }}
+        {% if instance.licence.url %}</a>{% endif %}
+    </h{{ header_level|default:2 }}>
+    <div class="licence-plugin__wrapper__content">
+        {{ instance.licence.content|safe }}
+    </div>
+    {% if instance.description %}
+    <div class="licence-plugin__wrapper__description">
+        {{ instance.description|safe }}
+    </div>
+    {% endif %}
   </div>
-  {% if instance.description %}<div class="licence-plugin__description">
-    {{ instance.description|safe }}
-  </div>{% endif %}
 </div>
 {% endspaceless %}

--- a/tests/apps/courses/test_licence_plugin.py
+++ b/tests/apps/courses/test_licence_plugin.py
@@ -53,7 +53,7 @@ class LicencePluginTestCase(CMSPluginTestCase):
         """
         # We deliberately use level '10' since it can be substituted from any
         # reasonable default level.
-        header_format = """<h10 class="licence-plugin__title">{}</h10>"""
+        header_format = """<h10 class="licence-plugin__wrapper__title">{}</h10>"""
 
         # Dummy slot where to include plugin
         placeholder = Placeholder.objects.create(slot="test")


### PR DESCRIPTION
## Purpose

Licence plugin from course detail did not have any styles. Also
teaser container from course detail take too much width.

## Proposal

This commit improves licence plugin look with some styles and
revised HTML structure in templates. Also course detail teaser
container include some padding.

![course-detail](https://user-images.githubusercontent.com/1572165/46350565-537cae80-c655-11e8-9e6c-6677260c59a2.png)
