### PR TITLE
🔥(settings) remove dead demo settings

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -71,10 +71,6 @@ class ElasticSearchMixin:
 
     ES_DEFAULT_PAGE_SIZE = 10
 
-    COURSE_API_ENDPOINT = "https://www.fun-mooc.fr/fun/api/courses"
-    ORGANIZATION_API_ENDPOINT = "https://www.fun-mooc.fr/fun/api/universities"
-    SUBJECT_API_ENDPOINT = "https://www.fun-mooc.fr/fun/api/course_subjects"
-
 
 class DRFMixin:
     """


### PR DESCRIPTION
## Purpose

We used to take demo data from the fun-mooc API to populate our search index.

## Proposal

 Now that we populate the index with real data from the models, we do not need these API endpoints in our settings anymore.
