### PR TITLE
Filter definitions

### DIFF
--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -83,7 +83,7 @@ FILTERS_DEFAULT = [
         {"name": "organizations", "human_name": _("Organizations")},
     ),
     (
-        "richie.apps.search.utils.filter_definitions.FilterDefinitionTerms",
+        "richie.apps.search.utils.filter_definitions.FilterDefinitionLanguages",
         {"name": "languages", "human_name": _("Languages")},
     ),
 ]

--- a/src/richie/apps/search/utils/filter_definitions.py
+++ b/src/richie/apps/search/utils/filter_definitions.py
@@ -3,6 +3,12 @@ Define our default FilterDefinition classes.
 They encapsulate common behavior around managing filters in ElasticSearch queries and
 API requests (to validate input) and responses (to produce easy-to-consume filters).
 """
+from functools import reduce
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+from .i18n import get_best_field_language
 
 
 class FilterDefinitionBase:
@@ -10,12 +16,13 @@ class FilterDefinitionBase:
     Base filter definition shape: just an init method to set common attributes.
     """
 
-    def __init__(self, name, human_name):
+    def __init__(self, name, human_name, is_drilldown=False):
         """
-        Assign the common attributes.
+        Assign the common attributes and set some defaults for optional parameters.
         """
         self.name = name
         self.human_name = human_name
+        self.is_drilldown = is_drilldown
 
 
 class FilterDefinitionCustom(FilterDefinitionBase):
@@ -24,14 +31,25 @@ class FilterDefinitionCustom(FilterDefinitionBase):
     ES filtering fragment.
     """
 
-    def __init__(self, name, human_name, choices):
+    def __init__(self, name, human_name, choices, **kwargs):
         """
-        Extend the base filter definition with key/fragment map to easily generate the
-        query & aggregation fragments for choices.
+        Extend the base filter definition with tools to easily generate query/aggregation
+        fragments and faceted filter definition.
         """
-        super().__init__(name, human_name)
+        super().__init__(name, human_name, **kwargs)
         # The key/fragment map is static and helpful to get query & aggregations fragments
         self._key_fragment_map = {choice[0]: choice[2] for choice in choices}
+        # Extend the base filter definition with a list of values that includes names & human
+        # names and is only missing the counts.
+        # We do this because:
+        #   - the number of choices is bounded as it is a static argument (as opposed to eg.)
+        #     a row in the database;
+        #   - it makes it easier to access the values by key with every search request if we
+        #     use a dict (while keeping a simpler interface for richie lib users).
+        self.values = {
+            value_name: {"human_name": value_human_name, "key": value_name}
+            for value_name, value_human_name, _ in choices
+        }
 
     def get_query_fragment(self, value_list):
         """
@@ -73,10 +91,38 @@ class FilterDefinitionCustom(FilterDefinitionBase):
             for choice_key, choice_fragment in self._key_fragment_map.items()
         }
 
+    def get_faceted_definition(self, facets, _):
+        """
+        Simply add the counts to the values from the initial definition to make them complete
+        as the frontend expects them.
+        """
+        return {
+            # We always need to pass the base definition to the frontend
+            "human_name": self.human_name,
+            "is_drilldown": self.is_drilldown,
+            "name": self.name,
+            "values": [
+                {
+                    # Use the current value's name and human_name from the initial definition
+                    # eg. for `availability@coming_soon` we pick self.values["comin_soon"]
+                    **self.values[facet_name[facet_name.find("@") + 1 :]],  # noqa: E203
+                    # Add the facet count
+                    "count": facets[facet_name]["doc_count"],
+                }
+                # Operate from the facets as opposed to the filter definition to keep a more
+                # flexible base that can support various ways to pick a subset of values for
+                # which to show facets
+                for facet_name in filter(
+                    lambda fct_name: fct_name.startswith("{:s}@".format(self.name)),
+                    facets,
+                )
+            ],
+        }
+
 
 class FilterDefinitionTerms(FilterDefinitionBase):
     """
-    Filter definition for a terms-based filter. The choices will be generated dynamically from
+    Filter definition for a terms-based filter. The choices are generated dynamically from
     the incoming facets to avoid having to hold in memory or iterate over an unbounded
     number of choices.
     """
@@ -114,3 +160,99 @@ class FilterDefinitionTerms(FilterDefinitionBase):
                 },
             }
         }
