### PR TITLE
Update Elasticsearch indices when a modification is published

### DIFF
--- a/src/richie/apps/core/management/commands/create_demo_site.py
+++ b/src/richie/apps/core/management/commands/create_demo_site.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.files import File
 from django.core.management.base import BaseCommand, CommandError
+from django.test.utils import override_settings
 
 from cms import models as cms_models
 from cms.api import add_plugin
@@ -293,6 +294,7 @@ def clear_cms_data():
 
 
 # pylint: disable=too-many-locals
+@override_settings(RICHIE_KEEP_SEARCH_UPDATED=False)
 def create_demo_site():
     """
     Create a simple site tree structure for developpers to work in realistic environment.

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -399,6 +399,15 @@ class CourseRun(BasePageExtension):
             self.start, self.end, self.enrollment_start, self.enrollment_end
         )
 
+    def get_course(self):
+        """Get the course for this course run."""
+        nodes = self.extended_object.node.get_ancestors()
+        return Course.objects.get(
+            extended_object__node__in=nodes,
+            extended_object__publisher_is_draft=self.extended_object.publisher_is_draft,
+            extended_object__node__parent__cms_pages__course__isnull=True,  # exclude snapshots
+        )
+
 
 class CoursePluginModel(PagePluginMixin, CMSPlugin):
     """

--- a/src/richie/apps/search/__init__.py
+++ b/src/richie/apps/search/__init__.py
@@ -1,0 +1,3 @@
+"""Define SearchConfig as the default app configuration."""
+# pylint: disable=invalid-name
+default_app_config = "richie.apps.search.apps.SearchConfig"

--- a/src/richie/apps/search/apps.py
+++ b/src/richie/apps/search/apps.py
@@ -1,0 +1,16 @@
+"""Signals to update the Elasticsearch indexes when page modifications are published."""
+from django.apps import AppConfig
+
+
+class SearchConfig(AppConfig):
+    """Configuration class for the search app."""
+
+    name = "richie.apps.search"
+    verbose_name = "Richie search app"
+
+    def ready(self):
+        """Register signals to update the Elasticsearch indexes."""
+        from cms.signals import post_publish
+        from .signals import on_page_publish
+
+        post_publish.connect(on_page_publish, dispatch_uid="search_post_publish")

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -13,6 +13,16 @@ from elasticsearch.helpers import bulk
 from .indexers import ES_INDICES
 
 
