### PR TITLE
Enable code reuse in viewsets

### DIFF
--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -83,7 +83,7 @@ class CoursesIndexer:
         # This means there can be no overlap between the various buckets, but we can still
         # sort courses inside each bucket as we see fit by simply adding timestamps (ascending
         # order) or substracting them (descending order).
-        "sort_courses_list": {
+        "sort_list": {
             "script": {
                 "lang": "expression",
                 "source": (
@@ -144,7 +144,7 @@ class CoursesIndexer:
                 raise IndexerDataException("Unexpected data shape in courses to index")
 
     @staticmethod
-    def format_es_course_for_api(es_course, best_language):
+    def format_es_object_for_api(es_course, best_language):
         """
         Format a course stored in ES into a consistent and easy-to-consume record for
         API consumers
@@ -350,7 +350,7 @@ class CoursesIndexer:
         )
 
     @staticmethod
-    def get_courses_list_sorting_script():
+    def get_list_sorting_script():
         """
         Call the relevant sorting script for courses lists, regenerating the parameters on each
         call. This will allow the ms_since_epoch value to stay relevant even if the ES instance
@@ -363,7 +363,7 @@ class CoursesIndexer:
             "_script": {
                 "order": "asc",
                 "script": {
-                    "id": "sort_courses_list",
+                    "id": "sort_list",
                     "params": {
                         "max_date": arrow.get(MAXYEAR, 12, 31).timestamp * 1000,
                         "ms_since_epoch": arrow.utcnow().timestamp * 1000,

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -54,7 +54,7 @@ class OrganizationsIndexer:
                 )
 
     @staticmethod
-    def format_es_organization_for_api(es_organization, best_language):
+    def format_es_object_for_api(es_organization, best_language):
         """
         Format an organization stored in ES into a consistent and easy-to-consume record for
         API consumers

--- a/src/richie/apps/search/indexers/subjects.py
+++ b/src/richie/apps/search/indexers/subjects.py
@@ -46,7 +46,7 @@ class SubjectsIndexer:
                 raise IndexerDataException("Unexpected data shape in subjects to index")
 
     @staticmethod
-    def format_es_subject_for_api(es_subject, best_language):
+    def format_es_object_for_api(es_subject, best_language):
         """
         Format a subject stored in ES into a consistent and easy-to-consume record for
         API consumers

--- a/src/richie/apps/search/utils/viewsets.py
+++ b/src/richie/apps/search/utils/viewsets.py
@@ -1,0 +1,17 @@
+"""
+Helpers to enable reuse for needs that are shared between viewsets.
+"""
+
+
+class ViewSetMetadata:
+    """
+    "Meta" class intended to be used as an attribute on ViewSets to provide a common set of
+    meta attributes, like the Django `class Meta` on eg. models.
+    """
+
+    def __init__(self, indexer):
+        """
+        Set the required attributes passed from the call site. Currently this only includes
+        the ViewSet's corresponding indexer.
+        """
+        self.indexer = indexer

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -43,7 +43,7 @@ class CoursesViewSet(ViewSet):
             body={
                 "aggs": aggs,
                 "query": query,
-                "sort": COURSE_INDEXER.get_courses_list_sorting_script(),
+                "sort": COURSE_INDEXER.get_list_sorting_script(),
             },
             # Directly pass meta-params through as arguments to the ES client
             from_=offset,
@@ -57,7 +57,7 @@ class CoursesViewSet(ViewSet):
                 "total_count": course_query_response["hits"]["total"],
             },
             "objects": [
-                COURSE_INDEXER.format_es_course_for_api(
+                COURSE_INDEXER.format_es_object_for_api(
                     es_course,
                     # Get the best language we can return multilingual fields in
                     get_language_from_request(request),
@@ -151,7 +151,7 @@ class CoursesViewSet(ViewSet):
 
         # Format a clean course object as a response
         return Response(
-            COURSE_INDEXER.format_es_course_for_api(
+            COURSE_INDEXER.format_es_object_for_api(
                 query_response,
                 # Get the best language we can return multilingual fields in
                 get_language_from_request(request),

--- a/src/richie/apps/search/viewsets/organizations.py
+++ b/src/richie/apps/search/viewsets/organizations.py
@@ -10,9 +10,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from ..exceptions import QueryFormatException
-
-# Get the organizations indexer from the settings
-ORGANIZATION_INDEXER = import_string(settings.ES_INDICES.organizations)
+from ..utils.viewsets import ViewSetMetadata
 
 
 class OrganizationsViewSet(ViewSet):
@@ -21,6 +19,9 @@ class OrganizationsViewSet(ViewSet):
     See API Blueprint for details on consumer use.
     """
 
+    # Get the organizations indexer from the settings
+    _meta = ViewSetMetadata(indexer=import_string(settings.ES_INDICES.organizations))
+
     # pylint: disable=no-self-use,unused-argument
     def list(self, request, version):
         """
@@ -28,14 +29,14 @@ class OrganizationsViewSet(ViewSet):
         organizations and returns a list of matching items
         """
         try:
-            limit, offset, query = ORGANIZATION_INDEXER.build_es_query(request)
+            limit, offset, query = self._meta.indexer.build_es_query(request)
         except QueryFormatException as exc:
             # Return a 400 with error information if the query params are not as expected
             return Response(status=400, data={"errors": exc.args[0]})
 
         search_query_response = settings.ES_CLIENT.search(
-            index=ORGANIZATION_INDEXER.index_name,
-            doc_type=ORGANIZATION_INDEXER.document_type,
+            index=self._meta.indexer.index_name,
+            doc_type=self._meta.indexer.document_type,
             body=query,
             # Directly pass meta-params through as arguments to the ES client
             from_=offset,
@@ -52,7 +53,7 @@ class OrganizationsViewSet(ViewSet):
                 "total_count": search_query_response["hits"]["total"],
             },
             "objects": [
-                ORGANIZATION_INDEXER.format_es_object_for_api(
+                self._meta.indexer.format_es_object_for_api(
                     organization,
                     # Get the best language to return multilingual fields
                     get_language_from_request(request),
@@ -60,7 +61,6 @@ class OrganizationsViewSet(ViewSet):
                 for organization in search_query_response["hits"]["hits"]
             ],
         }
-
         return Response(response_object)
 
     # pylint: disable=no-self-use,invalid-name,unused-argument
@@ -72,8 +72,8 @@ class OrganizationsViewSet(ViewSet):
         # raise and end up in a 500 error otherwise
         try:
             query_response = settings.ES_CLIENT.get(
-                index=ORGANIZATION_INDEXER.index_name,
-                doc_type=ORGANIZATION_INDEXER.document_type,
+                index=self._meta.indexer.index_name,
+                doc_type=self._meta.indexer.document_type,
                 id=pk,
             )
         except NotFoundError:
@@ -81,7 +81,7 @@ class OrganizationsViewSet(ViewSet):
 
         # Format a clean organization object as a response
         return Response(
-            ORGANIZATION_INDEXER.format_es_object_for_api(
+            self._meta.indexer.format_es_object_for_api(
                 query_response,
                 # Get the best language we can return multilingual fields in
                 get_language_from_request(request),

--- a/src/richie/apps/search/viewsets/organizations.py
+++ b/src/richie/apps/search/viewsets/organizations.py
@@ -52,7 +52,7 @@ class OrganizationsViewSet(ViewSet):
                 "total_count": search_query_response["hits"]["total"],
             },
             "objects": [
-                ORGANIZATION_INDEXER.format_es_organization_for_api(
+                ORGANIZATION_INDEXER.format_es_object_for_api(
                     organization,
                     # Get the best language to return multilingual fields
                     get_language_from_request(request),
@@ -81,7 +81,7 @@ class OrganizationsViewSet(ViewSet):
 
         # Format a clean organization object as a response
         return Response(
-            ORGANIZATION_INDEXER.format_es_organization_for_api(
+            ORGANIZATION_INDEXER.format_es_object_for_api(
                 query_response,
                 # Get the best language we can return multilingual fields in
                 get_language_from_request(request),

--- a/src/richie/apps/search/viewsets/subjects.py
+++ b/src/richie/apps/search/viewsets/subjects.py
@@ -10,9 +10,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from ..exceptions import QueryFormatException
-
-# Get the subjects indexer from the settings
-SUBJECT_INDEXER = import_string(settings.ES_INDICES.subjects)
+from ..utils.viewsets import ViewSetMetadata
 
 
 class SubjectsViewSet(ViewSet):
@@ -21,6 +19,9 @@ class SubjectsViewSet(ViewSet):
     See API Blueprint for details on consumer use.
     """
 
+    # Get the subjects indexer from the settings
+    _meta = ViewSetMetadata(indexer=import_string(settings.ES_INDICES.subjects))
+
     # pylint: disable=no-self-use,unused-argument
     def list(self, request, version):
         """
@@ -28,14 +29,14 @@ class SubjectsViewSet(ViewSet):
         and returns a list of matching items
         """
         try:
-            limit, offset, query = SUBJECT_INDEXER.build_es_query(request)
+            limit, offset, query = self._meta.indexer.build_es_query(request)
         except QueryFormatException as exc:
             # Return a 400 with error information if the query params are not as expected
             return Response(status=400, data={"errors": exc.args[0]})
 
         query_response = settings.ES_CLIENT.search(
-            index=SUBJECT_INDEXER.index_name,
-            doc_type=SUBJECT_INDEXER.document_type,
+            index=self._meta.indexer.index_name,
+            doc_type=self._meta.indexer.document_type,
             body=query,
             # Directly pass meta-params through as arguments to the ES client
             from_=offset,
@@ -52,7 +53,7 @@ class SubjectsViewSet(ViewSet):
                 "total_count": query_response["hits"]["total"],
             },
             "objects": [
-                SUBJECT_INDEXER.format_es_object_for_api(
+                self._meta.indexer.format_es_object_for_api(
                     subject,
                     # Get the best language we can return multilingual fields in
                     get_language_from_request(request),
@@ -72,8 +73,8 @@ class SubjectsViewSet(ViewSet):
         # raise and end up in a 500 error otherwise
         try:
             query_response = settings.ES_CLIENT.get(
-                index=SUBJECT_INDEXER.index_name,
-                doc_type=SUBJECT_INDEXER.document_type,
+                index=self._meta.indexer.index_name,
+                doc_type=self._meta.indexer.document_type,
                 id=pk,
             )
         except NotFoundError:
@@ -81,7 +82,7 @@ class SubjectsViewSet(ViewSet):
 
         # Format a clean subject object as a response
         return Response(
-            SUBJECT_INDEXER.format_es_object_for_api(
+            self._meta.indexer.format_es_object_for_api(
                 query_response,
                 # Get the best language we can return multilingual fields in
                 get_language_from_request(request),

--- a/src/richie/apps/search/viewsets/subjects.py
+++ b/src/richie/apps/search/viewsets/subjects.py
@@ -52,7 +52,7 @@ class SubjectsViewSet(ViewSet):
                 "total_count": query_response["hits"]["total"],
             },
             "objects": [
-                SUBJECT_INDEXER.format_es_subject_for_api(
+                SUBJECT_INDEXER.format_es_object_for_api(
                     subject,
                     # Get the best language we can return multilingual fields in
                     get_language_from_request(request),
@@ -81,7 +81,7 @@ class SubjectsViewSet(ViewSet):
 
         # Format a clean subject object as a response
         return Response(
-            SUBJECT_INDEXER.format_es_subject_for_api(
+            SUBJECT_INDEXER.format_es_object_for_api(
                 query_response,
                 # Get the best language we can return multilingual fields in
                 get_language_from_request(request),

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -165,9 +165,9 @@ class CoursesIndexersTestCase(TestCase):
                 CoursesIndexer.get_data_for_es(index="some_index", action="some_action")
             )
 
-    def test_indexers_courses_format_es_course_for_api(self):
+    def test_indexers_courses_format_es_object_for_api(self):
         """
-        Make sure format_es_course_for_api returns a properly formatted course
+        Make sure format_es_object_for_api returns a properly formatted course
         """
         es_course = {
             "_id": 93,
@@ -189,7 +189,7 @@ class CoursesIndexersTestCase(TestCase):
             },
         }
         self.assertEqual(
-            CoursesIndexer.format_es_course_for_api(es_course, "en"),
+            CoursesIndexer.format_es_object_for_api(es_course, "en"),
             {
                 "end_date": "2018-02-28T06:00:00Z",
                 "enrollment_end_date": "2018-01-31T06:00:00Z",
@@ -895,7 +895,7 @@ class CoursesIndexersTestCase(TestCase):
         )
 
         settings.ES_CLIENT.put_script(
-            id="sort_courses_list", body=CoursesIndexer.scripts["sort_courses_list"]
+            id="sort_list", body=CoursesIndexer.scripts["sort_list"]
         )
 
         # Add our sample of courses to the test index we just created
@@ -1010,7 +1010,7 @@ class CoursesIndexersTestCase(TestCase):
                     doc_type="courses",
                     body={
                         "query": {"match_all": {}},
-                        "sort": CoursesIndexer.get_courses_list_sorting_script(),
+                        "sort": CoursesIndexer.get_list_sorting_script(),
                     },
                     from_=0,
                     size=10,

--- a/tests/apps/search/test_indexers_organizations.py
+++ b/tests/apps/search/test_indexers_organizations.py
@@ -120,9 +120,9 @@ class OrganizationsIndexersTestCase(TestCase):
                 )
             )
 
-    def test_indexers_organizations_format_es_organization_for_api(self):
+    def test_indexers_organizations_format_es_object_for_api(self):
         """
-        Make sure format_es_organization_for_api returns a properly formatted organization
+        Make sure format_es_object_for_api returns a properly formatted organization
         """
         es_organization = {
             "_id": 217,
@@ -134,7 +134,7 @@ class OrganizationsIndexersTestCase(TestCase):
             },
         }
         self.assertEqual(
-            OrganizationsIndexer.format_es_organization_for_api(es_organization, "en"),
+            OrganizationsIndexer.format_es_object_for_api(es_organization, "en"),
             {
                 "banner": "example.com/banner.png",
                 "code": "univ-paris-13",

--- a/tests/apps/search/test_indexers_subjects.py
+++ b/tests/apps/search/test_indexers_subjects.py
@@ -106,9 +106,9 @@ class SubjectsIndexersTestCase(TestCase):
                 )
             )
 
-    def test_indexers_subjects_format_es_subject_for_api(self):
+    def test_indexers_subjects_format_es_object_for_api(self):
         """
-        Make sure format_es_subject_for_api returns a properly formatted subject
+        Make sure format_es_object_for_api returns a properly formatted subject
         """
         es_subject = {
             "_id": 89,
@@ -118,7 +118,7 @@ class SubjectsIndexersTestCase(TestCase):
             },
         }
         self.assertEqual(
-            SubjectsIndexer.format_es_subject_for_api(es_subject, "en"),
+            SubjectsIndexer.format_es_object_for_api(es_subject, "en"),
             {"id": 89, "image": "example.com/image.png", "name": "Computer science"},
         )
 

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -20,7 +20,7 @@ from richie.apps.search.viewsets.courses import CoursesViewSet
 # and avoid the distraction of passing around full-featured records.
 @mock.patch.object(
     CoursesIndexer,
-    "format_es_course_for_api",
+    "format_es_object_for_api",
     side_effect=lambda es_course, _: "Course #{:n}".format(es_course["_id"]),
 )
 class CoursesViewsetsTestCase(TestCase):
@@ -73,7 +73,7 @@ class CoursesViewsetsTestCase(TestCase):
         lambda *args: (2, 77, {"some": "query"}, {"some": "aggs"}),
     )
     @mock.patch(
-        "richie.apps.search.indexers.courses.CoursesIndexer.get_courses_list_sorting_script",
+        "richie.apps.search.indexers.courses.CoursesIndexer.get_list_sorting_script",
         lambda *args: {"some": "sorting"},
     )
     @mock.patch.object(settings.ES_CLIENT, "search")


### PR DESCRIPTION
## Purpose

We generally want to promote code reuse throughout Richie. Here, we're trying to apply this idea to consumers of our indexers, and ViewSets in particular.

As we were working on adding new endpoints for autocompletion to our ViewSets, we realized the functionality would be the same for all of our resources.

However, we encountered two issues that prevented us from just using a Mixin to share this code:
- indexers had different names for ES to API object formatted method. 
- there was no way for our Mixins to access the indexers.

## Proposal

- [x] Rename the method to `format_es_object_for_api` on all indexers. In our opinion, the indexers ought to have the same shape. All other common attributes and methods already share the same name.
- [x] Take a hint from Django,  add a `_meta` prop to our ViewSets. This way Mixins get to access the relevant indexer through `self._meta`.