### PR TITLE
Add a toolbar item to easily snapshot a course page

### DIFF
--- a/src/richie/apps/courses/admin.py
+++ b/src/richie/apps/courses/admin.py
@@ -1,16 +1,29 @@
 """
 Courses application admin
 """
+import time
+
+from django.conf.urls import url
 from django.contrib import admin
-from django.db import models
+from django.db import models, transaction
+from django.http import HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
+from django.utils.decorators import method_decorator
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.http import require_POST
 
 from cms.admin.placeholderadmin import FrontendEditableAdminMixin
+from cms.api import Page, create_title
 from cms.extensions import PageExtensionAdmin
+from cms.utils import page_permissions
+from cms.utils.admin import jsonify_request
 
 from .fields import CourseRunSplitDateTimeField
 from .forms import LicenceFormAdmin
 from .models import Course, CourseRun, Licence, Organization
 from .widgets import CourseRunSplitDateTimeWidget
+
+REQUIRE_POST = method_decorator(require_POST)
 
 
 class CourseAdmin(PageExtensionAdmin):
@@ -24,6 +37,103 @@ class CourseAdmin(PageExtensionAdmin):
         Display the course title as a read-only field from the related page
         """
         return obj.extended_object.get_title()
+
+    def get_urls(self):
+        """
+        Add admin URL to trigger the snapshot of a course.
+        """
+        url_patterns = super().get_urls()
+        return [
+            url(
+                r"^(?P<course_id>[0-9]+)/snapshot/$",
+                self.admin_site.admin_view(self.snapshot),
+                name="cms_course_snapshot",
+            )
+        ] + url_patterns
+
+    @REQUIRE_POST
+    @transaction.atomic
+    def snapshot(self, request, course_id, *args, **kwargs):
+        """
+        Snapshotting a course is making a copy of the course page with all its permissions and
+        extensions, and placing the copy as the first child of the page being snapshotted, then
+        moving all the course run of the page being snapshotted as children of the new snapshot
+        so we keep record of the course as it was when these course runs were played.
+        """
+        try:
+            page = Page.objects.select_related("node__site").get(
+                publisher_is_draft=True, course__id=course_id
+            )
+        except Page.DoesNotExist:
+            return jsonify_request(
+                HttpResponseBadRequest(
+                    force_text(_("Error! Course could not be found."))
+                )
+            )
+
+        # If the page has a parent that is a course page, it is a snapshot and should therefore
+        # not be allowed to be itself snapshotted.
+        if page.parent_page:
+            try:
+                page.parent_page.course
+            except Course.DoesNotExist:
+                pass
+            else:
+                return jsonify_request(
+                    HttpResponseForbidden(
+                        force_text(_("Error! You can't snapshot a snapshot."))
+                    )
+                )
+
+        site = page.node.site
+
+        # User can only snapshot pages he can see
+        can_snapshot = page_permissions.user_can_change_page(request.user, page, site)
+
+        if can_snapshot:
+            # User can only snapshot a page if he has the permission to add a page under it.
+            can_snapshot = page_permissions.user_can_add_subpage(
+                request.user, page, site
+            )
+
+        if not can_snapshot:
+            return jsonify_request(
+                HttpResponseForbidden(
+                    force_text(
+                        _("Error! You don't have permissions to snapshot this page.")
+                    )
+                )
+            )
+
+        # Copy the page as its own child with its extension.
+        # Titles are set to a timestamp in each language of the original page
+        new_page = page.copy(
+            site, parent_node=page.node, translations=False, extensions=True
+        )
+
+        # The snapshot title and slug is set to a timestamp of the time of snapshot. It is
+        # published only in languages for which the original course page was published.
+        for language in page.get_languages():
+            base = page.get_path(language)
+            timestamp = str(int(time.time()))
+            snapshot_title = _("Snapshot of {:s}").format(page.get_title(language))
+            create_title(
+                language=language,
+                menu_title=timestamp,
+                title="{:s} - {:s}".format(timestamp, snapshot_title),
+                slug=timestamp,
+                path="{:s}/{:s}".format(base, timestamp) if base else timestamp,
+                page=new_page,
+            )
+            if page.is_published(language) is True:
+                new_page.publish(language)
+
+        # Move the existing course run subpages as children of the snapshot
+        # Their publication status will be respected
+        for subpage in page.get_child_pages().filter(courserun__isnull=False):
+            subpage.move_page(new_page.node, position="last-child")
+
+        return JsonResponse({"id": new_page.course.id})
 
 
 class CourseRunAdmin(FrontendEditableAdminMixin, PageExtensionAdmin):

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -118,13 +118,13 @@ class OrganizationFactory(BLDPageExtensionDjangoModelFactory):
 
     template = Organization.TEMPLATE_DETAIL
 
-    @factory.lazy_attribute
-    def code(self):
+    @factory.lazy_attribute_sequence
+    def code(self, sequence):
         """
         Since `name` is required, let's just slugify it to get a meaningful code (and keep it
         below 100 characters)
         """
-        return self.extended_object.get_slug()[:100]
+        return "{:s}-{:d}".format(self.extended_object.get_slug()[:90], sequence)
 
     @factory.post_generation
     # pylint: disable=unused-argument

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -97,6 +97,7 @@ class Organization(BasePageExtension):
         language = language or translation.get_language()
         bfs = "extended_object__placeholders__cmsplugin__courses_organizationpluginmodel__page"
         filter_dict = {
+            "extended_object__node__parent__cms_pages__course__isnull": True,
             "extended_object__publisher_is_draft": True,
             "extended_object__placeholders__slot": "course_organizations",
             "extended_object__placeholders__cmsplugin__language": language,
@@ -115,6 +116,7 @@ class Organization(BasePageExtension):
                     queryset=Title.objects.filter(language=language),
                 )
             )
+            .distinct()
         )
 
 

--- a/src/richie/apps/courses/models/subject.py
+++ b/src/richie/apps/courses/models/subject.py
@@ -52,6 +52,7 @@ class Subject(BasePageExtension):
             "extended_object__placeholders__cmsplugin__courses_subjectpluginmodel__page"
         )
         filter_dict = {
+            "extended_object__node__parent__cms_pages__course__isnull": True,
             "extended_object__publisher_is_draft": True,
             "extended_object__placeholders__slot": "course_subjects",
             "extended_object__placeholders__cmsplugin__language": language,
@@ -70,6 +71,7 @@ class Subject(BasePageExtension):
                     queryset=Title.objects.filter(language=language),
                 )
             )
+            .distinct()
         )
 
 

--- a/src/richie/apps/courses/templates/courses/cms/_course_detail.scss
+++ b/src/richie/apps/courses/templates/courses/cms/_course_detail.scss
@@ -72,6 +72,15 @@ $richie-course-detail-aside-main-org-background: $white;
       }
     }
 
+    &__snapshot {
+      padding: 1rem 0 0;
+      text-align: center;
+
+      &__date {
+        color: $firebrick6;
+      }
+    }
+
     &__title {
       @include sv-flex-cell-width(100%);
       position: relative;

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -13,7 +13,25 @@
     {% with course=current_page.course header_level=2 %}
 
     <div class="course-detail__content course-detail__content--two">
-      <h1 class="course-detail__content__title">{% render_model request.current_page "titles" %}</h1>
+
+      {% if request.current_page.parent_page.course %}
+      <div class="course-detail__content__snapshot">
+        <div class="course-detail__content__snapshot__date">
+          {% blocktrans with creation_date=request.current_page.creation_date|date:"SHORT_DATE_FORMAT" %}
+          Archived on {{ creation_date }}
+          {% endblocktrans %}
+        </div>
+        <a href="{{ request.current_page.parent_page.get_absolute_url }}">{% trans "Go to current version" %}</a>
+      </div>
+      {% endif %}
+
+      <h1 class="course-detail__content__title">
+        {% if request.current_page.parent_page.course %}
+          {{ request.current_page.parent_page.get_title }}
+        {% else %}
+          {% render_model request.current_page "titles" %}
+        {% endif %}
+      </h1>
 
       <div class="course-detail__content__row course-detail__content__subjects">
           {% with form_factor="tag" %}

--- a/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
@@ -17,8 +17,12 @@
 
   <div class="course-detail__content course-detail__content--one">
     <h1 class="course-detail__content__title">
-      {% render_model request.current_page.parent_page "titles" %}
-      <br>
+      {% if request.current_page.parent_page.parent_page.course %}
+        {% render_model request.current_page.parent_page.parent_page "titles" %}
+      {% else %}
+        {% render_model request.current_page.parent_page "titles" %}
+      {% endif %}
+      <br />
       {% render_model request.current_page "titles" %}
     </h1>
 

--- a/src/richie/apps/persons/tests/utils.py
+++ b/src/richie/apps/persons/tests/utils.py
@@ -1,13 +1,9 @@
 """Test utils for the courses application"""
 
-from django.contrib.auth.models import AnonymousUser, Permission
-from django.core.exceptions import ImproperlyConfigured
 from django.test.client import RequestFactory
 
 from cms.middleware.toolbar import ToolbarMiddleware
 from cms.toolbar.items import Menu, ModalItem
-
-from richie.apps.core.factories import UserFactory
 
 
 class CheckToolbarMixin:
@@ -16,83 +12,34 @@ class CheckToolbarMixin:
     CMS toolbar unit tests
     """
 
