### PR TITLE
Improve full text search experience

### DIFF
--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../types/searchSuggest';
 import { Subject } from '../../types/Subject';
 import { handle } from '../../utils/errors/handle';
+import { getSearchParam } from '../../utils/indirection/getSearchParam';
 import { location } from '../../utils/indirection/location';
 import { getSuggestionsSection } from '../../utils/searchSuggest/getSuggestionsSection';
 import { suggestionHumanName } from '../../utils/searchSuggest/suggestionHumanName';
@@ -28,6 +29,11 @@ import {
 
 const mockHandle: jest.Mock<typeof handle> = handle as any;
 jest.mock('../../utils/errors/handle');
+
+const mockGetSearchParam: jest.Mock<
+  typeof getSearchParam
+> = getSearchParam as any;
+jest.mock('../../utils/indirection/getSearchParam');
 
 const mockGetSuggestionsSection: jest.Mock<
   typeof getSuggestionsSection
@@ -68,6 +74,20 @@ describe('components/SearchSuggestField', () => {
     expect(wrapper.html()).toContain(
       'Search for courses, organizations, subjects',
     );
+  });
+
+  it('picks the query from the URL if there is one', () => {
+    mockGetSearchParam.mockReturnValue('machine learning');
+    const wrapper = shallow(
+      <SearchSuggestFieldBase
+        addFilter={addFilter as any}
+        fullTextSearch={fullTextSearch as any}
+        intl={
+          { formatMessage: (message: any) => message.defaultMessage } as any
+        }
+      />,
+    );
+    expect(wrapper.html()).toContain('machine learning');
   });
 
   describe('getSuggestionValue()', () => {

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../types/searchSuggest';
 import { commonMessages } from '../../utils/commonMessages';
 import { handle } from '../../utils/errors/handle';
+import { getSearchParam } from '../../utils/indirection/getSearchParam';
 import { location } from '../../utils/indirection/location';
 import { getSuggestionsSection } from '../../utils/searchSuggest/getSuggestionsSection';
 import { suggestionHumanName } from '../../utils/searchSuggest/suggestionHumanName';
@@ -214,7 +215,14 @@ export class SearchSuggestFieldBase extends React.Component<
 > {
   constructor(props: SearchSuggestFieldProps & InjectedIntlProps) {
     super(props);
-    this.state = { suggestions: [], value: '' };
+    let valueFromUrl: string;
+    try {
+      valueFromUrl = getSearchParam('query') || '';
+    } catch (e) {
+      // Do not break, default to empty
+      valueFromUrl = '';
+    }
+    this.state = { suggestions: [], value: valueFromUrl };
   }
 
   render() {

--- a/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
+++ b/src/richie-front/js/components/SearchSuggestField/SearchSuggestField.tsx
@@ -230,6 +230,11 @@ export class SearchSuggestFieldBase extends React.Component<
     const { intl } = this.props;
     const inputProps = {
       onChange: onChange.bind(this),
+      onKeyDown: (event: React.KeyboardEvent) => {
+        if (event.keyCode === 13 /* enter */ && !value) {
+          this.props.fullTextSearch('');
+        }
+      },
       placeholder: intl.formatMessage(messages.searchFieldPlaceholder),
       value,
     };
@@ -238,17 +243,18 @@ export class SearchSuggestFieldBase extends React.Component<
       // TypeScript incorrectly infers the type of the Autosuggest suggestions prop as SearchSuggestion, which
       // would be correct if we did not use sections, but is incorrect as it is.
       <Autosuggest
-        suggestions={suggestions as any}
+        getSectionSuggestions={suggestionsFromSection as any}
         getSuggestionValue={getSuggestionValue}
-        highlightFirstSuggestion={true}
+        highlightFirstSuggestion={value.length > 2}
+        inputProps={inputProps}
+        multiSection={true}
         onSuggestionsClearRequested={onSuggestionsClearRequested.bind(this)}
         onSuggestionsFetchRequested={onSuggestionsFetchRequested.bind(this)}
         onSuggestionSelected={onSuggestionSelected.bind(this)}
-        renderSuggestion={renderSuggestion}
-        multiSection={true}
-        getSectionSuggestions={suggestionsFromSection as any}
         renderSectionTitle={renderSectionTitle.bind(null, intl)}
-        inputProps={inputProps}
+        renderSuggestion={renderSuggestion}
+        shouldRenderSuggestions={val => val.length > 2}
+        suggestions={suggestions as any}
       />
     );
   }

--- a/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
+++ b/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.spec.tsx
@@ -55,5 +55,11 @@ describe('components/SearchSuggestFieldContainer/mergeProps', () => {
       resourceName: modelName.COURSES,
       type: 'RESOURCE_LIST_GET',
     });
+    expect(dispatch).toHaveBeenCalledWith({
+      state: null,
+      title: '',
+      type: 'HISTORY_PUSH_STATE',
+      url: '?limit=20&offset=0&query=some%20query',
+    });
   });
 });

--- a/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.tsx
+++ b/src/richie-front/js/components/SearchSuggestFieldContainer/SearchSuggestFieldContainer.tsx
@@ -3,6 +3,7 @@ import { Action, Dispatch } from 'redux';
 
 import { ResourceListStateParams } from '../../data/genericReducers/resourceList/resourceList';
 import { getResourceList } from '../../data/genericSideEffects/getResourceList/actions';
+import { pushQueryStringToHistory } from '../../data/genericSideEffects/pushHistoryState/actions';
 import { RootState } from '../../data/rootReducer';
 import { API_LIST_DEFAULT_PARAMS } from '../../settings';
 import { filterGroupName } from '../../types/filters';
@@ -42,7 +43,10 @@ export const mergeProps = (
     },
     // Update the full text search with the current value of the search field (default suggestion).
     fullTextSearch: (query: string) => {
-      dispatch(getResourceList(modelName.COURSES, { ...currentParams, query }));
+      const newParams = { ...currentParams, query };
+      // Make sure we update both the query/results and the URL query string
+      dispatch(getResourceList(modelName.COURSES, newParams));
+      dispatch(pushQueryStringToHistory(newParams));
     },
   };
 };

--- a/src/richie-front/js/utils/indirection/getSearchParam.ts
+++ b/src/richie-front/js/utils/indirection/getSearchParam.ts
@@ -1,0 +1,6 @@
+/**
+ * Layer of indirection to facilitate testing of code that depends on search params.
+ * @param paramName name of the SearchParam to extract from the URL.
+ */
+export const getSearchParam = (paramName: string) =>
+  new URLSearchParams(new URL(window.location.href).search).get(paramName);


### PR DESCRIPTION
## Purpose

We were adding filters (such as facets or related resources) to the URL and history, but not full text search queries. They were only added to the URL when eg. a filter forced an update.

We also noticed the UI was no picking up the "query" param from the URL. We then added a call in the `<SearchSuggestField />` constructor to get it to initialize its state.

Finally, we needed to add a way for users to easily remove the full text query.

## Proposal

- [x] add the relevant action to the `fullTextSearch` handler to it adds full text searches to the history;
- [x] pick up full text search queries from the URL at startup;
- [x] delete the current full text search and update history when the user presses enter on an empty input.


Closes #453.