+
+    def get_i18n_names(self, keys, language):
+        """
+        Helper method to get the corresponding internationalized human name for each key in
+        a list of indexed objects' ids.
+        This covers the base case for terms eg. other models in their own ElasticSearch index
+        like organizations or categories
+        """
+        indexer = import_string(getattr(settings.ES_INDICES, self.name))
+
+        # Get just the documents we need from ElasticSearch
+        search_query_response = settings.ES_CLIENT.search(
+            # We only need the titles to get the i18n names
+            _source=["title.*"],
+            index=indexer.index_name,
+            doc_type=indexer.document_type,
+            body={
+                "query": {
+                    "terms": {
+                        "_uid": [
+                            "{:s}#{:s}".format(indexer.document_type, key)
+                            for key in keys
+                        ]
+                    }
+                }
+            },
+            size=len(keys),
+        )
+
+        # Extract the best available language here to avoid handling these kinds of implementation
+        # details in the ViewSet
+        return {
+            doc["_id"]: get_best_field_language(doc["_source"]["title"], language)
+            for doc in search_query_response["hits"]["hits"]
+        }
+
+    def get_faceted_definition(self, facets, language):
+        """
+        Build the filter definition's values from base definition and the faceted keys.
+        Those provide us with the keys and counts that we just have to consume. We resort to
+        another method to get the internationalized names so specific filter definitions
+        (ie subclasses) can have different ways to get those.
+        """
+        # Convert the keys & counts from ElasticSearch facets to a more readily consumable format
+        #   {
+        #       self.name: {
+        #           self.name: {
+        #               "buckets": [
+        #                   {"key": "A", "count": x}
+        #                   {"key": "B", "count": y}
+        #                   {"key": "C", "count": z}
+        #               ]
+        #           }
+        #       }
+        #   }
+        # 👆 becomes 👇
+        #   {"A": x, "B": y, "C": z}
+        key_count_map = reduce(
+            lambda agg, key_count_dict: {
+                **agg,
+                key_count_dict["key"]: key_count_dict["doc_count"],
+            },
+            facets[self.name][self.name]["buckets"],
+            {},
+        )
+
+        # Use the passed in callback to get internationalized names for all our keys
+        key_i18n_name_map = self.get_i18n_names(
+            [key for key in key_count_map], language
+        )
+
+        return {
+            # We always need to pass the base definition to the frontend
+            "human_name": self.human_name,
+            "is_drilldown": self.is_drilldown,
+            "name": self.name,
+            "values": [
+                # Aggregate the information from right above to build the values
+                {"count": count, "human_name": key_i18n_name_map[key], "key": key}
+                for key, count in key_count_map.items()
+            ],
+        }
+
+
+class FilterDefinitionLanguages(FilterDefinitionTerms):
+    """
+    Languages need their own FilterDefinition subclass as there's a different way to get their
+    human names from other terms-based filters
+    """
+
+    def get_i18n_names(self, keys, language):
+        """
+        All possible language keys should be in the ALL_LANGUAGES_DICT. We can just return it
+        and let `get_faceted_definition` pick what it needs
+        """
+        return settings.ALL_LANGUAGES_DICT

