### PR TITLE
🔧(project) update 'package.json' for sass rules with prettier

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --noEmit && webpack",
     "generate-l10n-template": "rip json2pot 'i18n/js/**/*.json' -o i18n/frontend.pot",
     "lint": "tslint -c tslint.json 'js/**/*.ts?(x)'",
-    "prettier-write": "prettier --write 'js/**/*.+(ts|tsx|json|js|jsx)' '*.+(ts|tsx|json|js|jsx)'",
+    "prettier-write": "prettier --write 'js/**/*.+(ts|tsx|json|js|jsx)' '*.+(ts|tsx|json|js|jsx)' '**/*.+(css|scss)'",
     "sass": "node-sass scss/_main.scss ../richie/static/richie/css/main.css",
     "test": "jest",
     "watch-sass": "nodemon -e scss -x 'yarn sass'"


### PR DESCRIPTION
## Purpose

CircleCI job recently included prettier task on Sass sources
but it was not reflected on 'package.json' so this was not
effective on 'make lint-front'.

## Proposal

'package.json' has been modified to include new rules about Sass
sources so it is ready now to match to CircleCI job constraint.
