### PR TITLE
Surface courses with categories/organizations even in full-text searches

### DIFF
--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -105,7 +105,16 @@ class CoursesIndexersTestCase(TestCase):
         Happy path: the data is retrieved from the models properly formatted
         """
         # Create a course with a page in both english and french
-        published_categories = CategoryFactory.create_batch(2, should_publish=True)
+        published_categories = [
+            CategoryFactory(
+                page_title={"en": "Open-architected radical application"},
+                should_publish=True,
+            ),
+            CategoryFactory(
+                page_title={"en": "Public-key transitional solution"},
+                should_publish=True,
+            ),
+        ]
         draft_category = CategoryFactory()
 
         main_organization = OrganizationFactory(
@@ -158,6 +167,15 @@ class CoursesIndexersTestCase(TestCase):
 
         # The results were properly formatted and passed to the consumer
         expected_course = {
+            "categories": [
+                str(s.public_extension.extended_object_id) for s in published_categories
+            ],
+            "categories_names": {
+                "en": [
+                    "Open-architected radical application",
+                    "Public-key transitional solution",
+                ]
+            },
             "complete": {
                 "en": [
                     "an english course title",
@@ -181,9 +199,16 @@ class CoursesIndexersTestCase(TestCase):
                 str(main_organization.public_extension.extended_object_id),
                 str(other_published_organization.public_extension.extended_object_id),
             ],
-            "categories": [
-                str(s.public_extension.extended_object_id) for s in published_categories
-            ],
+            "organizations_names": {
+                "en": [
+                    "english main organization title",
+                    "english other organization title",
+                ],
+                "fr": [
+                    "titre organisation principale français",
+                    "titre autre organisation français",
+                ],
+            },
             "title": {"fr": "un titre cours français", "en": "an english course title"},
         }
         self.assertEqual(

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -382,10 +382,24 @@ class CoursesIndexersTestCase(TestCase):
             )
         )
         multi_match = {
-            "multi_match": {
-                "fields": ["description.*", "title.*"],
-                "query": "some phrase terms",
-                "type": "cross_fields",
+            "bool": {
+                "should": [
+                    {
+                        "multi_match": {
+                            "fields": ["description.*", "title.*"],
+                            "query": "some phrase terms",
+                            "type": "cross_fields",
+                        }
+                    },
+                    {
+                        "multi_match": {
+                            "boost": 0.05,
+                            "fields": ["categories_names.*", "organizations_names.*"],
+                            "query": "some phrase terms",
+                            "type": "cross_fields",
+                        }
+                    },
+                ]
             }
         }
 
@@ -394,19 +408,7 @@ class CoursesIndexersTestCase(TestCase):
             (
                 2,
                 20,
-                {
-                    "bool": {
-                        "must": [
-                            {
-                                "multi_match": {
-                                    "fields": ["description.*", "title.*"],
-                                    "query": "some phrase terms",
-                                    "type": "cross_fields",
-                                }
-                            }
-                        ]
-                    }
-                },
+                {"bool": {"must": [multi_match]}},
                 {
                     "all_courses": {
                         "global": {},
@@ -860,10 +862,24 @@ class CoursesIndexersTestCase(TestCase):
         # Search fragments that are repeated in the query
         availability = {"term": {"availability": "current"}}
         multi_match = {
-            "multi_match": {
-                "fields": ["description.*", "title.*"],
-                "query": "these phrase terms",
-                "type": "cross_fields",
+            "bool": {
+                "should": [
+                    {
+                        "multi_match": {
+                            "fields": ["description.*", "title.*"],
+                            "query": "these phrase terms",
+                            "type": "cross_fields",
+                        }
+                    },
+                    {
+                        "multi_match": {
+                            "boost": 0.05,
+                            "fields": ["categories_names.*", "organizations_names.*"],
+                            "query": "these phrase terms",
+                            "type": "cross_fields",
+                        }
+                    },
+                ]
             }
         }
         range_end = {


### PR DESCRIPTION
## Purpose

We need to be able to surface courses with organization X or category Y when a user does a full-text search for X or Y.
Currently, this does not happen if X and/or Y do not appear in the syllabus or title of the course.

## Proposal

- [x] Index categories & organization names on courses
- [x] Add a query element to the full text search fragment to all search the text in these new fields