-    def check_toolbar_item(self, page_extension, menu_item_text):
-        """
-        Not a test. This method is a helper to test the toolbar for the presence of a menu item
-        for editing page extensions.
-        """
-        # Create different users for each possible level of access
-        # pylint: disable=too-many-locals
-        superuser = UserFactory(is_staff=True, is_superuser=True)
-        staff_with_permission = UserFactory(is_staff=True)
-        user_with_permission = UserFactory()
-        staff = UserFactory(is_staff=True)
-        user = UserFactory()
-        anonymous = AnonymousUser()
+    def check_active(self, toolbar, name, item_type=ModalItem):
+        """The item should be present in the toolbar and active."""
+        page_menu_result = toolbar.find_items(Menu, name="Page")[0]
+        results = page_menu_result.item.find_items(item_type, name=name)
+        self.assertEqual(len(results), 1)
+        item = results[0].item
+        self.assertFalse(item.disabled)
+        return item
 
-        # Add global permission to change page for users concerned
-        can_change_page = Permission.objects.get(codename="change_page")
-        staff_with_permission.user_permissions.add(can_change_page)
-        user_with_permission.user_permissions.add(can_change_page)
+    def check_disabled(self, toolbar, name, item_type=ModalItem):
+        """The item should be present in the toolbar and disabled."""
+        page_menu_result = toolbar.find_items(Menu, name="Page")[0]
+        results = page_menu_result.item.find_items(item_type, name=name)
+        self.assertEqual(len(results), 1)
+        item = results[0].item
+        self.assertTrue(item.disabled)
+        return item
 
