### PR TITLE
🔧(single-column) proper placeholder config for single column template

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -304,6 +304,26 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
                 ]
             },
         },
+        # Single column page
+        "richie/single-column.html maincontent": {
+            "name": _("Main content"),
+            "excluded_plugins": ["CKEditorPlugin", "GoogleMapPlugin"],
+            "parent_classes": {
+                "CoursePlugin": ["SectionPlugin"],
+                "OrganizationPlugin": ["SectionPlugin"],
+                "CategoryPlugin": ["SectionPlugin"],
+                "PersonPlugin": ["SectionPlugin"],
+            },
+            "child_classes": {
+                "SectionPlugin": [
+                    "CoursePlugin",
+                    "OrganizationPlugin",
+                    "CategoryPlugin",
+                    "PersonPlugin",
+                    "LinkPlugin",
+                ]
+            },
+        },
         # Course detail
         "courses/cms/course_detail.html course_cover": {
             "name": _("Cover"),
@@ -424,7 +444,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
         "toolbar": "CMS",
         "toolbar_CMS": [
             ["Undo", "Redo"],
-            ["ShowBlocks"],
+            ["cmsplugins", "-", "ShowBlocks"],
             ["Format", "Styles"],
             ["RemoveFormat"],
             ["Maximize"],


### PR DESCRIPTION
## Purpose

We stated about available plugins on single column template which
should not have every plugins enabled because some are useless and
some other duplicate features with other plugins.

## Proposal

This commit updates the main placeholder configuration for single
column template so we have a limited accurate set of available
plugins such as:

* TextPlugin (the default one from DjangoCMS) is disabled in profit
  to our "CKEditorPlugin";
* GoogleMapPlugin is disabled because it's not really useful for
  richie cases;
* PicturePlugin (Image) is disabled because CKEditor already allow
  to include an image;
* Plugins for Courses, Organizations, Person and Category are only
  allowed inside a SectionPlugin so they are correctly aligned;
* Link is only allowed inside a SectionPlugin to display them as a
  Button with the correct section template;
* Every other available plugins are allowed without constraints;