--- a/src/richie/apps/search/utils/filter_definitions.py
+++ b/src/richie/apps/search/utils/filter_definitions.py
@@ -1,0 +1,116 @@
+"""
+Define our default FilterDefinition classes.
+They encapsulate common behavior around managing filters in ElasticSearch queries and
+API requests (to validate input) and responses (to produce easy-to-consume filters).
+"""
+
+
+class FilterDefinitionBase:
+    """
+    Base filter definition shape: just an init method to set common attributes.
+    """
+
+    def __init__(self, name, human_name):
+        """
+        Assign the common attributes.
+        """
+        self.name = name
+        self.human_name = human_name
+
+
+class FilterDefinitionCustom(FilterDefinitionBase):
+    """
+    Filter definition for a custom filter with hardcoded choices provided along with their
+    ES filtering fragment.
+    """
+
+    def __init__(self, name, human_name, choices):
+        """
+        Extend the base filter definition with key/fragment map to easily generate the
+        query & aggregation fragments for choices.
+        """
+        super().__init__(name, human_name)
+        # The key/fragment map is static and helpful to get query & aggregations fragments
+        self._key_fragment_map = {choice[0]: choice[2] for choice in choices}
+
+    def get_query_fragment(self, value_list):
+        """
+        Build the query fragment to use in the ElasticSearch filter & aggregations.
+        """
+        # For custom filters, we pick the hardcoded fragment from the corresponding choices
+        return [
+            {"key": self.name, "fragment": self._key_fragment_map[value]}
+            for value in value_list
+        ]
+
+    def get_aggs_fragment(self, queries):
+        """
+        Build the aggregations fragment to use to extract aggregations from ElasticSearch.
+        """
+        return {
+            # Create a custom aggregation for each possible choice for this filter
+            # eg `availability@coming_soon` & `availability@current` & `availability@open`
+            "{:s}@{:s}".format(self.name, choice_key): {
+                "filter": {
+                    "bool": {
+                        # Use all the query fragments from the queries *but* the one(s) that
+                        # filter on the current filter: we manually add back the only one that
+                        # is relevant to the current choice.
+                        "must": choice_fragment
+                        + [
+                            # queries
+                            # |> filter(kv_pair["key"] != self.name)
+                            # |> map(pluck("fragment"))
+                            # |> flatten()
+                            clause
+                            for kf_pair in queries
+                            for clause in kf_pair["fragment"]
+                            if kf_pair["key"] is not self.name
+                        ]
+                    }
+                }
+            }
+            for choice_key, choice_fragment in self._key_fragment_map.items()
+        }
+
+
+class FilterDefinitionTerms(FilterDefinitionBase):
+    """
+    Filter definition for a terms-based filter. The choices will be generated dynamically from
+    the incoming facets to avoid having to hold in memory or iterate over an unbounded
+    number of choices.
+    """
+
+    def get_query_fragment(self, value_list):
+        """
+        Build the query fragment to use in the ElasticSearch filter & aggregations.
+        """
+        # For terms filters, as the name implies, it's a simple terms fragment
+        return [{"key": self.name, "fragment": [{"terms": {self.name: value_list}}]}]
+
+    def get_aggs_fragment(self, queries):
+        """
+        Build the aggregations fragment to use to extract aggregations from ElasticSearch.
+        """
+        return {
+            self.name: {
+                # Rely on the built-in "terms" aggregation to get everything we need
+                "aggregations": {self.name: {"terms": {"field": self.name}}},
+                "filter": {
+                    "bool": {
+                        # Use all the query fragments from the queries *but* the one(s) that
+                        # filter on the current filter, as it is handled by ElasticSearch for us
+                        "must": [
+                            # queries
+                            # |> filter(kv_pair["key"] != self.name)
+                            # |> map(pluck("fragment"))
+                            # |> flatten()
+                            clause
+                            for kf_pair in queries
+                            for clause in kf_pair["fragment"]
+                            if kf_pair["key"] is not self.name
+                        ]
+                    }
+                },
+            }
+        }

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -141,6 +141,13 @@ class CoursesViewSet(AutocompleteMixin, ViewSet):
                     {},
                 ),
             },
+            "filters": {
+                filter.name: filter.get_faceted_definition(
+                    course_query_response["aggregations"]["all_courses"],
+                    get_language_from_request(request),
+                )
+                for filter in filters.values()
+            },
         }
 
         # Will be formatting a response_object for consumption

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -29,6 +29,7 @@ from richie.apps.search.indexers.courses import CoursesIndexer
 from richie.apps.search.indexers.organizations import OrganizationsIndexer
 from richie.apps.search.utils.filter_definitions import (
     FilterDefinitionCustom,
+    FilterDefinitionLanguages,
     FilterDefinitionTerms,
 )
 
@@ -44,7 +45,7 @@ DEFAULT_FILTERS = {
         ],
     ),
     "categories": FilterDefinitionTerms(name="categories", human_name="categories"),
-    "languages": FilterDefinitionTerms(name="languages", human_name="languages"),
+    "languages": FilterDefinitionLanguages(name="languages", human_name="languages"),
     "organizations": FilterDefinitionTerms(
         name="organizations", human_name="organizations"
     ),