-        cases = [
-            ([superuser, False, False], "disabled"),
-            ([superuser, True, False], "active"),
-            ([superuser, False, True], "disabled"),
-            ([staff_with_permission, False, False], "disabled"),
-            ([staff_with_permission, True, False], "active"),
-            ([staff_with_permission, False, True], "disabled"),
-            ([staff, False, False], "missing"),
-            ([staff, True, False], "missing"),
-            ([staff, False, True], "missing"),
-            ([user_with_permission, False, False], "absent"),
-            ([user_with_permission, True, False], "absent"),
-            ([user_with_permission, False, True], "absent"),
-            ([user, False, False], "absent"),
-            ([user, True, False], "absent"),
-            ([user, False, True], "absent"),
-            ([anonymous, False, False], "absent"),
-            ([anonymous, True, False], "absent"),
-            ([anonymous, False, True], "absent"),
-        ]
-        admin_url = "/en/admin/{app_name:s}/{model_name:s}/{id:d}/change/".format(
-            app_name=page_extension._meta.app_label,
-            model_name=page_extension.__class__.__name__.lower(),
-            id=page_extension.id,
-        )
+    def check_missing(self, toolbar, name, item_type=ModalItem):
+        """The item should not be in the toolbar."""
+        page_menu_result = toolbar.find_items(Menu, name="Page")[0]
+        results = page_menu_result.item.find_items(item_type, name=name)
+        self.assertEqual(results, [])
 
