### PR TITLE
🐛(category) fix duplicate category

### DIFF
--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -121,10 +121,16 @@ class Category(BasePageExtension):
 def get_category_limit_choices_to():
     """Return a query limiting the categories proposed when creating a CategoryPlugin."""
     limit_choices_to = {
+        # Joining on `cms_pages` generate duplicates for categories that are under a parent page
+        # when this page exists both in draft and public versions. We need to exclude the
+        # parent public page to avoid this duplication with the first condition.
+        # The second condition makes sure the parent is a category.
+        # The third condition filters out public category.
+        # The fourth condition makes sure only categories show up.
+        "node__parent__cms_pages__publisher_is_draft": True,  # exclude category published parent
+        "node__parent__cms_pages__category__isnull": False,  # exclude meta categories
         "publisher_is_draft": True,  # plugins work with draft instances
         "category__isnull": False,  # limit to pages linked to a category object
-        "node__parent__cms_pages__category__isnull": False,  # exclude meta categories
-        "node__parent__cms_pages__publisher_is_draft": True,  # exclude published categories
     }
     # Limit to leaf categories only if active in settings (False by default)
     if getattr(settings, "LIMIT_PLUGIN_CATEGORIES_TO_LEAF", False):

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -124,6 +124,7 @@ def get_category_limit_choices_to():
         "publisher_is_draft": True,  # plugins work with draft instances
         "category__isnull": False,  # limit to pages linked to a category object
         "node__parent__cms_pages__category__isnull": False,  # exclude meta categories
+        "node__parent__cms_pages__publisher_is_draft": True,  # exclude published categories
     }
     # Limit to leaf categories only if active in settings (False by default)
     if getattr(settings, "LIMIT_PLUGIN_CATEGORIES_TO_LEAF", False):

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -433,16 +433,16 @@ class CoursePluginModel(PagePluginMixin, CMSPlugin):
         on_delete=models.CASCADE,
         related_name="course_plugins",
         limit_choices_to={
-            # There's a draft and a public course attached to the draft and
-            # the public parent. Without the first condition, 4 options are
-            # availables for each course. The second condition makes sure the
-            # parent is not a course. The third option filters out public
-            # course. The fourth option makes sure only courses show up.
-            # If there's is no parent, the course is filtered out.
-            "node__parent__cms_pages__publisher_is_draft": True,
-            "node__parent__cms_pages__course__isnull": True,
-            "publisher_is_draft": True,
-            "course__isnull": False,
+            # Joining on `cms_pages` generate duplicates for courses that are under a parent page
+            # when this page exists both in draft and public versions. We need to exclude the
+            # parent public page to avoid this duplication with the first condition.
+            # The second condition makes sure the parent is not a course to exclude snapshots.
+            # The third condition filters out public course.
+            # The fourth condition makes sure only courses show up.
+            "node__parent__cms_pages__publisher_is_draft": True,  # exclude course published parent
+            "node__parent__cms_pages__course__isnull": True,  # limit to course - no snapshot
+            "publisher_is_draft": True,  # plugins work with draft instances
+            "course__isnull": False,  # limit to pages linked to a course object
         },
     )
 

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -132,7 +132,10 @@ class OrganizationPluginModel(PagePluginMixin, CMSPlugin):
         Page,
         on_delete=models.CASCADE,
         related_name="organization_plugins",
-        limit_choices_to={"publisher_is_draft": True, "organization__isnull": False},
+        limit_choices_to={
+            "publisher_is_draft": True,  # plugins work with draft instances
+            "organization__isnull": False,  # limit to pages linked to a course object
+        },
     )
 
     class Meta:

