### PR TITLE
💄(layout) style course subject to look as badges

### DIFF
--- a/src/richie/apps/courses/templates/courses/cms/_course_detail.scss
+++ b/src/richie/apps/courses/templates/courses/cms/_course_detail.scss
@@ -70,6 +70,47 @@ $richie-course-detail-row-fontsize: 0.95rem;
       }
     }
 
+    &__subjects{
+      display: flex;
+      padding-top: 0;
+      padding-bottom: 0;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: center;
+
+      &__item{
+        $item-selector: &;
+
+        @include sv-flex(0, 0, auto);
+        margin-bottom: 0.3rem;
+        padding: 0.25rem 0.4rem;
+        color: $white;
+        font-size: 0.7rem;
+        background: $gray7;
+        text-decoration: none;
+
+        &:hover{
+          color: $white;
+        }
+
+        &--empty{
+          @include sv-flex(1, 0, 100%);
+          font-style: italic;
+          color: $gray40;
+          text-align: center;
+          background: transparent;
+
+          &:hover{
+            color: $gray40;
+          }
+        }
+
+        & + #{$item-selector}{
+          margin-left: 0.3rem;
+        }
+      }
+    }
+
     &__teaser {
       @include sv-flex-cell-width(100%);
       margin: 0;

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -13,6 +13,32 @@
         <h1 class="course-detail__title">{{ current_page.get_title }}</h1>
       </div>
 
+      <div class="course-detail__content__row course-detail__content__subjects">
+        {% for subject in course.subjects.all %}
+          {# If the current page is a draft, show draft subjects with a class annotation for styling #}
+          {% if current_page.publisher_is_draft %}
+            {% if subject.check_publication is True %}
+              <a class="course-detail__content__subjects__item" href="{{ subject.public_extension.extended_object.get_absolute_url }}">
+                {{ subject.public_extension.extended_object.get_title }}
+              </a>
+            {% else %}
+              <a class="course-detail__content__subjects__item course-detail__content__subjects__item--draft" href="{{ subject.extended_object.get_absolute_url }}">
+                {{ subject.extended_object.get_title }}
+              </a>
+            {% endif %}
+          {# If the current course page is the published version, show only the subjects that are published #}
+          {% elif subject.check_publication is True %}
+            <a class="course-detail__content__subjects__item" href="{{ subject.extended_object.get_absolute_url }}">
+              {{ subject.extended_object.get_title }}
+            </a>
+          {% endif %}
+        {% empty %}
+          <p class="course-detail__content__subjects__item course-detail__content__subjects__item--empty">
+            {% trans "No associated subjects" %}
+          </p>
+        {% endfor %}
+      </div>
+
       <div class="course-detail__content__row course-detail__content__teaser">
         {% placeholder "course_teaser" or %}
         <p>{% trans 'Add a video teaser.' %}</p>
@@ -47,35 +73,6 @@
         {% placeholder "course_plan" or %}
         <p>{% trans 'Enter here the detailed course plan' %}</p>
         {% endplaceholder %}
-      </div>
-
-      <div class="course-detail__content__row course-detail__content__subjects">
-        <h2 class="course-detail__content__row__title">{% trans 'Subjects' %}</h2>
-        <ul class="course-detail__content__subjects__list">
-          {% for subject in course.subjects.all %}
-            {# If the current page is a draft, show draft subjects with a class annotation for styling #}
-            {% if current_page.publisher_is_draft %}
-              {% if subject.check_publication is True %}
-                <li class="course-detail__content__subjects__item">
-                  {{ subject.public_extension.extended_object.get_title }}
-                </li>
-              {% else %}
-                <li class="course-detail__content__subjects__item course-detail__content__subjects__item--draft">
-                  {{ subject.extended_object.get_title }}
-                </li>
-              {% endif %}
-            {# If the current course page is the published version, show only the subjects that are published #}
-            {% elif subject.check_publication is True %}
-              <li class="course-detail__content__subjects__item">
-                {{ subject.extended_object.get_title }}
-              </li>
-            {% endif %}
-          {% empty %}
-            <li class="course-detail__content__subjects course-detail__content__subjects--empty">
-              {% trans "No associated subjects" %}
-            </li>
-          {% endfor %}
-        </ul>
       </div>
 
       <div class="course-detail__content__row course-detail__content__information">

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -80,8 +80,9 @@ class CourseCMSTestCase(CMSTestCase):
         for subject in subjects[:2]:
             self.assertContains(
                 response,
-                '<li class="course-detail__content__subjects__item">{:s}</li>'.format(
-                    subject.extended_object.get_title()
+                '<a class="course-detail__content__subjects__item" href="{:s}">{:s}</a>'.format(
+                    subject.extended_object.get_absolute_url(),
+                    subject.extended_object.get_title(),
                 ),
                 html=True,
             )
@@ -207,8 +208,9 @@ class CourseCMSTestCase(CMSTestCase):
         for subject in subjects[:2]:
             self.assertContains(
                 response,
-                '<li class="course-detail__content__subjects__item">{:s}</li>'.format(
-                    subject.extended_object.get_title()
+                '<a class="course-detail__content__subjects__item" href="{:s}">{:s}</a>'.format(
+                    subject.extended_object.get_absolute_url(),
+                    subject.extended_object.get_title(),
                 ),
                 html=True,
             )
@@ -216,7 +218,8 @@ class CourseCMSTestCase(CMSTestCase):
         for subject in subjects[-2:]:
             self.assertContains(
                 response,
-                '<li class="{element:s} {element:s}--draft">{title:s}</li>'.format(
+                '<a class="{element:s} {element:s}--draft" href="{url:s}">{title:s}</a>'.format(
+                    url=subject.extended_object.get_absolute_url(),
                     element="course-detail__content__subjects__item",
                     title=subject.extended_object.get_title(),
                 ),


### PR DESCRIPTION
## Purpose

Actually subjects in Course detail is just a simple list of subject
item.

## Proposal

This commit change course detail template and styles so the subject
now look like tiny badges under Course title. Tests has been update
to match against template changes.

![course-detail](https://user-images.githubusercontent.com/1572165/46361188-4c619a80-c66d-11e8-9f6e-bfbbdd27b2f9.png)
