### PR TITLE
🐛(course) fix cover fixture for course factory

### DIFF
--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -24,17 +24,15 @@ VideoSample = namedtuple("VideoSample", ["label", "image", "url"])
 VIDEO_SAMPLE_LINKS = (
     VideoSample(
         "Anant Agarwal: Why massively open online courses (still) matter",
-        "anant_aggarwal.jpg",
+        "cover1.jpg",
         "//www.youtube.com/embed/rYwTA5RA9eU",
     ),
     VideoSample(
-        "Installing Open edX",
-        "installing_openedx.jpg",
-        "//www.youtube.com/embed/YDm6bAPxeg0",
+        "Installing Open edX", "cover2.jpg", "//www.youtube.com/embed/YDm6bAPxeg0"
     ),
     VideoSample(
         "Open edX Conference 2018 Opening and Welcome remarks",
-        "openedx_2018.jpg",
+        "cover3.jpg",
         "//www.youtube.com/embed/zzx6MgBAbCc",
     ),
 )


### PR DESCRIPTION
## Purpose

Previous commit #535 has renamed cover fixture files but filenames has
not been updated to the new names. It didn't have any impact on
tests so it didn't triggered any error but it leads to
"create_demo_site" to fail.

## Proposal

This commit just fix "courses.factories.VIDEO_SAMPLE_LINKS" to fit
to the new names. I promise this fix has been correctly tested from
tests and "create_demo_site" so there will be no "fix fix" to
happen.
