### PR TITLE
💄 (front) Active filters are more distinguishable

### DIFF
--- a/src/richie-front/js/components/SearchFilter/SearchFilter.tsx
+++ b/src/richie-front/js/components/SearchFilter/SearchFilter.tsx
@@ -21,6 +21,7 @@ export const SearchFilter = (props: SearchFilterProps) => {
           ? removeFilter(filter.primaryKey)
           : addFilter(filter.primaryKey)
       }
+      aria-label={isActive ? 'Close' : ''}
     >
       {typeof filter.humanName === 'string' ? (
         <span>{filter.humanName}</span>
@@ -29,6 +30,13 @@ export const SearchFilter = (props: SearchFilterProps) => {
       )}
       {filter.count || filter.count === 0 ? (
         <span className="search-filter__count">{filter.count}</span>
+      ) : (
+        ''
+      )}
+      {isActive ? (
+        <span className="search-filter__close" aria-hidden="true">
+          &times;
+        </span>
       ) : (
         ''
       )}

--- a/src/richie-front/js/components/SearchFilter/_SearchFilter.scss
+++ b/src/richie-front/js/components/SearchFilter/_SearchFilter.scss
@@ -19,6 +19,7 @@ $richie-search-filters-active-fontweight: null !default;
 $richie-search-filters-active-background: null !default;
 $richie-search-filters-active-divider-border: null !default;
 
+$richie-search-filters-icon-font-size: $font-size-base * 2 !default;
 
 .search-filter {
   @include m-o-list-group__item(
@@ -49,5 +50,12 @@ $richie-search-filters-active-divider-border: null !default;
 
     color: $white;
     background: $firebrick6;
+  }
+
+  &__close {
+
+    color: $white;
+    font-size: $richie-search-filters-icon-font-size;
+    font-weight: $font-weight-bold;
   }
 }


### PR DESCRIPTION
When a filter is active, emphasizes it by adding a close button. Doing
this you know that this filter is active and you can only remove it.

Part of issue #376

A screenshot of what it looks like : 

![screenshot from 2018-10-04 15-49-19](https://user-images.githubusercontent.com/767834/46478367-1cd99c00-c7ed-11e8-9cb8-d3ebb79c44c2.png)