-        page = page_extension.extended_object
-        for args, state in cases:
-            toolbar = self.get_toolbar_for_page(page, *args)
-
-            if state in ["active", "disabled", "missing"]:
-                page_menu_result = toolbar.find_items(Menu, name="Page")[0]
-                results = page_menu_result.item.find_items(
-                    ModalItem, name=menu_item_text
-                )
-                if state in ["active", "disabled"]:
-                    self.assertEqual(len(results), 1)
-                    item = results[0].item
-                    self.assertEqual(item.url, admin_url)
-
-                    if state == "active":
-                        self.assertFalse(item.disabled)
-
-                    elif state == "disabled":
-                        self.assertTrue(item.disabled)
-
-                elif state == "missing":
-                    self.assertEqual(results, [])
-
-                else:
-                    raise ImproperlyConfigured()
-
-            elif state == "absent":
-                # The whole toolbar should be hidden
-                self.assertEqual(toolbar.get_left_items(), [])
-
-            else:
-                raise ImproperlyConfigured()
+    # pylint: disable=unused-argument
+    def check_absent(self, toolbar, *args, **kwargs):
+        """The whole toolbar should be hidden."""
+        self.assertEqual(toolbar.get_left_items(), [])
 
     @staticmethod
     def get_toolbar_for_page(page, user, edit, preview):

