### PR TITLE
Add link to course run on search glimpses

### DIFF
--- a/src/richie-front/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
+++ b/src/richie-front/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
@@ -1,6 +1,6 @@
 import '../../testSetup';
 
-import { render } from 'enzyme';
+import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { Course } from '../../types/Course';
@@ -17,13 +17,16 @@ describe('components/CourseGlimpse', () => {
     const organization = {
       title: 'Some Organization',
     } as Organization;
-    const wrapper = render(
+    const wrapper = shallow(
       <CourseGlimpse course={course} organizationMain={organization} />,
     );
 
     expect(wrapper.html()).toContain('Course 42');
-    expect(wrapper.find('img').attr('src')).toEqual('/thumbs/small.png');
+    expect(wrapper.html()).toContain('Details page for {courseTitle}');
     expect(wrapper.html()).toContain('Starts on {date}');
     expect(wrapper.html()).toContain('Some Organization');
+    const img = wrapper.dive().find('img');
+    expect(img.prop('src')).toEqual('/thumbs/small.png');
+    expect(img.prop('alt')).toEqual('Logo for {courseTitle}');
   });
 });

--- a/src/richie-front/js/components/CourseGlimpse/CourseGlimpse.tsx
+++ b/src/richie-front/js/components/CourseGlimpse/CourseGlimpse.tsx
@@ -18,7 +18,7 @@ export interface CourseGlimpseProps {
 
 const messages = defineMessages({
   altText: {
-    defaultMessage: 'Logo for {courseTitle} course.',
+    defaultMessage: 'Logo for {courseTitle}',
     description: 'Alternate text for the course logo in a course glimpse.',
     id: 'components.CourseGlimpse.logoAltText',
   },
@@ -28,6 +28,11 @@ const messages = defineMessages({
       "Shows the start date for a course in a course glimpse in a short format such as Sep 4, '1986'",
     id: 'components.CourseGlimpse.startsOn',
   },
+  linkText: {
+    defaultMessage: 'Details page for {courseTitle}.',
+    description: 'Accessibility title for links on course glimpses.',
+    id: 'components.CourseGlimpse.linkText',
+  },
 });
 
 export const CourseGlimpse = injectIntl(
@@ -35,7 +40,13 @@ export const CourseGlimpse = injectIntl(
     const { course, intl, organizationMain } = props;
 
     return (
-      <a className="course-glimpse course-glimpse--link" href="#">
+      <a
+        className="course-glimpse course-glimpse--link"
+        href={course.absolute_url}
+        title={intl.formatMessage(messages.linkText, {
+          courseTitle: course.title,
+        })}
+      >
         <div className="course-glimpse__media">
           <img
             src={course.cover_image}

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -231,9 +231,17 @@ describe('components/SearchSuggestField', () => {
 
     it('moves to the courses page when it is called with a course', () => {
       onSuggestionSelected.bind(that)(formEvent, {
-        suggestion: { model: modelName.COURSES, data: { id: 42 } as Course },
+        suggestion: {
+          data: {
+            absolute_url: 'https://example.com/courses/42',
+            id: 42,
+          } as Course,
+          model: modelName.COURSES,
+        },
       });
-      expect(location.setHref).toHaveBeenCalledWith('https://42');
+      expect(location.setHref).toHaveBeenCalledWith(
+        'https://example.com/courses/42',
+      );
     });
 
     it('updates the filter and resets the suggestion state when it is called with a resource suggestion', () => {

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
@@ -171,9 +171,8 @@ export function onSuggestionSelected(
 ) {
   switch (suggestion.model) {
     case modelName.COURSES:
-      // TODO: pick a real URL on the course object when it is available on the API
-      const url = 'https://' + suggestion.data.id;
-      return location.setHref(url);
+      // Behave like a link to the course run's page
+      return location.setHref(suggestion.data.absolute_url);
 
     case modelName.ORGANIZATIONS:
     case modelName.SUBJECTS:


### PR DESCRIPTION
## Purpose

We could not link to the courses / course runs from the course glimpses in seach before actual courses from the models were indexed in elasticsearch.

Ditto for the courses in suggestions.

## Proposal

Now that we have a real index, we can trivially add those links by using the new `absolute_url` field on Courses.

~NB: rebased on #450~ 