### PR TITLE
Add course run state to the search API document

### DIFF
--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -87,19 +87,13 @@
             </dd>
             {% endif %}
           </dl>
-          {% if run.state == 'is_open' %}
-          <a class="course-detail__aside__run__block__cta" href="{{ run.resource_link }}">{% trans "Enroll now" %}</a>
-          {% elif run.state == 'is_ongoing' or run.state == 'is_closed' %}
-          <a class="course-detail__aside__run__block__cta course-detail__aside__run__block__cta--projected" href="{{ run.extended_object.get_absolute_url }}">
-            {% trans "Enrollment closed" %}
+          {% if run.state.cta %}
+          <a class="course-detail__aside__run__block__cta" href="{{ run.extended_object.get_absolute_url }}">
+            {{ run.state.cta|capfirst }}
           </a>
-          {% elif run.state == 'is_archived' %}
+          {% else %}
           <a class="course-detail__aside__run__block__cta course-detail__aside__run__block__cta--projected" href="{{ run.extended_object.get_absolute_url }}">
-            {% trans "Archived" %}
-          </a>
-          {% elif run.state == 'is_coming' %}
-          <a class="course-detail__aside__run__block__cta course-detail__aside__run__block__cta--projected" href="{{ run.extended_object.get_absolute_url }}">
-            {% trans "Coming soon" %}
+            {{ run.state.text|capfirst }}
           </a>
           {% endif %}
         </div>

--- a/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
@@ -59,22 +59,14 @@
           <dt>{% trans "Languages" %}</dt>
           <dd>{% render_model course_run "get_languages_display" "languages" %}</dd>
         </dl>
-        {% if course_run.state == 'is_open' %}
-          <a class="course-detail__content__run__block__cta" href="{{ course_run.resource_link }}">
-            {% trans "Enroll now" %}
-          </a>
-        {% elif course_run.state == 'is_ongoing' or course_run.state == 'is_closed' %}
-          <button class="course-detail__content__run__block__cta course-detail__content__run__block__cta--projected">
-            {% trans "Enrollment closed" %}
-          </button>
-        {% elif course_run.state == 'is_archived' %}
-          <button class="course-detail__content__run__block__cta course-detail__content__run__block__cta--projected">
-            {% trans "Archived" %}
-          </button>
-        {% elif course_run.state == 'is_coming' %}
-          <button class="course-detail__content__run__block__cta course-detail__content__run__block__cta--projected">
-            {% trans "Coming soon" %}
-          </button>
+        {% if course_run.state.cta %}
+        <a class="course-detail__content__run__block__cta" href="{{ course_run.resource_link }}">
+          {{ course_run.state.cta|capfirst }}
+        </a>
+        {% else %}
+        <button class="course-detail__content__run__block__cta course-detail__content__run__block__cta--projected">
+          {{ course_run.state.text|capfirst }}
+        </button>
         {% endif %}
       </div>
       {% if current_page.publisher_is_draft %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -1,6 +1,6 @@
 {% load i18n cms_tags %}
 {% comment %}Obviously, the context template variable "course" is required and must be a Course page extension{% endcomment %}
-{% with glimpse_info=course.glimpse_info %}
+{% with course_state=course.state %}
 <div class="course-glimpse__media">
     {% show_placeholder "course_cover" course.extended_object %}
 </div>
@@ -11,12 +11,12 @@
     </div>
     <div class="course-glimpse__footer">
         <p class="course-glimpse__footer__date">
-            {{ glimpse_info.text|title }}<br>
-            {{ glimpse_info.datetime|date:"DATE_FORMAT" }}
+            {{ course_state.text|title }}<br>
+            {{ course_state.datetime|date:"DATE_FORMAT" }}
         </p>
-        {% if glimpse_info.cta %}
+        {% if course_state.cta %}
         <div class="course-glimpse__footer__cta">
-            <button class="button">{{ glimpse_info.cta|title }}</button>
+            <button class="button">{{ course_state.cta|title }}</button>
         </div>
         {% endif %}
     </div>

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -249,6 +249,12 @@ class CoursesIndexersTestCase(TestCase):
                 "cover_image": "image.jpg",
                 "languages": ["en", "es"],
                 "organizations": [42, 84],
+                "state": {
+                    "priority": 5,
+                    "cta": None,
+                    "text": "archived",
+                    "datetime": None,
+                },
                 "subjects": [43, 86],
                 "title": "Duis eu arcu erat",
             },


### PR DESCRIPTION
## Purpose

We need to harmonize the course glimpse displayed in search results with the course glimpse displayed elsewhere in the CMS. The first step to do this is to make the course run state available in the search API document.

## Proposal

- [x] Refactor the `glimpse info` dictionary into a state object. 
    * replace the `glimpse info` dictionary by a `CourseState` namedtuple,
    * simplify state computation and make it coherent between the course state and the course run state, by computing the course state directly from the state of its course runs,
    * allow computing the course run state directly from dates (ie without a course run instance) so that we can use this method also with Elasticsearch results,
- [x] Add a `state` field to the search API document.