### PR TITLE
♻️(front) use an Enum for model names

### DIFF
--- a/src/richie-front/js/components/CourseGlimpseListContainer/CourseGlimpseListContainer.spec.tsx
+++ b/src/richie-front/js/components/CourseGlimpseListContainer/CourseGlimpseListContainer.spec.tsx
@@ -1,4 +1,5 @@
 import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
+import { modelName } from '../../types/models';
 import { mapStateToProps, mergeProps } from './CourseGlimpseListContainer';
 
 describe('components/CourseGlimpseListContainer', () => {
@@ -81,7 +82,7 @@ describe('components/CourseGlimpseListContainer', () => {
 
       expect(dispatch).toHaveBeenCalledWith({
         params: { limit: 999, offset: 0, subjects: 42 },
-        resourceName: 'courses',
+        resourceName: modelName.COURSES,
         type: 'RESOURCE_LIST_GET',
       });
     });

--- a/src/richie-front/js/components/CourseGlimpseListContainer/CourseGlimpseListContainer.tsx
+++ b/src/richie-front/js/components/CourseGlimpseListContainer/CourseGlimpseListContainer.tsx
@@ -5,6 +5,7 @@ import { ResourceListStateParams } from '../../data/genericReducers/resourceList
 import { getResourceList } from '../../data/genericSideEffects/getResourceList/actions';
 import { RootState } from '../../data/rootReducer';
 import { Course } from '../../types/Course';
+import { modelName } from '../../types/models';
 import { Maybe } from '../../utils/types';
 import { CourseGlimpseList } from '../CourseGlimpseList/CourseGlimpseList';
 
@@ -55,7 +56,7 @@ export const mergeProps = (
   courses,
   requestCourses: () =>
     dispatch(
-      getResourceList('courses', {
+      getResourceList(modelName.COURSES, {
         ...(currentParams || {}),
         limit: 999,
       }),

--- a/src/richie-front/js/components/SearchContainer/SearchContainer.tsx
+++ b/src/richie-front/js/components/SearchContainer/SearchContainer.tsx
@@ -2,13 +2,14 @@ import partial from 'lodash-es/partial';
 import { connect } from 'react-redux';
 
 import { getResourceList } from '../../data/genericSideEffects/getResourceList/actions';
+import { modelName } from '../../types/models';
 import { Search } from '../Search/Search';
 
 const mapDispatchToProps = {
-  requestOrganizations: partial(getResourceList, 'organizations', {
+  requestOrganizations: partial(getResourceList, modelName.ORGANIZATIONS, {
     limit: 999,
   }),
-  requestSubjects: partial(getResourceList, 'subjects', { limit: 999 }),
+  requestSubjects: partial(getResourceList, modelName.SUBJECTS, { limit: 999 }),
 };
 
 export const SearchContainer = connect(

--- a/src/richie-front/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
+++ b/src/richie-front/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import * as React from 'react';
 
 import { FilterDefinitionWithValues } from '../../types/filters';
+import { modelName } from '../../types/models';
 import { SearchFilter } from '../SearchFilter/SearchFilter';
 import { SearchFilterGroup } from './SearchFilterGroup';
 
@@ -14,7 +15,7 @@ describe('components/SearchFilterGroup', () => {
   it('renders the name of the filter', () => {
     const filter = {
       humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-      machineName: 'organizations',
+      machineName: modelName.ORGANIZATIONS,
       values: [],
     } as FilterDefinitionWithValues;
     const element = (

--- a/src/richie-front/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.spec.tsx
+++ b/src/richie-front/js/components/SearchFilterGroupContainer/SearchFilterGroupContainer.spec.tsx
@@ -2,6 +2,7 @@ import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
 import { ResourceListState } from '../../data/genericReducers/resourceList/resourceList';
 import { RootState } from '../../data/rootReducer';
 import { Course } from '../../types/Course';
+import { modelName } from '../../types/models';
 import { getFilterFromState } from '../../utils/filters/getFilterFromState';
 import { updateFilter } from '../../utils/filters/updateFilter';
 import { mapStateToProps, mergeProps } from './SearchFilterGroupContainer';
@@ -17,7 +18,7 @@ jest.mock('../../utils/filters/updateFilter');
 describe('components/SearchFilterGroupContainer/mergeProps', () => {
   const exampleFilter = {
     humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-    machineName: 'organizations' as 'organizations',
+    machineName: modelName.ORGANIZATIONS,
     values: [
       {
         count: 3,
@@ -39,7 +40,9 @@ describe('components/SearchFilterGroupContainer/mergeProps', () => {
 
   it('returns the relevant filter, its current value & partially applied update helpers', () => {
     const dispatch: any = () => undefined;
-    const props = { machineName: 'organizations' as 'organizations' };
+    const props = {
+      machineName: modelName.ORGANIZATIONS as modelName.ORGANIZATIONS,
+    };
     const state = {
       filterDefinitions: {} as FilterDefinitionState,
       resources: {

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { Course } from '../../types/Course';
+import { modelName } from '../../types/models';
 import {
   DefaultSuggestionSection,
   ResourceSuggestionSection,
@@ -77,7 +78,7 @@ describe('components/SearchSuggestField', () => {
     beforeEach(mockSuggestionHumanName.mockClear);
 
     it('returns the human name for a resource-based suggestion', () => {
-      const suggestion = { data: '3', model: 'organizations' } as any;
+      const suggestion = { data: '3', model: modelName.ORGANIZATIONS } as any;
       mockSuggestionHumanName.mockReturnValue('Some Human Name');
       expect(getSuggestionValue(suggestion)).toEqual('Some Human Name');
       expect(mockSuggestionHumanName).toHaveBeenCalledWith(suggestion);
@@ -96,7 +97,7 @@ describe('components/SearchSuggestField', () => {
       expect(
         renderSuggestion({
           data: { title: 'Some course title' } as Course,
-          model: 'courses',
+          model: modelName.COURSES,
         }),
       ).toEqual(<span>Some course title</span>);
     });
@@ -112,7 +113,7 @@ describe('components/SearchSuggestField', () => {
               defaultMessage: 'Some section title',
               id: 'someMessage',
             },
-            model: 'organizations',
+            model: modelName.ORGANIZATIONS,
           } as ResourceSuggestionSection,
         ),
       ).toEqual(<span>Some section title</span>);
@@ -162,21 +163,25 @@ describe('components/SearchSuggestField', () => {
       mockGetSuggestionsSection.mockImplementation(
         async (model: ResourceSuggestionSection['model']) => {
           switch (model) {
-            case 'courses':
+            case modelName.COURSES:
               return {
                 message: 'Courses',
-                model: 'courses',
+                model: modelName.COURSES,
                 values: [
                   { title: 'Course #1' } as Course,
                   { title: 'Course #2' } as Course,
                 ],
               };
-            case 'subjects':
-              return { message: 'Subjects', model: 'subjects', values: [] };
-            case 'organizations':
+            case modelName.SUBJECTS:
+              return {
+                message: 'Subjects',
+                model: modelName.SUBJECTS,
+                values: [],
+              };
+            case modelName.ORGANIZATIONS:
               return {
                 message: 'Organizations',
-                model: 'organizations',
+                model: modelName.ORGANIZATIONS,
                 values: [],
               };
           }
@@ -196,7 +201,7 @@ describe('components/SearchSuggestField', () => {
           },
           {
             message: 'Courses',
-            model: 'courses',
+            model: modelName.COURSES,
             values: [{ title: 'Course #1' }, { title: 'Course #2' }],
           },
         ],
@@ -228,7 +233,9 @@ describe('components/SearchSuggestField', () => {
     it('moves to the courses page when it is called with a course', () => {
       onSuggestionSelected.bind(that)(
         {},
-        { suggestion: { model: 'courses', data: { id: 42 } as Course } },
+        {
+          suggestion: { model: modelName.COURSES, data: { id: 42 } as Course },
+        },
       );
       expect(location.setHref).toHaveBeenCalledWith('https://42');
     });
@@ -236,16 +243,16 @@ describe('components/SearchSuggestField', () => {
     it('updates the filter and resets the suggestion state when it is called with a resource suggestion', () => {
       onSuggestionSelected.bind(that)(
         {},
-        { suggestion: { model: 'subjects', data: { id: 43 } } },
+        { suggestion: { model: modelName.SUBJECTS, data: { id: 43 } } },
       );
-      expect(addFilter).toHaveBeenCalledWith('subjects', '43');
+      expect(addFilter).toHaveBeenCalledWith(modelName.SUBJECTS, '43');
       expect(location.setHref).not.toHaveBeenCalled();
 
       onSuggestionSelected.bind(that)(
         {},
-        { suggestion: { model: 'organizations', data: { id: 44 } } },
+        { suggestion: { model: modelName.ORGANIZATIONS, data: { id: 44 } } },
       );
-      expect(addFilter).toHaveBeenCalledWith('organizations', '44');
+      expect(addFilter).toHaveBeenCalledWith(modelName.ORGANIZATIONS, '44');
       expect(location.setHref).not.toHaveBeenCalled();
     });
 

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-intl';
 
 import { filterGroupName } from '../../types/filters';
+import { modelName } from '../../types/models';
 import {
   ResourceSuggestionSection,
   SearchSuggestion,
@@ -121,9 +122,9 @@ export async function onSuggestionsFetchRequested(
   const sectionParams: Array<
     [ResourceSuggestionSection['model'], FormattedMessage.MessageDescriptor]
   > = [
-    ['courses', commonMessages.coursesHumanName],
-    ['organizations', commonMessages.organizationsHumanName],
-    ['subjects', commonMessages.subjectsHumanName],
+    [modelName.COURSES, commonMessages.coursesHumanName],
+    [modelName.ORGANIZATIONS, commonMessages.organizationsHumanName],
+    [modelName.SUBJECTS, commonMessages.subjectsHumanName],
   ];
 
   // Fetch the suggestions for each resource-based section to build out the sections
@@ -169,13 +170,13 @@ export function onSuggestionSelected(
   { suggestion }: { suggestion: SearchSuggestion },
 ) {
   switch (suggestion.model) {
-    case 'courses':
+    case modelName.COURSES:
       // TODO: pick a real URL on the course object when it is available on the API
       const url = 'https://' + suggestion.data.id;
       return location.setHref(url);
 
-    case 'organizations':
-    case 'subjects':
+    case modelName.ORGANIZATIONS:
+    case modelName.SUBJECTS:
       // Update the search with the newly selected filter
       this.props.addFilter(suggestion.model, String(suggestion.data.id));
       // Reset the search field state: the task has been completed

--- a/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
@@ -1,4 +1,5 @@
 import { FilterDefinitionState } from '../../data/filterDefinitions/reducer';
+import { modelName } from '../../types/models';
 import { updateFilter } from '../../utils/filters/updateFilter';
 import { mapStateToProps, mergeProps } from './SearchSuggestFieldContainer';
 
@@ -11,7 +12,7 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
     filterDefinitions: {
       organizations: {
         humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-        machineName: 'organizations',
+        machineName: modelName.ORGANIZATIONS,
       },
     } as FilterDefinitionState,
     resources: {
@@ -31,7 +32,7 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
 
   it('builds props with an addFilter function that calls updateFilter', () => {
     const { addFilter } = mergeProps(mapStateToProps(state), { dispatch });
-    addFilter('organizations', '84');
+    addFilter(modelName.ORGANIZATIONS, '84');
 
     expect(mockUpdateFilter).toHaveBeenCalledWith(
       dispatch,
@@ -39,7 +40,7 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
       'add',
       {
         humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-        machineName: 'organizations',
+        machineName: modelName.ORGANIZATIONS,
       },
       '84',
     );
@@ -51,7 +52,7 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
 
     expect(dispatch).toHaveBeenCalledWith({
       params: { limit: 20, offset: 0, query: 'some query' },
-      resourceName: 'courses',
+      resourceName: modelName.COURSES,
       type: 'RESOURCE_LIST_GET',
     });
   });

--- a/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.tsx
+++ b/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.tsx
@@ -6,6 +6,7 @@ import { getResourceList } from '../../data/genericSideEffects/getResourceList/a
 import { RootState } from '../../data/rootReducer';
 import { API_LIST_DEFAULT_PARAMS } from '../../settings';
 import { filterGroupName } from '../../types/filters';
+import { modelName } from '../../types/models';
 import { updateFilter } from '../../utils/filters/updateFilter';
 import { SearchSuggestField } from '../SearchSuggestField/SearchSuggestField';
 
@@ -30,18 +31,18 @@ export const mergeProps = (
 ) => {
   return {
     // Add a single filter from a suggestion to the current search.
-    addFilter: (modelName: filterGroupName, filterValue: string) => {
+    addFilter: (filterName: filterGroupName, filterValue: string) => {
       updateFilter(
         dispatch,
         currentParams,
         'add',
-        filterDefinitions[modelName],
+        filterDefinitions[filterName],
         filterValue,
       );
     },
     // Update the full text search with the current value of the search field (default suggestion).
     fullTextSearch: (query: string) => {
-      dispatch(getResourceList('courses', { ...currentParams, query }));
+      dispatch(getResourceList(modelName.COURSES, { ...currentParams, query }));
     },
   };
 };

--- a/src/richie-front/js/data/courses/reducer.spec.ts
+++ b/src/richie-front/js/data/courses/reducer.spec.ts
@@ -1,3 +1,4 @@
+import { modelName } from '../../types/models';
 import { courses } from './reducer';
 
 describe('data/courses reducer', () => {
@@ -62,7 +63,7 @@ describe('data/courses reducer', () => {
       expect(
         courses(previousState, {
           resource: course44,
-          resourceName: 'subjects',
+          resourceName: modelName.SUBJECTS,
           type: 'RESOURCE_ADD',
         }),
       ).toEqual(previousState);
@@ -74,7 +75,7 @@ describe('data/courses reducer', () => {
       expect(
         courses(previousState, {
           resource: course44,
-          resourceName: 'courses',
+          resourceName: modelName.COURSES,
           type: 'RESOURCE_ADD',
         }),
       ).toEqual({ byId: { 43: course43, 44: course44 } });

--- a/src/richie-front/js/data/courses/reducer.ts
+++ b/src/richie-front/js/data/courses/reducer.ts
@@ -4,6 +4,7 @@ import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
 import { Course } from '../../types/Course';
+import { modelName } from '../../types/models';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
 import {
@@ -34,7 +35,7 @@ export const courses: Reducer<CoursesState> = (
   // Discriminate resource related actions by resource name
   if (
     get(action, 'resourceName') &&
-    get(action, 'resourceName') !== 'courses'
+    get(action, 'resourceName') !== modelName.COURSES
   ) {
     return state;
   }

--- a/src/richie-front/js/data/genericReducers/resourceById/resourceById.spec.ts
+++ b/src/richie-front/js/data/genericReducers/resourceById/resourceById.spec.ts
@@ -1,3 +1,4 @@
+import { modelName } from '../../../types/models';
 import { byId } from './resourceById';
 
 describe('data/genericReducers/resourceById reducer', () => {
@@ -40,7 +41,7 @@ describe('data/genericReducers/resourceById reducer', () => {
       expect(
         byId(previousState, {
           resource: subj44,
-          resourceName: 'subjects',
+          resourceName: modelName.SUBJECTS,
           type: 'RESOURCE_ADD',
         }),
       ).toEqual({ byId: { 43: subj43, 44: subj44 } });
@@ -54,7 +55,7 @@ describe('data/genericReducers/resourceById reducer', () => {
       };
       expect(
         byId(previousState, {
-          resourceName: 'subjects',
+          resourceName: modelName.SUBJECTS,
           resources: [subj44, subj45],
           type: 'RESOURCE_MULTIPLE_ADD',
         }),

--- a/src/richie-front/js/data/genericReducers/resourceList/resourceList.spec.ts
+++ b/src/richie-front/js/data/genericReducers/resourceList/resourceList.spec.ts
@@ -1,3 +1,4 @@
+import { modelName } from '../../../types/models';
 import { currentQuery } from './resourceList';
 
 describe('data/genericReducers/resourceList reducer', () => {
@@ -52,7 +53,7 @@ describe('data/genericReducers/resourceList reducer', () => {
             objects: [course43, course44],
           },
           params: { limit: 12, offset: 2 },
-          resourceName: 'courses',
+          resourceName: modelName.COURSES,
           type: 'RESOURCE_LIST_GET_SUCCESS',
         }),
       )
@@ -84,7 +85,7 @@ describe('data/genericReducers/resourceList reducer', () => {
             objects: [course44, course43],
           },
           params: { limit: 2, match: 'some query', offset: 0 },
-          resourceName: 'courses',
+          resourceName: modelName.COURSES,
           type: 'RESOURCE_LIST_GET_SUCCESS',
         }),
       ).toEqual({

--- a/src/richie-front/js/data/genericSideEffects/getResourceList/getResourceList.spec.ts
+++ b/src/richie-front/js/data/genericSideEffects/getResourceList/getResourceList.spec.ts
@@ -1,5 +1,6 @@
 import { call, put } from 'redux-saga/effects';
 
+import { modelName } from '../../../types/models';
 import { addMultipleResources } from '../../genericReducers/resourceById/actions';
 import { didGetResourceList, failedToGetResourceList } from './actions';
 import { fetchList, getList } from './getResourceList';
@@ -70,7 +71,7 @@ describe('data/genericSideEffects/getResourceList saga', () => {
         }),
       );
 
-      fetchList('courses', { limit: 2, offset: 43 }).then(response => {
+      fetchList(modelName.COURSES, { limit: 2, offset: 43 }).then(response => {
         // The correct request given parameters is performed
         expect(mockFetch).toHaveBeenCalledWith(
           '/api/v1.0/courses/?limit=2&offset=43',
@@ -91,7 +92,7 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       );
 
       // Don't check params again as it was done in the first test
-      fetchList('courses', { limit: 2, offset: 43 }).then(response => {
+      fetchList(modelName.COURSES, { limit: 2, offset: 43 }).then(response => {
         // Our polymorphic response object is properly shaped - with an error this time
         expect(response.objects).not.toBeDefined();
         expect(response.error).toEqual(jasmine.any(Error));
@@ -103,7 +104,7 @@ describe('data/genericSideEffects/getResourceList saga', () => {
       mockFetch.and.returnValue(Promise.resolve({ ok: false, status: 404 }));
 
       // Don't check params again as it was done in the first test
-      fetchList('courses', { limit: 2, offset: 43 }).then(response => {
+      fetchList(modelName.COURSES, { limit: 2, offset: 43 }).then(response => {
         // Our polymorphic response object is properly shaped - with an error this time
         expect(response.objects).not.toBeDefined();
         expect(response.error).toEqual(jasmine.any(Error));
@@ -115,7 +116,7 @@ describe('data/genericSideEffects/getResourceList saga', () => {
   describe('getList', () => {
     const action = {
       params: { limit: 10, name: 'python', offset: 0 },
-      resourceName: 'courses' as 'courses',
+      resourceName: modelName.COURSES,
       type: 'RESOURCE_LIST_GET' as 'RESOURCE_LIST_GET',
     };
 
@@ -130,15 +131,15 @@ describe('data/genericSideEffects/getResourceList saga', () => {
 
       // The call to fetch (the actual side-effect) is triggered
       expect(gen.next().value).toEqual(
-        call(fetchList, 'courses', action.params),
+        call(fetchList, modelName.COURSES, action.params),
       );
       // Both courses are added to the state
       expect(gen.next(response).value).toEqual(
-        put(addMultipleResources('courses', response.objects)),
+        put(addMultipleResources(modelName.COURSES, response.objects)),
       );
       // The success action is dispatched
       expect(gen.next().value).toEqual(
-        put(didGetResourceList('courses', response, action.params)),
+        put(didGetResourceList(modelName.COURSES, response, action.params)),
       );
     });
 
@@ -151,11 +152,11 @@ describe('data/genericSideEffects/getResourceList saga', () => {
 
       // The call to fetch is triggered, but fails for some reason
       expect(gen.next().value).toEqual(
-        call(fetchList, 'courses', action.params),
+        call(fetchList, modelName.COURSES, action.params),
       );
       // The failure action is dispatched
       expect(gen.next(response).value).toEqual(
-        put(failedToGetResourceList('courses', response.error)),
+        put(failedToGetResourceList(modelName.COURSES, response.error)),
       );
     });
   });

--- a/src/richie-front/js/data/organizations/reducer.spec.ts
+++ b/src/richie-front/js/data/organizations/reducer.spec.ts
@@ -1,3 +1,4 @@
+import { modelName } from '../../types/models';
 import { organizations } from './reducer';
 
 describe('data/organizations reducer', () => {
@@ -26,7 +27,7 @@ describe('data/organizations reducer', () => {
       expect(
         organizations(previousState, {
           resource: org44,
-          resourceName: 'subjects',
+          resourceName: modelName.SUBJECTS,
           type: 'RESOURCE_ADD',
         }),
       ).toEqual(previousState);
@@ -38,7 +39,7 @@ describe('data/organizations reducer', () => {
       expect(
         organizations(previousState, {
           resource: org44,
-          resourceName: 'organizations',
+          resourceName: modelName.ORGANIZATIONS,
           type: 'RESOURCE_ADD',
         }),
       ).toEqual({ byId: { 43: org43, 44: org44 } });

--- a/src/richie-front/js/data/organizations/reducer.ts
+++ b/src/richie-front/js/data/organizations/reducer.ts
@@ -3,6 +3,7 @@ import get from 'lodash-es/get';
 import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
+import { modelName } from '../../types/models';
 import { Organization } from '../../types/Organization';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
@@ -37,7 +38,7 @@ export const organizations: Reducer<OrganizationsState> = (
   // Discriminate resource related actions by resource name
   if (
     get(action, 'resourceName') &&
-    get(action, 'resourceName') !== 'organizations'
+    get(action, 'resourceName') !== modelName.ORGANIZATIONS
   ) {
     return state;
   }

--- a/src/richie-front/js/data/subjects/reducer.spec.ts
+++ b/src/richie-front/js/data/subjects/reducer.spec.ts
@@ -1,3 +1,4 @@
+import { modelName } from '../../types/models';
 import { subjects } from './reducer';
 
 describe('data/subjects reducer', () => {
@@ -20,7 +21,7 @@ describe('data/subjects reducer', () => {
       expect(
         subjects(previousState, {
           resource: subj44,
-          resourceName: 'organizations',
+          resourceName: modelName.ORGANIZATIONS,
           type: 'RESOURCE_ADD',
         }),
       ).toEqual(previousState);
@@ -32,7 +33,7 @@ describe('data/subjects reducer', () => {
       expect(
         subjects(previousState, {
           resource: subj44,
-          resourceName: 'subjects',
+          resourceName: modelName.SUBJECTS,
           type: 'RESOURCE_ADD',
         }),
       ).toEqual({ byId: { 43: subj43, 44: subj44 } });

--- a/src/richie-front/js/data/subjects/reducer.ts
+++ b/src/richie-front/js/data/subjects/reducer.ts
@@ -3,6 +3,7 @@ import get from 'lodash-es/get';
 import partialRight from 'lodash-es/partialRight';
 import { Reducer } from 'redux';
 
+import { modelName } from '../../types/models';
 import { Subject } from '../../types/Subject';
 import { Maybe } from '../../utils/types';
 import { ResourceAdd } from '../genericReducers/resourceById/actions';
@@ -37,7 +38,7 @@ export const subjects: Reducer<SubjectsState> = (
   // Discriminate resource related actions by resource name
   if (
     get(action, 'resourceName') &&
-    get(action, 'resourceName') !== 'subjects'
+    get(action, 'resourceName') !== modelName.SUBJECTS
   ) {
     return state;
   }

--- a/src/richie-front/js/integration_tests/filters.spec.tsx
+++ b/src/richie-front/js/integration_tests/filters.spec.tsx
@@ -13,6 +13,7 @@ import { SearchFiltersPane } from '../components/SearchFiltersPane/SearchFilters
 import { addMultipleResources } from '../data/genericReducers/resourceById/actions';
 import { didGetResourceList } from '../data/genericSideEffects/getResourceList/actions';
 import { RootState } from '../data/rootReducer';
+import { modelName } from '../types/models';
 
 describe('Integration tests - filters', () => {
   let store: Store<RootState>;
@@ -49,10 +50,10 @@ describe('Integration tests - filters', () => {
         name: 'Organization Five',
       },
     ];
-    store.dispatch(addMultipleResources('organizations', orgs));
+    store.dispatch(addMultipleResources(modelName.ORGANIZATIONS, orgs));
     store.dispatch(
       didGetResourceList(
-        'organizations',
+        modelName.ORGANIZATIONS,
         {
           meta: { limit: 3, offset: 0, total_count: 3 },
           objects: orgs,
@@ -65,10 +66,10 @@ describe('Integration tests - filters', () => {
       { id: 41, image: null, name: 'Subject Forty-One' },
       { id: 51, image: null, name: 'Subject Fifty-One' },
     ];
-    store.dispatch(addMultipleResources('subjects', subjects));
+    store.dispatch(addMultipleResources(modelName.SUBJECTS, subjects));
     store.dispatch(
       didGetResourceList(
-        'subjects',
+        modelName.SUBJECTS,
         {
           meta: { limit: 3, offset: 0, total_count: 3 },
           objects: subjects,
@@ -78,7 +79,7 @@ describe('Integration tests - filters', () => {
     );
     store.dispatch(
       didGetResourceList(
-        'courses',
+        modelName.COURSES,
         {
           facets: {
             organizations: { 3: 12, 4: 87, 5: 56 },
@@ -114,7 +115,9 @@ describe('Integration tests - filters', () => {
   it('shows the values for the resource-based filters in their groups, ordered by facet count', () => {
     const filtersOrganizations = makeSearchFilterPane()
       .find(SearchFilterGroupContainer)
-      .filterWhere(wrapper => wrapper.prop('machineName') === 'organizations')
+      .filterWhere(
+        wrapper => wrapper.prop('machineName') === modelName.ORGANIZATIONS,
+      )
       .find(SearchFilter);
     expect(filtersOrganizations.at(0).html()).toContain('Organization Four');
     expect(filtersOrganizations.at(0).html()).toContain('87');
@@ -149,7 +152,9 @@ describe('Integration tests - filters', () => {
     // Our newly active filter should be at the top
     const topOrgsFilter = makeSearchFilterPane()
       .find(SearchFilterGroupContainer)
-      .filterWhere(wrapper => wrapper.prop('machineName') === 'organizations')
+      .filterWhere(
+        wrapper => wrapper.prop('machineName') === modelName.ORGANIZATIONS,
+      )
       .find(SearchFilter)
       .first();
 
@@ -180,7 +185,7 @@ describe('Integration tests - filters', () => {
     // Set the subjects filter to '41'
     store.dispatch(
       didGetResourceList(
-        'courses',
+        modelName.COURSES,
         {
           facets: {
             organizations: { 3: 12, 4: 87, 5: 56 },
@@ -216,7 +221,9 @@ describe('Integration tests - filters', () => {
     expect(
       makeSearchFilterPane()
         .find(SearchFilterGroupContainer)
-        .filterWhere(wrapper => wrapper.prop('machineName') === 'subjects')
+        .filterWhere(
+          wrapper => wrapper.prop('machineName') === modelName.SUBJECTS,
+        )
         .find(SearchFilter)
         .first()
         .html(),

--- a/src/richie-front/js/settings.ts
+++ b/src/richie-front/js/settings.ts
@@ -7,12 +7,13 @@ import {
   hardcodedFilterGroupName,
   resourceBasedFilterGroupName,
 } from './types/filters';
+import { modelName } from './types/models';
 import { commonMessages } from './utils/commonMessages';
 
 export const API_ENDPOINTS = {
-  courses: '/api/v1.0/courses/',
-  organizations: '/api/v1.0/organizations/',
-  subjects: '/api/v1.0/subjects/',
+  [modelName.COURSES]: '/api/v1.0/courses/',
+  [modelName.ORGANIZATIONS]: '/api/v1.0/organizations/',
+  [modelName.SUBJECTS]: '/api/v1.0/subjects/',
 };
 
 export const API_LIST_DEFAULT_PARAMS = {
@@ -23,8 +24,8 @@ export const API_LIST_DEFAULT_PARAMS = {
 export const FILTERS_ACTIVE: filterGroupName[] = [
   'new',
   'availability',
-  'subjects',
-  'organizations',
+  modelName.SUBJECTS,
+  modelName.ORGANIZATIONS,
   'language',
 ];
 
@@ -140,11 +141,11 @@ export const FILTERS_RESOURCES: {
 } = {
   organizations: {
     humanName: commonMessages.organizationsHumanName,
-    machineName: 'organizations',
+    machineName: modelName.ORGANIZATIONS,
   },
   subjects: {
     humanName: commonMessages.subjectsHumanName,
-    machineName: 'subjects',
+    machineName: modelName.SUBJECTS,
   },
 };
 

--- a/src/richie-front/js/types/filters.ts
+++ b/src/richie-front/js/types/filters.ts
@@ -1,8 +1,11 @@
 import { FormattedMessage } from 'react-intl';
+import { modelName } from './models';
 
 export type hardcodedFilterGroupName = 'availability' | 'language' | 'new';
 
-export type resourceBasedFilterGroupName = 'organizations' | 'subjects';
+export type resourceBasedFilterGroupName =
+  | modelName.ORGANIZATIONS
+  | modelName.SUBJECTS;
 
 export type filterGroupName =
   | resourceBasedFilterGroupName

--- a/src/richie-front/js/types/models.ts
+++ b/src/richie-front/js/types/models.ts
@@ -1,1 +1,5 @@
-export type modelNameList = 'courses' | 'organizations' | 'subjects';
+export enum modelName {
+  COURSES = 'courses',
+  ORGANIZATIONS = 'organizations',
+  SUBJECTS = 'subjects',
+}

--- a/src/richie-front/js/types/searchSuggest.ts
+++ b/src/richie-front/js/types/searchSuggest.ts
@@ -1,7 +1,7 @@
 import { FormattedMessage } from 'react-intl';
 
 import { Course } from './Course';
-import { modelNameList } from './models';
+import { modelName } from './models';
 import { Organization } from './Organization';
 import { Resource } from './Resource';
 import { Subject } from './Subject';
@@ -13,20 +13,20 @@ import { Subject } from './Subject';
  * @data The model instance for this suggestion.
  */
 interface ResourceSuggestionBase {
-  model: modelNameList;
+  model: modelName;
   data: Resource;
 }
 
 export interface CourseSuggestion extends ResourceSuggestionBase {
-  model: 'courses';
+  model: modelName.COURSES;
   data: Course;
 }
 export interface OrganizationSuggestion extends ResourceSuggestionBase {
-  model: 'organizations';
+  model: modelName.ORGANIZATIONS;
   data: Organization;
 }
 export interface SubjectSuggestion extends ResourceSuggestionBase {
-  model: 'subjects';
+  model: modelName.SUBJECTS;
   data: Subject;
 }
 
@@ -62,22 +62,22 @@ export type SearchSuggestion = ResourceSuggestion | DefaultSuggestion;
  */
 interface ResourceSuggestionSectionBase {
   message: FormattedMessage.MessageDescriptor;
-  model: modelNameList;
+  model: modelName;
   values: Resource[];
 }
 
 export interface CourseSuggestionSection extends ResourceSuggestionSectionBase {
-  model: 'courses';
+  model: modelName.COURSES;
   values: Course[];
 }
 export interface OrganizationSuggestionSection
   extends ResourceSuggestionSectionBase {
-  model: 'organizations';
+  model: modelName.ORGANIZATIONS;
   values: Organization[];
 }
 export interface SubjectSuggestionSection
   extends ResourceSuggestionSectionBase {
-  model: 'subjects';
+  model: modelName.SUBJECTS;
   values: Subject[];
 }
 

--- a/src/richie-front/js/utils/filters/getActiveFilterValues.spec.ts
+++ b/src/richie-front/js/utils/filters/getActiveFilterValues.spec.ts
@@ -1,10 +1,11 @@
 import { RootState } from '../../data/rootReducer';
+import { modelName } from '../../types/models';
 import { getActiveFilterValues } from './getActiveFilterValues';
 
 describe('utils/filters/getActiveFilterValues', () => {
   it('returns an empty array if there are no currently active values', () => {
     expect(
-      getActiveFilterValues({} as RootState, 'organizations', {
+      getActiveFilterValues({} as RootState, modelName.ORGANIZATIONS, {
         limit: 20,
         offset: 0,
         organizations: undefined,
@@ -23,7 +24,7 @@ describe('utils/filters/getActiveFilterValues', () => {
       },
     };
     expect(
-      getActiveFilterValues(state as any, 'organizations', {
+      getActiveFilterValues(state as any, modelName.ORGANIZATIONS, {
         limit: 20,
         offset: 0,
         organizations: 42,
@@ -43,7 +44,7 @@ describe('utils/filters/getActiveFilterValues', () => {
       },
     };
     expect(
-      getActiveFilterValues(state as any, 'subjects', {
+      getActiveFilterValues(state as any, modelName.SUBJECTS, {
         limit: 20,
         offset: 0,
         subjects: [21, 22],

--- a/src/richie-front/js/utils/filters/getFilterFromState.spec.ts
+++ b/src/richie-front/js/utils/filters/getFilterFromState.spec.ts
@@ -6,6 +6,7 @@ import {
   FilterDefinition,
   FilterDefinitionWithValues,
 } from '../../types/filters';
+import { modelName } from '../../types/models';
 import { Organization } from '../../types/Organization';
 import { getFilterFromState } from './getFilterFromState';
 
@@ -82,7 +83,7 @@ describe('utils/filters/getFilterFromState', () => {
         new: {} as FilterDefinitionWithValues,
         organizations: {
           humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-          machineName: 'organizations',
+          machineName: modelName.ORGANIZATIONS,
           values: [],
         },
         subjects: {} as FilterDefinition,
@@ -107,9 +108,11 @@ describe('utils/filters/getFilterFromState', () => {
       },
     };
 
-    expect(getFilterFromState(state as RootState, 'organizations')).toEqual({
+    expect(
+      getFilterFromState(state as RootState, modelName.ORGANIZATIONS),
+    ).toEqual({
       humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-      machineName: 'organizations',
+      machineName: modelName.ORGANIZATIONS,
       values: [
         { count: 15, humanName: 'Organization #Fourty-Two', primaryKey: '42' },
         { count: 7, humanName: 'Organization #Eighty-Four', primaryKey: '84' },
@@ -126,7 +129,7 @@ describe('utils/filters/getFilterFromState', () => {
         new: {} as FilterDefinitionWithValues,
         organizations: {
           humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-          machineName: 'organizations',
+          machineName: modelName.ORGANIZATIONS,
           values: [],
         },
         subjects: {} as FilterDefinition,
@@ -142,10 +145,13 @@ describe('utils/filters/getFilterFromState', () => {
       },
     };
 
-    const filter = getFilterFromState(state as RootState, 'organizations');
+    const filter = getFilterFromState(
+      state as RootState,
+      modelName.ORGANIZATIONS,
+    );
     expect(filter).toEqual({
       humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-      machineName: 'organizations',
+      machineName: modelName.ORGANIZATIONS,
       // Values might be mis-ordered as we're sampling them instead of just reusing the array
       values: expect.arrayContaining([
         { humanName: 'Organization #Twenty-One', primaryKey: '21' },
@@ -166,7 +172,7 @@ describe('utils/filters/getFilterFromState', () => {
         new: {} as FilterDefinitionWithValues,
         organizations: {
           humanName: { defaultMessage: 'Organizations', id: 'organizations' },
-          machineName: 'organizations',
+          machineName: modelName.ORGANIZATIONS,
           values: [],
         },
         subjects: {} as FilterDefinition,
@@ -192,7 +198,10 @@ describe('utils/filters/getFilterFromState', () => {
       },
     };
 
-    const filter = getFilterFromState(state as RootState, 'organizations');
+    const filter = getFilterFromState(
+      state as RootState,
+      modelName.ORGANIZATIONS,
+    );
     expect(filter.values.length).toEqual(10);
     // Count included unique organizations
     const uniqueOrgCount = Object.keys(

--- a/src/richie-front/js/utils/filters/updateFilter.spec.ts
+++ b/src/richie-front/js/utils/filters/updateFilter.spec.ts
@@ -1,6 +1,7 @@
 import { stringify } from 'query-string';
 
 import { FilterDefinition } from '../../types/filters';
+import { modelName } from '../../types/models';
 import { computeNewFilterValue } from './computeNewFilterValue';
 import { updateFilter } from './updateFilter';
 
@@ -37,7 +38,7 @@ describe('utils/filters/updateFilter', () => {
         offset: 3,
         organizations: [42, 84],
       },
-      resourceName: 'courses',
+      resourceName: modelName.COURSES,
       type: 'RESOURCE_LIST_GET',
     });
     expect(dispatch).toHaveBeenCalledWith({

--- a/src/richie-front/js/utils/filters/updateFilter.ts
+++ b/src/richie-front/js/utils/filters/updateFilter.ts
@@ -4,6 +4,7 @@ import { ResourceListStateParams } from '../../data/genericReducers/resourceList
 import { getResourceList } from '../../data/genericSideEffects/getResourceList/actions';
 import { pushQueryStringToHistory } from '../../data/genericSideEffects/pushHistoryState/actions';
 import { FilterDefinition } from '../../types/filters';
+import { modelName } from '../../types/models';
 import { computeNewFilterValue } from './computeNewFilterValue';
 
 // Update a search filter for our main Search view/state
@@ -31,6 +32,6 @@ export const updateFilter = (
     ),
   };
   // Make sure we update both the query/results and the URL query string
-  dispatch(getResourceList('courses', newParams));
+  dispatch(getResourceList(modelName.COURSES, newParams));
   dispatch(pushQueryStringToHistory(newParams));
 };

--- a/src/richie-front/js/utils/searchSuggest/getSuggestionsSections.spec.ts
+++ b/src/richie-front/js/utils/searchSuggest/getSuggestionsSections.spec.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { Course } from '../../types/Course';
+import { modelName } from '../../types/models';
 import { handle } from '../../utils/errors/handle';
 import { getSuggestionsSection } from './getSuggestionsSection';
 
@@ -20,7 +21,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
     let suggestionsSection;
     try {
       suggestionsSection = await getSuggestionsSection(
-        'courses',
+        modelName.COURSES,
         { defaultMessage: 'Courses', id: 'coursesHumanName' },
         'some search',
       );
@@ -30,7 +31,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
 
     expect(suggestionsSection).toEqual({
       message: { defaultMessage: 'Courses', id: 'coursesHumanName' },
-      model: 'courses',
+      model: modelName.COURSES,
       values: [
         { title: 'Course #1' } as Course,
         { title: 'Course #2' } as Course,
@@ -43,7 +44,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
       throws: 'Failed to send API request',
     });
     await getSuggestionsSection(
-      'courses',
+      modelName.COURSES,
       { defaultMessage: 'Courses', id: 'coursesHumanName' },
       'some search',
     );
@@ -58,7 +59,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
       status: 403,
     });
     await getSuggestionsSection(
-      'courses',
+      modelName.COURSES,
       { defaultMessage: 'Courses', id: 'coursesHumanName' },
       'some search',
     );
@@ -70,7 +71,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
   it('reports the error when it receives broken json', async () => {
     fetchMock.get('/api/v1.0/courses/?query=some%20search', 'not json');
     await getSuggestionsSection(
-      'courses',
+      modelName.COURSES,
       { defaultMessage: 'Courses', id: 'coursesHumanName' },
       'some search',
     );

--- a/src/richie-front/js/utils/searchSuggest/suggestionHumanName.spec.ts
+++ b/src/richie-front/js/utils/searchSuggest/suggestionHumanName.spec.ts
@@ -1,4 +1,5 @@
 import { Course } from '../../types/Course';
+import { modelName } from '../../types/models';
 import { Organization } from '../../types/Organization';
 import { Subject } from '../../types/Subject';
 import { suggestionHumanName } from './suggestionHumanName';
@@ -6,22 +7,25 @@ import { suggestionHumanName } from './suggestionHumanName';
 describe('utils/searchSuggest/suggestionHumanName', () => {
   it('returns the correct human name for a course', () => {
     const course = { title: 'Some course title' } as Course;
-    expect(suggestionHumanName({ model: 'courses', data: course })).toEqual(
-      'Some course title',
-    );
+    expect(
+      suggestionHumanName({ model: modelName.COURSES, data: course }),
+    ).toEqual('Some course title');
   });
 
   it('returns the correct human name for an organization', () => {
     const organization = { name: 'Some organization name' } as Organization;
     expect(
-      suggestionHumanName({ model: 'organizations', data: organization }),
+      suggestionHumanName({
+        data: organization,
+        model: modelName.ORGANIZATIONS,
+      }),
     ).toEqual('Some organization name');
   });
 
   it('returns the correct human name for a subject', () => {
     const subject = { name: 'Some subject matter' } as Subject;
-    expect(suggestionHumanName({ model: 'subjects', data: subject })).toEqual(
-      'Some subject matter',
-    );
+    expect(
+      suggestionHumanName({ model: modelName.SUBJECTS, data: subject }),
+    ).toEqual('Some subject matter');
   });
 });

--- a/src/richie-front/js/utils/searchSuggest/suggestionHumanName.ts
+++ b/src/richie-front/js/utils/searchSuggest/suggestionHumanName.ts
@@ -1,16 +1,17 @@
+import { modelName } from '../../types/models';
 import { ResourceSuggestion } from '../../types/searchSuggest';
 
 export const suggestionHumanName = (suggestion: ResourceSuggestion) => {
   switch (suggestion.model) {
-    case 'courses':
+    case modelName.COURSES:
       const course = suggestion.data;
       return course.title;
 
-    case 'organizations':
+    case modelName.ORGANIZATIONS:
       const organization = suggestion.data;
       return organization.name;
 
-    case 'subjects':
+    case modelName.SUBJECTS:
       const subject = suggestion.data;
       return subject.name;
   }

--- a/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.spec.ts
+++ b/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.spec.ts
@@ -1,4 +1,5 @@
 import { Course } from '../../types/Course';
+import { modelName } from '../../types/models';
 import { Organization } from '../../types/Organization';
 import { Subject } from '../../types/Subject';
 import { suggestionsFromSection } from './suggestionsFromSection';
@@ -8,7 +9,7 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
     expect(
       suggestionsFromSection({
         message: { defaultMessage: 'Courses', id: 'coursesHumanName' },
-        model: 'courses',
+        model: modelName.COURSES,
         values: [
           { title: 'Example course #1' } as Course,
           { title: 'Example course #2' } as Course,
@@ -17,11 +18,11 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
     ).toEqual([
       {
         data: { title: 'Example course #1' } as Course,
-        model: 'courses',
+        model: modelName.COURSES,
       },
       {
         data: { title: 'Example course #2' } as Course,
-        model: 'courses',
+        model: modelName.COURSES,
       },
     ]);
   });
@@ -33,7 +34,7 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
           defaultMessage: 'Organizations',
           id: 'organizationsHumanName',
         },
-        model: 'organizations',
+        model: modelName.ORGANIZATIONS,
         values: [
           { name: 'Example organization #1' } as Organization,
           { name: 'Example organization #2' } as Organization,
@@ -42,11 +43,11 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
     ).toEqual([
       {
         data: { name: 'Example organization #1' } as Organization,
-        model: 'organizations',
+        model: modelName.ORGANIZATIONS,
       },
       {
         data: { name: 'Example organization #2' } as Organization,
-        model: 'organizations',
+        model: modelName.ORGANIZATIONS,
       },
     ]);
   });
@@ -55,7 +56,7 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
     expect(
       suggestionsFromSection({
         message: { defaultMessage: 'Subjects', id: 'subjectsHumanName' },
-        model: 'subjects',
+        model: modelName.SUBJECTS,
         values: [
           { name: 'Example subject #1' } as Subject,
           { name: 'Example subject #2' } as Subject,
@@ -64,11 +65,11 @@ describe('utils/searchSuggest/suggestionsFromSection', () => {
     ).toEqual([
       {
         data: { name: 'Example subject #1' } as Subject,
-        model: 'subjects',
+        model: modelName.SUBJECTS,
       },
       {
         data: { name: 'Example subject #2' } as Subject,
-        model: 'subjects',
+        model: modelName.SUBJECTS,
       },
     ]);
   });

--- a/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.ts
+++ b/src/richie-front/js/utils/searchSuggest/suggestionsFromSection.ts
@@ -1,3 +1,4 @@
+import { modelName } from '../../types/models';
 import {
   DefaultSuggestionSection,
   ResourceSuggestion,
@@ -40,18 +41,18 @@ function suggestionsFromResourceSection(
   // This leads us to this switch which solves both issues as neither the model name nor the values
   // are union types anymore.
   switch (section.model) {
-    case 'courses':
+    case modelName.COURSES:
       return section.values.map(value => ({
         data: value,
         model: section.model,
       }));
-    case 'organizations':
+    case modelName.ORGANIZATIONS:
       return section.values.map(value => ({
         data: value,
         model: section.model,
       }));
 
-    case 'subjects':
+    case modelName.SUBJECTS:
       return section.values.map(value => ({
         data: value,
         model: section.model,


### PR DESCRIPTION
## Purpose

I ran into this while adding stuff to the settings.

We used simple string literals for model names until now. This resulted in a lot of "magic strings" floating around in the code, which can be confusing.

It also forced us to do some manual typecasting in certain situations.

## Proposal

In our opinion, enums are the way to handle these kinds of fixed values that exist both as types & runtime values.

We get a clear source of truth for all use cases related to the model name and the best possible type checking for these values.