### PR TITLE
Limit resource-based filters to 10 displayed suggestions

### DIFF
--- a/src/richie-front/js/utils/filters/getFilterFromState.spec.ts
+++ b/src/richie-front/js/utils/filters/getFilterFromState.spec.ts
@@ -1,3 +1,5 @@
+import { find } from 'lodash-es';
+
 import { CoursesState } from '../../data/courses/reducer';
 import { RootState } from '../../data/rootReducer';
 import {
@@ -140,14 +142,67 @@ describe('utils/filters/getFilterFromState', () => {
       },
     };
 
-    expect(getFilterFromState(state as RootState, 'organizations')).toEqual({
+    const filter = getFilterFromState(state as RootState, 'organizations');
+    expect(filter).toEqual({
       humanName: { defaultMessage: 'Organizations', id: 'organizations' },
       machineName: 'organizations',
-      values: [
+      // Values might be mis-ordered as we're sampling them instead of just reusing the array
+      values: expect.arrayContaining([
         { humanName: 'Organization #Twenty-One', primaryKey: '21' },
         { humanName: 'Organization #Fourty-Two', primaryKey: '42' },
         { humanName: 'Organization #Eighty-Four', primaryKey: '84' },
-      ],
+      ]),
     });
+    // If the array contains only 3 values *and* contains our 3 values, we can reasonably think
+    // it's just our three values (arrayContaining does not ensure the array does not contain anything else)
+    expect(filter.values.length).toEqual(3);
+  });
+
+  it('samples 10 values from the filter definition when there are more than 10 and no facets', () => {
+    const state = {
+      filterDefinitions: {
+        availability: {} as FilterDefinitionWithValues,
+        language: {} as FilterDefinitionWithValues,
+        new: {} as FilterDefinitionWithValues,
+        organizations: {
+          humanName: { defaultMessage: 'Organizations', id: 'organizations' },
+          machineName: 'organizations',
+          values: [],
+        },
+        subjects: {} as FilterDefinition,
+      },
+      resources: {
+        organizations: {
+          byId: {
+            // Note we have 12 organizations here
+            21: { id: 21, name: 'Organization #Twenty-One' } as Organization,
+            22: { id: 22, name: 'Organization #Twenty-Two' } as Organization,
+            23: { id: 23, name: 'Organization #Twenty-Three' } as Organization,
+            24: { id: 24, name: 'Organization #Twenty-Four' } as Organization,
+            42: { id: 42, name: 'Organization #Fourty-Two' } as Organization,
+            43: { id: 43, name: 'Organization #Fourty-Three' } as Organization,
+            44: { id: 44, name: 'Organization #Fourty-Four' } as Organization,
+            45: { id: 45, name: 'Organization #Fourty-Five' } as Organization,
+            84: { id: 84, name: 'Organization #Eighty-Four' } as Organization,
+            85: { id: 85, name: 'Organization #Eighty-Five' } as Organization,
+            86: { id: 86, name: 'Organization #Eighty-Six' } as Organization,
+            87: { id: 87, name: 'Organization #Eighty-Seven' } as Organization,
+          },
+        },
+      },
+    };
+
+    const filter = getFilterFromState(state as RootState, 'organizations');
+    expect(filter.values.length).toEqual(10);
+    // Count included unique organizations
+    const uniqueOrgCount = Object.keys(
+      state.resources.organizations.byId,
+    ).reduce(
+      (count, orgId) =>
+        count +
+        (find(filter.values, item => item.primaryKey === orgId) ? 1 : 0),
+      0,
+    );
+    expect(uniqueOrgCount).toEqual(10);
   });
 });

--- a/src/richie-front/js/utils/filters/getFilterFromState.ts
+++ b/src/richie-front/js/utils/filters/getFilterFromState.ts
@@ -1,3 +1,4 @@
+import sampleSize from 'lodash-es/sampleSize';
 import values from 'lodash-es/values';
 
 import { RootState } from '../../data/rootReducer';
@@ -61,7 +62,9 @@ export function getFilterFromState(
     // We don't have the facets yet or something broke upstream: provide some filtering
     // capabilities anyway (without counts, as we can't generate those)
     if (!facets_[resourceName] || !Object.keys(facets_[resourceName]).length) {
-      return values(state.resources[resourceName]!.byId)
+      // Return a maximum of 10 values so the page does not seem bugged when missing the facet
+      // counts, and the display is always consistent (as our facet counts cap at the top 10)
+      return sampleSize(values(state.resources[resourceName]!.byId), 10)
         .filter(organization => !!organization)
         .map(organization => ({
           humanName: organization!.name,


### PR DESCRIPTION
## Purpose

When we're using facet counts to display a resource-based filter, we're only showing the top 10 available values in the list. (We'll be adding a UI element to filter using other values).

When there are no facet counts, we're displaying all possible values. This is not ideal as it might make the UI jitter on load & looks bad / makes it seem like there is a bug when we really are missing the facets.

## Proposal

Sample 10 random values from the full list in this case.