### PR TITLE
🐛(person) fix Person.get_full_name when person_title is empty

### DIFF
--- a/src/richie/apps/persons/models.py
+++ b/src/richie/apps/persons/models.py
@@ -110,8 +110,12 @@ class Person(BasePageExtension):
         """
         Return person's full name
         """
-        return "{person_title} {first_name} {last_name}".format(
-            person_title=self.person_title.title,
+        person_title = (
+            "{:s} ".format(self.person_title.title) if self.person_title else ""
+        )
+
+        return "{person_title}{first_name} {last_name}".format(
+            person_title=person_title,
             first_name=self.first_name,
             last_name=self.last_name,
         )

--- a/tests/apps/persons/test_models_person.py
+++ b/tests/apps/persons/test_models_person.py
@@ -62,11 +62,15 @@ class PersonModelsTestCase(TestCase):
         The get_full_name method should return title, first name and last name separated by space.
         No SQL query should be generated.
         """
-        person = PersonFactory(
+        person1 = PersonFactory(
             first_name="Louise",
             last_name="Dupont",
             person_title__translation__title="Madam",
             person_title__translation__abbreviation="Mme",
         )
+        person2 = PersonFactory(
+            first_name="Jacques", last_name="Martin", person_title=None
+        )
         with self.assertNumQueries(1):
-            self.assertEqual(person.get_full_name(), "Madam Louise Dupont")
+            self.assertEqual(person1.get_full_name(), "Madam Louise Dupont")
+            self.assertEqual(person2.get_full_name(), "Jacques Martin")


### PR DESCRIPTION
## Purpose

"get_full_name" method expected "person_title" was allways filled
although this field is not required resulting in an AttributeError
on page which display full name (at least the course detail).

## Proposal

Method has been fixed to support empty "person_title" and a test
has been modified to check this case.
