### PR TITLE
🐛(sandbox) remove STATICFILES_DIRS setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the `collectstatic` management command execution (bad `STATICFILES_DIRS` definition)
+
 ## [1.0.0-beta.3] - 2019-03-15
 
 ### Changed

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -133,7 +133,6 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
     MEDIA_URL = "/media/"
     MEDIA_ROOT = os.path.join(DATA_DIR, "media")
     STATIC_ROOT = os.path.join(DATA_DIR, "static")
-    STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
 
     # Internationalization
     TIME_ZONE = "Europe/Paris"


### PR DESCRIPTION
## Purpose

The `collectstatic` management command is broken.

## Proposal

- [x] Remove the `STATICFILES_DIRS` setting pointing to a missing directory