--- a/tests/apps/courses/test_cms_plugins_category.py
+++ b/tests/apps/courses/test_cms_plugins_category.py
@@ -22,6 +22,33 @@ class CategoryPluginTestCase(CMSTestCase):
     Test that CategoryPlugin correctly displays a Category's page placeholders content
     """
 
+    @staticmethod
+    def test_cms_plugins_category_unique():
+        """
+        The form to create a category plugin should only list draft category pages in the
+        select box.
+        """
+
+        class CategoryPluginModelForm(forms.ModelForm):
+            """A form for testing the choices in the select box"""
+
+            class Meta:
+                model = CategoryPluginModel
+                fields = ["page"]
+
+        meta_category = CategoryFactory()
+        meta_category.extended_object.publish("en")
+        parent_category = CategoryFactory(page_parent=meta_category.extended_object)
+        parent_category.extended_object.publish("en")
+
+        other_page_title = "other page"
+        create_page(other_page_title, "richie/fullwidth.html", settings.LANGUAGE_CODE)
+
+        plugin_form = CategoryPluginModelForm()
+        rendered_form = plugin_form.as_table()
+
+        assert rendered_form.count(parent_category.extended_object.get_title()) == 1
+
     @override_settings(LIMIT_PLUGIN_CATEGORIES_TO_LEAF=True)
     def test_cms_plugins_category_form_page_choices_leaf_only(self):
         """

--- a/tests/apps/courses/test_cms_plugins_course.py
+++ b/tests/apps/courses/test_cms_plugins_course.py
@@ -23,7 +23,8 @@ class CoursePluginTestCase(TestCase):
     def test_cms_plugins_course_form_page_choices(self):
         """
         The form to create a course plugin should only list course pages
-        in the select box and no snapshot.
+        in the select box and no snapshot. There shouldn't be any duplicate because
+        of published status.
         """
 
         class CoursePluginModelForm(forms.ModelForm):
@@ -34,11 +35,13 @@ class CoursePluginTestCase(TestCase):
                 fields = ["page"]
 
         page = create_i18n_page("A page")
-        course = CourseFactory(page_parent=page)
+        page.publish("en")
+        course = CourseFactory(page_parent=page, should_publish=True)
         other_page_title = "other page"
         create_page(other_page_title, "richie/fullwidth.html", settings.LANGUAGE_CODE)
         plugin_form = CoursePluginModelForm()
-        self.assertIn(course.extended_object.get_title(), plugin_form.as_table())
+        rendered_form = plugin_form.as_table()
+        self.assertEqual(rendered_form.count(course.extended_object.get_title()), 1)
         self.assertNotIn(other_page_title, plugin_form.as_table())
 
         # Create a fake course snapshot and make sure it's not available to select

--- a/tests/apps/courses/test_cms_plugins_organization.py
+++ b/tests/apps/courses/test_cms_plugins_organization.py
@@ -24,7 +24,7 @@ class OrganizationPluginTestCase(CMSTestCase):
     def test_cms_plugins_organization_form_page_choices(self):
         """
         The form to create a organization plugin should only list organization pages
-        in the select box.
+        in the select box. There shouldn't be any duplicate because of published status.
         """
 
         class OrganizationPluginModelForm(forms.ModelForm):
@@ -34,11 +34,14 @@ class OrganizationPluginTestCase(CMSTestCase):
                 model = OrganizationPluginModel
                 fields = ["page"]
 
-        organization = OrganizationFactory()
+        organization = OrganizationFactory(should_publish=True)
         other_page_title = "other page"
         create_page(other_page_title, "richie/fullwidth.html", settings.LANGUAGE_CODE)
         plugin_form = OrganizationPluginModelForm()
-        self.assertIn(organization.extended_object.get_title(), plugin_form.as_table())
+        rendered_form = plugin_form.as_table()
+        self.assertEqual(
+            rendered_form.count(organization.extended_object.get_title()), 1
+        )
         self.assertNotIn(other_page_title, plugin_form.as_table())
 
     def test_cms_plugins_organization_render_on_public_page(self):


### PR DESCRIPTION
## Purpose

Make sure there's only one version of each category found by category plugin
Fix issue #506 

## Proposal

Add an extra filter
