### PR TITLE
🔧(utils) add clean makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ build-ts: ## build TypeScript application
 	@$(YARN) build
 .PHONY: build-ts
 
+clean: ## restore repository state as it was freshly cloned
+	git clean -idx
+
 compilemessages: ## compile the gettext files
 	@$(COMPOSE_RUN) -w /app/src/richie app python /app/sandbox/manage.py compilemessages
 


### PR DESCRIPTION
## Purpose

Temporary files generated by the python packaging suite (egg-related), can lead to unexpected behavior during the bootstrap phase.

I've experimented this during the development Docker image build: no development dependencies definition were found (due to an old `setup.cfg` file version stored in an egg).

## Proposal

- [x] add an interactive `git clean` shortcut to restore a freshly cloned repository state
