### PR TITLE
♻️(search) refactor languages into a dynamic filter

### DIFF
--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -21,8 +21,10 @@ CATEGORIES_LOGO_IMAGE_HEIGHT = getattr(settings, "CATEGORIES_LOGO_IMAGE_HEIGHT",
 
 # Define our aggregations names, for our ES query, which will match with the field
 # names on the objects & the facets we return on the API response
-RESOURCE_FACETS = getattr(
-    settings, "RICHIE_SEARCH_RESOURCE_FACETS", ["organizations", "categories"]
+FILTERS_DYNAMIC = getattr(
+    settings,
+    "RICHIE_SEARCH_FILTERS_DYNAMIC",
+    ["categories", "languages", "organizations"],
 )
 
 FILTERS_HARDCODED_DEFAULT = {
@@ -50,10 +52,6 @@ FILTERS_HARDCODED_DEFAULT = {
                 {"range": {"end": {"gte": arrow.utcnow().datetime}}},
             ],
         },
-    },
-    "language": {
-        "field": MultipleChoiceField,
-        "choices": {lang: [{"term": {"languages": lang}}] for lang in ["en", "fr"]},
     },
     "new": {
         "field": MultipleChoiceField,

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -2,6 +2,7 @@
 Validate and clean request parameters for our endpoints using Django forms
 """
 from django import forms
+from django.conf import settings
 
 from .defaults import FILTERS_HARDCODED
 from .fields.array import ArrayField
@@ -27,6 +28,9 @@ class CourseListForm(forms.Form):
     end = DatetimeRangeField(required=False)
     enrollment_end = DatetimeRangeField(required=False)
     enrollment_start = DatetimeRangeField(required=False)
+    languages = ArrayField(
+        required=False, base_type=forms.ChoiceField(choices=settings.ALL_LANGUAGES)
+    )
     limit = forms.IntegerField(required=False, min_value=1, initial=10)
     organizations = ArrayField(
         required=False, base_type=forms.IntegerField(min_value=0)

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -11,7 +11,7 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
-from ..defaults import FILTERS_HARDCODED, RESOURCE_FACETS
+from ..defaults import FILTERS_DYNAMIC, FILTERS_HARDCODED
 from ..exceptions import QueryFormatException
 from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
 
@@ -79,7 +79,7 @@ class CoursesViewSet(AutocompleteMixin, ViewSet):
                         "all_courses"
                     ].items()
                     # Remove default fields inserted by elasticsearch
-                    if field in RESOURCE_FACETS
+                    if field in FILTERS_DYNAMIC
                 },
                 # Custom (filter-based) facets are structured in another, common way
                 **reduce(

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -263,11 +263,12 @@ class CoursesIndexersTestCase(TestCase):
     @patch(
         "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
         new={
-            "language": {
+            "availability": {
                 "choices": {
-                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                    choice: [{"term": {"availability": choice}}]
+                    for choice in ["coming_soon", "current"]
                 },
-                "field": MultipleChoiceField,
+                "field": ChoiceField,
             }
         },
     )
@@ -289,15 +290,33 @@ class CoursesIndexersTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
-                            "language@en": {
+                            "availability@coming_soon": {
                                 "filter": {
-                                    "bool": {"must": [{"term": {"language": "en"}}]}
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"availability": "coming_soon"}}
+                                        ]
+                                    }
                                 }
                             },
-                            "language@fr": {
+                            "availability@current": {
                                 "filter": {
-                                    "bool": {"must": [{"term": {"language": "fr"}}]}
+                                    "bool": {
+                                        "must": [{"term": {"availability": "current"}}]
+                                    }
                                 }
+                            },
+                            "categories": {
+                                "filter": {"bool": {"must": []}},
+                                "aggregations": {
+                                    "categories": {"terms": {"field": "categories"}}
+                                },
+                            },
+                            "languages": {
+                                "filter": {"bool": {"must": []}},
+                                "aggregations": {
+                                    "languages": {"terms": {"field": "languages"}}
+                                },
                             },
                             "organizations": {
                                 "filter": {"bool": {"must": []}},
@@ -305,12 +324,6 @@ class CoursesIndexersTestCase(TestCase):
                                     "organizations": {
                                         "terms": {"field": "organizations"}
                                     }
-                                },
-                            },
-                            "categories": {
-                                "filter": {"bool": {"must": []}},
-                                "aggregations": {
-                                    "categories": {"terms": {"field": "categories"}}
                                 },
                             },
                         },
@@ -322,9 +335,10 @@ class CoursesIndexersTestCase(TestCase):
     @patch(
         "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
         new={
-            "language": {
+            "availability": {
                 "choices": {
-                    lang: [{"term": {"languages": lang}}] for lang in ["en", "fr"]
+                    choice: [{"term": {"availability": choice}}]
+                    for choice in ["coming_soon", "current"]
                 },
                 "field": ChoiceField,
             }
@@ -370,25 +384,37 @@ class CoursesIndexersTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
-                            "language@en": {
+                            "availability@coming_soon": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"languages": "en"}},
+                                            {"term": {"availability": "coming_soon"}},
                                             multi_match,
                                         ]
                                     }
                                 }
                             },
-                            "language@fr": {
+                            "availability@current": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"languages": "fr"}},
+                                            {"term": {"availability": "current"}},
                                             multi_match,
                                         ]
                                     }
                                 }
+                            },
+                            "categories": {
+                                "filter": {"bool": {"must": [multi_match]}},
+                                "aggregations": {
+                                    "categories": {"terms": {"field": "categories"}}
+                                },
+                            },
+                            "languages": {
+                                "filter": {"bool": {"must": [multi_match]}},
+                                "aggregations": {
+                                    "languages": {"terms": {"field": "languages"}}
+                                },
                             },
                             "organizations": {
                                 "filter": {"bool": {"must": [multi_match]}},
@@ -396,12 +422,6 @@ class CoursesIndexersTestCase(TestCase):
                                     "organizations": {
                                         "terms": {"field": "organizations"}
                                     }
-                                },
-                            },
-                            "categories": {
-                                "filter": {"bool": {"must": [multi_match]}},
-                                "aggregations": {
-                                    "categories": {"terms": {"field": "categories"}}
                                 },
                             },
                         },
@@ -413,11 +433,12 @@ class CoursesIndexersTestCase(TestCase):
     @patch(
         "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
         new={
-            "language": {
+            "availability": {
                 "choices": {
-                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                    choice: [{"term": {"availability": choice}}]
+                    for choice in ["coming_soon", "current"]
                 },
-                "field": MultipleChoiceField,
+                "field": ChoiceField,
             }
         },
     )
@@ -442,25 +463,41 @@ class CoursesIndexersTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
-                            "language@en": {
+                            "availability@coming_soon": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"language": "en"}},
+                                            {"term": {"availability": "coming_soon"}},
                                             terms_organizations,
                                         ]
                                     }
                                 }
                             },
-                            "language@fr": {
+                            "availability@current": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"language": "fr"}},
+                                            {"term": {"availability": "current"}},
                                             terms_organizations,
                                         ]
                                     }
                                 }
+                            },
+                            "categories": {
+                                "filter": {"bool": {"must": [terms_organizations]}},
+                                "aggregations": {
+                                    "categories": {"terms": {"field": "categories"}}
+                                },
+                            },
+                            "languages": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [{"terms": {"organizations": [13, 15]}}]
+                                    }
+                                },
+                                "aggregations": {
+                                    "languages": {"terms": {"field": "languages"}}
+                                },
                             },
                             "organizations": {
                                 "filter": {"bool": {"must": []}},
@@ -468,12 +505,6 @@ class CoursesIndexersTestCase(TestCase):
                                     "organizations": {
                                         "terms": {"field": "organizations"}
                                     }
-                                },
-                            },
-                            "categories": {
-                                "filter": {"bool": {"must": [terms_organizations]}},
-                                "aggregations": {
-                                    "categories": {"terms": {"field": "categories"}}
                                 },
                             },
                         },
@@ -485,9 +516,10 @@ class CoursesIndexersTestCase(TestCase):
     @patch(
         "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
         new={
-            "language": {
+            "availability": {
                 "choices": {
-                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                    choice: [{"term": {"availability": choice}}]
+                    for choice in ["coming_soon", "current"]
                 },
                 "field": ChoiceField,
             }
@@ -512,25 +544,41 @@ class CoursesIndexersTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
-                            "language@en": {
+                            "availability@coming_soon": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"language": "en"}},
+                                            {"term": {"availability": "coming_soon"}},
                                             term_organization,
                                         ]
                                     }
                                 }
                             },
-                            "language@fr": {
+                            "availability@current": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"language": "fr"}},
+                                            {"term": {"availability": "current"}},
                                             term_organization,
                                         ]
                                     }
                                 }
+                            },
+                            "categories": {
+                                "filter": {"bool": {"must": [term_organization]}},
+                                "aggregations": {
+                                    "categories": {"terms": {"field": "categories"}}
+                                },
+                            },
+                            "languages": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [{"terms": {"organizations": [345]}}]
+                                    }
+                                },
+                                "aggregations": {
+                                    "languages": {"terms": {"field": "languages"}}
+                                },
                             },
                             "organizations": {
                                 "filter": {"bool": {"must": []}},
@@ -538,12 +586,6 @@ class CoursesIndexersTestCase(TestCase):
                                     "organizations": {
                                         "terms": {"field": "organizations"}
                                     }
-                                },
-                            },
-                            "categories": {
-                                "filter": {"bool": {"must": [term_organization]}},
-                                "aggregations": {
-                                    "categories": {"terms": {"field": "categories"}}
                                 },
                             },
                         },
@@ -555,11 +597,12 @@ class CoursesIndexersTestCase(TestCase):
     @patch(
         "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
         new={
-            "language": {
+            "availability": {
                 "choices": {
-                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                    choice: [{"term": {"availability": choice}}]
+                    for choice in ["coming_soon", "current"]
                 },
-                "field": MultipleChoiceField,
+                "field": ChoiceField,
             }
         },
     )
@@ -601,27 +644,39 @@ class CoursesIndexersTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
-                            "language@en": {
+                            "availability@coming_soon": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"language": "en"}},
+                                            {"term": {"availability": "coming_soon"}},
                                             range_end,
                                             range_start,
                                         ]
                                     }
                                 }
                             },
-                            "language@fr": {
+                            "availability@current": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"language": "fr"}},
+                                            {"term": {"availability": "current"}},
                                             range_end,
                                             range_start,
                                         ]
                                     }
                                 }
+                            },
+                            "categories": {
+                                "filter": {"bool": {"must": [range_end, range_start]}},
+                                "aggregations": {
+                                    "categories": {"terms": {"field": "categories"}}
+                                },
+                            },
+                            "languages": {
+                                "filter": {"bool": {"must": [range_end, range_start]}},
+                                "aggregations": {
+                                    "languages": {"terms": {"field": "languages"}}
+                                },
                             },
                             "organizations": {
                                 "filter": {"bool": {"must": [range_end, range_start]}},
@@ -629,12 +684,6 @@ class CoursesIndexersTestCase(TestCase):
                                     "organizations": {
                                         "terms": {"field": "organizations"}
                                     }
-                                },
-                            },
-                            "categories": {
-                                "filter": {"bool": {"must": [range_end, range_start]}},
-                                "aggregations": {
-                                    "categories": {"terms": {"field": "categories"}}
                                 },
                             },
                         },
@@ -646,9 +695,10 @@ class CoursesIndexersTestCase(TestCase):
     @patch(
         "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
         new={
-            "language": {
+            "availability": {
                 "choices": {
-                    lang: [{"term": {"language": lang}}] for lang in ["en", "fr"]
+                    choice: [{"term": {"availability": choice}}]
+                    for choice in ["coming_soon", "current"]
                 },
                 "field": ChoiceField,
             },
@@ -661,30 +711,37 @@ class CoursesIndexersTestCase(TestCase):
     def test_indexers_courses_build_es_query_search_by_custom_filter(self):
         """
         Happy path: build a query using custom filters
-        Note: we're keeping fields from defaults.py instead of mocking for simplicity
         """
         # Build a request stub
         request = SimpleNamespace(
-            query_params=QueryDict(query_string="limit=2&offset=10&language=fr")
+            query_params=QueryDict(
+                query_string="limit=2&offset=10&availability=coming_soon"
+            )
         )
         self.assertEqual(
             CoursesIndexer.build_es_query(request),
             (
                 2,
                 10,
-                {"bool": {"must": [{"term": {"language": "fr"}}]}},
+                {"bool": {"must": [{"term": {"availability": "coming_soon"}}]}},
                 {
                     "all_courses": {
                         "global": {},
                         "aggregations": {
-                            "language@en": {
+                            "availability@coming_soon": {
                                 "filter": {
-                                    "bool": {"must": [{"term": {"language": "en"}}]}
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"availability": "coming_soon"}}
+                                        ]
+                                    }
                                 }
                             },
-                            "language@fr": {
+                            "availability@current": {
                                 "filter": {
-                                    "bool": {"must": [{"term": {"language": "fr"}}]}
+                                    "bool": {
+                                        "must": [{"term": {"availability": "current"}}]
+                                    }
                                 }
                             },
                             "new@new": {
@@ -692,27 +749,47 @@ class CoursesIndexersTestCase(TestCase):
                                     "bool": {
                                         "must": [
                                             {"term": {"session_number": 1}},
-                                            {"term": {"language": "fr"}},
+                                            {"term": {"availability": "coming_soon"}},
                                         ]
                                     }
                                 }
                             },
+                            "categories": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"availability": "coming_soon"}}
+                                        ]
+                                    }
+                                },
+                                "aggregations": {
+                                    "categories": {"terms": {"field": "categories"}}
+                                },
+                            },
+                            "languages": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"availability": "coming_soon"}}
+                                        ]
+                                    }
+                                },
+                                "aggregations": {
+                                    "languages": {"terms": {"field": "languages"}}
+                                },
+                            },
                             "organizations": {
                                 "filter": {
-                                    "bool": {"must": [{"term": {"language": "fr"}}]}
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"availability": "coming_soon"}}
+                                        ]
+                                    }
                                 },
                                 "aggregations": {
                                     "organizations": {
                                         "terms": {"field": "organizations"}
                                     }
-                                },
-                            },
-                            "categories": {
-                                "filter": {
-                                    "bool": {"must": [{"term": {"language": "fr"}}]}
-                                },
-                                "aggregations": {
-                                    "categories": {"terms": {"field": "categories"}}
                                 },
                             },
                         },
@@ -724,15 +801,16 @@ class CoursesIndexersTestCase(TestCase):
     @patch(
         "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
         new={
-            "language": {
+            "availability": {
                 "choices": {
-                    lang: [{"term": {"languages": lang}}] for lang in ["en", "fr"]
+                    choice: [{"term": {"availability": choice}}]
+                    for choice in ["coming_soon", "current"]
                 },
-                "field": MultipleChoiceField,
+                "field": ChoiceField,
             },
             "new": {
                 "choices": {"new": [{"term": {"is_new": True}}]},
-                "field": ChoiceField,
+                "field": MultipleChoiceField,
             },
         },
     )
@@ -747,23 +825,26 @@ class CoursesIndexersTestCase(TestCase):
         request = SimpleNamespace(
             query_params=QueryDict(
                 query_string="categories=42&categories=84&query=these%20phrase%20terms&limit=2&"
-                + "language=fr&"
+                + "languages=fr&availability=current&"
                 + "start={start}&end={end}".format(start=start, end=end)
             )
         )
+
+        # Search fragments that are repeated in the query
+        availability = {"term": {"availability": "current"}}
+        multi_match = {
+            "multi_match": {
+                "fields": ["description.*", "title.*"],
+                "query": "these phrase terms",
+                "type": "cross_fields",
+            }
+        }
         range_end = {
             "range": {
                 "end": {
                     "gte": arrow.get("2018-04-30T06:00:00Z").datetime,
                     "lte": arrow.get("2018-06-30T06:00:00Z").datetime,
                 }
-            }
-        }
-        multi_match = {
-            "multi_match": {
-                "fields": ["description.*", "title.*"],
-                "query": "these phrase terms",
-                "type": "cross_fields",
             }
         }
         range_start = {
@@ -775,7 +856,8 @@ class CoursesIndexersTestCase(TestCase):
             }
         }
         terms_categories = {"terms": {"categories": [42, 84]}}
-        term_language_fr = {"term": {"languages": "fr"}}
+        terms_languages = {"terms": {"languages": ["fr"]}}
+
         self.assertEqual(
             CoursesIndexer.build_es_query(request),
             (
@@ -785,10 +867,11 @@ class CoursesIndexersTestCase(TestCase):
                     "bool": {
                         "must": [
                             range_end,
+                            terms_languages,
                             multi_match,
                             range_start,
                             terms_categories,
-                            term_language_fr,
+                            availability,
                         ]
                     }
                 },
@@ -796,12 +879,13 @@ class CoursesIndexersTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
-                            "language@en": {
+                            "availability@coming_soon": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            {"term": {"languages": "en"}},
+                                            {"term": {"availability": "coming_soon"}},
                                             range_end,
+                                            terms_languages,
                                             multi_match,
                                             range_start,
                                             terms_categories,
@@ -809,12 +893,13 @@ class CoursesIndexersTestCase(TestCase):
                                     }
                                 }
                             },
-                            "language@fr": {
+                            "availability@current": {
                                 "filter": {
                                     "bool": {
                                         "must": [
-                                            term_language_fr,
+                                            availability,
                                             range_end,
+                                            terms_languages,
                                             multi_match,
                                             range_start,
                                             terms_categories,
@@ -828,15 +913,32 @@ class CoursesIndexersTestCase(TestCase):
                                         "must": [
                                             {"term": {"is_new": True}},
                                             range_end,
+                                            terms_languages,
                                             multi_match,
                                             range_start,
                                             terms_categories,
-                                            term_language_fr,
+                                            availability,
                                         ]
                                     }
                                 }
                             },
-                            "organizations": {
+                            "categories": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            range_end,
+                                            terms_languages,
+                                            multi_match,
+                                            range_start,
+                                            availability,
+                                        ]
+                                    }
+                                },
+                                "aggregations": {
+                                    "categories": {"terms": {"field": "categories"}}
+                                },
+                            },
+                            "languages": {
                                 "filter": {
                                     "bool": {
                                         "must": [
@@ -844,7 +946,24 @@ class CoursesIndexersTestCase(TestCase):
                                             multi_match,
                                             range_start,
                                             terms_categories,
-                                            term_language_fr,
+                                            availability,
+                                        ]
+                                    }
+                                },
+                                "aggregations": {
+                                    "languages": {"terms": {"field": "languages"}}
+                                },
+                            },
+                            "organizations": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            range_end,
+                                            terms_languages,
+                                            multi_match,
+                                            range_start,
+                                            terms_categories,
+                                            availability,
                                         ]
                                     }
                                 },
@@ -854,28 +973,24 @@ class CoursesIndexersTestCase(TestCase):
                                     }
                                 },
                             },
-                            "categories": {
-                                "filter": {
-                                    "bool": {
-                                        "must": [
-                                            range_end,
-                                            multi_match,
-                                            range_start,
-                                            term_language_fr,
-                                        ]
-                                    }
-                                },
-                                "aggregations": {
-                                    "categories": {"terms": {"field": "categories"}}
-                                },
-                            },
                         },
                     }
                 },
             ),
         )
 
-    @patch("richie.apps.search.indexers.courses.FILTERS_HARDCODED", new={})
+    @patch(
+        "richie.apps.search.indexers.courses.FILTERS_HARDCODED",
+        new={
+            "availability": {
+                "choices": {
+                    choice: [{"term": {"availability": choice}}]
+                    for choice in ["coming_soon", "current"]
+                },
+                "field": ChoiceField,
+            }
+        },
+    )
     def test_indexers_courses_build_es_query_search_with_empty_filters(self):
         """
         Edge case: custom filters have been removed entirely through settings
@@ -884,6 +999,7 @@ class CoursesIndexersTestCase(TestCase):
         request = SimpleNamespace(
             query_params=QueryDict(query_string="limit=20&offset=40")
         )
+
         self.assertEqual(
             CoursesIndexer.build_es_query(request),
             (
@@ -894,18 +1010,40 @@ class CoursesIndexersTestCase(TestCase):
                     "all_courses": {
                         "global": {},
                         "aggregations": {
+                            "availability@coming_soon": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [
+                                            {"term": {"availability": "coming_soon"}}
+                                        ]
+                                    }
+                                }
+                            },
+                            "availability@current": {
+                                "filter": {
+                                    "bool": {
+                                        "must": [{"term": {"availability": "current"}}]
+                                    }
+                                }
+                            },
+                            "categories": {
+                                "filter": {"bool": {"must": []}},
+                                "aggregations": {
+                                    "categories": {"terms": {"field": "categories"}}
+                                },
+                            },
+                            "languages": {
+                                "filter": {"bool": {"must": []}},
+                                "aggregations": {
+                                    "languages": {"terms": {"field": "languages"}}
+                                },
+                            },
                             "organizations": {
                                 "filter": {"bool": {"must": []}},
                                 "aggregations": {
                                     "organizations": {
                                         "terms": {"field": "organizations"}
                                     }
-                                },
-                            },
-                            "categories": {
-                                "filter": {"bool": {"must": []}},
-                                "aggregations": {
-                                    "categories": {"terms": {"field": "categories"}}
                                 },
                             },
                         },

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -93,13 +93,19 @@ class CoursesViewsetsTestCase(TestCase):
                     "availability@coming_soon": {"doc_count": 8},
                     "availability@current": {"doc_count": 42},
                     "availability@open": {"doc_count": 59},
-                    "language@en": {"doc_count": 81},
-                    "language@fr": {"doc_count": 23},
                     "categories": {
                         "categories": {
                             "buckets": [
                                 {"key": "11", "doc_count": 17},
                                 {"key": "21", "doc_count": 19},
+                            ]
+                        }
+                    },
+                    "languages": {
+                        "languages": {
+                            "buckets": [
+                                {"key": "en", "doc_count": 81},
+                                {"key": "fr", "doc_count": 23},
                             ]
                         }
                     },
@@ -118,7 +124,7 @@ class CoursesViewsetsTestCase(TestCase):
                 "objects": ["Course #523", "Course #861"],
                 "facets": {
                     "availability": {"coming_soon": 8, "current": 42, "open": 59},
-                    "language": {"en": 81, "fr": 23},
+                    "languages": {"en": 81, "fr": 23},
                     "categories": {"11": 17, "21": 19},
                 },
             },


### PR DESCRIPTION
## Purpose

We first implemented the languages filter as a hardcoded filter with predefined choices in `defaults.py`.

This was not perfect as it prevented us from using all the possible language choices from `settings.ALL_LANGUAGES`.

## Proposal

Instead, we can use a simple "terms" in ElasticSearch and treat the field exactly like we already do categories and organizations. 

The new `FILTERS_DYNAMIC` name also reflects the fact that it's not just resources.