--- a/tests/apps/courses/test_admin_page_snapshot.py
+++ b/tests/apps/courses/test_admin_page_snapshot.py
@@ -1,0 +1,320 @@
+"""
+Test suite defining the admin pages for the Course model
+"""
+import json
+import random
+from unittest import mock
+
+from django.test.utils import override_settings
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.factories import UserFactory
+from richie.apps.courses.factories import CourseFactory, CourseRunFactory
+from richie.apps.courses.models import Course, CourseRun
+
+
+@override_settings(LANGUAGES=(("en", "En"), ("fr", "Fr"), ("de", "De")))
+@override_settings(CMS_LANGUAGES={})  # Ensure not set so LANGUAGES setting is used
+class SnapshotPageAdminTestCase(CMSTestCase):
+    """
+    Integration test suite to validate the behavior of course snapshots.
+    """
+
+    def test_admin_page_snapshot_with_cms_permissions(self):
+        """
+        Confirm the creation of a snapshot works as expected:
+        - snapshot title and slug are set to a timestamp,
+        - publication status of the course is respected on the snapshot,
+        - course runs are moved below the snapshot,
+        - publication status of course runs is respected,
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create a course page (not published in german)
+        course = CourseFactory(
+            title={"en": "a course", "fr": "un cours", "de": "ein Kurs"}
+        )
+        course.extended_object.publish("en")
+        course.extended_object.publish("fr")
+
+        # Create a course run published only in English
+        course_run1 = CourseRunFactory(parent=course.extended_object)
+        course_run1.extended_object.publish("en")
+        self.assertTrue(course_run1.check_publication("en"))
+        self.assertFalse(course_run1.check_publication("fr"))
+        self.assertFalse(course_run1.check_publication("de"))
+
+        # Create a course run published only in French
+        course_run2 = CourseRunFactory(parent=course.extended_object)
+        course_run2.extended_object.publish("fr")
+        self.assertFalse(course_run2.check_publication("en"))
+        self.assertTrue(course_run2.check_publication("fr"))
+        self.assertFalse(course_run2.check_publication("de"))
+
+        # Add the necessary permissions (global and per page)
+        self.add_permission(user, "add_page")
+        self.add_permission(user, "change_page")
+        self.add_page_permission(
+            user, course.extended_object, can_change=True, can_add=True
+        )
+
+        # Trigger the creation of a snapshot for the course
+        url = "/fr/admin/courses/course/{:d}/snapshot/".format(course.id)
+        with mock.patch("time.time", mock.MagicMock(return_value=1541946888)):
+            response = self.client.post(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(Course.objects.count(), 4)
+        snapshot = (
+            Course.objects.exclude(id=course.id)
+            .exclude(public_extension__isnull=True)
+            .get()
+        )
+        self.assertEqual(content, {"id": snapshot.id})
+
+        # The snapshot title and slug should be the timestamp at the time of snapshot
+        expected_titles = {
+            "en": "1541946888 - Snapshot of a course",
+            "fr": "1541946888 - Snapshot of un cours",
+            "de": "1541946888 - Snapshot of ein Kurs",
+        }
+        for language in ["en", "fr", "de"]:
+            self.assertEqual(
+                snapshot.extended_object.get_title(language), expected_titles[language]
+            )
+            self.assertEqual(snapshot.extended_object.get_slug(language), "1541946888")
+
+        # The publication status of the course should be respected on the snapshot
+        self.assertTrue(snapshot.check_publication("en"))
+        self.assertTrue(snapshot.check_publication("fr"))
+        self.assertFalse(snapshot.check_publication("de"))
+
+        # The course runs should have moved below the snapshot
+        # and they should have kept their publication status
+        self.assertEqual(CourseRun.objects.count(), 2 + 2)  # 2 drafts + 2 published
+
+        # - course run 1 should be published only in english
+        course_run1 = CourseRun.objects.get(id=course_run1.id)
+        self.assertEqual(
+            course_run1.extended_object.parent_page, snapshot.extended_object
+        )
+        self.assertTrue(course_run1.check_publication("en"))
+        self.assertFalse(course_run1.check_publication("fr"))
+        self.assertFalse(course_run1.check_publication("de"))
+
+        # - course run 2 should be published only in french
+        course_run2 = CourseRun.objects.get(id=course_run2.id)
+        self.assertEqual(
+            course_run2.extended_object.parent_page, snapshot.extended_object
+        )
+        self.assertFalse(course_run2.check_publication("en"))
+        self.assertTrue(course_run2.check_publication("fr"))
+        self.assertFalse(course_run2.check_publication("de"))
+
+    def test_admin_page_snapshot_page_permissions_not_granted(self):
+        """
+        When CMS permissions are activated, snapshot should be forbidden if page permissions
+        are not granted.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create a course page
+        course = CourseFactory(should_publish=True)
+
+        # Add global permissions only
+        self.add_permission(user, "add_page")
+        self.add_permission(user, "change_page")
+
+        # Trigger the creation of a snapshot for the course
+        url = "/fr/admin/courses/course/{:d}/snapshot/".format(course.id)
+        response = self.client.post(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            {
+                "status": 403,
+                "content": "Error! You don't have permissions to snapshot this page.",
+            },
+        )
+        # No additional courses should have been created
+        self.assertEqual(Course.objects.count(), 2)
+
+    def test_admin_page_snapshot_global_permissions_not_granted(self):
+        """
+        Snapshot should be forbidden if global permissions are not granted.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create a course page
+        course = CourseFactory(should_publish=True)
+
+        # Add page permissions only
+        self.add_page_permission(
+            user, course.extended_object, can_change=True, can_add=True
+        )
+
+        # Trigger the creation of a snapshot for the course
+        url = "/fr/admin/courses/course/{:d}/snapshot/".format(course.id)
+        response = self.client.post(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            {
+                "status": 403,
+                "content": "Error! You don't have permissions to snapshot this page.",
+            },
+        )
+        # No additional courses should have been created
+        self.assertEqual(Course.objects.count(), 2)
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_admin_page_snapshot_cms_permissions_deactivated(self):
+        """
+        If the CMS permissions are not activated, general permissions should suffice.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create a course page
+        course = CourseFactory(should_publish=True)
+
+        # Add global permissions only
+        self.add_permission(user, "add_page")
+        self.add_permission(user, "change_page")
+
+        # Trigger the creation of a snapshot for the course
+        url = "/fr/admin/courses/course/{:d}/snapshot/".format(course.id)
+        with mock.patch("time.time", mock.MagicMock(return_value=1541946888)):
+            response = self.client.post(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        snapshot = (
+            Course.objects.exclude(id=course.id)
+            .exclude(public_extension__isnull=True)
+            .get()
+        )
+        self.assertEqual(content, {"id": snapshot.id})
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_admin_page_snapshot_cms_permissions_deactivated_no_permissions(self):
+        """
+        Snapshot should not be allowed if the CMS permissions are not activated and no
+        permissions are granted.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create a course page
+        course = CourseFactory(should_publish=True)
+
+        # One or both of the permissions are deactivated
+        can_add_page = random.choice([True, False])
+        if can_add_page:
+            self.add_permission(user, "add_page")
+        if not can_add_page and random.choice([True, False]):
+            self.add_permission(user, "change_page")
+
+        # Trigger the creation of a snapshot for the course
+        url = "/fr/admin/courses/course/{:d}/snapshot/".format(course.id)
+        with mock.patch("time.time", mock.MagicMock(return_value=1541946888)):
+            response = self.client.post(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content,
+            {
+                "status": 403,
+                "content": "Error! You don't have permissions to snapshot this page.",
+            },
+        )
+        # No additional courses should have been created
+        self.assertEqual(Course.objects.count(), 2)
+
+    def test_admin_page_snapshot_post_required(self):
+        """
+        Snapshots can only be triggered with a POST method.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create a course page
+        course = CourseFactory(should_publish=True)
+
+        # Add the necessary permissions (global and per page)
+        self.add_permission(user, "add_page")
+        self.add_permission(user, "change_page")
+        self.add_page_permission(
+            user, course.extended_object, can_change=True, can_add=True
+        )
+
+        # Try triggering the snapshot with other methods
+        url = "/fr/admin/courses/course/{:d}/snapshot/".format(course.id)
+
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.put(url, follow=True)
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.delete(url, follow=True)
+        self.assertEqual(response.status_code, 405)
+
+    def test_admin_page_snapshot_forbidden_for_snapshots(self):
+        """
+        It should not be allowed to snapshot a course snapshot.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        course = CourseFactory()
+        snapshot = CourseFactory(parent=course.extended_object)
+
+        # Add the necessary permissions (global and per page)
+        self.add_permission(user, "add_page")
+        self.add_permission(user, "change_page")
+        self.add_page_permission(
+            user, snapshot.extended_object, can_change=True, can_add=True
+        )
+
+        # Try triggering the creation of a snapshot for the snapshot
+        url = "/fr/admin/courses/course/{:d}/snapshot/".format(snapshot.id)
+        response = self.client.post(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"status": 403, "content": "Error! You can't snapshot a snapshot."}
+        )
+
+    @override_settings(CMS_PERMISSION=False)
+    def test_admin_page_snapshot_unknown_page(self):
+        """
+        Trying to snapshot a course that does not exist should return a 400 error.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add the necessary permissions (global and per page)
+        self.add_permission(user, "add_page")
+        self.add_permission(user, "change_page")
+
+        # Try triggering the creation of a snapshot for an unknown course
+        url = "/fr/admin/courses/course/1/snapshot/"
+        response = self.client.post(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content, {"status": 400, "content": "Error! Course could not be found."}
+        )

--- a/tests/apps/courses/test_models_organization.py
+++ b/tests/apps/courses/test_models_organization.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from cms.api import create_page
 
+from richie.apps.core.helpers import create_i18n_page
 from richie.apps.courses.factories import CourseFactory, OrganizationFactory
 from richie.apps.courses.models import Course, Organization
 
@@ -103,3 +104,31 @@ class OrganizationModelsTestCase(TestCase):
         )
         self.assertEqual(Course.objects.count(), 2)
         self.assertEqual(organization.get_courses().count(), 1)
