### PR TITLE
🐛(search) exclude snapshots from the courses index

### DIFF
--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -480,8 +480,9 @@ class CoursesIndexer:
         Loop on all the courses in database and format them for the ElasticSearch index
         """
         for course in Course.objects.filter(
-            extended_object__publisher_is_draft=False,
-            extended_object__title_set__published=True,
+            extended_object__publisher_is_draft=False,  # index the public object
+            extended_object__title_set__published=True,  # only index published courses
+            extended_object__node__parent__cms_pages__course__isnull=True,  # exclude snapshots
         ).distinct():
             yield cls.get_es_document_for_course(course, index, action)
 

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -79,6 +79,21 @@ class CoursesIndexersTestCase(TestCase):
         self.assertEqual(len(indexed_courses), 1)
         self.assertEqual(indexed_courses[0]["course_runs"], [])
 
+    def test_indexers_courses_get_es_documents_snapshots(self):
+        """
+        Course snapshots should not get indexed.
+        """
+        course = CourseFactory(should_publish=True)
+        CourseFactory(page_parent=course.extended_object, should_publish=True)
+
+        indexed_courses = list(
+            CoursesIndexer.get_es_documents(index="some_index", action="some_action")
+        )
+        self.assertEqual(len(indexed_courses), 1)
+        self.assertEqual(
+            indexed_courses[0]["_id"], str(course.public_extension.extended_object_id)
+        )
+
     @mock.patch.object(
         Picture, "img_src", new_callable=mock.PropertyMock, return_value="123.jpg"
     )


### PR DESCRIPTION

## Purpose

We forgot to exclude snapshots so they were getting indexed along side their parent course.

## Proposal

- [x] Add a test to reproduce the bug,
- [x] Add a condition to exclude snapshots in the query that browses courses to index them.
