### PR TITLE
🔖(chore) bump release to 1.0.0-beta.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-front-dependencies-{{ checksum "package.json" }}
+            - v3-front-dependencies-{{ checksum "yarn.lock" }}
       - attach_workspace:
           at: ~/fun/src/richie/locale
       - run:
@@ -533,7 +533,7 @@ jobs:
       - save_cache:
           paths:
             - ./node_modules
-          key: v3-front-dependencies-{{ checksum "package.json" }}
+          key: v3-front-dependencies-{{ checksum "yarn.lock" }}
 
   lint-front-tslint:
     docker:
@@ -543,7 +543,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-front-dependencies-{{ checksum "package.json" }}
+            - v3-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Lint code with tslint
           command: yarn lint
@@ -556,7 +556,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-front-dependencies-{{ checksum "package.json" }}
+            - v3-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Lint JS/TS/JSON and CSS/SCSS code with prettier
           command: yarn prettier --list-different "src/richie-front/js/**/*.+(ts|tsx|json|js|jsx)" "*.+(ts|tsx|json|js|jsx)" "src/**/*.+(css|scss)"
@@ -569,7 +569,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-front-dependencies-{{ checksum "package.json" }}
+            - v3-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Run tests
           # Circle CI needs the tests to be ran sequentially, otherwise it hangs. See Jest docs below:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.0] - 2019-02-04
+
+This release indicates our intention to release richie 1.0. It also marks the beginning of this changelog.
+
+Here are the core features that enabled us to reach this milestone:
+
+- index the courses, organizations & subjects (now categories) in ElasticSearch from the DjangoCMS models;
+- create course snapshots to keep a history of the versions of a course Page throughout its various course runs;
+- add full text search queries to the course Search;
+- handle facet counts for all our filters in course Search;
+- develop plugins for all essential parts: courses, organizations, categories, people, licences...
+
+As we prepare to release, here are some improvements and fixes still ahead of us:
+
+- allow nesting of categories, to let users customize "meta" categories and build their own subtrees;
+- finish integrating the missing pages and improve the sandbox environment;
+- test and polish the use of richie as a django app / node dependency.
+
+[unreleased]: https://github.com/openfun/richie/compare/v1.0.0-beta.0...master
+[1.0.0-beta.0]: https://github.com/openfun/richie/compare/11ec5d911b9a9097535adbbf4f62957a7ab05356...v1.0.0-beta.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie",
-  "version": "0.1.0",
+  "version": "1.0.0-beta.0",
   "description": "A Django-CMS based portal for Open edX courses discovery",
   "main": "sandbox/manage.py",
   "scripts": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 0.1.0
+version = 1.0.0-beta.0
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This release indicates our intention to release richie 1.0.

Here are the core features that enabled us to reach this milestone:
- index the courses, organizations & subjects (now categories) in  ElasticSearch from the DjangoCMS models;
- create course snapshots to keep a history of the versions of a course Page throughout its various course runs;
- add full text search queries to the course Search;
- handle facet counts for all our filters in course Search;
- develop plugins for all essential parts: courses, organizations, categories, people, licences...

As we prepare to release, here are some improvements and fixes still ahead of us:
- allow nesting of categories, to let users customize "meta" categories and build their own subtrees;
- finish integrating the missing pages and improve the sandbox environment;
- test and polish the use of richie as a django app / node dependency.