### PR TITLE
Allow building category trees

### DIFF
--- a/src/richie/apps/core/management/commands/create_demo_site.py
+++ b/src/richie/apps/core/management/commands/create_demo_site.py
@@ -39,17 +39,17 @@ NB_PERSONS = 10
 NB_CATEGORIES = 8
 PAGE_INFOS = {
     "home": {
-        "content": {"en": "Home", "fr": "Accueil"},
+        "title": {"en": "Home", "fr": "Accueil"},
         "in_navigation": False,
         "kwargs": {"template": "richie/fullwidth.html"},
     },
     "news": {
-        "content": {"en": "News", "fr": "Actualités"},
+        "title": {"en": "News", "fr": "Actualités"},
         "in_navigation": True,
         "kwargs": {"template": "richie/fullwidth.html"},
     },
     "courses": {
-        "content": {"en": "Courses", "fr": "Cours"},
+        "title": {"en": "Courses", "fr": "Cours"},
         "in_navigation": True,
         "kwargs": {
             "reverse_id": Course.ROOT_REVERSE_ID,
@@ -57,7 +57,7 @@ PAGE_INFOS = {
         },
     },
     "categories": {
-        "content": {"en": "Categories", "fr": "Catégories"},
+        "title": {"en": "Categories", "fr": "Catégories"},
         "in_navigation": False,
         "kwargs": {
             "reverse_id": Category.ROOT_REVERSE_ID,
@@ -65,7 +65,7 @@ PAGE_INFOS = {
         },
     },
     "organizations": {
-        "content": {"en": "Organizations", "fr": "Etablissements"},
+        "title": {"en": "Organizations", "fr": "Etablissements"},
         "in_navigation": True,
         "kwargs": {
             "reverse_id": Organization.ROOT_REVERSE_ID,
@@ -73,7 +73,7 @@ PAGE_INFOS = {
         },
     },
     "persons": {
-        "content": {"en": "Persons", "fr": "Personnes"},
+        "title": {"en": "Persons", "fr": "Personnes"},
         "in_navigation": False,
         "kwargs": {
             "reverse_id": Person.ROOT_REVERSE_ID,
@@ -81,21 +81,21 @@ PAGE_INFOS = {
         },
     },
     "dashboard": {
-        "content": {"en": "Dashboard", "fr": "Tableau de bord"},
+        "title": {"en": "Dashboard", "fr": "Tableau de bord"},
         "in_navigation": False,
         "cms": False,
         "kwargs": {"template": "richie/fullwidth.html"},
     },
     "annex": {
-        "content": {"en": "Annex", "fr": "Annexe"},
+        "title": {"en": "Annex", "fr": "Annexe"},
         "in_navigation": False,
         "kwargs": {
             "template": "richie/fullwidth.html",
             "reverse_id": DEMO_ANNEX_PAGE_ID,
         },
         "children": {
-            "about": {
-                "content": {"en": "About", "fr": "A propos"},
+            "annex__about": {
+                "title": {"en": "About", "fr": "A propos"},
                 "in_navigation": True,
                 "kwargs": {"template": "richie/fullwidth.html"},
             }

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -172,7 +172,27 @@ class CategoryWizardForm(BaseWizardForm):
     A related Category model is created for each category page.
     """
 
+    parent_category = forms.ModelChoiceField(
+        required=False,
+        queryset=Category.objects.filter(
+            extended_object__publisher_is_draft=True
+        ).order_by("extended_object__node__path"),
+        label=_("Parent category"),
+        help_text=_("Choose a parent if you are building a category tree."),
+    )
+
     model = Category
+
+    @cached_property
+    def parent_page(self):
+        """
+        The parent page may be defined in the form but defaults to the categories root page
+        defined by the `ROOT_REVERSE_ID` property of the Category model.
+        """
+        parent_category = self.cleaned_data.get("parent_category")
+        return (
+            parent_category.extended_object if parent_category else super().parent_page
+        )
 
     def save(self):
         """

--- a/src/richie/apps/courses/helpers.py
+++ b/src/richie/apps/courses/helpers.py
@@ -1,0 +1,50 @@
+"""
+Helpers that can be useful throughout Richie's courses app
+"""
+from .factories import CategoryFactory
+
+
+def create_categories(info, parent, should_publish=True):
+    """
+    Create the category tree from the SUBJECTS dictionary.
+
+
+    Arguments:
+        info (List): definition of the category tree to create in the following format:
+
+            {
+                "title": "Subject",
+                "children": [
+                    {
+                        "title": "Computer science",
+                        "children": [
+                            {"title": "Coding"},
+                            {"title": "Security"},
+                        ],
+                    },
+                    {"title": "Languages"},
+                ],
+            }
+
+        page (cms.models.pagemodel.Page): Instance of a Page below which the category
+            tree is created.
+
+    Returns:
+        generator[courses.models.Category]: yield only the leaf categories of the created tree.
+
+    """
+    category = CategoryFactory(
+        page_title=info["title"],
+        page_in_navigation=info.get("in_navigation", True),
+        page_parent=parent,
+        should_publish=should_publish,
+    )
+
+    if info.get("children", None):
+        for child_info in info["children"]:
+            yield from create_categories(
+                child_info, category.extended_object, should_publish=should_publish
+            )
+    else:
+        # we only return leaf categories (no children)
+        yield category

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -33,8 +33,13 @@ class Category(BasePageExtension):
 
     def __str__(self):
         """Human representation of a category"""
-        return "{model}: {title}".format(
-            model=self._meta.verbose_name.title(),
+        ancestors = self.extended_object.get_ancestor_pages().filter(
+            category__isnull=False
+        )
+        return "{ancestors:s}{title:s}".format(
+            ancestors="{:s} / ".format(" / ".join([a.get_title() for a in ancestors]))
+            if ancestors
+            else "",
             title=self.extended_object.get_title(),
         )
 

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -92,7 +92,7 @@ class CategoriesIndexer:
                 description[simple_text.cmsplugin_ptr.language].append(simple_text.body)
 
             yield {
-                "_id": str(category.pk),
+                "_id": str(category.extended_object_id),
                 "_index": index,
                 "_op_type": action,
                 "_type": cls.document_type,

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -187,7 +187,7 @@ class CoursesIndexer:
             for course_run in course_runs:
 
                 yield {
-                    "_id": str(course_run.pk),
+                    "_id": str(course_run.extended_object_id),
                     "_index": index,
                     "_op_type": action,
                     "_type": cls.document_type,
@@ -212,14 +212,14 @@ class CoursesIndexer:
                     "organizations": [
                         str(id)
                         for id in course.get_organizations().values_list(
-                            "public_extension", flat=True
+                            "public_extension__extended_object", flat=True
                         )
                         if id is not None
                     ],
                     "categories": [
                         str(id)
                         for id in course.get_categories().values_list(
-                            "public_extension", flat=True
+                            "public_extension__extended_object", flat=True
                         )
                         if id is not None
                     ],

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -217,11 +217,10 @@ class CoursesIndexer:
                         if id is not None
                     ],
                     "categories": [
-                        str(id)
-                        for id in course.get_categories().values_list(
-                            "public_extension__extended_object", flat=True
+                        str(pk)
+                        for pk in course.get_root_to_leaf_category_pages().values_list(
+                            "pk", flat=True
                         )
-                        if id is not None
                     ],
                     "title": titles,
                 }

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -93,7 +93,7 @@ class OrganizationsIndexer:
                 description[simple_text.cmsplugin_ptr.language].append(simple_text.body)
 
             yield {
-                "_id": str(organization.pk),
+                "_id": str(organization.extended_object_id),
                 "_index": index,
                 "_op_type": action,
                 "_type": cls.document_type,

--- a/tests/apps/courses/test_helpers.py
+++ b/tests/apps/courses/test_helpers.py
@@ -1,0 +1,56 @@
+"""
+Test suite for all helpers in the `courses` application
+"""
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.helpers import create_i18n_page
+from richie.apps.courses.helpers import create_categories
+from richie.apps.courses.models import Category
+
+
+class CoursesHelpersTestCase(CMSTestCase):
+    """Test suite for the helpers of Richie's course app."""
+
+    def test_helpers_create_categories(self):
+        """
+        The `create_categories` method should create the whole category tree and return
+        only the leaf categories.
+        """
+        page = create_i18n_page(title="Root page")
+        test_info = {
+            "title": "Subject",
+            "children": [
+                {
+                    "title": {"en": "Computer science", "fr": "Informatique"},
+                    "children": [
+                        {"title": {"en": "Coding", "fr": "Programmation"}},
+                        {"title": {"en": "Security", "fr": "Sécurité"}},
+                    ],
+                },
+                {"title": "Languages"},
+            ],
+        }
+
+        # The function returns a generator so it should not have been executed yet
+        categories = create_categories(test_info, page)
+        self.assertFalse(Category.objects.exists())
+
+        # Now force its execution and check that the category tree was created as expected
+        categories = list(categories)
+        self.assertEqual(Category.objects.count(), 5)
+        self.assertEqual(len(list(categories)), 3)
+        self.assertEqual(
+            ["Coding", "Security", "Languages"],
+            [c.extended_object.get_title() for c in categories],
+        )
+        self.assertEqual(
+            [
+                ["Root page", "Subject", "Computer science"],
+                ["Root page", "Subject", "Computer science"],
+                ["Root page", "Subject"],
+            ],
+            [
+                [a.get_title() for a in c.extended_object.get_ancestor_pages()]
+                for c in categories
+            ],
+        )

--- a/tests/apps/courses/test_models_category.py
+++ b/tests/apps/courses/test_models_category.py
@@ -17,13 +17,34 @@ class CategoryModelsTestCase(TestCase):
 
     def test_models_category_str(self):
         """
-        The string representation should be built with the title of the related page.
-        Only 1 query to the associated page should be generated.
+        The string representation should be built with the title of the related page
+        and its ancestors as long as they are category page.
         """
-        page = create_page("Art", "courses/cms/category_detail.html", "en")
+        not_a_category_page = create_page("Categories", "richie/fullwidth.html", "en")
+
+        # Art
+        page = create_page(
+            "Art", "courses/cms/category_detail.html", "en", parent=not_a_category_page
+        )
         category = CategoryFactory(extended_object=page)
-        with self.assertNumQueries(1):
-            self.assertEqual(str(category), "Category: Art")
+        with self.assertNumQueries(2):
+            self.assertEqual(str(category), "Art")
+
+        # Art / Literature
+        child_page = create_page(
+            "Literature", "courses/cms/category_detail.html", "en", parent=page
+        )
+        child_category = CategoryFactory(extended_object=child_page)
+        with self.assertNumQueries(3):
+            self.assertEqual(str(child_category), "Art / Literature")
+
+        # Art / Literature / Novels
+        leaf_page = create_page(
+            "Novels", "courses/cms/category_detail.html", "en", parent=child_page
+        )
+        leaf_category = CategoryFactory(extended_object=leaf_page)
+        with self.assertNumQueries(4):
+            self.assertEqual(str(leaf_category), "Art / Literature / Novels")
 
     def test_models_category_get_courses(self):
         """

--- a/tests/apps/courses/test_models_course.py
+++ b/tests/apps/courses/test_models_course.py
@@ -48,18 +48,18 @@ class CourseModelsTestCase(TestCase):
         # only the categories linked to the course are retrieved (its name starts with `_`
         # because it is not used and only here for unpacking purposes)
         *draft_categories, _other_draft = CategoryFactory.create_batch(3)
-        *public_categories, _other_public = CategoryFactory.create_batch(
+        *published_categories, _other_public = CategoryFactory.create_batch(
             3, should_publish=True
         )
         course = CourseFactory(
-            fill_categories=draft_categories + public_categories, should_publish=True
+            fill_categories=draft_categories + published_categories, should_publish=True
         )
 
         self.assertEqual(
-            list(course.get_categories()), draft_categories + public_categories
+            list(course.get_categories()), draft_categories + published_categories
         )
         self.assertEqual(
-            list(course.public_extension.get_categories()), public_categories
+            list(course.public_extension.get_categories()), published_categories
         )
 
     def test_models_course_get_organizations_empty(self):
@@ -81,19 +81,20 @@ class CourseModelsTestCase(TestCase):
         # only the organizations linked to the course are retrieved (its name starts with `_`
         # because it is not used and only here for unpacking purposes)
         *draft_organizations, _other_draft = OrganizationFactory.create_batch(3)
-        *public_organizations, _other_public = OrganizationFactory.create_batch(
+        *published_organizations, _other_public = OrganizationFactory.create_batch(
             3, should_publish=True
         )
         course = CourseFactory(
-            fill_organizations=draft_organizations + public_organizations,
+            fill_organizations=draft_organizations + published_organizations,
             should_publish=True,
         )
 
         self.assertEqual(
-            list(course.get_organizations()), draft_organizations + public_organizations
+            list(course.get_organizations()),
+            draft_organizations + published_organizations,
         )
         self.assertEqual(
-            list(course.public_extension.get_organizations()), public_organizations
+            list(course.public_extension.get_organizations()), published_organizations
         )
 
     def test_models_course_get_main_organization_empty(self):
@@ -115,17 +116,17 @@ class CourseModelsTestCase(TestCase):
         # only the organizations linked to the course are retrieved (its name starts with `_`
         # because it is not used and only here for unpacking purposes)
         *draft_organizations, _other_draft = OrganizationFactory.create_batch(3)
-        *public_organizations, _other_public = OrganizationFactory.create_batch(
+        *published_organizations, _other_public = OrganizationFactory.create_batch(
             3, should_publish=True
         )
         course = CourseFactory(
-            fill_organizations=draft_organizations + public_organizations,
+            fill_organizations=draft_organizations + published_organizations,
             should_publish=True,
         )
 
         self.assertEqual(course.get_main_organization(), draft_organizations[0])
         self.assertEqual(
-            course.public_extension.get_main_organization(), public_organizations[0]
+            course.public_extension.get_main_organization(), published_organizations[0]
         )
 
     def test_models_course_get_course_runs_empty(self):

--- a/tests/apps/search/test_indexers_categories.py
+++ b/tests/apps/search/test_indexers_categories.py
@@ -56,7 +56,7 @@ class CategoriesIndexersTestCase(TestCase):
             ),
             [
                 {
-                    "_id": str(category2.public_extension.pk),
+                    "_id": str(category2.public_extension.extended_object_id),
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "category",
@@ -80,7 +80,7 @@ class CategoriesIndexersTestCase(TestCase):
                     },
                 },
                 {
-                    "_id": str(category1.public_extension.pk),
+                    "_id": str(category1.public_extension.extended_object_id),
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "category",

--- a/tests/apps/search/test_indexers_categories.py
+++ b/tests/apps/search/test_indexers_categories.py
@@ -33,10 +33,10 @@ class CategoriesIndexersTestCase(TestCase):
             should_publish=True,
         )
         category2 = CategoryFactory(
+            page_parent=category1.extended_object,
             page_title={"en": "my second category", "fr": "ma deuxième thématique"},
             should_publish=True,
         )
-
         # Add a description in several languages to the first category
         placeholder = category1.public_extension.extended_object.placeholders.get(
             slot="description"
@@ -61,8 +61,8 @@ class CategoriesIndexersTestCase(TestCase):
                     "_op_type": "some_action",
                     "_type": "category",
                     "absolute_url": {
-                        "en": "/en/my-second-category/",
-                        "fr": "/fr/ma-deuxieme-thematique/",
+                        "en": "/en/my-first-category/my-second-category/",
+                        "fr": "/fr/ma-premiere-thematique/ma-deuxieme-thematique/",
                     },
                     "complete": {
                         "en": ["my second category", "second category", "category"],
@@ -73,7 +73,10 @@ class CategoriesIndexersTestCase(TestCase):
                         ],
                     },
                     "description": {},
+                    "is_meta": False,
                     "logo": {},
+                    "nb_children": 0,
+                    "path": "00010001",
                     "title": {
                         "en": "my second category",
                         "fr": "ma deuxième thématique",
@@ -100,7 +103,10 @@ class CategoriesIndexersTestCase(TestCase):
                         "en": "english description line 1. english description line 2.",
                         "fr": "description français ligne 1. description français ligne 2.",
                     },
+                    "is_meta": True,
                     "logo": {"en": "123.jpg", "fr": "123.jpg"},
+                    "nb_children": 1,
+                    "path": "0001",
                     "title": {
                         "en": "my first category",
                         "fr": "ma première thématique",
@@ -116,13 +122,23 @@ class CategoriesIndexersTestCase(TestCase):
         es_category = {
             "_id": 89,
             "_source": {
+                "is_meta": True,
                 "logo": {"en": "/image_en.png", "fr": "/image_fr.png"},
+                "nb_children": 3,
+                "path": "00010001",
                 "title": {"en": "Computer science", "fr": "Informatique"},
             },
         }
         self.assertEqual(
             CategoriesIndexer.format_es_object_for_api(es_category, "en"),
-            {"id": 89, "logo": "/image_en.png", "title": "Computer science"},
+            {
+                "id": 89,
+                "is_meta": True,
+                "logo": "/image_en.png",
+                "nb_children": 3,
+                "path": "00010001",
+                "title": "Computer science",
+            },
         )
 
     def test_indexers_categories_build_es_query_search_all_categories(self):

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -178,10 +178,12 @@ class CoursesIndexersTestCase(TestCase):
                 "fr": "syllabus français ligne 1. syllabus français ligne 2.",
             },
             "organizations": [
-                str(main_organization.public_extension.id),
-                str(other_public_organization.public_extension.id),
+                str(main_organization.public_extension.extended_object_id),
+                str(other_published_organization.public_extension.extended_object_id),
             ],
-            "categories": [str(s.public_extension.id) for s in public_categories],
+            "categories": [
+                str(s.public_extension.extended_object_id) for s in published_categories
+            ],
             "title": {"fr": "un titre cours français", "en": "an english course title"},
         }
         self.assertEqual(
@@ -191,7 +193,7 @@ class CoursesIndexersTestCase(TestCase):
             [
                 {
                     **{
-                        "_id": str(cr.public_extension.id),
+                        "_id": str(cr.public_extension.extended_object_id),
                         "_index": "some_index",
                         "_op_type": "some_action",
                         "_type": "course",

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -105,7 +105,7 @@ class CoursesIndexersTestCase(TestCase):
         Happy path: the data is retrieved from the models properly formatted
         """
         # Create a course with a page in both english and french
-        public_categories = CategoryFactory.create_batch(2, should_publish=True)
+        published_categories = CategoryFactory.create_batch(2, should_publish=True)
         draft_category = CategoryFactory()
 
         main_organization = OrganizationFactory(
@@ -121,7 +121,7 @@ class CoursesIndexersTestCase(TestCase):
                 "fr": "titre autre organisation français",
             }
         )
-        other_public_organization = OrganizationFactory(
+        other_published_organization = OrganizationFactory(
             page_title={
                 "en": "english other organization title",
                 "fr": "titre autre organisation français",
@@ -136,9 +136,9 @@ class CoursesIndexersTestCase(TestCase):
             fill_organizations=[
                 main_organization,
                 other_draft_organization,
-                other_public_organization,
+                other_published_organization,
             ],
-            fill_categories=public_categories + [draft_category],
+            fill_categories=published_categories + [draft_category],
             fill_cover=True,
             should_publish=True,
         )

--- a/tests/apps/search/test_indexers_organizations.py
+++ b/tests/apps/search/test_indexers_organizations.py
@@ -62,7 +62,7 @@ class OrganizationsIndexersTestCase(TestCase):
             ),
             [
                 {
-                    "_id": str(organization2.public_extension.pk),
+                    "_id": str(organization2.public_extension.extended_object_id),
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "organization",
@@ -90,7 +90,7 @@ class OrganizationsIndexersTestCase(TestCase):
                     },
                 },
                 {
-                    "_id": str(organization1.public_extension.pk),
+                    "_id": str(organization1.public_extension.extended_object_id),
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "organization",

--- a/tests/apps/search/test_viewsets_categories.py
+++ b/tests/apps/search/test_viewsets_categories.py
@@ -31,7 +31,10 @@ class CategoriesViewsetsTestCase(TestCase):
             return_value={
                 "_id": 42,
                 "_source": {
+                    "is_meta": True,
                     "logo": {"fr": "/image42.png"},
+                    "nb_children": 1,
+                    "path": "0001",
                     "title": {"fr": "Some Category"},
                 },
             },
@@ -44,7 +47,15 @@ class CategoriesViewsetsTestCase(TestCase):
         # The client received a proper response with the relevant category
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.data, {"id": 42, "logo": "/image42.png", "title": "Some Category"}
+            response.data,
+            {
+                "id": 42,
+                "is_meta": True,
+                "logo": "/image42.png",
+                "nb_children": 1,
+                "path": "0001",
+                "title": "Some Category",
+            },
         )
 
     def test_viewsets_categories_retrieve_unknown(self):
@@ -81,14 +92,20 @@ class CategoriesViewsetsTestCase(TestCase):
                     {
                         "_id": 21,
                         "_source": {
+                            "is_meta": True,
                             "logo": {"fr": "/image21.png"},
+                            "nb_children": 1,
+                            "path": "0002",
                             "title": {"fr": "Computer Science"},
                         },
                     },
                     {
                         "_id": 61,
                         "_source": {
+                            "is_meta": False,
                             "logo": {"fr": "/image61.png"},
+                            "nb_children": 0,
+                            "path": "00020001",
                             "title": {"fr": "Engineering Sciences"},
                         },
                     },
@@ -106,14 +123,35 @@ class CategoriesViewsetsTestCase(TestCase):
             {
                 "meta": {"count": 2, "offset": 0, "total_count": 32},
                 "objects": [
-                    {"id": 21, "logo": "/image21.png", "title": "Computer Science"},
-                    {"id": 61, "logo": "/image61.png", "title": "Engineering Sciences"},
+                    {
+                        "id": 21,
+                        "is_meta": True,
+                        "logo": "/image21.png",
+                        "nb_children": 1,
+                        "path": "0002",
+                        "title": "Computer Science",
+                    },
+                    {
+                        "id": 61,
+                        "is_meta": False,
+                        "logo": "/image61.png",
+                        "nb_children": 0,
+                        "path": "00020001",
+                        "title": "Engineering Sciences",
+                    },
                 ],
             },
         )
         # The ES connector was called with a query that matches the client's request
         mock_search.assert_called_with(
-            _source=["absolute_url", "logo", "title.*"],
+            _source=[
+                "absolute_url",
+                "is_meta",
+                "logo",
+                "nb_children",
+                "path",
+                "title.*",
+            ],
             body={"query": "example"},
             doc_type="category",
             from_=0,


### PR DESCRIPTION
## Purpose

We want to allow building category taxonomies in the CMS:
- multiple types of categories e.g. `Subject` versus `Level`
- nested categories e.g. `subject / maths / algebra` versus `level / expert`

## Proposal

We propose to use the DjangoCMS page tree to build the taxonomy. Everything is already there to do it... so we just had to:

- [x] refactor the demo site generator to generate an example of category taxonomy,
- [x] limit to tree leaves the categories that can be linked via a plugin,
- [x] improve `str` display of a category to show the whole ancestors tree,
- [x] add support for category taxonomies in the course search index (filtering on a parent of the category that is linked to the course should still select the course),
- [x] add support for taxonomy to the category search index (add tree information to allow the frontend to display category filters: find what are the meta categories, what are the first level categories in each meta category, what are the children of each first level category, etc...)

Some side clean-up was made in the process:

- [x] rename `public` to `published` in tests to make a clear difference between a `published draft object` and its `public` sibling,
- [x] use the page ID instead of the page extension ID for search indexes as they are much easier to get when retrieving a categories ancestors,
- [x] improve recursive page creation in the demo site generator.
