### PR TITLE
🐛(package) fix simple_text_ckeditor plugin discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The simple_text_ckeditor plugin was not discovered as a python module and thus
+  not distributed with Richie's python package.
+
 ## [1.0.0-beta.0] - 2019-02-04
 
 This release indicates our intention to release richie 1.0. It also marks the beginning of this changelog.

--- a/src/richie/plugins/simple_text_ckeditor/forms.py
+++ b/src/richie/plugins/simple_text_ckeditor/forms.py
@@ -1,4 +1,6 @@
-# -*- coding: utf-8 -*-
+"""
+Simple text plugin forms
+"""
 from django import forms
 
 from djangocms_text_ckeditor.widgets import TextEditorWidget

--- a/src/richie/plugins/simple_text_ckeditor/models.py
+++ b/src/richie/plugins/simple_text_ckeditor/models.py
@@ -29,6 +29,7 @@ class SimpleText(CMSPlugin):
         super(SimpleText, self).__init__(*args, **kwargs)
         self.body = force_text(self.body)
 
+    # pylint: disable=arguments-differ
     def save(self, *args, **kwargs):
         # Clean HTML from potential XSS content
         self.body = clean_html(self.body, full=False)


### PR DESCRIPTION
## Purpose

The `simple_text_ckeditor` plugin is not distributed as a python package, only templates are part of the packaged plugin.

## Proposal

```
$ touch src/richie/plugins/simple_text_ckeditor/__init__.py
```
