### PR TITLE
🐛(courserun) fix randomly failing tests linked to course run datetimes

### DIFF
--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -388,8 +388,10 @@ class CourseRunFactory(PageExtensionDjangoModelFactory):
         now = timezone.now()
         period = timedelta(days=200)
         return pytz.timezone("UTC").localize(
-            datetime.fromordinal(
-                random.randrange((now - period).toordinal(), (now + period).toordinal())
+            datetime.fromtimestamp(
+                random.randrange(
+                    int((now - period).timestamp()), int((now + period).timestamp())
+                )
             )
         )
 
@@ -402,9 +404,9 @@ class CourseRunFactory(PageExtensionDjangoModelFactory):
             return None
         period = timedelta(days=90)
         return pytz.timezone("UTC").localize(
-            datetime.fromordinal(
+            datetime.fromtimestamp(
                 random.randrange(
-                    self.start.toordinal(), (self.start + period).toordinal()
+                    int(self.start.timestamp()), int((self.start + period).timestamp())
                 )
             )
         )
@@ -418,9 +420,9 @@ class CourseRunFactory(PageExtensionDjangoModelFactory):
             return None
         period = timedelta(days=90)
         return pytz.timezone("UTC").localize(
-            datetime.fromordinal(
+            datetime.fromtimestamp(
                 random.randrange(
-                    (self.start - period).toordinal(), self.start.toordinal()
+                    int((self.start - period).timestamp()), int(self.start.timestamp())
                 )
             )
         )
@@ -435,15 +437,20 @@ class CourseRunFactory(PageExtensionDjangoModelFactory):
         """
         if not self.start:
             return None
-        end = self.end or self.start + timedelta(days=random.randint(1, 90))
         enrollment_start = self.enrollment_start or self.start - timedelta(
             days=random.randint(1, 90)
         )
+        max_enrollment_end = self.end or self.start + timedelta(
+            days=random.randint(1, 90)
+        )
+        max_enrollment_end = max(
+            enrollment_start + timedelta(hours=1), max_enrollment_end
+        )
         return pytz.timezone("UTC").localize(
-            datetime.fromordinal(
+            datetime.fromtimestamp(
                 random.randrange(
-                    (enrollment_start + timedelta(hours=1)).toordinal(),
-                    (end - timedelta(hours=1)).toordinal(),
+                    int(enrollment_start.timestamp()),
+                    int(max_enrollment_end.timestamp()),
                 )
             )
         )

--- a/tests/apps/courses/test_models_course_glimpse_date.py
+++ b/tests/apps/courses/test_models_course_glimpse_date.py
@@ -33,7 +33,7 @@ class CourseRunModelsTestCase(TestCase):
             page_parent=course.extended_object,
             start=self.now - timedelta(hours=1),
             end=self.now + timedelta(hours=1),
-            enrollment_end=self.now - timedelta(hours=1),
+            enrollment_end=self.now,
         )
 
     def create_run_archived(self, course):


### PR DESCRIPTION
## Purpose

The CourseRunFactory was randomly randomly failing to instantiate because random dates were picked incoherently.

## Proposal

I was using `toordinal` for datetimes. In fact, `toordinal` represents dates...

Using timestamps is more appropriate. I made sure that picking random datetimes was never incoherent any more and ran the tests in loop for several hours to try it out.
