### PR TITLE
🌐(courses) translate course run language

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -224,7 +224,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
     # for example for the choice of languages on the course run which should not be limited to
     # the few languages active in the CMS.
     # pylint: disable=no-member
-    ALL_LANGUAGES = Configuration.LANGUAGES
+    ALL_LANGUAGES = [(language, _(name)) for language, name in Configuration.LANGUAGES]
     ALL_LANGUAGES_DICT = dict(ALL_LANGUAGES)
 
     # Careful! Languages should be ordered by priority, as this tuple is used to get

--- a/src/richie/apps/core/fields/multiselect.py
+++ b/src/richie/apps/core/fields/multiselect.py
@@ -23,10 +23,12 @@ def to_sentence(elements):
 
     """
     if len(elements) > 2:
-        return _("{:s} and {:s}").format(
-            ", ".join(map(str.lower, elements[:-1])), str.lower(elements[-1])
-        )
-    return _(" and ").join(map(str.lower, elements))
+        return (
+            _("{:s} and {:s}").format(
+                ", ".join(map(str, elements[:-1])), str(elements[-1])
+            )
+        ).lower()
+    return (_(" and ").join(map(str, elements))).lower()
 
 
 class MaxChoicesValidator(validators.MaxLengthValidator):


### PR DESCRIPTION
## Purpose

Translate languages used for course run through multiselect field.
They were untranslated up till now.


## Proposal

Make the values used in setting translatable.
Fix the multiselect field to return lower string values only after translation is done.