+
+    def test_models_organization_get_courses_snapshots(self):
+        """
+        Snapshot courses should be excluded from the list of courses returned.
+        The new filter query we added to exclude snapshots should not create duplicates.
+        Indeed, we had to add a "distinct" clause to the query so this test enforces it.
+        """
+        # We create a root page because it was responsible for duplicate results when the
+        # distinct clause is not applied.
+        # This is because of the clause "extended_object__node__parent__cms_pages__..."
+        # which is there to exclude snapshots but also acts on the main course page and
+        # checks its parent (so the root page) and the duplicate comes from the fact that
+        # the parent has a draft and a public page... so "cms_pages" has a cardinality of 2
+        root_page = create_i18n_page(published=True)
+
+        organization = OrganizationFactory(should_publish=True)
+        course = CourseFactory(
+            parent=root_page, fill_organizations=[organization], should_publish=True
+        )
+        CourseFactory(
+            parent=course.extended_object,
+            fill_organizations=[organization],
+            should_publish=True,
+        )
+
+        self.assertEqual(Course.objects.count(), 4)
+        self.assertEqual(organization.get_courses().count(), 1)
+        self.assertEqual(organization.public_extension.get_courses().count(), 1)

--- a/tests/apps/persons/test_cms_toolbars.py
+++ b/tests/apps/persons/test_cms_toolbars.py
@@ -1,6 +1,7 @@
 """
 Test suite of the toolbar extension for person pages
 """
