### PR TITLE
🐛(courses) define availability as a drilldown filter

### DIFF
--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -53,6 +53,7 @@ FILTERS_DEFAULT = [
                         "name": "availability",
                         "human_name": _("Availability"),
                         "position": 1,
+                        "is_drilldown": True,
                     },
                 ),
                 (

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -298,7 +298,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                     },
                     "availability": {
                         "human_name": "Availability",
-                        "is_drilldown": False,
+                        "is_drilldown": True,
                         "name": "availability",
                         "position": 1,
                         "values": [

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -163,7 +163,7 @@ class CoursesViewsetsTestCase(TestCase):
                 "filters": {
                     "availability": {
                         "human_name": "Availability",
-                        "is_drilldown": False,
+                        "is_drilldown": True,
                         "name": "availability",
                         "position": 1,
                         "values": [


### PR DESCRIPTION
## Purpose

Availability filter possiblities are not compatible between each other and should be selected independantly. 

## Proposal

Define the `availability` filter as a "drilldown".
