### PR TITLE
🐛(docker) fix default command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,9 @@ RUN chmod g=u /etc/passwd
 # ID.
 ENTRYPOINT [ "/app/bin/entrypoint" ]
 
-# The default command runs gunicorn WSGI server
-CMD gunicorn -c /usr/local/etc/gunicorn/richie.py richie.wsgi:application
+# The default command runs gunicorn WSGI server in the sandbox
+CMD cd sandbox && \
+    gunicorn -c /usr/local/etc/gunicorn/richie.py wsgi:application
 
 # Un-privileged user running the application
 USER 10000

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -110,8 +110,9 @@ RUN chmod g=u /etc/passwd
 # ID.
 ENTRYPOINT [ "/app/bin/entrypoint" ]
 
-# The default command runs gunicorn WSGI server
-CMD gunicorn -c /usr/local/etc/gunicorn/richie.py richie.wsgi:application
+# The default command runs gunicorn WSGI server in the sandbox
+CMD cd sandbox && \
+    gunicorn -c /usr/local/etc/gunicorn/richie.py wsgi:application
 
 # Un-privileged user running the application
 USER 10000


### PR DESCRIPTION
## Purpose

When we've refactored the project tree, we forgot to fix the path to our WSGI configuration to run `gunicorn`.

## Proposal

We choose to change to the `sandbox` directory before running `gunicorn` to prevent PYTHONPATH-related issues (e.g. to import settings). Another strategy would have been to change the `WORKDIR`, but it also means that this would break our development images building, and it would be disturbing to default to the sandbox directory instead of the project's root.

