### PR TITLE
Use jest mocks instead of "import * as" patches

### DIFF
--- a/src/richie-front/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.spec.tsx
+++ b/src/richie-front/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.spec.tsx
@@ -2,9 +2,17 @@ import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
 import { ResourceListState } from '../../data/genericReducers/resourceList/resourceList';
 import { RootState } from '../../data/rootReducer';
 import { Course } from '../../types/Course';
-import * as filterFromStateGetter from '../../utils/filters/getFilterFromState';
-import * as filterUpdater from '../../utils/filters/updateFilter';
+import { getFilterFromState } from '../../utils/filters/getFilterFromState';
+import { updateFilter } from '../../utils/filters/updateFilter';
 import { mapStateToProps, mergeProps } from './SearchFilterGroupContainer';
+
+const mockGetFilterFromState: jest.Mock<
+  typeof getFilterFromState
+> = getFilterFromState as any;
+jest.mock('../../utils/filters/getFilterFromState');
+
+const mockUpdateFilter: jest.Mock<typeof updateFilter> = updateFilter as any;
+jest.mock('../../utils/filters/updateFilter');
 
 describe('components/SearchFilterGroupContainer/mergeProps', () => {
   const exampleFilter = {
@@ -25,12 +33,8 @@ describe('components/SearchFilterGroupContainer/mergeProps', () => {
   };
 
   beforeEach(() => {
-    spyOn(filterUpdater, 'updateFilter').and.callFake(
-      (...params: any[]) => params,
-    );
-    spyOn(filterFromStateGetter, 'getFilterFromState').and.returnValue(
-      exampleFilter,
-    );
+    mockUpdateFilter.mockImplementation((...params: any[]) => params);
+    mockGetFilterFromState.mockReturnValue(exampleFilter);
   });
 
   it('returns the relevant filter, its current value & partially applied update helpers', () => {

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -5,17 +5,32 @@ import * as React from 'react';
 
 import { Course } from '../../types/Course';
 import { SearchSuggestionSection } from '../../types/searchSuggest';
-import * as errors from '../../utils/errors/handle';
+import { handle } from '../../utils/errors/handle';
 import { location } from '../../utils/indirection/location';
-import * as searchSuggestUtils from '../../utils/searchSuggest/getSuggestionsSection';
-import * as searchSuggestField from './SearchSuggestField';
+import { getSuggestionsSection } from '../../utils/searchSuggest/getSuggestionsSection';
+import {
+  onChange,
+  onSuggestionsClearRequested,
+  onSuggestionSelected,
+  onSuggestionsFetchRequested,
+  renderSectionTitle,
+  renderSuggestion,
+  SearchSuggestFieldBase,
+} from './SearchSuggestField';
+
+const mockHandle: jest.Mock<typeof handle> = handle as any;
+jest.mock('../../utils/errors/handle');
+
+const mockGetSuggestionsSection: jest.Mock<
+  typeof getSuggestionsSection
+> = getSuggestionsSection as any;
+jest.mock('../../utils/searchSuggest/getSuggestionsSection');
 
 describe('components/SearchSuggestField', () => {
   let addFilter: jasmine.Spy;
   let that: { props: { addFilter: jasmine.Spy }; setState: jasmine.Spy };
 
   beforeEach(() => {
-    spyOn(errors, 'handle');
     // addFilter is the method passed through the props
     addFilter = jasmine.createSpy('addFilter');
     // Stub the parts of the component instance we need to access
@@ -23,7 +38,6 @@ describe('components/SearchSuggestField', () => {
   });
 
   it('renders', () => {
-    const { SearchSuggestFieldBase } = searchSuggestField;
     const wrapper = shallow(
       <SearchSuggestFieldBase
         addFilter={addFilter}
@@ -40,7 +54,7 @@ describe('components/SearchSuggestField', () => {
   describe('renderSuggestion()', () => {
     it('renders a single suggestion', () => {
       expect(
-        searchSuggestField.renderSuggestion({
+        renderSuggestion({
           data: { title: 'Some course title' } as Course,
           model: 'courses',
         }),
@@ -51,7 +65,7 @@ describe('components/SearchSuggestField', () => {
   describe('renderSectionTitle()', () => {
     it('renders a section title', () => {
       expect(
-        searchSuggestField.renderSectionTitle(
+        renderSectionTitle(
           { formatMessage: ({ defaultMessage }: any) => defaultMessage } as any,
           {
             message: {
@@ -66,42 +80,33 @@ describe('components/SearchSuggestField', () => {
 
   describe('onChange', () => {
     it('updates the value in state', () => {
-      searchSuggestField.onChange.bind(that)({}, { newValue: 'the new value' });
+      onChange.bind(that)({}, { newValue: 'the new value' });
       expect(that.setState).toHaveBeenCalledWith({ value: 'the new value' });
     });
 
     it('does not update the state when it is handed no params', () => {
-      searchSuggestField.onChange.bind(that)({});
+      onChange.bind(that)({});
       expect(that.setState).not.toHaveBeenCalled();
     });
   });
 
   describe('onSuggestionsClearRequested()', () => {
     it('cleans up the suggestions in state', () => {
-      searchSuggestField.onSuggestionsClearRequested.bind(that)();
+      onSuggestionsClearRequested.bind(that)();
       expect(that.setState).toHaveBeenCalledWith({ suggestions: [] });
     });
   });
 
   describe('onSuggestionsFetchRequested', () => {
-    let getSuggestionsSectionSpy: jasmine.Spy;
-
-    beforeEach(() => {
-      getSuggestionsSectionSpy = spyOn(
-        searchSuggestUtils,
-        'getSuggestionsSection',
-      );
-    });
-
     it('just resets the suggestions when the value is less than 3 characters long', () => {
-      searchSuggestField.onSuggestionsFetchRequested.bind(that)({ value: 'c' });
+      onSuggestionsFetchRequested.bind(that)({ value: 'c' });
       expect(that.setState).toHaveBeenCalledWith({ suggestions: [] });
-      expect(getSuggestionsSectionSpy).not.toHaveBeenCalled();
-      expect(errors.handle).not.toHaveBeenCalled();
+      expect(mockGetSuggestionsSection).not.toHaveBeenCalled();
+      expect(mockHandle).not.toHaveBeenCalled();
     });
 
     it('uses getSuggestionsSection to get and build a SearchhSuggestionsSection', async () => {
-      getSuggestionsSectionSpy.and.callFake(
+      mockGetSuggestionsSection.mockImplementation(
         async (model: SearchSuggestionSection['model']) => {
           switch (model) {
             case 'courses':
@@ -125,7 +130,7 @@ describe('components/SearchSuggestField', () => {
         },
       );
 
-      await searchSuggestField.onSuggestionsFetchRequested.bind(that)({
+      await onSuggestionsFetchRequested.bind(that)({
         value: 'some search',
       });
 
@@ -141,29 +146,29 @@ describe('components/SearchSuggestField', () => {
     });
 
     it('reports the error when getSuggestionsSection fails', async () => {
-      getSuggestionsSectionSpy.and.returnValue(
+      mockGetSuggestionsSection.mockReturnValue(
         new Promise((resolve, reject) =>
           reject(new Error('Failed to get Suggestions Section!')),
         ),
       );
 
-      await searchSuggestField.onSuggestionsFetchRequested.bind(that)({
+      await onSuggestionsFetchRequested.bind(that)({
         value: 'some search',
       });
 
-      expect(errors.handle).toHaveBeenCalledWith(
+      expect(mockHandle).toHaveBeenCalledWith(
         new Error('Failed to get Suggestions Section!'),
       );
     });
   });
 
   describe('onSuggestionSelected', () => {
-    beforeEach(() => {
-      spyOn(location, 'setHref');
-    });
+    const mockSetHref = jest.spyOn(location, 'setHref');
+
+    beforeEach(() => mockSetHref.mockReset());
 
     it('moves to the courses page when it is called with a course', () => {
-      searchSuggestField.onSuggestionSelected.bind(that)(
+      onSuggestionSelected.bind(that)(
         {},
         { suggestion: { model: 'courses', data: { id: 42 } as Course } },
       );
@@ -171,14 +176,14 @@ describe('components/SearchSuggestField', () => {
     });
 
     it('updates the filer and resets the suggestion state when it is called with an org or a subject', () => {
-      searchSuggestField.onSuggestionSelected.bind(that)(
+      onSuggestionSelected.bind(that)(
         {},
         { suggestion: { model: 'subjects', data: { id: 43 } } },
       );
       expect(addFilter).toHaveBeenCalledWith('subjects', '43');
       expect(location.setHref).not.toHaveBeenCalled();
 
-      searchSuggestField.onSuggestionSelected.bind(that)(
+      onSuggestionSelected.bind(that)(
         {},
         { suggestion: { model: 'organizations', data: { id: 44 } } },
       );

--- a/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
@@ -1,12 +1,11 @@
 import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
-import * as filterUpdater from '../../utils/filters/updateFilter';
+import { updateFilter } from '../../utils/filters/updateFilter';
 import { mapStateToProps, mergeProps } from './SearchSuggestFieldContainer';
 
-describe('components/SearchSuggestFieldContainer/mergeProps', () => {
-  beforeEach(() => {
-    spyOn(filterUpdater, 'updateFilter');
-  });
+const mockUpdateFilter: jest.Mock<typeof updateFilter> = updateFilter as any;
+jest.mock('../../utils/filters/updateFilter');
 
+describe('components/SearchSuggestFieldContainer/mergeProps', () => {
   it('builds props with an addFilter function that calls updateFilter', () => {
     const dispatch = jasmine.createSpy('dispatch');
     const state = {
@@ -32,7 +31,7 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
 
     addFilter('organizations', '84');
 
-    expect(filterUpdater.updateFilter).toHaveBeenCalledWith(
+    expect(mockUpdateFilter).toHaveBeenCalledWith(
       dispatch,
       { limit: 20, offset: 0 },
       'add',

--- a/src/richie-front/js/integration_tests/filters.spec.tsx
+++ b/src/richie-front/js/integration_tests/filters.spec.tsx
@@ -17,9 +17,10 @@ import { RootState } from '../data/rootReducer';
 describe('Integration tests - filters', () => {
   let store: Store<RootState>;
   let makeSearchFilterPane: () => ReactWrapper;
+  const mockHistoryPushState = jest.spyOn(window.history, 'pushState');
 
   beforeEach(() => {
-    spyOn(window.history, 'pushState');
+    mockHistoryPushState.mockReset();
 
     // Create the store with the same initial state as in-app
     store = bootstrapStore();

--- a/src/richie-front/js/utils/filters/updateFilter.spec.ts
+++ b/src/richie-front/js/utils/filters/updateFilter.spec.ts
@@ -1,17 +1,20 @@
 import { stringify } from 'query-string';
 
 import { FilterDefinition } from '../../types/filters';
-import * as filterComputer from './computeNewFilterValue';
+import { computeNewFilterValue } from './computeNewFilterValue';
 import { updateFilter } from './updateFilter';
+
+const mockComputeNewFilterValue: jest.Mock<
+  typeof computeNewFilterValue
+> = computeNewFilterValue as any;
+jest.mock('./computeNewFilterValue');
 
 describe('utils/filters/updateFilter', () => {
   let dispatch: jasmine.Spy;
 
   beforeEach(() => {
     dispatch = jasmine.createSpy('dispatch');
-    spyOn(filterComputer, 'computeNewFilterValue').and.returnValue(
-      'some filter value',
-    );
+    mockComputeNewFilterValue.mockReturnValue('some filter value');
   });
 
   it('dispatches relevant actions with the updated params', () => {

--- a/src/richie-front/js/utils/searchSuggest/getSuggestionsSections.spec.ts
+++ b/src/richie-front/js/utils/searchSuggest/getSuggestionsSections.spec.ts
@@ -1,14 +1,13 @@
 import fetchMock from 'fetch-mock';
 
 import { Course } from '../../types/Course';
-import * as errors from '../../utils/errors/handle';
+import { handle } from '../../utils/errors/handle';
 import { getSuggestionsSection } from './getSuggestionsSection';
 
-describe('utils/searchSuggest/getSuggestionsSection', () => {
-  beforeEach(() => {
-    spyOn(errors, 'handle');
-  });
+const mockHandle: jest.Mock<typeof handle> = handle as any;
+jest.mock('../../utils/errors/handle');
 
+describe('utils/searchSuggest/getSuggestionsSection', () => {
   afterEach(() => {
     fetchMock.restore();
   });
@@ -48,7 +47,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
       { defaultMessage: 'Courses', id: 'coursesHumanName' },
       'some search',
     );
-    expect(errors.handle).toHaveBeenCalledWith(
+    expect(mockHandle).toHaveBeenCalledWith(
       new Error('Failed to send API request'),
     );
   });
@@ -63,7 +62,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
       { defaultMessage: 'Courses', id: 'coursesHumanName' },
       'some search',
     );
-    expect(errors.handle).toHaveBeenCalledWith(
+    expect(mockHandle).toHaveBeenCalledWith(
       new Error('Failed to get list from /api/v1.0/courses/ : 403'),
     );
   });
@@ -75,7 +74,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
       { defaultMessage: 'Courses', id: 'coursesHumanName' },
       'some search',
     );
-    expect(errors.handle).toHaveBeenCalledWith(
+    expect(mockHandle).toHaveBeenCalledWith(
       new Error(
         'Failed to decode JSON in getSuggestionSection FetchError: invalid json response body at ' +
           '/api/v1.0/courses/?query=some%20search reason: Unexpected token o in JSON at position 1',


### PR DESCRIPTION
## Purpose

Using "import * as {name}" and then patching {name} with a spy is practical but it is not spec compliant. For example, it did not work in our previous karma + jasmine environment with babel 7.

## Proposal

Just use jest mocks instead, which are more explicit and do work out of the box.