+def richie_bulk(actions):
+    """Wrap bulk helper to set default parameters."""
+    return bulk(
+        actions=actions,
+        chunk_size=settings.ES_CHUNK_SIZE,
+        client=settings.ES_CLIENT,
+        stats_only=True,
+    )
+
+
 def get_indexes_by_alias(existing_indexes, alias):
     """
     Get existing index(es) for an alias. Support multiple existing aliases so the command
@@ -41,12 +51,7 @@ def perform_create_index(indexable, logger):
     )
 
     # Populate the new index with data provided from our indexable class
-    bulk(
-        actions=indexable.get_es_documents(new_index, "create"),
-        chunk_size=settings.ES_CHUNK_SIZE,
-        client=settings.ES_CLIENT,
-        stats_only=True,
-    )
+    richie_bulk(indexable.get_es_documents(new_index))
 
     # Return the name of the index we just created in ElasticSearch
     return new_index

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -341,10 +341,12 @@ class CoursesIndexer:
     }
 
     @classmethod
-    def get_es_document_for_course(cls, course, index, action):
+    def get_es_document_for_course(cls, course, index=None, action="index"):
         """
         Build an Elasticsearch document from the course instance.
         """
+        index = index or cls.index_name
+
         # Prepare published titles
         titles = {
             t.language: t.title
@@ -475,16 +477,18 @@ class CoursesIndexer:
         }
 
     @classmethod
-    def get_es_documents(cls, index, action):
+    def get_es_documents(cls, index=None, action="index"):
         """
         Loop on all the courses in database and format them for the ElasticSearch index
         """
+        index = index or cls.index_name
+
         for course in Course.objects.filter(
             extended_object__publisher_is_draft=False,  # index the public object
             extended_object__title_set__published=True,  # only index published courses
             extended_object__node__parent__cms_pages__course__isnull=True,  # exclude snapshots
         ).distinct():
-            yield cls.get_es_document_for_course(course, index, action)
+            yield cls.get_es_document_for_course(course, index=index, action=action)
 
     @staticmethod
     def format_es_object_for_api(es_course, language=None):

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -4,7 +4,6 @@ ElasticSearch organization document management utilities
 from collections import defaultdict
 
 from django.conf import settings
-from django.db.models import Prefetch
 
 from cms.models import Title
 from djangocms_picture.models import Picture
@@ -47,68 +46,70 @@ class OrganizationsIndexer:
     display_fields = ["absolute_url", "logo", "title.*"]
 
     @classmethod
-    def get_es_documents(cls, index, action):
-        """
-        Load all the organizations from the Organization model and format them for the
-        ElasticSearch index.
-        """
-        for organization in (
-            Organization.objects.filter(
-                extended_object__publisher_is_draft=False,
-                extended_object__title_set__published=True,
+    def get_es_document_for_organization(cls, organization, index=None, action="index"):
+        """Build an Elasticsearch document from the category instance."""
+        index = index or cls.index_name
+
+        # Get published titles
+        titles = {
+            t.language: t.title
+            for t in Title.objects.filter(
+                page=organization.extended_object, published=True
             )
-            .prefetch_related(
-                Prefetch(
-                    "extended_object__title_set",
-                    to_attr="published_titles",
-                    queryset=Title.objects.filter(published=True),
-                )
-            )
-            .distinct()
+        }
+
+        # Get logo images
+        logo_images = {}
+        for logo_image in Picture.objects.filter(
+            cmsplugin_ptr__placeholder__page=organization.extended_object,
+            cmsplugin_ptr__placeholder__slot="logo",
         ):
-            # Get published titles
-            titles = {
-                t.language: t.title
-                for t in organization.extended_object.published_titles
-            }
+            # Force the image format before computing it
+            logo_image.use_no_cropping = False
+            logo_image.width = defaults.ORGANIZATIONS_LOGO_IMAGE_WIDTH
+            logo_image.height = defaults.ORGANIZATIONS_LOGO_IMAGE_HEIGHT
+            logo_images[logo_image.cmsplugin_ptr.language] = logo_image.img_src
 
-            # Get logo images
-            logo_images = {}
-            for logo_image in Picture.objects.filter(
-                cmsplugin_ptr__placeholder__page=organization.extended_object,
-                cmsplugin_ptr__placeholder__slot="logo",
-            ):
-                # Force the image format before computing it
-                logo_image.use_no_cropping = False
-                logo_image.width = defaults.ORGANIZATIONS_LOGO_IMAGE_WIDTH
-                logo_image.height = defaults.ORGANIZATIONS_LOGO_IMAGE_HEIGHT
-                logo_images[logo_image.cmsplugin_ptr.language] = logo_image.img_src
+        # Get syllabus texts
+        description = defaultdict(list)
+        for simple_text in SimpleText.objects.filter(
+            cmsplugin_ptr__placeholder__page=organization.extended_object,
+            cmsplugin_ptr__placeholder__slot="description",
+        ):
+            description[simple_text.cmsplugin_ptr.language].append(simple_text.body)
 
-            # Get syllabus texts
-            description = defaultdict(list)
-            for simple_text in SimpleText.objects.filter(
-                cmsplugin_ptr__placeholder__page=organization.extended_object,
-                cmsplugin_ptr__placeholder__slot="description",
-            ):
-                description[simple_text.cmsplugin_ptr.language].append(simple_text.body)
+        return {
+            "_id": str(organization.extended_object_id),
+            "_index": index,
+            "_op_type": action,
+            "_type": cls.document_type,
+            "absolute_url": {
+                language: organization.extended_object.get_absolute_url(language)
+                for language in titles.keys()
+            },
+            "complete": {
+                language: slice_string_for_completion(title)
+                for language, title in titles.items()
+            },
+            "logo": logo_images,
+            "description": {l: " ".join(st) for l, st in description.items()},
+            "title": titles,
+        }
 
-            yield {
-                "_id": str(organization.extended_object_id),
-                "_index": index,
-                "_op_type": action,
-                "_type": cls.document_type,
-                "absolute_url": {
-                    language: organization.extended_object.get_absolute_url(language)
-                    for language in titles.keys()
-                },
-                "complete": {
-                    language: slice_string_for_completion(title)
-                    for language, title in titles.items()
-                },
-                "logo": logo_images,
-                "description": {l: " ".join(st) for l, st in description.items()},
-                "title": titles,
-            }
+    @classmethod
+    def get_es_documents(cls, index=None, action="index"):
+        """
+        Loop on all the organizations in database and format them for the ElasticSearch index
+        """
+        index = index or cls.index_name
+
+        for organization in Organization.objects.filter(
+            extended_object__publisher_is_draft=False,
+            extended_object__title_set__published=True,
+        ).distinct():
+            yield cls.get_es_document_for_organization(
+                organization, index=index, action=action
+            )
 
     @staticmethod
     def format_es_object_for_api(es_organization, best_language):

--- a/src/richie/apps/search/signals.py
+++ b/src/richie/apps/search/signals.py
@@ -1,0 +1,107 @@
+"""Update Elasticsearch indexes each time a page is modified."""
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
+
+from richie.apps.courses.models import Category, Course, Organization
+from richie.apps.search.index_manager import richie_bulk
+from richie.apps.search.indexers import ES_INDICES
+
+
+def update_course(instance, _language):
+    """
+    Update Elasticsearch indexes when a course was modified and published:
+    - update the course document in the Elasticsearch courses index.
+
+    Returns None if the page was related to a course and the Elasticsearch update is done.
+    Raises ObjectDoesNotExist if the page instance is not related to a course.
+    """
+    course = Course.objects.get(draft_extension__extended_object=instance)
+    richie_bulk([ES_INDICES.courses.get_es_document_for_course(course)])
+
+
+def update_course_run(instance, _language):
+    """
+    Update Elasticsearch indexes when a course run was modified and published:
+    - update the course document in the Elasticsearch courses index for the parent course
+      of this course run.
+
+    Returns None if the page was related to a course run and the Elasticsearch update is done.
+    Raises ObjectDoesNotExist if the page instance is not related to a course run.
+    """
+    course = instance.courserun.get_course().public_extension
+    richie_bulk([ES_INDICES.courses.get_es_document_for_course(course)])
+
+
+def update_organization(instance, language):
+    """
+    Update Elasticsearch indexes when an organization was modified and published:
+    - update the organization document in the Elasticsearch organizations index,
+    - update the course documents in the Elasticsearch courses index for all courses linked to
+      this organization.
+
+    Returns None if the page was related to an organization and the Elasticsearch update is done.
+    Raises ObjectDoesNotExist if the page instance is not related to an organization.
+    """
+    organization = Organization.objects.get(draft_extension__extended_object=instance)
+    course_actions = [
+        ES_INDICES.courses.get_es_document_for_course(course.public_extension)
+        # get_courses always returns the draft course instance
+        for course in organization.get_courses(language)
+        if course.public_extension
+    ]
+    richie_bulk(
+        course_actions
+        + [ES_INDICES.organizations.get_es_document_for_organization(organization)]
+    )
+
+
+def update_category(instance, language):
+    """
+    Update Elasticsearch indexes when a category was modified and published:
+    - update the category document in the Elasticsearch categories index,
+    - update the course documents in the Elasticsearch courses index for all courses linked to
+      this category.
+
+    Returns None if the page was related to a category and the Elasticsearch update is done.
+    Raises ObjectDoesNotExist if the page instance is not related to a category.
+    """
+    category = Category.objects.get(draft_extension__extended_object=instance)
+    course_actions = [
+        ES_INDICES.courses.get_es_document_for_course(course.public_extension)
+        # get_courses always returns the draft course instance
+        for course in category.get_courses(language)
+        if course.public_extension
+    ]
+    richie_bulk(
+        course_actions + [ES_INDICES.categories.get_es_document_for_category(category)]
+    )
+
+
+def update_page_extension(instance, language):
+    """
+    Try updating each type of page extension one-by-one until one works (because we don't know
+    to which type of page extension this page is related).
+    """
+    for method in [
+        update_course,
+        update_course_run,
+        update_category,
+        update_organization,
+    ]:
+        try:
+            # The method should raise an ObjectDoesNotExist exception if the page extension
+            # linked to this instance is of another type.
+            method(instance, language)
+        except ObjectDoesNotExist:
+            continue
+        else:
+            return
+
+
+# pylint: disable=unused-argument
+def on_page_publish(sender, instance, language, **kwargs):
+    """
+    Trigger update of the Elasticsearch indices impacted by the modification of the instance
+    only once the database transaction is successful.
+    """
+    transaction.on_commit(lambda: update_page_extension(instance, language))

--- a/src/richie/apps/search/signals.py
+++ b/src/richie/apps/search/signals.py
@@ -1,4 +1,5 @@
 """Update Elasticsearch indexes each time a page is modified."""
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 
@@ -104,4 +105,5 @@ def on_page_publish(sender, instance, language, **kwargs):
     Trigger update of the Elasticsearch indices impacted by the modification of the instance
     only once the database transaction is successful.
     """
