### PR TITLE
Handle full text search

### DIFF
--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -37,20 +37,32 @@ const mockSuggestionHumanName: jest.Mock<
 jest.mock('../../utils/searchSuggest/suggestionHumanName');
 
 describe('components/SearchSuggestField', () => {
-  let addFilter: jasmine.Spy;
-  let that: { props: { addFilter: jasmine.Spy }; setState: jasmine.Spy };
+  let addFilter: jest.SpyInstance;
+  let fullTextSearch: jest.SpyInstance;
+  let that: {
+    props: {
+      addFilter: typeof addFilter;
+      fullTextSearch: typeof fullTextSearch;
+    };
+    setState: jasmine.Spy;
+  };
 
   beforeEach(() => {
-    // addFilter is the method passed through the props
-    addFilter = jasmine.createSpy('addFilter');
+    // addFilter & fullTextSearch are used to update the current search query
+    addFilter = jest.fn();
+    fullTextSearch = jest.fn();
     // Stub the parts of the component instance we need to access
-    that = { props: { addFilter }, setState: jasmine.createSpy('setState') };
+    that = {
+      props: { addFilter, fullTextSearch },
+      setState: jasmine.createSpy('setState'),
+    };
   });
 
   it('renders', () => {
     const wrapper = shallow(
       <SearchSuggestFieldBase
-        addFilter={addFilter}
+        addFilter={addFilter as any}
+        fullTextSearch={fullTextSearch as any}
         intl={
           { formatMessage: (message: any) => message.defaultMessage } as any
         }
@@ -221,7 +233,7 @@ describe('components/SearchSuggestField', () => {
       expect(location.setHref).toHaveBeenCalledWith('https://42');
     });
 
-    it('updates the filer and resets the suggestion state when it is called with an org or a subject', () => {
+    it('updates the filter and resets the suggestion state when it is called with a resource suggestion', () => {
       onSuggestionSelected.bind(that)(
         {},
         { suggestion: { model: 'subjects', data: { id: 43 } } },
@@ -234,6 +246,15 @@ describe('components/SearchSuggestField', () => {
         { suggestion: { model: 'organizations', data: { id: 44 } } },
       );
       expect(addFilter).toHaveBeenCalledWith('organizations', '44');
+      expect(location.setHref).not.toHaveBeenCalled();
+    });
+
+    it('updates the full text search when it is called with the default suggestion', () => {
+      onSuggestionSelected.bind(that)(
+        {},
+        { suggestion: { model: null, data: 'my search' } },
+      );
+      expect(fullTextSearch).toHaveBeenCalledWith('my search');
       expect(location.setHref).not.toHaveBeenCalled();
     });
   });

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
@@ -183,6 +183,12 @@ export function onSuggestionSelected(
         suggestions: [],
         value: '',
       });
+      break;
+
+    default:
+      // Update the current query with the default suggestion data (the contents of the search query)
+      this.props.fullTextSearch(suggestion.data);
+      break;
   }
 }
 

--- a/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
@@ -6,29 +6,31 @@ const mockUpdateFilter: jest.Mock<typeof updateFilter> = updateFilter as any;
 jest.mock('../../utils/filters/updateFilter');
 
 describe('components/SearchSuggestFieldContainer/mergeProps', () => {
-  it('builds props with an addFilter function that calls updateFilter', () => {
-    const dispatch = jasmine.createSpy('dispatch');
-    const state = {
-      filterDefinitions: {
-        organizations: {
-          humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-          machineName: 'organizations',
-        },
-      } as FilterDefinitionState,
-      resources: {
-        courses: {
-          byId: {},
-          currentQuery: {
-            facets: {},
-            items: { 0: 42 },
-            params: { limit: 20, offset: 0 },
-            total_count: 0,
-          },
+  const dispatch = jest.fn();
+  const state = {
+    filterDefinitions: {
+      organizations: {
+        humanName: { defaultMessage: 'Organizations', id: 'organizations' },
+        machineName: 'organizations',
+      },
+    } as FilterDefinitionState,
+    resources: {
+      courses: {
+        byId: {},
+        currentQuery: {
+          facets: {},
+          items: { 0: 42 },
+          params: { limit: 20, offset: 0 },
+          total_count: 0,
         },
       },
-    };
-    const { addFilter } = mergeProps(mapStateToProps(state), { dispatch });
+    },
+  };
 
+  beforeEach(dispatch.mockClear);
+
+  it('builds props with an addFilter function that calls updateFilter', () => {
+    const { addFilter } = mergeProps(mapStateToProps(state), { dispatch });
     addFilter('organizations', '84');
 
     expect(mockUpdateFilter).toHaveBeenCalledWith(
@@ -41,5 +43,16 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
       },
       '84',
     );
+  });
+
+  it('builds props with a fullTextSearch function that updates search params', () => {
+    const { fullTextSearch } = mergeProps(mapStateToProps(state), { dispatch });
+    fullTextSearch('some query');
+
+    expect(dispatch).toHaveBeenCalledWith({
+      params: { limit: 20, offset: 0, query: 'some query' },
+      resourceName: 'courses',
+      type: 'RESOURCE_LIST_GET',
+    });
   });
 });

--- a/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.tsx
+++ b/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.tsx
@@ -2,6 +2,7 @@ import { connect } from 'react-redux';
 import { Action, Dispatch } from 'redux';
 
 import { ResourceListStateParams } from '../../data/genericReducers/resourceList/resourceList';
+import { getResourceList } from '../../data/genericSideEffects/getResourceList/actions';
 import { RootState } from '../../data/rootReducer';
 import { API_LIST_DEFAULT_PARAMS } from '../../settings';
 import { filterGroupName } from '../../types/filters';
@@ -28,6 +29,7 @@ export const mergeProps = (
   { dispatch }: { dispatch: Dispatch<Action> },
 ) => {
   return {
+    // Add a single filter from a suggestion to the current search.
     addFilter: (modelName: filterGroupName, filterValue: string) => {
       updateFilter(
         dispatch,
@@ -36,6 +38,10 @@ export const mergeProps = (
         filterDefinitions[modelName],
         filterValue,
       );
+    },
+    // Update the full text search with the current value of the search field (default suggestion).
+    fullTextSearch: (query: string) => {
+      dispatch(getResourceList('courses', { ...currentParams, query }));
     },
   };
 };

--- a/src/richie-front/js/types/searchSuggest.ts
+++ b/src/richie-front/js/types/searchSuggest.ts
@@ -6,46 +6,106 @@ import { Organization } from './Organization';
 import { Resource } from './Resource';
 import { Subject } from './Subject';
 
-interface ResourceSuggestion<M extends modelNameList, T extends Resource> {
-  model: M;
-  data: T;
+/**
+ * The base shape of a search suggestion. Used by our `react-autosuggest` callbacks
+ * to display, build & generally use our suggestions.
+ * @model The (standard pluralized) name for the relevant model.
+ * @data The model instance for this suggestion.
+ */
+interface ResourceSuggestionBase {
+  model: modelNameList;
+  data: Resource;
 }
 
-export type CourseSuggestion = ResourceSuggestion<'courses', Course>;
-export type OrganizationSuggestion = ResourceSuggestion<
-  'organizations',
-  Organization
->;
-export type SubjectSuggestion = ResourceSuggestion<'subjects', Subject>;
+export interface CourseSuggestion extends ResourceSuggestionBase {
+  model: 'courses';
+  data: Course;
+}
+export interface OrganizationSuggestion extends ResourceSuggestionBase {
+  model: 'organizations';
+  data: Organization;
+}
+export interface SubjectSuggestion extends ResourceSuggestionBase {
+  model: 'subjects';
+  data: Subject;
+}
 
-export type SearchSuggestion =
+/**
+ * Any search suggestion based on a resource eg. course, organization, subject.
+ */
+export type ResourceSuggestion =
   | CourseSuggestion
   | OrganizationSuggestion
   | SubjectSuggestion;
 
-interface ResourceSuggestionSection<
-  M extends modelNameList,
-  T extends Resource
-> {
-  message: FormattedMessage.MessageDescriptor;
-  model: M;
-  values: T[];
+/**
+ * The default search suggestion, eg. "Search for foo" based on the full text.
+ * @model Always `null` for the default suggestion.
+ * @data The current content of the search field.
+ */
+export interface DefaultSuggestion {
+  model: null;
+  data: string;
 }
 
-export type CourseSuggestionSection = ResourceSuggestionSection<
-  'courses',
-  Course
->;
-export type OrganizationSuggestionSection = ResourceSuggestionSection<
-  'organizations',
-  Organization
->;
-export type SubjectSuggestionSection = ResourceSuggestionSection<
-  'subjects',
-  Subject
->;
+/**
+ * Any search suggestion, whether resource based or the default one.
+ */
+export type SearchSuggestion = ResourceSuggestion | DefaultSuggestion;
 
-export type SearchSuggestionSection =
+/**
+ * The base shape of a search suggestion section. Contains a bunch of suggestions and a title.
+ * Used by our `react-autosuggest` callbacks to display, build & generally use our suggestions.
+ * @message A `react-intl` MessageDescriptor for the title of the section
+ * @model The (standard pluralized) name for the relevant model.
+ * @values An array that contains all the Suggestion instances for this section.
+ */
+interface ResourceSuggestionSectionBase {
+  message: FormattedMessage.MessageDescriptor;
+  model: modelNameList;
+  values: Resource[];
+}
+
+export interface CourseSuggestionSection extends ResourceSuggestionSectionBase {
+  model: 'courses';
+  values: Course[];
+}
+export interface OrganizationSuggestionSection
+  extends ResourceSuggestionSectionBase {
+  model: 'organizations';
+  values: Organization[];
+}
+export interface SubjectSuggestionSection
+  extends ResourceSuggestionSectionBase {
+  model: 'subjects';
+  values: Subject[];
+}
+
+/**
+ * Any search suggestion section based on a resource eg. course, organization, subject.
+ */
+export type ResourceSuggestionSection =
   | CourseSuggestionSection
   | OrganizationSuggestionSection
   | SubjectSuggestionSection;
+
+/**
+ * The default search suggestion section. The only reason this is a section is we cannot put sections and
+ * suggestions directly in the same autosuggest. We can instead make a section with only one suggestion and
+ * no title to effectively get a suggestion.
+ * @message Always `null` for the default suggestion.
+ * @model Always `null` for the default suggestion.
+ * @value The default suggestion.
+ */
+export interface DefaultSuggestionSection {
+  message: null;
+  model: null;
+  value: string;
+}
+
+/**
+ * Any search suggestion section, whether resource based or the default one.
+ */
+export type SearchSuggestionSection =
+  | ResourceSuggestionSection
+  | DefaultSuggestionSection;

--- a/src/richie-front/js/utils/searchSuggest/getSuggestionsSection.ts
+++ b/src/richie-front/js/utils/searchSuggest/getSuggestionsSection.ts
@@ -4,13 +4,13 @@ import { FormattedMessage } from 'react-intl';
 
 import { API_ENDPOINTS } from '../../settings';
 import { Resource } from '../../types/Resource';
-import { SearchSuggestionSection } from '../../types/searchSuggest';
+import { ResourceSuggestionSection } from '../../types/searchSuggest';
 import { handle } from '../../utils/errors/handle';
 
 // Build a suggestion section from a model name and a title, requesting the relevant
 // values to populate it from the API
 export const getSuggestionsSection = async (
-  sectionModel: SearchSuggestionSection['model'],
+  sectionModel: ResourceSuggestionSection['model'],
   sectionTitleMessage: FormattedMessage.MessageDescriptor,
   query: string,
 ) => {
@@ -53,5 +53,5 @@ export const getSuggestionsSection = async (
     message: sectionTitleMessage,
     model: sectionModel,
     values: take(data.objects, 3),
-  } as SearchSuggestionSection;
+  };
 };

--- a/src/richie-front/js/utils/searchSuggest/suggestionHumanName.ts
+++ b/src/richie-front/js/utils/searchSuggest/suggestionHumanName.ts
@@ -1,6 +1,6 @@
-import { SearchSuggestion } from '../../types/searchSuggest';
+import { ResourceSuggestion } from '../../types/searchSuggest';
 
-export const suggestionHumanName = (suggestion: SearchSuggestion) => {
+export const suggestionHumanName = (suggestion: ResourceSuggestion) => {
   switch (suggestion.model) {
     case 'courses':
       const course = suggestion.data;

--- a/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.spec.ts
+++ b/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.spec.ts
@@ -72,4 +72,14 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
       },
     ]);
   });
+
+  it('accepts the default suggestion section and returns the default suggestion', () => {
+    expect(
+      suggestionsFromSection({
+        message: null,
+        model: null,
+        value: 'example message',
+      }),
+    ).toEqual([{ data: 'example message', model: null }]);
+  });
 });

--- a/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.ts
+++ b/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.ts
@@ -1,31 +1,73 @@
 import {
-  CourseSuggestion,
-  CourseSuggestionSection,
-  OrganizationSuggestion,
-  OrganizationSuggestionSection,
-  SearchSuggestion,
+  DefaultSuggestionSection,
+  ResourceSuggestion,
+  ResourceSuggestionSection,
   SearchSuggestionSection,
-  SubjectSuggestion,
-  SubjectSuggestionSection,
 } from '../../types/searchSuggest';
 
-export function suggestionsFromSection(
-  coursesSection: CourseSuggestionSection,
-): CourseSuggestion[];
-export function suggestionsFromSection(
-  Organizationsection: OrganizationSuggestionSection,
-): OrganizationSuggestion[];
-export function suggestionsFromSection(
-  SubjectsSection: SubjectSuggestionSection,
-): SubjectSuggestion[];
-export function suggestionsFromSection(
+/**
+ *  Type guard. Determines the kind of section to pick the correct suggestions extractor.
+ */
+function isResourceSection(
   section: SearchSuggestionSection,
-): SearchSuggestion[] {
-  // Compiler breaks down: it can't understand `T[] | U[]` is necessarily an array
-  return (section.values as any[]).map(value => ({
-    data: value,
-    model: section.model,
-    // Compiler breaks down: it merges SearchSuggestionSection 'model' as an intersection type
-    // but does not do the same with SearchSuggestion model
-  })) as any[];
+): section is ResourceSuggestionSection {
+  return !!section.model;
+}
+
+/**
+ * Handles the default section for the more general `suggestionsFromSection()`.
+ */
+function suggestionsFromDefaultSection(section: DefaultSuggestionSection) {
+  return [
+    {
+      data: section.value,
+      model: section.model,
+    },
+  ];
+}
+
+/**
+ * Handles resource sections for the more general `suggestionsFromSection()`.
+ */
+function suggestionsFromResourceSection(
+  section: ResourceSuggestionSection,
+): ResourceSuggestion[] {
+  // We have two issues here:
+  // - the compiler can't understand `T[] | U[]` is necessarily an array. See this issue on call
+  //   signatures of union types (https://github.com/Microsoft/TypeScript/issues/7294)
+  // - contents of model on ResourceSuggestion input are merged which breaks down as they are not
+  //   merged on the output
+  // This leads us to this switch which solves both issues as neither the model name nor the values
+  // are union types anymore.
+  switch (section.model) {
+    case 'courses':
+      return section.values.map(value => ({
+        data: value,
+        model: section.model,
+      }));
+    case 'organizations':
+      return section.values.map(value => ({
+        data: value,
+        model: section.model,
+      }));
+
+    case 'subjects':
+      return section.values.map(value => ({
+        data: value,
+        model: section.model,
+      }));
+  }
+}
+
+/**
+ * Extract the search suggestions from a suggestions section object. Used as a `react-autosuggest` param
+ * called internally by the library.
+ * @param section The search suggestion section we need to extract the suggestions from.
+ * @returns An array containing the suggestions themselves.
+ */
+export function suggestionsFromSection(section: SearchSuggestionSection) {
+  if (isResourceSection(section)) {
+    return suggestionsFromResourceSection(section);
+  }
+  return suggestionsFromDefaultSection(section);
 }


### PR DESCRIPTION
## Purpose

The course search bar in the courses page only offers suggestion for courses of resource-based filters. We also intend to support full-text search through both course title, metadata & syllabus.

## Proposal

- [x] Add a special-case "default" suggestion that simply displays the current content of the fields along with a cue "Search for foo".
- [x] Handle the full text search suggestion in the main courses search.