### PR TITLE
💄(homepage) enable PersonPlugin on homepage sections

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -302,6 +302,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
                     "CoursePlugin",
                     "OrganizationPlugin",
                     "CategoryPlugin",
+                    "PersonPlugin",
                     "LinkPlugin",
                 ]
             },

--- a/src/richie/apps/core/management/commands/create_demo_site.py
+++ b/src/richie/apps/core/management/commands/create_demo_site.py
@@ -47,6 +47,7 @@ NB_PERSONS = 10
 NB_HOME_HIGHLIGHTED_COURSES = 8
 NB_HOME_HIGHLIGHTED_ORGANIZATIONS = 4
 NB_HOME_HIGHLIGHTED_SUBJECTS = 6
+NB_HOME_HIGHLIGHTED_PERSONS = 3
 PAGE_INFOS = {
     "home": {
         "title": {"en": "Home", "fr": "Accueil"},
@@ -246,6 +247,7 @@ HOMEPAGE_CONTENT = {
         "section_template": "richie/section/highlighted_items.html",
         "courses_title": "Popular courses",
         "organizations_title": "Universities",
+        "persons_title": "Persons",
         "subjects_title": "Subjects",
     },
     "fr": {
@@ -256,6 +258,7 @@ HOMEPAGE_CONTENT = {
         "courses_title": "Cours à la une",
         "organizations_title": "Universités",
         "subjects_title": "Thématiques",
+        "persons_title": "Personnes",
     },
 }
 
@@ -485,6 +488,28 @@ def create_demo_site():
                 target=subjects_section,
                 page=subject.extended_object,
             )
+
+        # Add highlighted persons
+        persons_section = add_plugin(
+            language=language,
+            placeholder=placeholder,
+            plugin_type="SectionPlugin",
+            title=content["persons_title"],
+            template=content["section_template"],
+        )
+        for person in random.sample(persons, NB_HOME_HIGHLIGHTED_PERSONS):
+            add_plugin(
+                language=language,
+                placeholder=placeholder,
+                plugin_type="PersonPlugin",
+                target=persons_section,
+                page=person.extended_object,
+            )
+
+        # Once content has been added we must publish again homepage in every
+        # edited Languages
+        pages_created["home"].publish("en")
+        pages_created["home"].publish("fr")
 
 
 class Command(BaseCommand):

--- a/src/richie/plugins/section/templates/richie/section/_highlighted_items.scss
+++ b/src/richie/plugins/section/templates/richie/section/_highlighted_items.scss
@@ -93,6 +93,26 @@ $richie-section-highlights-item-gutter: 0.625rem !default;
                 }
             }
 
+            .person-plugin{
+                @include sv-flex(1, 0, calc(100% - #{$richie-section-highlights-item-gutter * 2}));
+                margin: $richie-section-highlights-item-gutter;
+                padding: 1rem;
+                border: 1px solid $gray97;
+                border-radius: 0.2rem;
+
+                &__content{
+                    &__wrapper{
+                        padding: 0 0 0 1rem;
+                    }
+                    &__title{
+                        font-size: 1rem;
+                    }
+                    &__text{
+                        font-size: 0.9rem;
+                    }
+                }
+            }
+
             // Make a caesura in flex flow so button row allway takes full width
             .button-caesura{
                 @include sv-flex(1, 0, 100%);

--- a/src/richie/plugins/section/templates/richie/section/highlighted_items.html
+++ b/src/richie/plugins/section/templates/richie/section/highlighted_items.html
@@ -4,7 +4,9 @@
     <h{{ header_level|default:1 }} class="section__title">{{ instance.title }}</h{{ header_level|default:1 }}>
     <div class="section__items">
         {% for plugin in instance.child_plugin_instances %}
-            {% render_plugin plugin %}
+            {% with header_level=3 %}
+                {% render_plugin plugin %}
+            {% endwith %}
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
## Purpose

Homepage misses a "Persons" section like for Organizations, Courses,
etc..

## Proposal

This add some new styles on highlight section to correctly include
PersonPlugin and "create_demo_site" has been changed to include some
PersonPlugin in a section on homepage. 

Also include a little fix on "create_demo_site" that did not published again 
homepage after adding section and plugins.