--- a/tests/apps/search/test_utils_filter_definitions.py
+++ b/tests/apps/search/test_utils_filter_definitions.py
@@ -1,0 +1,294 @@
+"""
+Test for our FilterDefintion classes
+"""
+from django.test import TestCase
+
+from richie.apps.search.utils.filter_definitions import (
+    FilterDefinitionCustom,
+    FilterDefinitionTerms,
+)
+
+
+class FilterDefinitionTestCase(TestCase):
+    """
+    Instantiate our FilterDefinition classes with various parameters and make sure their
+    methods generate the proper shapes for ES.
+    """
+
+    def test_filter_definition_custom_init(self):
+        """
+        FilterDefinitionCustom implements the common attributes.
+        """
+        filterdef = FilterDefinitionCustom(
+            name="languages",
+            human_name="Langues",
+            choices=[("fr", "Français", [{"terms": {"languages": "fr"}}])],
+        )
+        self.assertEqual(filterdef.name, "languages")
+        self.assertEqual(filterdef.human_name, "Langues")
+
+    def test_filter_definition_custom_get_query_fragment(self):
+        """
+        Returns a list of key/fragment pairs mapped to the list of values it received.
+        """
+        filterdef = FilterDefinitionCustom(
+            name="languages",
+            human_name="Langues",
+            choices=[
+                ("en", "English", [{"must": {"languages": "en"}}]),
+                ("fr", "Français", [{"must": {"languages": "fr"}}]),
+            ],
+        )
+        # Accepts a single value, as long as it's wrapped in a list
+        self.assertEqual(
+            filterdef.get_query_fragment(["fr"]),
+            [{"key": "languages", "fragment": [{"must": {"languages": "fr"}}]}],
+        )
+        # Accepts more than one value
+        self.assertEqual(
+            filterdef.get_query_fragment(["fr", "en"]),
+            [
+                {"key": "languages", "fragment": [{"must": {"languages": "fr"}}]},
+                {"key": "languages", "fragment": [{"must": {"languages": "en"}}]},
+            ],
+        )
+
+    def test_filter_definition_custom_get_aggs_fragment(self):
+        """
+        Create a custom aggregation with an ES filtering that reuses all non-related queries
+        and that of the specific choice for each of the possible choices.
+        """
+        filterdef = FilterDefinitionCustom(
+            name="availability",
+            human_name="Disponibilité",
+            choices=[
+                ("coming_soon", "Coming soon", [{"is_coming_soon": True}]),
+                ("current", "Current", [{"is_current": True}]),
+                ("open", "Open for enrollment", [{"is_open": True}]),
+            ],
+        )
+        # Simply uses the query fragment when the queries list is empty
+        self.assertEqual(
+            filterdef.get_aggs_fragment([]),
+            {
+                "availability@coming_soon": {
+                    "filter": {"bool": {"must": [{"is_coming_soon": True}]}}
+                },
+                "availability@current": {
+                    "filter": {"bool": {"must": [{"is_current": True}]}}
+                },
+                "availability@open": {
+                    "filter": {"bool": {"must": [{"is_open": True}]}}
+                },
+            },
+        )
+        # Concatenates the query fragment with the queries list when only non-related
+        # fragments are included in the queries list
+        self.assertEqual(
+            filterdef.get_aggs_fragment(
+                [
+                    {
+                        "key": "categories",
+                        "fragment": [{"terms": {"categories": [42, 84]}}],
+                    },
+                    {"key": "new", "fragment": [{"is_new": True}]},
+                ]
+            ),
+            {
+                "availability@coming_soon": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"is_coming_soon": True},
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    }
+                },
+                "availability@current": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"is_current": True},
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    }
+                },
+                "availability@open": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"is_open": True},
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    }
+                },
+            },
+        )
+        # Removes part of the query related to the current filter if there were any
+        self.assertEqual(
+            filterdef.get_aggs_fragment(
+                [
+                    {
+                        "key": "categories",
+                        "fragment": [{"terms": {"categories": [42, 84]}}],
+                    },
+                    {"key": "new", "fragment": [{"is_new": True}]},
+                    {"key": "availability", "fragment": [{"is_current": True}]},
+                ]
+            ),
+            {
+                "availability@coming_soon": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"is_coming_soon": True},
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    }
+                },
+                "availability@current": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"is_current": True},
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    }
+                },
+                "availability@open": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"is_open": True},
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    }
+                },
+            },
+        )
+
+    def test_filter_definition_terms_init(self):
+        """
+        FilterDefinitionTerms implements the common attributes.
+        """
+        filterdef = FilterDefinitionTerms(name="languages", human_name="Langues")
+        self.assertEqual(filterdef.name, "languages")
+        self.assertEqual(filterdef.human_name, "Langues")
+
+    def test_filter_definition_terms_get_query_fragment(self):
+        """
+        Returns a terms query fragment along with the filter name as key.
+        """
+        filterdef = FilterDefinitionTerms(
+            name="organizations", human_name="Organizaciónes"
+        )
+        # Terms query is a list even when there is only one value
+        self.assertEqual(
+            filterdef.get_query_fragment([42]),
+            [
+                {
+                    "key": "organizations",
+                    "fragment": [{"terms": {"organizations": [42]}}],
+                }
+            ],
+        )
+        # The fragment is built the same way with more than one value
+        self.assertEqual(
+            filterdef.get_query_fragment([42, 84]),
+            [
+                {
+                    "key": "organizations",
+                    "fragment": [{"terms": {"organizations": [42, 84]}}],
+                }
+            ],
+        )
+
+    def test_filter_definition_terms_get_aggs_fragment(self):
+        """
+        Use the builtin ES `terms` aggregation, filter with all non-related queries.
+        """
+        filterdef = FilterDefinitionTerms(
+            name="organizations", human_name="Organizaciónes"
+        )
+        # Simply uses the builtin aggregation when the queries list is empty
+        self.assertEqual(
+            filterdef.get_aggs_fragment([]),
+            {
+                "organizations": {
+                    "aggregations": {
+                        "organizations": {"terms": {"field": "organizations"}}
+                    },
+                    "filter": {"bool": {"must": []}},
+                }
+            },
+        )
+        # Reuses the fragments from the query if none are related to the same filter
+        self.assertEqual(
+            filterdef.get_aggs_fragment(
+                [
+                    {
+                        "key": "categories",
+                        "fragment": [{"terms": {"categories": [42, 84]}}],
+                    },
+                    {"key": "new", "fragment": [{"is_new": True}]},
+                ]
+            ),
+            {
+                "organizations": {
+                    "aggregations": {
+                        "organizations": {"terms": {"field": "organizations"}}
+                    },
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    },
+                }
+            },
+        )
+        # Drops any fragment related to the same filter
+        self.assertEqual(
+            filterdef.get_aggs_fragment(
+                [
+                    {
+                        "key": "categories",
+                        "fragment": [{"terms": {"categories": [42, 84]}}],
+                    },
+                    {"key": "new", "fragment": [{"is_new": True}]},
+                    {
+                        "key": "organizations",
+                        "fragment": [{"terms": {"organizations": [33, 66]}}],
+                    },
+                ]
+            ),
+            {
+                "organizations": {
+                    "aggregations": {
+                        "organizations": {"terms": {"field": "organizations"}}
+                    },
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    },
+                }
+            },
+        )