+from django.contrib.auth.models import AnonymousUser, Permission
 from django.test.utils import override_settings
 
 from cms.api import create_page
@@ -17,13 +18,56 @@ class PersonCMSToolbarTestCase(CheckToolbarMixin, CMSTestCase):
     """Testing the integration of person page extensions in the toolbar"""
 
     @override_settings(CMS_PERMISSION=False)
+    # pylint: disable=too-many-locals
     def test_cms_toolbars_person_has_page_extension_settings_item(self):
         """
         Validate that a new item to edit the person is available only when visiting the page
         in edit mode and for users with permission to edit the page.
         """
         person = PersonFactory()
-        self.check_toolbar_item(person, "Person settings...")
+
+        # Create different users for each possible level of access
+        # pylint: disable=too-many-locals
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        staff_with_permission = UserFactory(is_staff=True)
+        user_with_permission = UserFactory()
+        staff = UserFactory(is_staff=True)
+        user = UserFactory()
+        anonymous = AnonymousUser()
+
+        # Add global permission to change page for users concerned
+        can_change_page = Permission.objects.get(codename="change_page")
+        staff_with_permission.user_permissions.add(can_change_page)
+        user_with_permission.user_permissions.add(can_change_page)
+
+        cases = [
+            ([superuser, False, False], self.check_disabled),
+            ([superuser, True, False], self.check_active),
+            ([superuser, False, True], self.check_disabled),
+            ([staff_with_permission, False, False], self.check_disabled),
+            ([staff_with_permission, True, False], self.check_active),
+            ([staff_with_permission, False, True], self.check_disabled),
+            ([staff, False, False], self.check_missing),
+            ([staff, True, False], self.check_missing),
+            ([staff, False, True], self.check_missing),
+            ([user_with_permission, False, False], self.check_absent),
+            ([user_with_permission, True, False], self.check_absent),
+            ([user_with_permission, False, True], self.check_absent),
+            ([user, False, False], self.check_absent),
+            ([user, True, False], self.check_absent),
+            ([user, False, True], self.check_absent),
+            ([anonymous, False, False], self.check_absent),
+            ([anonymous, True, False], self.check_absent),
+            ([anonymous, False, True], self.check_absent),
+        ]
+
+        url = "/en/admin/persons/person/{id:d}/change/".format(id=person.id)
+
+        for args, method in cases:
+            toolbar = self.get_toolbar_for_page(person.extended_object, *args)
+            item = method(toolbar, "Person settings...")
+            if item:
+                self.assertEqual(item.url, url)
 
     @override_settings(CMS_PERMISSION=False)
     def test_cms_toolbars_no_page_extension(self):


### PR DESCRIPTION
## Purpose

In previous commits, we re-engineered courses to accomodate snapshots (copies of a course in a given version that is placed as a child of the course). We now need to make it easy to generate the snapshot of a course.

If a course has course runs, the course runs should be moved as course runs of the new snapshot so that we keep track of the state of the course at the time these course runs were created.

## Proposal

- [x] Add a item in the toolbar of a course page to trigger a snapshot,
- [x] Add an admin method that handles the actual snapshotting of a course,
- [x] On a snapshot page, display the title of the parent course, not the title of the snapshot (which is now just a timestamp),
- [x] Add tests to secure this feature.

While working on this, I encountered bugs for which I also propose fixes:

- [x] Fix random error in tests caused by the organization factory generating duplicate values for its `code` field:
  :point_right: add a unique sequence to the organization code.
- [x] Hide snapshots from the list of courses displayed on the organization (resp. subject) detail page:
  :point_right: add a query filter to exclude snapshots and a test to secure this behavior.

Screenshot of the toolbar item visible on a course page:
 
![snapshot_toolbar](https://user-images.githubusercontent.com/1427165/48424418-e9cae680-e762-11e8-9e3a-3bf4eb83ce87.png)