-    transaction.on_commit(lambda: update_page_extension(instance, language))
+    if getattr(settings, "RICHIE_KEEP_SEARCH_UPDATED", True):
+        transaction.on_commit(lambda: update_page_extension(instance, language))

--- a/tests/apps/courses/test_models_course.py
+++ b/tests/apps/courses/test_models_course.py
@@ -154,7 +154,7 @@ class CourseModelsTestCase(TestCase):
         # - a draft course run
         # - a course run published in the current language
         # - a course run published in another language
-        # - a course run published in the current language that xas then unpublished
+        # - a course run published in the current language that was then unpublished
         course_runs = CourseRunFactory.create_batch(
             3, page_parent=course.extended_object, page_languages=["en"]
         )

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -109,7 +109,7 @@ class IndexManagerTestCase(TestCase):
             }
 
             # pylint: disable=no-self-use
-            def get_es_documents(self, index, action):
+            def get_es_documents(self, index, action="index"):
                 """Stub method"""
 
                 for i in range(0, 10):

--- a/tests/apps/search/test_signals.py
+++ b/tests/apps/search/test_signals.py
@@ -1,0 +1,170 @@
+"""
+Tests for the course viewset
+"""
+from unittest import mock
+
+from django.db import connection
+from django.test import TestCase
+
+from richie.apps.courses.factories import (
+    CategoryFactory,
+    CourseFactory,
+    CourseRunFactory,
+    OrganizationFactory,
+)
+from richie.apps.search.indexers.courses import CoursesIndexer
+
+
+@mock.patch.object(  # Avoid messing up the development Elasticsearch index
+    CoursesIndexer,
+    "index_name",
+    new_callable=mock.PropertyMock,
+    return_value="test_courses",
+)
+@mock.patch("richie.apps.search.index_manager.bulk")  # Mock call to Elasticsearch
+class CoursesSignalsTestCase(TestCase):
+    """
+    Test signals to keep the Elasticsearch indexes up-to-date.
+    """
+
+    @staticmethod
+    def run_commit_hooks():
+        """
+        Run commit hooks as if the database transaction had been successful.
+        """
+        while connection.run_on_commit:
+            _sids, func = connection.run_on_commit.pop(0)
+            func()
+
+    def test_signals_courses(self, mock_bulk, *_):
+        """
+        Publishing a course should update its document in the Elasticsearch courses index.
+        """
+        course = CourseFactory()
+        self.run_commit_hooks()
+
+        # Elasticsearch should not be called until the course is published
+        self.assertFalse(mock_bulk.called)
+
+        self.assertTrue(course.extended_object.publish("en"))
+        course.refresh_from_db()
+
+        # Elasticsearch should not be called before the db transaction is successful
+        self.assertFalse(mock_bulk.called)
+
+        self.run_commit_hooks()
+
+        self.assertEqual(mock_bulk.call_count, 1)
+        self.assertEqual(len(mock_bulk.call_args[1]["actions"]), 1)
+        action = mock_bulk.call_args[1]["actions"][0]
+        self.assertEqual(action["_id"], str(course.public_extension.extended_object_id))
+        self.assertEqual(action["_type"], "course")
+
+    def test_signals_course_runs_course_published(self, mock_bulk, *_):
+        """
+        Publishing a course run should update its course document in the Elasticsearch courses
+        index if published, excluding snapshots.
+        """
+        course = CourseFactory(should_publish=True)
+        CourseFactory(page_parent=course.extended_object, should_publish=True)
+        self.run_commit_hooks()
+        mock_bulk.reset_mock()
+
+        course_run = CourseRunFactory(page_parent=course.extended_object)
+        self.run_commit_hooks()
+
+        # Elasticsearch should not be called until the course run is published
+        self.assertFalse(mock_bulk.called)
+
+        self.assertTrue(course_run.extended_object.publish("en"))
+
+        # Elasticsearch should not be called before the db transaction is successful
+        self.assertFalse(mock_bulk.called)
+        self.run_commit_hooks()
+
+        self.assertEqual(mock_bulk.call_count, 1)
+        self.assertEqual(len(mock_bulk.call_args[1]["actions"]), 1)
+        action = mock_bulk.call_args[1]["actions"][0]
+        self.assertEqual(action["_id"], str(course.public_extension.extended_object_id))
+        self.assertEqual(action["_type"], "course")
+
+    def test_signals_course_runs_course_unpublished(self, mock_bulk, *_):
+        """
+        Publishing a course run should not update its course document in Elasticsearch if not
+        published.
+        """
+        course = CourseFactory()
+        course_run = CourseRunFactory(
+            page_parent=course.extended_object, should_publish=True
+        )
+
+        self.assertFalse(course_run.extended_object.publish("en"))
+        self.run_commit_hooks()
+
+        self.assertFalse(mock_bulk.called)
+
+    def test_signals_organizations(self, mock_bulk, *_):
+        """
+        Publishing an organization should update its document in the Elasticsearch organizations
+        index, and the documents for published courses to which it is related, excluding snapshots.
+        """
+        organization = OrganizationFactory()
+        published_course, _unpublished_course = CourseFactory.create_batch(
+            2, fill_organizations=[organization]
+        )
+        published_course.extended_object.publish("en")
+        published_course.refresh_from_db()
+        self.run_commit_hooks()
+        mock_bulk.reset_mock()
+
+        organization.extended_object.publish("en")
+        organization.refresh_from_db()
+
+        # Elasticsearch should not be called before the db transaction is successful
+        self.assertFalse(mock_bulk.called)
+        self.run_commit_hooks()
+
+        self.assertEqual(mock_bulk.call_count, 1)
+        self.assertEqual(len(mock_bulk.call_args[1]["actions"]), 2)
+        actions = list(mock_bulk.call_args[1]["actions"])
+        self.assertEqual(
+            actions[0]["_id"], str(published_course.public_extension.extended_object_id)
+        )
+        self.assertEqual(actions[0]["_type"], "course")
+        self.assertEqual(
+            actions[1]["_id"], str(organization.public_extension.extended_object_id)
+        )
+        self.assertEqual(actions[1]["_type"], "organization")
+
+    def test_signals_categories(self, mock_bulk, *_):
+        """
+        Publishing a category should update its document in the Elasticsearch categories
+        index, and the documents for published courses to which it is related, excluding snapshots.
+        """
+        category = CategoryFactory()
+        published_course, _unpublished_course = CourseFactory.create_batch(
+            2, fill_categories=[category]
+        )
+        published_course.extended_object.publish("en")
+        published_course.refresh_from_db()
+        self.run_commit_hooks()
+        mock_bulk.reset_mock()
+
+        category.extended_object.publish("en")
+        category.refresh_from_db()
+
+        # Elasticsearch should not be called before the db transaction is successful
+        self.assertFalse(mock_bulk.called)
+        self.run_commit_hooks()
+
+        self.assertEqual(mock_bulk.call_count, 1)
+        self.assertEqual(len(mock_bulk.call_args[1]["actions"]), 2)
+        actions = list(mock_bulk.call_args[1]["actions"])
+        self.assertEqual(
+            actions[0]["_id"], str(published_course.public_extension.extended_object_id)
+        )
+        self.assertEqual(actions[0]["_type"], "course")
+        self.assertEqual(
+            actions[1]["_id"], str(category.public_extension.extended_object_id)
+        )
+        self.assertEqual(actions[1]["_type"], "category")


### PR DESCRIPTION
## Purpose

Elasticsearch indices are created and populated via a management command. 

Up to now, any modification to the pages that was done after running this command were not reflected in the search indices.

## Proposal

- [x] add a method on the course run to easily get its parent course,
- [x] refactor indexers to allow updating documents one-by-one in Elasticsearch,
- [x] add signals to trigger update of the impacted documents in Elasticsearch,
- [x] test the added signals.