--- a/tests/apps/search/test_utils_filter_definitions.py
+++ b/tests/apps/search/test_utils_filter_definitions.py
@@ -1,12 +1,18 @@
 """
 Test for our FilterDefintion classes
 """
+from unittest import mock
+
+from django.conf import settings
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from richie.apps.search.utils.filter_definitions import (
     FilterDefinitionCustom,
+    FilterDefinitionLanguages,
     FilterDefinitionTerms,
 )
+from richie.apps.search.utils.indexers import IndicesList
 
 
 class FilterDefinitionTestCase(TestCase):
@@ -26,6 +32,15 @@ class FilterDefinitionTestCase(TestCase):
         )
         self.assertEqual(filterdef.name, "languages")
         self.assertEqual(filterdef.human_name, "Langues")
+        self.assertEqual(filterdef.is_drilldown, False)
+
+        filterdef = FilterDefinitionCustom(
+            name="languages",
+            human_name="Langues",
+            choices=[("fr", "Français", [{"terms": {"languages": "fr"}}])],
+            is_drilldown=True,
+        )
+        self.assertEqual(filterdef.is_drilldown, True)
 
     def test_filter_definition_custom_get_query_fragment(self):
         """
@@ -179,13 +194,70 @@ class FilterDefinitionTestCase(TestCase):
             },
         )
 
+    def test_filter_definition_custom_get_faceted_definition(self):
+        """
+        Return a complete filter definition in a format usable by the frontend, including
+        the base definition and the values with their facet counts.
+        """
+        filterdef = FilterDefinitionCustom(
+            name="availability",
+            human_name="Disponibilité",
+            choices=[
+                ("coming_soon", "Coming soon", [{"is_coming_soon": True}]),
+                ("current", "Current", [{"is_current": True}]),
+                ("open", "Open for enrollment", [{"is_open": True}]),
+            ],
+        )
+        self.assertEqual(
+            filterdef.get_faceted_definition(
+                {
+                    "availability@coming_soon": {"doc_count": 12},
+                    "availability@current": {"doc_count": 3},
+                    "availability@open": {"doc_count": 7},
+                    # Non-availability related facet counts should be ignored here as
+                    # we're only generating the availability faceted definition
+                    "new@new": {"doc_count": 4},
+                    "organizations": {
+                        "organizations": {
+                            "buckets": [
+                                {"key": 42, "doc_count": 11},
+                                {"key": 84, "doc_count": 9},
+                                {"key": 168, "doc_count": 0},
+                            ]
+                        }
+                    },
+                },
+                # Language is passed by the course ViewSet but is not useful for custom
+                # filter definitions as their human names i18n is managed by gettext
+                "fr",
+            ),
+            {
+                "human_name": "Disponibilité",
+                "is_drilldown": False,
+                "name": "availability",
+                "values": [
+                    {"human_name": "Coming soon", "key": "coming_soon", "count": 12},
+                    {"human_name": "Current", "key": "current", "count": 3},
+                    {"human_name": "Open for enrollment", "key": "open", "count": 7},
+                ],
+            },
+        )
+
     def test_filter_definition_terms_init(self):
         """
         FilterDefinitionTerms implements the common attributes.
         """
-        filterdef = FilterDefinitionTerms(name="languages", human_name="Langues")
-        self.assertEqual(filterdef.name, "languages")
-        self.assertEqual(filterdef.human_name, "Langues")
+        filterdef = FilterDefinitionTerms(
+            name="organizations", human_name="Organizations"
+        )
+        self.assertEqual(filterdef.name, "organizations")
+        self.assertEqual(filterdef.human_name, "Organizations")
+        self.assertEqual(filterdef.is_drilldown, False)
+
+        filterdef = FilterDefinitionTerms(
+            name="organizations", human_name="Organizations", is_drilldown=True
+        )
+        self.assertEqual(filterdef.is_drilldown, True)
 
     def test_filter_definition_terms_get_query_fragment(self):
         """
