### PR TITLE
🐛(project) fix watch-sass for sources out of frontend directory

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -10,7 +10,7 @@
     "prettier-write": "prettier --write 'js/**/*.+(ts|tsx|json|js|jsx)' '*.+(ts|tsx|json|js|jsx)' '**/*.+(css|scss)'",
     "sass": "node-sass scss/_main.scss ../richie/static/richie/css/main.css",
     "test": "jest",
-    "watch-sass": "nodemon -e scss -x 'yarn sass'"
+    "watch-sass": "nodemon --watch scss --watch ../richie/apps -e scss -x 'yarn sass'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Purpose

Currently watch-sass does not see when a Sass source from an app is
changed and so it does not perform a new build. This would fix and
close #499 

## Proposal

Fix only add `--watch` arguments to nodemon command to define every
directory to watch instead of default behavior to watch only current
directory.
