### PR TITLE
💄(homepage) add homepage plugin constraints and enable LinkPlugin

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -296,6 +296,14 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
         "richie/homepage.html maincontent": {
             "name": _("Main content"),
             "plugins": ["LargeBannerPlugin", "SectionPlugin"],
+            "child_classes": {
+                "SectionPlugin": [
+                    "CoursePlugin",
+                    "OrganizationPlugin",
+                    "CategoryPlugin",
+                    "LinkPlugin",
+                ]
+            },
         },
         # Course detail
         "courses/cms/course_detail.html course_cover": {
@@ -457,6 +465,11 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
         "toolbar": "HTMLField",
         "toolbar_HTMLField": [["Undo", "Redo"], ["Bold", "Italic"], ["Link", "Unlink"]],
     }
+
+    # Additional LinkPlugin templates. Note how choice value is just a keyword
+    # instead of full template path. Value is used inside a path formatting
+    # such as "templates/djangocms_link/VALUE/link.html"
+    DJANGOCMS_LINK_TEMPLATES = [("button-caesura", _("Button caesura"))]
 
     # Thumbnails settings
     THUMBNAIL_PROCESSORS = (

--- a/sandbox/templates/djangocms_link/button-caesura/link.html
+++ b/sandbox/templates/djangocms_link/button-caesura/link.html
@@ -1,0 +1,6 @@
+{% load cms_tags %}{% spaceless %}
+
+{# this needs to be in one line for rendering purpose #}
+{% endspaceless %}<p class="button-caesura"><a href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name }}{% endfor %}</a></p>{% spaceless %}
+
+{% endspaceless %}

--- a/src/richie/plugins/section/templates/richie/section/_highlighted_items.scss
+++ b/src/richie/plugins/section/templates/richie/section/_highlighted_items.scss
@@ -92,6 +92,31 @@ $richie-section-highlights-item-gutter: 0.625rem !default;
                     margin: 0;
                 }
             }
+
+            // Make a caesura in flex flow so button row allway takes full width
+            .button-caesura{
+                @include sv-flex(1, 0, 100%);
+                margin: 2rem 0.5rem 0;
+                display: flex;
+                justify-content: center;
+
+                a{
+                  @include sv-flex(0, 0, auto);
+                  display: block;
+                  padding: 1rem 2.5rem;
+                  color: $dodgerblue7;
+                  background: $white;
+                  border: 1px solid $dodgerblue5;
+
+                  &:hover,
+                  &:focus{
+                      color: $firebrick3;
+                      background: $white;
+                      border: 1px solid $firebrick3;
+                      text-decoration: none;
+                  }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose

Sections allowed every available plugins for inclusion while we
want to restrict available plugin to a little set. Also, Sections
need capacity to have a button link like "Read more".

## Proposal

This commits add placeholder plugins rules on homepage main
placeholder to only enable CoursePlugin, OrganizationPlugin,
CategoryPlugin and LinkPlugin inside a SectionPlugin. Also there is
a new template for LinkPlugin to correctly style a link include in
section.
