### PR TITLE
♻️ (front) create a type guard to check machine name in search filters

### DIFF
--- a/src/richie-front/js/utils/filters/getActiveFilterValues.ts
+++ b/src/richie-front/js/utils/filters/getActiveFilterValues.ts
@@ -1,11 +1,7 @@
 import { ResourceListStateParams } from '../../data/genericReducers/resourceList/resourceList';
 import { RootState } from '../../data/rootReducer';
-import {
-  filterGroupName,
-  FilterValue,
-  hardcodedFilterGroupName,
-  resourceBasedFilterGroupName,
-} from '../../types/filters';
+import { filterGroupName, FilterValue } from '../../types/filters';
+import { isResourceBasedFilterGroupName } from './isResourceBasedFilterGroupName';
 
 // Return the list of *currenly active* filter values for a dimension built from the state & current params
 export const getActiveFilterValues = (
@@ -24,37 +20,35 @@ export const getActiveFilterValues = (
     currentValues = [currentValues];
   }
 
-  switch (machineName) {
-    case 'organizations':
-    case 'subjects':
-      return (
-        currentValues
-          // Get the value for each our the keys we received
-          .map(
-            key =>
-              state.resources &&
-              state.resources[machineName] &&
-              state.resources[machineName]!.byId[key],
-          )
-          // Drop missing values (avoid throwing)
-          .filter(value => !!value)
-          // Build filter values from the Resource instances
-          .map(value => ({
-            humanName: value!.name,
-            primaryKey: String(value!.id),
-          }))
-      );
-    default:
-      return currentValues
-        .map(key => {
-          return state.filterDefinitions[machineName].values.find(
-            value => value.primaryKey === key,
-          );
-        })
+  if (isResourceBasedFilterGroupName(machineName)) {
+    return (
+      currentValues
+        // Get the value for each our the keys we received
+        .map(
+          key =>
+            state.resources &&
+            state.resources[machineName] &&
+            state.resources[machineName]!.byId[key],
+        )
+        // Drop missing values (avoid throwing)
         .filter(value => !!value)
+        // Build filter values from the Resource instances
         .map(value => ({
-          humanName: value!.humanName,
-          primaryKey: value!.primaryKey,
-        }));
+          humanName: value!.name,
+          primaryKey: String(value!.id),
+        }))
+    );
+  } else {
+    return currentValues
+      .map(key => {
+        return state.filterDefinitions[machineName].values.find(
+          value => value.primaryKey === key,
+        );
+      })
+      .filter(value => !!value)
+      .map(value => ({
+        humanName: value!.humanName,
+        primaryKey: value!.primaryKey,
+      }));
   }
 };

--- a/src/richie-front/js/utils/filters/getFilterFromState.ts
+++ b/src/richie-front/js/utils/filters/getFilterFromState.ts
@@ -7,6 +7,7 @@ import {
   hardcodedFilterGroupName,
   resourceBasedFilterGroupName,
 } from '../../types/filters';
+import { isResourceBasedFilterGroupName } from './isResourceBasedFilterGroupName';
 
 // Get (or build) a complete filter definition for `machineName` from the state, using:
 // - filterDefinitions for hardcoded filters and hardcoded props of resource based filters
@@ -22,22 +23,12 @@ export function getFilterFromState(
       state.resources.courses.currentQuery.facets) ||
     {};
 
-  switch (machineName) {
-    // Use the facets to build the values for resource based filters
-    case 'organizations':
-    case 'subjects':
-      return {
-        ...state.filterDefinitions[machineName],
-        values: getFacetedValues(state, facets, machineName),
-      };
-
-    // Values from state are usable as-is for hardcoded filters
-    default:
-      return {
-        ...state.filterDefinitions[machineName],
-        values: getHarcodedFilterFacetedValues(facets, machineName),
-      };
-  }
+  return {
+    ...state.filterDefinitions[machineName],
+    values: isResourceBasedFilterGroupName(machineName)
+      ? getFacetedValues(state, facets, machineName)
+      : getHarcodedFilterFacetedValues(facets, machineName),
+  };
 
   /* tslint:disable:variable-name */
   function getHarcodedFilterFacetedValues(

--- a/src/richie-front/js/utils/filters/isResourceBasedFilterGroupName.ts
+++ b/src/richie-front/js/utils/filters/isResourceBasedFilterGroupName.ts
@@ -1,0 +1,13 @@
+import includes from 'lodash-es/includes';
+
+import { FILTERS_RESOURCES } from '../../settings';
+import {
+  filterGroupName,
+  resourceBasedFilterGroupName,
+} from '../../types/filters';
+
+export function isResourceBasedFilterGroupName(
+  name: filterGroupName,
+): name is resourceBasedFilterGroupName {
+  return includes(Object.keys(FILTERS_RESOURCES), name);
+}


### PR DESCRIPTION
we don't want to hardcode filter name anymore. This PR creates a type
guard to  detect if the filter name is a resource or hardcoded one.

## Purpose

In PR #384 @mbenadda suggests to stop harcoding filter name in each switch statement. 

![screenshot from 2018-10-08 11-21-46](https://user-images.githubusercontent.com/767834/46601068-5f9cbc00-caec-11e8-8990-cc2bbe4583d8.png)


## Proposal

![screenshot from 2018-10-08 10-11-50](https://user-images.githubusercontent.com/767834/46601186-adb1bf80-caec-11e8-918b-7dfc3cb1856b.png)


create a type guard allowing us to detect if the filter name is a `resource` or `hardcoded` one.

- [x] create the type guard
- [x] apply it in `getActiveFilterValues` and `getFilterFromState` functions
