### PR TITLE
💄(project) add new template for a simple single column page

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -288,6 +288,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
         ("richie/fullwidth.html", "Fullwidth"),
         ("richie/child_pages_list.html", _("List of child pages")),
         ("richie/homepage.html", _("Homepage")),
+        ("richie/single-column.html", _("Single column")),
     )
     CMS_PERMISSION = True
 

--- a/sandbox/templates/richie/_single-column.scss
+++ b/sandbox/templates/richie/_single-column.scss
@@ -1,0 +1,6 @@
+.single-column {
+  @include make-container();
+  @include make-container-max-widths();
+  padding: 1rem;
+  background: $richie-content-container-bg;
+}

--- a/sandbox/templates/richie/single-column.html
+++ b/sandbox/templates/richie/single-column.html
@@ -1,0 +1,14 @@
+{% extends "richie/base.html" %}
+{% load cms_tags %}
+
+{% block title %}
+    {% page_attribute "page_title" %}
+{% endblock title %}
+
+{% block content %}
+<div class="single-column">
+    {% block column %}
+        {% placeholder "maincontent" %}
+    {% endblock column %}
+</div>
+{% endblock content %}

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -42,6 +42,7 @@
 
 // Shared object styles
 @import '../../../sandbox/templates/menu/_menu';
+@import '../../../sandbox/templates/richie/single-column';
 @import './objects/course_glimpses';
 @import '../../richie/apps/courses/templates/courses/plugins/category_plugin';
 @import '../../richie/apps/persons/templates/persons/plugins/person_plugin';


### PR DESCRIPTION
## Purpose

Currently there is only a "full width" page where content takes the
full width which is a little rude to make simple page like Annexes.

## Proposal

We need to add a new simple template which only include a single
column structure with a little vertical padding so we have a nicer
render for simple pages.

## Sample screenshot

![screenshot_2019-03-07 about](https://user-images.githubusercontent.com/1572165/53959917-3a38cc00-40e5-11e9-81a5-e37816c5a927.png)