@@ -292,3 +364,307 @@ class FilterDefinitionTestCase(TestCase):
                 }
             },
         )
+
+    @override_settings(
+        ES_INDICES=IndicesList(
+            categories="_", courses="_", organizations="the.class.OrganizationsIndexer"
+        )
+    )
+    @mock.patch("richie.apps.search.utils.filter_definitions.import_string")
+    @mock.patch.object(settings.ES_CLIENT, "search")
+    def test_filter_definition_terms_get_i18n_names(
+        self, mock_search, mock_import_string, *_
+    ):
+        """
+        Use the relevant ES index to build a map of keys to best available i18n human names.
+        """
+
+        class OrganizationIndexer:
+            """We only use `document_type` & `index_name` from the indexer we import."""
+
+            document_type = "organization"
+            index_name = "organization-index"
+
+        mock_import_string.return_value = OrganizationIndexer()
+        # Mock a bunch of organization hits from the organization index
+        mock_search.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_id": "42",
+                        "_source": {"title": {"en": "Org 42", "fr": "Orga 42"}},
+                    },
+                    {
+                        "_id": "84",
+                        "_source": {"title": {"en": "Org 84", "fr": "Orga 84"}},
+                    },
+                    {
+                        "_id": "168",
+                        "_source": {"title": {"en": "Org 168", "fr": "Orga 168"}},
+                    },
+                ]
+            }
+        }
+
+        filterdef = FilterDefinitionTerms(
+            name="organizations", human_name="Organizations"
+        )
+        # Build a map with the best i18n name for the given language
+        self.assertEqual(
+            filterdef.get_i18n_names(["42", "84", "168"], "fr"),
+            {"42": "Orga 42", "84": "Orga 84", "168": "Orga 168"},
+        )
+        mock_import_string.assert_called_once_with("the.class.OrganizationsIndexer")
+        mock_search.assert_called_once_with(
+            _source=["title.*"],
+            index="organization-index",
+            doc_type="organization",
+            body={
+                "query": {
+                    "terms": {
+                        "_uid": [
+                            "organization#42",
+                            "organization#84",
+                            "organization#168",
+                        ]
+                    }
+                }
+            },
+            size=3,
+        )
+        # Make sure the return value changes with the language
+        self.assertEqual(
+            filterdef.get_i18n_names(["42", "84", "168"], "en"),
+            {"42": "Org 42", "84": "Org 84", "168": "Org 168"},
+        )
+
+    def test_filter_definition_terms_get_faceted_definition(self):
+        """
+        Return a complete filter definition in a format usable by the frontend, including
+        the base definition and values with their facet counts generated from the passed
+        facets directly.
+        """
+        filterdef = FilterDefinitionTerms(
+            name="organizations", human_name="Organizations"
+        )
+
+        with mock.patch.object(
+            filterdef,
+            "get_i18n_names",
+            mock.MagicMock(
+                return_value={"42": "Orga #42", "84": "Orga #84", "168": "Orga #168"}
+            ),
+        ) as mock_get_i18n_names:
+            self.assertEqual(
+                filterdef.get_faceted_definition(
+                    {
+                        "organizations": {
+                            "organizations": {
+                                "buckets": [
+                                    {"key": "42", "doc_count": 11},
+                                    {"key": "84", "doc_count": 9},
+                                    {"key": "168", "doc_count": 0},
+                                ]
+                            }
+                        },
+                        # Non-organizations related facet counts should be ignored here as
+                        # we're only generating the organizations faceted definition
+                        "new@new": {"doc_count": 4},
+                        "categories": {
+                            "categories": {
+                                "buckets": [
+                                    {"key": "13", "doc_count": 3},
+                                    {"key": "26", "doc_count": 5},
+                                    {"key": "52", "doc_count": 7},
+                                ]
+                            }
+                        },
+                    },
+                    "fr",
+                ),
+                {
+                    "human_name": "Organizations",
+                    "is_drilldown": False,
+                    "name": "organizations",
+                    "values": [
+                        {"count": 11, "human_name": "Orga #42", "key": "42"},
+                        {"count": 9, "human_name": "Orga #84", "key": "84"},
+                        {"count": 0, "human_name": "Orga #168", "key": "168"},
+                    ],
+                },
+            )
+            mock_get_i18n_names.assert_called_once_with(["42", "84", "168"], "fr")
+
+    def test_filter_definition_languages_init(self):
+        """
+        FilterDefinitionLanguages implements the common attributes.
+        """
+        filterdef = FilterDefinitionLanguages(name="languages", human_name="Langues")
+        self.assertEqual(filterdef.name, "languages")
+        self.assertEqual(filterdef.human_name, "Langues")
+        self.assertEqual(filterdef.is_drilldown, False)
+
+        filterdef = FilterDefinitionLanguages(
+            name="languages", human_name="Langues", is_drilldown=True
+        )
+        self.assertEqual(filterdef.is_drilldown, True)
+
+    def test_filter_definition_languages_get_query_fragment(self):
+        """
+        Returns a terms query fragment along with the filter name as key.
+        """
+        filterdef = FilterDefinitionLanguages(name="languages", human_name="Langues")
+        # Terms query is a list even when there is only one value
+        self.assertEqual(
+            filterdef.get_query_fragment(["fr"]),
+            [{"key": "languages", "fragment": [{"terms": {"languages": ["fr"]}}]}],
+        )
+        # The fragment is built the same way with more than one value
+        self.assertEqual(
+            filterdef.get_query_fragment(["fr", "en"]),
+            [
+                {
+                    "key": "languages",
+                    "fragment": [{"terms": {"languages": ["fr", "en"]}}],
+                }
+            ],
+        )
+
+    def test_filter_definition_languages_get_aggs_fragment(self):
+        """
+        Use the builtin ES `terms` aggregation, filter with all non-related queries.
+        """
+        filterdef = FilterDefinitionLanguages(name="languages", human_name="Langues")
+        # Simply uses the builtin aggregation when the queries list is empty
+        self.assertEqual(
+            filterdef.get_aggs_fragment([]),
+            {
+                "languages": {
+                    "aggregations": {"languages": {"terms": {"field": "languages"}}},
+                    "filter": {"bool": {"must": []}},
+                }
+            },
+        )
+        # Reuses the fragments from the query if none are related to the same filter
+        self.assertEqual(
+            filterdef.get_aggs_fragment(
+                [
+                    {
+                        "key": "categories",
+                        "fragment": [{"terms": {"categories": [42, 84]}}],
+                    },
+                    {"key": "new", "fragment": [{"is_new": True}]},
+                ]
+            ),
+            {
+                "languages": {
+                    "aggregations": {"languages": {"terms": {"field": "languages"}}},
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    },
+                }
+            },
+        )
+        # Drops any fragment related to the same filter
+        self.assertEqual(
+            filterdef.get_aggs_fragment(
+                [
+                    {
+                        "key": "categories",
+                        "fragment": [{"terms": {"categories": [42, 84]}}],
+                    },
+                    {"key": "new", "fragment": [{"is_new": True}]},
+                    {
+                        "key": "languages",
+                        "fragment": [{"terms": {"languages": [33, 66]}}],
+                    },
+                ]
+            ),
+            {
+                "languages": {
+                    "aggregations": {"languages": {"terms": {"field": "languages"}}},
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {"terms": {"categories": [42, 84]}},
+                                {"is_new": True},
+                            ]
+                        }
+                    },
+                }
+            },
+        )
+
+    @override_settings(ALL_LANGUAGES_DICT={"es": "Español", "fr": "Francès"})
+    def test_filter_definition_languages_get_i18n_names(self):
+        """
+        Languages use a different implementation of get_i18n_names as their i18n names
+        are directly available from the settings.
+        """
+        filterdef = FilterDefinitionLanguages(name="languages", human_name="Langues")
+        self.assertEqual(
+            # We don't need to bother with the keys nor the preferred language here as all
+            # available languages must be in the dict from `ALL_LANGUAGES_DICT`
+            filterdef.get_i18n_names([], "fr"),
+            {"es": "Español", "fr": "Francès"},
+        )
+
+    def test_filter_definition_languages_get_faceted_definition(self):
+        """
+        Return a complete filter definition in a format usable by the frontend, including
+        the base definition and values with their facet counts generated from the passed
+        facets directly.
+        """
+        filterdef = FilterDefinitionLanguages(name="languages", human_name="Langues")
+
+        with mock.patch.object(
+            filterdef,
+            "get_i18n_names",
+            mock.MagicMock(
+                return_value={"en": "Anglais", "es": "Espagnol", "fr": "Français"}
+            ),
+        ) as mock_get_i18n_names:
+            self.assertEqual(
+                filterdef.get_faceted_definition(
+                    {
+                        "languages": {
+                            "languages": {
+                                "buckets": [
+                                    {"key": "en", "doc_count": 0},
+                                    {"key": "es", "doc_count": 4},
+                                    {"key": "fr", "doc_count": 25},
+                                ]
+                            }
+                        },
+                        # Non-languages related facet counts should be ignored here as
+                        # we're only generating the languages faceted definition
+                        "new@new": {"doc_count": 4},
+                        "categories": {
+                            "categories": {
+                                "buckets": [
+                                    {"key": "13", "doc_count": 3},
+                                    {"key": "26", "doc_count": 5},
+                                    {"key": "52", "doc_count": 7},
+                                ]
+                            }
+                        },
+                    },
+                    "fr",
+                ),
+                {
+                    "human_name": "Langues",
+                    "is_drilldown": False,
+                    "name": "languages",
+                    "values": [
+                        {"count": 0, "human_name": "Anglais", "key": "en"},
+                        {"count": 4, "human_name": "Espagnol", "key": "es"},
+                        {"count": 25, "human_name": "Français", "key": "fr"},
+                    ],
+                },
+            )
+            mock_get_i18n_names.assert_called_once_with(["en", "es", "fr"], "fr")


### PR DESCRIPTION
## Purpose

Work on points 2, 3 & 4 of #476.

Generating the filters on the server-side, instead of reconstructing them from their disparate sources in the frontend, will help us scale them better with our needs.
Notably, it will be helpful when we reflect the category taxonomy in our search filters.

## Proposal

We decided to implement a series of `FilterDefinition` classes that manage the way filters interact with ElasticSearch, from ES query & aggs building to their consumption and the output of complete filter definitions.

Those are intended as defaults that can be removed, replaced or modified through settings.

The rest of #476 will be tackled in subsequent PRs, as we felt this one was large enough as it is, and it does not contain any breaking change.