### PR TITLE
Search missing facets

### DIFF
--- a/src/richie-front/js/utils/filters/getActiveFilterValues.spec.ts
+++ b/src/richie-front/js/utils/filters/getActiveFilterValues.spec.ts
@@ -50,4 +50,29 @@ describe('utils/filters/getActiveFilterValues', () => {
       }),
     );
   });
+
+  it('returns an array of FilterValues from harcoded filter list', () => {
+    const state = {
+      filterDefinitions: {
+        new: {
+          humanName: { defaultMessage: 'New courses', id: 'newCourses' },
+          machineName: 'new' as 'new',
+          values: [{ primaryKey: 'new', humanName: 'First session' }],
+        },
+      },
+    } as any;
+
+    expect(
+      getActiveFilterValues(state, 'new', {
+        limit: 20,
+        new: 'new',
+        offset: 0,
+      }),
+    ).toEqual([
+      {
+        humanName: 'First session',
+        primaryKey: 'new',
+      },
+    ]);
+  });
 });

--- a/src/richie-front/js/utils/filters/getFilterFromState.spec.ts
+++ b/src/richie-front/js/utils/filters/getFilterFromState.spec.ts
@@ -8,7 +8,7 @@ import { Organization } from '../../types/Organization';
 import { getFilterFromState } from './getFilterFromState';
 
 describe('utils/filters/getFilterFromState', () => {
-  it('returns a FilterDefinition for a hardcoded filter group', () => {
+  it('returns a FilterDefinition for a hardcoded filter group with facets', () => {
     const state = {
       filterDefinitions: {
         availability: {} as FilterDefinitionWithValues,
@@ -21,7 +21,49 @@ describe('utils/filters/getFilterFromState', () => {
         organizations: {} as FilterDefinition,
         subjects: {} as FilterDefinition,
       },
-      resources: {},
+      resources: {
+        courses: {
+          byId: {},
+          currentQuery: {
+            facets: { new: { new: 3 } },
+            items: {},
+            params: { limit: 20, offset: 0 },
+            total_count: 3,
+          },
+        },
+      },
+    } as RootState;
+    expect(getFilterFromState(state, 'new')).toEqual({
+      humanName: { defaultMessage: 'New courses', id: 'newCourses' },
+      machineName: 'new',
+      values: [{ primaryKey: 'new', humanName: 'First session', count: 3 }],
+    });
+  });
+
+  it('returns a FilterDefinition for a hardcoded filter group without facet', () => {
+    const state = {
+      filterDefinitions: {
+        availability: {} as FilterDefinitionWithValues,
+        language: {} as FilterDefinitionWithValues,
+        new: {
+          humanName: { defaultMessage: 'New courses', id: 'newCourses' },
+          machineName: 'new' as 'new',
+          values: [{ primaryKey: 'new', humanName: 'First session' }],
+        },
+        organizations: {} as FilterDefinition,
+        subjects: {} as FilterDefinition,
+      },
+      resources: {
+        courses: {
+          byId: {},
+          currentQuery: {
+            facets: {},
+            items: {},
+            params: { limit: 20, offset: 0 },
+            total_count: 0,
+          },
+        },
+      },
     } as RootState;
     expect(getFilterFromState(state, 'new')).toEqual({
       humanName: { defaultMessage: 'New courses', id: 'newCourses' },

--- a/src/richie-front/js/utils/filters/getFilterFromState.ts
+++ b/src/richie-front/js/utils/filters/getFilterFromState.ts
@@ -4,6 +4,7 @@ import { RootState } from '../../data/rootReducer';
 import {
   FilterDefinitionWithValues,
   filterGroupName,
+  hardcodedFilterGroupName,
   resourceBasedFilterGroupName,
 } from '../../types/filters';
 
@@ -32,10 +33,31 @@ export function getFilterFromState(
 
     // Values from state are usable as-is for hardcoded filters
     default:
-      return state.filterDefinitions[machineName];
+      return {
+        ...state.filterDefinitions[machineName],
+        values: getHarcodedFilterFacetedValues(facets, machineName),
+      };
   }
 
   /* tslint:disable:variable-name */
+  function getHarcodedFilterFacetedValues(
+    facets_: typeof facets,
+    resourceName: hardcodedFilterGroupName,
+  ) {
+    if (!state.filterDefinitions[resourceName]) {
+      return [];
+    }
+
+    if (!facets_[resourceName] || !Object.keys(facets_[resourceName]).length) {
+      return state.filterDefinitions[resourceName].values;
+    }
+
+    return state.filterDefinitions[resourceName].values.map(value => ({
+      ...value,
+      count: facets_[resourceName][value.primaryKey],
+    }));
+  }
+
   function getFacetedValues(
     state_: typeof state,
     facets_: typeof facets,


### PR DESCRIPTION
## Purpose

deal with a point in #376 

> The filters are not implemented nor the facets displayed for other dimensions than organizations & subjects. They are available on the backend and just need to be plugged in here.

## Proposal

- [x] display a facet counter in front of each harcoded filters
- [x] display then as active once selected
