### PR TITLE
Open autocomplete endpoints

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -10,7 +10,7 @@ import raven
 from configurations import Configuration, values
 from elasticsearch import Elasticsearch
 
-from richie.apps.search.utils.es_indices import IndicesList
+from richie.apps.search.utils.indexers import IndicesList
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join("/", "data")

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -8,6 +8,7 @@ from ..forms import OrganizationListForm
 from ..partial_mappings import MULTILINGUAL_TEXT
 from ..utils.api_consumption import walk_api_json_list
 from ..utils.i18n import get_best_field_language
+from ..utils.indexers import slice_string_for_completion
 
 
 class OrganizationsIndexer:
@@ -24,6 +25,10 @@ class OrganizationsIndexer:
             "banner": {"type": "text", "index": False},
             "code": {"type": "keyword"},
             "logo": {"type": "text", "index": False},
+            **{
+                "complete.{:s}".format(lang): {"type": "completion"}
+                for lang, _ in settings.LANGUAGES
+            },
         },
     }
     scripts = {}
@@ -47,6 +52,12 @@ class OrganizationsIndexer:
                         "code": organization["code"],
                         "logo": organization["logo"],
                         "name": {"fr": organization["name"]},
+                        "complete": {
+                            "{:s}".format(lang): slice_string_for_completion(
+                                organization["name"]
+                            )
+                            for lang, _ in settings.LANGUAGES
+                        },
                     }
             except KeyError:
                 raise IndexerDataException(

--- a/src/richie/apps/search/utils/es_indices.py
+++ b/src/richie/apps/search/utils/es_indices.py
@@ -1,7 +1,0 @@
-"""
-Define a named tuple type that will enforce the necessary keys for our ES_INDICES setting
-(and also make iteration, both with and without keys, trivial)
-"""
-from collections import namedtuple
-
-IndicesList = namedtuple("IndicesList", ["courses", "organizations", "subjects"])

--- a/src/richie/apps/search/utils/indexers.py
+++ b/src/richie/apps/search/utils/indexers.py
@@ -1,0 +1,22 @@
+"""
+Common utilities related to our indexers. For use in our indexers and related settings,
+or as helpers for users of the project.
+"""
+from collections import namedtuple
+
+# Define a named tuple type that will enforce the necessary keys for our ES_INDICES setting
+# (and also make iteration, both with and without keys, trivial)
+IndicesList = namedtuple("IndicesList", ["courses", "organizations", "subjects"])
+
+
+def slice_string_for_completion(string):
+    """
+    Split a string in significant parts for use in completion.
+    Example: "University of Paris 13" => "University of Paris 13", "of Paris 13", "Paris 13", "13"
+
+    This is useful to enable autocompletion starting from any part of a name. If we just use the
+    name directly in the ES completion type, it will only return options that match on the first
+    characters of the whole string, which is not always suitable.
+    """
+    parts = [part for part in string.split(" ") if part != ""]
+    return [" ".join(parts[index:]) for index, _ in enumerate(parts)]

--- a/src/richie/apps/search/utils/viewsets.py
+++ b/src/richie/apps/search/utils/viewsets.py
@@ -1,6 +1,11 @@
 """
 Helpers to enable reuse for needs that are shared between viewsets.
 """
+from django.conf import settings
+from django.utils.translation import get_language_from_request
+
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 
 class ViewSetMetadata:
@@ -15,3 +20,50 @@ class ViewSetMetadata:
         the ViewSet's corresponding indexer.
         """
         self.indexer = indexer
+
+
+class AutocompleteMixin:
+    """
+    Add a `/{resource}/autocomplete` route on a ViewSet enabling clients to make autocompletion
+    requests using the specific fields & queries in ElasticSearch, as defined in the relevant
+    resource's indexer.
+    """
+
+    @action(detail=False)
+    def autocomplete(self, request, version):
+        """
+        Use the "completion" field on the organization mapping & objects to provide autocomplete
+        functionality through an API endpoint.
+        """
+        # This mixin is intended to be used on ViewSets. It requires a _meta attribute holding
+        # the relevant indexer
+        indexer = self._meta.indexer
+
+        # Query our specific ES completion field
+        autocomplete_query_response = settings.ES_CLIENT.search(
+            index=indexer.index_name,
+            doc_type=indexer.document_type,
+            body={
+                "suggest": {
+                    "organizations": {
+                        "prefix": request.query_params["query"],
+                        "completion": {
+                            "field": "complete.{:s}".format(
+                                get_language_from_request(request)
+                            )
+                        },
+                    }
+                }
+            },
+        )
+        # Build a response array from the list of completion options
+        return Response(
+            [
+                indexer.format_es_object_for_api(
+                    option, get_language_from_request(request)
+                )
+                for option in autocomplete_query_response["suggest"]["organizations"][
+                    0
+                ]["options"]
+            ]
+        )

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -13,10 +13,10 @@ from rest_framework.viewsets import ViewSet
 
 from ..defaults import FILTERS_HARDCODED, RESOURCE_FACETS
 from ..exceptions import QueryFormatException
-from ..utils.viewsets import ViewSetMetadata
+from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
 
 
-class CoursesViewSet(ViewSet):
+class CoursesViewSet(AutocompleteMixin, ViewSet):
     """
     A simple viewset with GET endpoints to fetch courses
     See API Blueprint for details on consumer use

--- a/src/richie/apps/search/viewsets/organizations.py
+++ b/src/richie/apps/search/viewsets/organizations.py
@@ -10,10 +10,10 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from ..exceptions import QueryFormatException
-from ..utils.viewsets import ViewSetMetadata
+from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
 
 
-class OrganizationsViewSet(ViewSet):
+class OrganizationsViewSet(AutocompleteMixin, ViewSet):
     """
     A simple viewset with GET endpoints to fetch organizations
     See API Blueprint for details on consumer use.

--- a/src/richie/apps/search/viewsets/subjects.py
+++ b/src/richie/apps/search/viewsets/subjects.py
@@ -10,10 +10,10 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from ..exceptions import QueryFormatException
-from ..utils.viewsets import ViewSetMetadata
+from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
 
 
-class SubjectsViewSet(ViewSet):
+class SubjectsViewSet(AutocompleteMixin, ViewSet):
     """
     A simple viewset with GET endpoints to fetch subjects
     See API Blueprint for details on consumer use.

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -18,7 +18,7 @@ from richie.apps.search.index_manager import (
     regenerate_indexes,
     store_es_scripts,
 )
-from richie.apps.search.utils.es_indices import IndicesList
+from richie.apps.search.utils.indexers import IndicesList
 
 
 class IndexManagerTestCase(TestCase):

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -95,6 +95,22 @@ class CoursesIndexersTestCase(TestCase):
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "course",
+                    "complete": {
+                        "en": [
+                            "A course in filler text",
+                            "course in filler text",
+                            "in filler text",
+                            "filler text",
+                            "text",
+                        ],
+                        "fr": [
+                            "A course in filler text",
+                            "course in filler text",
+                            "in filler text",
+                            "filler text",
+                            "text",
+                        ],
+                    },
                     "end_date": "2018-02-28T06:00:00Z",
                     "enrollment_end_date": "2018-01-31T06:00:00Z",
                     "enrollment_start_date": "2018-01-01T06:00:00Z",
@@ -113,6 +129,10 @@ class CoursesIndexersTestCase(TestCase):
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "course",
+                    "complete": {
+                        "en": ["Filler text 102", "text 102", "102"],
+                        "fr": ["Filler text 102", "text 102", "102"],
+                    },
                     "end_date": "2019-02-28T06:00:00Z",
                     "enrollment_end_date": "2019-01-31T06:00:00Z",
                     "enrollment_start_date": "2019-01-01T06:00:00Z",

--- a/tests/apps/search/test_indexers_organizations.py
+++ b/tests/apps/search/test_indexers_organizations.py
@@ -74,6 +74,10 @@ class OrganizationsIndexersTestCase(TestCase):
                     "_type": "organization",
                     "banner": "example.com/banner_1.png",
                     "code": "org-1",
+                    "complete": {
+                        "en": ["Organization N°1", "N°1"],
+                        "fr": ["Organization N°1", "N°1"],
+                    },
                     "logo": "example.com/logo_1.png",
                     "name": {"fr": "Organization N°1"},
                 },
