### PR TITLE
💄(single-column) add proper basic layout for available plugins 

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -490,6 +490,8 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
     # such as "templates/djangocms_link/VALUE/link.html"
     DJANGOCMS_LINK_TEMPLATES = [("button-caesura", _("Button caesura"))]
 
+    DJANGOCMS_VIDEO_TEMPLATES = [("full-width", _("Full width"))]
+
     # Thumbnails settings
     THUMBNAIL_PROCESSORS = (
         "easy_thumbnails.processors.colorspace",

--- a/sandbox/templates/cms/plugins/text.html
+++ b/sandbox/templates/cms/plugins/text.html
@@ -1,0 +1,3 @@
+<div class="rich-text-container">
+{{ body|safe }}
+</div>

--- a/sandbox/templates/djangocms_link/button-caesura/link.html
+++ b/sandbox/templates/djangocms_link/button-caesura/link.html
@@ -1,6 +1,6 @@
 {% load cms_tags %}{% spaceless %}
 
 {# this needs to be in one line for rendering purpose #}
-{% endspaceless %}<p class="button-caesura"><a href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name }}{% endfor %}</a></p>{% spaceless %}
+{% endspaceless %}<div class="button-caesura"><a href="{{ link }}"{% if instance.target %} target="{{ instance.target }}"{% endif %}{% if instance.attributes %} {{ instance.attributes_str }}{% endif %}>{% for plugin in instance.child_plugin_instances %}{% render_plugin plugin %}{% empty %}{{ instance.name }}{% endfor %}</a></div>{% spaceless %}
 
 {% endspaceless %}

--- a/sandbox/templates/djangocms_video/full-width/video_player.html
+++ b/sandbox/templates/djangocms_video/full-width/video_player.html
@@ -1,0 +1,3 @@
+<div class="embed-responsive embed-responsive-16by9">
+    {% include "djangocms_video/default/video_player.html" %}
+</div>

--- a/sandbox/templates/richie/_single-column.scss
+++ b/sandbox/templates/richie/_single-column.scss
@@ -3,4 +3,44 @@
   @include make-container-max-widths();
   padding: 1rem;
   background: $richie-content-container-bg;
+
+  // Add shared margin for vertical divider between allowed plugins
+  .hero-intro,
+  .embed-responsive,
+  .section--highlights,
+  .licence-plugin,
+  .button-caesura,
+  .rich-text-container{
+    margin: 1rem 0;
+
+    &:first-child{
+      margin-top: 0;
+    }
+
+    &:last-child{
+      margin-bottom: 0;
+    }
+  }
+
+  // Adjust section highlights
+  .section--highlights{
+    padding: 1rem 0;
+    background: $richie-content-container-bg;
+
+    &:nth-child(odd){
+      background: $richie-content-container-bg;
+    }
+
+    // Remove useless spacing for item grid
+    .section__items{
+      padding-right: 0;
+      padding-left: 0;
+
+      // Remove useless spacing from caesura inside a section
+      .button-caesura{
+        margin-left: 0;
+        margin-right: 0;
+      }
+    }
+  }
 }

--- a/sandbox/templates/richie/single-column.html
+++ b/sandbox/templates/richie/single-column.html
@@ -8,7 +8,9 @@
 {% block content %}
 <div class="single-column">
     {% block column %}
-        {% placeholder "maincontent" %}
+        {% with header_level=2 %}
+            {% placeholder "maincontent" %}
+        {% endwith %}
     {% endblock column %}
 </div>
 {% endblock content %}

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -26,6 +26,7 @@
 @import '../node_modules/bootstrap/scss/utilities/display';
 @import '../node_modules/bootstrap/scss/utilities/flex';
 @import '../node_modules/bootstrap/scss/utilities/text';
+@import '../node_modules/bootstrap/scss/utilities/embed';
 
 // PORTAL STYLES
 // Objects from Partials (eg. styles for templates produced by dependencies)

--- a/src/frontend/scss/components/_content.scss
+++ b/src/frontend/scss/components/_content.scss
@@ -1,7 +1,39 @@
 // Main body content container
-
 $richie-body-content-background: $gray98 !default;
+
+$richie-caesura-padding: 1rem 2.5rem !default;
+$richie-caesura-button-fontcolor: $dodgerblue7 !default;
+$richie-caesura-button-background: $white !default;
+$richie-caesura-button-border: 1px solid $dodgerblue5 !default;
+
+$richie-caesura-button-fontcolor-hover: $firebrick3 !default;
+$richie-caesura-button-background-hover: $white !default;
+$richie-caesura-button-border-hover: 1px solid $firebrick3 !default;
 
 .body-content {
   background: $richie-body-content-background;
+}
+
+// Caesura block for single centered button on its own row
+.button-caesura {
+  display: flex;
+  justify-content: center;
+
+  // Enforce an "hollow" display
+  a {
+    @include sv-flex(0, 0, auto);
+    display: block;
+    padding: $richie-caesura-padding;
+    color: $richie-caesura-button-fontcolor;
+    background: $richie-caesura-button-background;
+    border: $richie-caesura-button-border;
+
+    &:hover,
+    &:focus {
+      color: $richie-caesura-button-fontcolor-hover;
+      background: $richie-caesura-button-background-hover;
+      border: $richie-caesura-button-border-hover;
+      text-decoration: none;
+    }
+  }
 }

--- a/src/richie/plugins/section/templates/richie/section/_highlighted_items.scss
+++ b/src/richie/plugins/section/templates/richie/section/_highlighted_items.scss
@@ -113,29 +113,11 @@ $richie-section-highlights-item-gutter: 0.625rem !default;
                 }
             }
 
-            // Make a caesura in flex flow so button row allway takes full width
+            // Ensure caesura always takes full width with some space around
+            // within flex grid
             .button-caesura{
                 @include sv-flex(1, 0, 100%);
                 margin: 2rem 0.5rem 0;
-                display: flex;
-                justify-content: center;
-
-                a{
-                  @include sv-flex(0, 0, auto);
-                  display: block;
-                  padding: 1rem 2.5rem;
-                  color: $dodgerblue7;
-                  background: $white;
-                  border: 1px solid $dodgerblue5;
-
-                  &:hover,
-                  &:focus{
-                      color: $firebrick3;
-                      background: $white;
-                      border: 1px solid $firebrick3;
-                      text-decoration: none;
-                  }
-                }
             }
         }
     }


### PR DESCRIPTION
## Purpose

Single column template allow a dozen of plugins but without any
proper layout, this is not really pretty.

## Proposal

This commit adds some styles around these plugins for single column
template so it have a nicer basic layout.

## Todo

- [x] Depends from #522 merge (would work without but does not have any sense);
- [x] Decide about image;
