### PR TITLE
Use autocomplete endpoints in main search autosuggest

### DIFF
--- a/src/richie-front/js/data/genericSideEffects/getResourceList/getResourceList.ts
+++ b/src/richie-front/js/data/genericSideEffects/getResourceList/getResourceList.ts
@@ -30,7 +30,7 @@ export function fetchList(
   resourceName: keyof RootState['resources'],
   params: ResourceListGet['params'] = API_LIST_DEFAULT_PARAMS,
 ): Promise<Response> {
-  const endpoint = API_ENDPOINTS[resourceName];
+  const endpoint = API_ENDPOINTS.search[resourceName];
 
   return fetch(`${endpoint}?${stringify(params)}`, {
     headers: {

--- a/src/richie-front/js/data/rootReducer.ts
+++ b/src/richie-front/js/data/rootReducer.ts
@@ -1,5 +1,6 @@
 import { Reducer } from 'redux';
 
+import { modelName } from '../types/models';
 import { courses, CoursesState } from './courses/reducer';
 import {
   filterDefinitions,
@@ -11,9 +12,9 @@ import { subjects, SubjectsState } from './subjects/reducer';
 export interface RootState {
   filterDefinitions: FilterDefinitionState;
   resources: {
-    courses?: CoursesState;
-    organizations?: OrganizationsState;
-    subjects?: SubjectsState;
+    [modelName.COURSES]?: CoursesState;
+    [modelName.ORGANIZATIONS]?: OrganizationsState;
+    [modelName.SUBJECTS]?: SubjectsState;
   };
 }
 
@@ -24,12 +25,15 @@ export const rootReducer: Reducer<RootState> = (state, action) => {
       action,
     ),
     resources: {
-      courses: courses((state && state.resources.courses) || undefined, action),
-      organizations: organizations(
+      [modelName.COURSES]: courses(
+        (state && state.resources.courses) || undefined,
+        action,
+      ),
+      [modelName.ORGANIZATIONS]: organizations(
         (state && state.resources.organizations) || undefined,
         action,
       ),
-      subjects: subjects(
+      [modelName.SUBJECTS]: subjects(
         (state && state.resources.subjects) || undefined,
         action,
       ),

--- a/src/richie-front/js/settings.ts
+++ b/src/richie-front/js/settings.ts
@@ -11,9 +11,16 @@ import { modelName } from './types/models';
 import { commonMessages } from './utils/commonMessages';
 
 export const API_ENDPOINTS = {
-  [modelName.COURSES]: '/api/v1.0/courses/',
-  [modelName.ORGANIZATIONS]: '/api/v1.0/organizations/',
-  [modelName.SUBJECTS]: '/api/v1.0/subjects/',
+  autocomplete: {
+    [modelName.COURSES]: '/api/v1.0/courses/autocomplete/',
+    [modelName.ORGANIZATIONS]: '/api/v1.0/organizations/autocomplete/',
+    [modelName.SUBJECTS]: '/api/v1.0/subjects/autocomplete/',
+  },
+  search: {
+    [modelName.COURSES]: '/api/v1.0/courses/',
+    [modelName.ORGANIZATIONS]: '/api/v1.0/organizations/',
+    [modelName.SUBJECTS]: '/api/v1.0/subjects/',
+  },
 };
 
 export const API_LIST_DEFAULT_PARAMS = {

--- a/src/richie-front/js/utils/searchSuggest/getSuggestionsSection.ts
+++ b/src/richie-front/js/utils/searchSuggest/getSuggestionsSection.ts
@@ -18,7 +18,7 @@ export const getSuggestionsSection = async (
   let response: Response;
   try {
     response = await fetch(
-      `${API_ENDPOINTS[sectionModel]}?${stringify({ query })}`,
+      `${API_ENDPOINTS.autocomplete[sectionModel]}?${stringify({ query })}`,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -34,12 +34,14 @@ export const getSuggestionsSection = async (
   if (!response.ok) {
     return handle(
       new Error(
-        `Failed to get list from ${API_ENDPOINTS.courses} : ${response.status}`,
+        `Failed to get list from ${
+          API_ENDPOINTS.autocomplete[sectionModel]
+        } : ${response.status}`,
       ),
     );
   }
 
-  let data: { objects: Resource[] };
+  let data: Resource[];
   try {
     data = await response.json();
   } catch (error) {
@@ -52,6 +54,6 @@ export const getSuggestionsSection = async (
   return {
     message: sectionTitleMessage,
     model: sectionModel,
-    values: take(data.objects, 3),
+    values: take(data, 3),
   };
 };

--- a/src/richie-front/js/utils/searchSuggest/getSuggestionsSections.spec.ts
+++ b/src/richie-front/js/utils/searchSuggest/getSuggestionsSections.spec.ts
@@ -14,9 +14,10 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
   });
 
   it('runs the search and builds a SearchSuggestionSection with the results', async () => {
-    fetchMock.get('/api/v1.0/courses/?query=some%20search', {
-      objects: [{ title: 'Course #1' }, { title: 'Course #2' }],
-    });
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=some%20search', [
+      { title: 'Course #1' },
+      { title: 'Course #2' },
+    ]);
 
     let suggestionsSection;
     try {
@@ -40,7 +41,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
   });
 
   it('reports the error when the request fails', async () => {
-    fetchMock.get('/api/v1.0/courses/?query=some%20search', {
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=some%20search', {
       throws: 'Failed to send API request',
     });
     await getSuggestionsSection(
@@ -54,7 +55,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
   });
 
   it('reports the error when the server returns an error code', async () => {
-    fetchMock.get('/api/v1.0/courses/?query=some%20search', {
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=some%20search', {
       body: {},
       status: 403,
     });
@@ -64,12 +65,17 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
       'some search',
     );
     expect(mockHandle).toHaveBeenCalledWith(
-      new Error('Failed to get list from /api/v1.0/courses/ : 403'),
+      new Error(
+        'Failed to get list from /api/v1.0/courses/autocomplete/ : 403',
+      ),
     );
   });
 
   it('reports the error when it receives broken json', async () => {
-    fetchMock.get('/api/v1.0/courses/?query=some%20search', 'not json');
+    fetchMock.get(
+      '/api/v1.0/courses/autocomplete/?query=some%20search',
+      'not json',
+    );
     await getSuggestionsSection(
       modelName.COURSES,
       { defaultMessage: 'Courses', id: 'coursesHumanName' },
@@ -78,7 +84,7 @@ describe('utils/searchSuggest/getSuggestionsSection', () => {
     expect(mockHandle).toHaveBeenCalledWith(
       new Error(
         'Failed to decode JSON in getSuggestionSection FetchError: invalid json response body at ' +
-          '/api/v1.0/courses/?query=some%20search reason: Unexpected token o in JSON at position 1',
+          '/api/v1.0/courses/autocomplete/?query=some%20search reason: Unexpected token o in JSON at position 1',
       ),
     );
   });


### PR DESCRIPTION
## Purpose

We opened autocomplete endpoints specifically to have better suggestion results in search boxes with the autosuggest UI.

Autocomplete as a functionality needs to be very easy to understand for users. They need to see at a glance why so or so result is being suggested.

## Proposal

- [x] Add the autocomplete endpoints to the settings & call them instead of the search endpoints when generating suggestions.
- [x] ~Add a helper to find the query in the proposed suggestions and highlight it~