@@ -84,6 +88,10 @@ class OrganizationsIndexersTestCase(TestCase):
                     "_type": "organization",
                     "banner": "example.com/banner_80.png",
                     "code": "org-80",
+                    "complete": {
+                        "en": ["Organization N°80", "N°80"],
+                        "fr": ["Organization N°80", "N°80"],
+                    },
                     "logo": "example.com/logo_80.png",
                     "name": {"fr": "Organization N°80"},
                 },

--- a/tests/apps/search/test_indexers_subjects.py
+++ b/tests/apps/search/test_indexers_subjects.py
@@ -64,6 +64,10 @@ class SubjectsIndexersTestCase(TestCase):
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "subject",
+                    "complete": {
+                        "en": ["Computer Science", "Science"],
+                        "fr": ["Computer Science", "Science"],
+                    },
                     "image": "example_cs.png",
                     "name": {"fr": "Computer Science"},
                 },
@@ -72,6 +76,10 @@ class SubjectsIndexersTestCase(TestCase):
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "subject",
+                    "complete": {
+                        "en": ["Software Engineering", "Engineering"],
+                        "fr": ["Software Engineering", "Engineering"],
+                    },
                     "image": "example_se.png",
                     "name": {"fr": "Software Engineering"},
                 },

--- a/tests/apps/search/test_utils_indexers.py
+++ b/tests/apps/search/test_utils_indexers.py
@@ -1,0 +1,38 @@
+"""
+Tests for the indexer helpers.
+"""
+from django.test import TestCase
+
+from richie.apps.search.utils.indexers import slice_string_for_completion
+
+
+class UtilsIndexersTestCase(TestCase):
+    """
+    Test any functions we're exposing for use in our indexers.
+    """
+
+    def test_slice_string_for_completion(self):
+        """
+        The slice_string_for_completion function slices a string into an array of strings suitable
+        for use in a completion field.
+
+        This means including all strings contained in the original string, that begin after a
+        space and end at the end of the original string.
+        """
+        self.assertEqual(slice_string_for_completion(""), [])
+        self.assertEqual(slice_string_for_completion("Physics"), ["Physics"])
+        self.assertEqual(
+            slice_string_for_completion("Communication dans les organisations"),
+            [
+                "Communication dans les organisations",
+                "dans les organisations",
+                "les organisations",
+                "organisations",
+            ],
+        )
+        # Trailing spaces are discarded and strings trimmed as those spaces are not useful &
+        # ES rejects empty strings from completion mappings
+        self.assertEqual(
+            slice_string_for_completion("Université Paris 18 "),
+            ["Université Paris 18", "Paris 18", "18"],
+        )

