### PR TITLE
🚸(front) enable usage of redux dev tools extension

### DIFF
--- a/src/richie-front/js/data/configureStore.ts
+++ b/src/richie-front/js/data/configureStore.ts
@@ -1,4 +1,4 @@
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, compose, createStore } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 
 import { rootReducer, RootState } from './rootReducer';
@@ -7,10 +7,12 @@ import { rootSaga } from './rootSaga';
 const sagaMiddleware = createSagaMiddleware();
 
 export function configureStore(preloadedState: RootState) {
+  const composeEnhancers =
+    (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   const store = createStore(
     rootReducer,
     preloadedState,
-    applyMiddleware(sagaMiddleware),
+    composeEnhancers(applyMiddleware(sagaMiddleware)),
   );
 
   sagaMiddleware.run(rootSaga);


### PR DESCRIPTION
[redux devtools extension](https://github.com/zalmoxisus/redux-devtools-extension) is a nice browser extension allowing to follow state change in realtime.
It's a great tools when developing with react + redux.

this tool can be enable only in development if needed. The author wrote a
nice article about that : https://medium.com/@zalmoxis/using-redux-devtools-in-production-4c5b56c5600f

## Purpose

React development ecosystem has great tool to give a better development experience. If you probably know the [react devtool](https://github.com/facebook/react-devtools), it's brother the [redux devtools extension](https://github.com/zalmoxisus/redux-devtools-extension) is really great but need some configuration when you create the redux store.

## Proposal

Enable usage of redux devtools extension

You probably want to know if there are some overhead in production. You can read this article https://medium.com/@zalmoxis/using-redux-devtools-in-production-4c5b56c5600f and the project [FAQ](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/FAQ.md)
