### PR TITLE
⚡️(docker) upgrade pip to its latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ WORKDIR /builder
 COPY setup.py setup.cfg MANIFEST.in /builder/
 COPY ./src /builder/src/
 
+# Upgrade pip to its latest release to speed up dependencies installation
+RUN pip install --upgrade pip
+
 RUN mkdir /install && \
     pip install --prefix=/install .
 

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -47,6 +47,9 @@ WORKDIR /builder
 COPY setup.py setup.cfg MANIFEST.in /builder/
 COPY ./src /builder/src/
 
+# Upgrade pip to its latest release to speed up dependencies installation
+RUN pip install --upgrade pip
+
 RUN mkdir /install && \
     pip install --prefix=/install .
 

--- a/docker/images/alpine/dev/Dockerfile
+++ b/docker/images/alpine/dev/Dockerfile
@@ -21,6 +21,9 @@ RUN apk --no-cache add --update \
         musl-dev \
         vim
 
+# Upgrade pip to its latest release to speed up dependencies installation
+RUN pip install --upgrade pip
+
 # Install development dependencies
 RUN pip install -e .[dev]
 

--- a/docker/images/dev/Dockerfile
+++ b/docker/images/dev/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get update && \
     vim && \
     rm -rf /var/lib/apt/lists/*
 
+# Upgrade pip to its latest release to speed up dependencies installation
+RUN pip install --upgrade pip
+
 # Install development dependencies
 RUN pip install -e .[dev]
 


### PR DESCRIPTION
## Purpose

`python:3.6` base Docker image is bundled with a rather old release of pip (`9.0.3` vs `19.0.1` at the time of writing), leading to warnings during the build. 

## Proposal

Using the latest release of pip ensures that we benefit from latest performance improvements of the package manager.