--- a/tests/apps/search/test_utils_viewsets.py
+++ b/tests/apps/search/test_utils_viewsets.py
@@ -1,0 +1,94 @@
+"""
+Tests for the viewset helpers.
+"""
+from types import SimpleNamespace
+from unittest import mock
+
+from django.conf import settings
+from django.http.request import QueryDict
+from django.test import TestCase
+
+from richie.apps.search.utils.viewsets import AutocompleteMixin, ViewSetMetadata
+
+
+class Indexer:
+    """Stub indexer to set on our `ExampleViewSet`."""
+
+    index_name = "some_index"
+    document_type = "some_type"
+
+    @staticmethod
+    def format_es_object_for_api(obj, _):
+        """Just return the object as-is with a formatted flag."""
+        return {**obj, "formatted": True}
+
+
+class UtilsViewSetsTestCase(TestCase):
+    """
+    Test any functions we're exposing for use in our viewsets.
+    """
+
+    @mock.patch(
+        "richie.apps.search.utils.viewsets.get_language_from_request", lambda _: "en"
+    )
+    @mock.patch.object(settings.ES_CLIENT, "search")
+    def test_autocomplete_mixin(self, mock_search, *_):
+        """
+        The autocomplete mixin adds an `autocomplete` method that makes a completion call to
+        elasticsearch and returns a list of formatted results.
+        """
+        mock_search.return_value = {
+            "suggest": {"organizations": [{"options": [{"id": 0}, {"id": 1}]}]}
+        }
+
+        class ExampleViewSet(AutocompleteMixin):
+            """Instantiate a stub `ViewSet` to test the mixin."""
+
+            _meta = ViewSetMetadata(Indexer)
+
+        request = SimpleNamespace(
+            query_params=QueryDict(query_string="query=some%20query")
+        )
+        response = ExampleViewSet().autocomplete(request, "1.0")
+
+        # Make sure the ES client was called with the proper params
+        mock_search.assert_called_with(
+            body={
+                "suggest": {
+                    "organizations": {
+                        "prefix": "some query",
+                        "completion": {"field": "complete.en"},
+                    }
+                }
+            },
+            doc_type="some_type",
+            index="some_index",
+        )
+        # The helper returns the list of results, as formatted by the indexer
+        self.assertEqual(
+            response.data, [{"id": 0, "formatted": True}, {"id": 1, "formatted": True}]
+        )
+
+    @mock.patch(
+        "richie.apps.search.utils.viewsets.get_language_from_request", lambda _: "en"
+    )
+    @mock.patch.object(settings.ES_CLIENT, "search")
+    def test_autocomplete_mixin_without_results(self, mock_search, *_):
+        """
+        The autocomplete mixin returns an empty answer when there is nothing to suggest.
+        """
+        mock_search.return_value = {"suggest": {"organizations": [{"options": []}]}}
+
+        class ExampleViewSet(AutocompleteMixin):
+            """Instantiate a stub `ViewSet` to test the mixin."""
+
+            _meta = ViewSetMetadata(Indexer)
+
+        # We're making the same call as in the test above
+        request = SimpleNamespace(
+            query_params=QueryDict(query_string="query=some%20query")
+        )
+        response = ExampleViewSet().autocomplete(request, "1.0")
+
+        # The helper returns an empty list as there are not results
+        self.assertEqual(response.data, [])


### PR DESCRIPTION
## Purpose

We're providing autocompletion functionality on the frontend. If we use the full-text search with standard/language analyzers, this gets us weird results.

We can get better results using ElasticSearch's builtin completion type. 

## Proposal

Use a separate endpoint to handle those requests separately from our general search endpoints.

Notes:
- to get the most predictable results, we had to enrich the data we  index in the completion fields;
- we used a Mixin to add the new autocomplete endpoints as it's basically the same code for all resources.