### PR TITLE
Allow nested categories and categories split on several filters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         - "5440:5432"
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.1
+    image: fundocker/openshift-elasticsearch:6.6.2
 
   # We use our production image as a basis for the development image, hence, we
   # define a "base" service upon which the "app" service depends to force

--- a/docker/compose/ci/mysql/docker-compose.yml
+++ b/docker/compose/ci/mysql/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   #
   # [1] https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_notes_for_production_use_and_defaults
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.1
+    image: fundocker/openshift-elasticsearch:6.6.2
     ulimits:
       memlock:
         soft: -1

--- a/docker/compose/ci/postgresql/docker-compose.yml
+++ b/docker/compose/ci/postgresql/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   #
   # [1] https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_notes_for_production_use_and_defaults
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.1
+    image: fundocker/openshift-elasticsearch:6.6.2
     ulimits:
       memlock:
         soft: -1

--- a/docker/compose/development/mysql/docker-compose.yml
+++ b/docker/compose/development/mysql/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.1
+    image: fundocker/openshift-elasticsearch:6.6.2
 
   # We use our production image as a basis for the development image, hence, we
   # define a "base" service upon which the "app" service depends to force

--- a/docker/compose/test/mysql/docker-compose.yml
+++ b/docker/compose/test/mysql/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.1
+    image: fundocker/openshift-elasticsearch:6.6.2
 
   app:
     image: richie:dev

--- a/docker/compose/test/postgresql/docker-compose.yml
+++ b/docker/compose/test/postgresql/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - env.d/test/postgresql
  
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.1
+    image: fundocker/openshift-elasticsearch:6.6.2
 
   app:
     image: richie:dev

--- a/src/richie/apps/core/factories.py
+++ b/src/richie/apps/core/factories.py
@@ -83,6 +83,7 @@ class PageExtensionDjangoModelFactory(factory.django.DjangoModelFactory):
             in_navigation=getattr(self, "page_in_navigation", False),
             languages=getattr(self, "page_languages", None),
             parent=getattr(self, "page_parent", None),
+            reverse_id=getattr(self, "page_reverse_id", None),
             template=getattr(self, "page_template", None),
             title=getattr(self, "page_title", None),
         )

--- a/src/richie/apps/core/management/commands/create_demo_site.py
+++ b/src/richie/apps/core/management/commands/create_demo_site.py
@@ -330,8 +330,14 @@ def create_demo_site():
     )
 
     # Generate each category tree and return a list of the leaf categories
-    levels = list(create_categories(LEVELS_INFO, pages_created["categories"]))
-    subjects = list(create_categories(SUBJECTS_INFO, pages_created["categories"]))
+    levels = list(
+        create_categories(LEVELS_INFO, pages_created["categories"], reverse_id="levels")
+    )
+    subjects = list(
+        create_categories(
+            SUBJECTS_INFO, pages_created["categories"], reverse_id="subjects"
+        )
+    )
 
     title = PersonTitleFactory(translation=None)
     PersonTitleTranslationFactory(

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -116,6 +116,7 @@ class OrganizationFactory(BLDPageExtensionDjangoModelFactory):
             "page_in_navigation",
             "page_languages",
             "page_parent",
+            "page_reverse_id",
             "page_template",
             "page_title",
         ]
@@ -456,6 +457,7 @@ class CategoryFactory(BLDPageExtensionDjangoModelFactory):
             "page_in_navigation",
             "page_languages",
             "page_parent",
+            "page_reverse_id",
             "page_template",
             "page_title",
         ]

--- a/src/richie/apps/courses/helpers.py
+++ b/src/richie/apps/courses/helpers.py
@@ -4,7 +4,7 @@ Helpers that can be useful throughout Richie's courses app
 from .factories import CategoryFactory
 
 
-def create_categories(info, parent, should_publish=True):
+def create_categories(info, parent, reverse_id=None, should_publish=True):
     """
     Create the category tree from the SUBJECTS dictionary.
 
@@ -35,6 +35,7 @@ def create_categories(info, parent, should_publish=True):
     """
     category = CategoryFactory(
         page_title=info["title"],
+        page_reverse_id=reverse_id,
         page_in_navigation=info.get("in_navigation", True),
         page_parent=parent,
         should_publish=should_publish,

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -61,7 +61,7 @@ FILTERS_DEFAULT = [
                     {
                         "name": "languages",
                         "human_name": _("Languages"),
-                        "position": 4,
+                        "position": 5,
                         "sorting": "count",
                     },
                 ),
@@ -70,10 +70,31 @@ FILTERS_DEFAULT = [
     ),
     (
         "richie.apps.search.filter_definitions.IndexableFilterDefinition",
-        {"name": "categories", "human_name": _("Categories"), "position": 2},
+        {
+            "name": "subjects",
+            "human_name": _("Subjects"),
+            "position": 2,
+            "reverse_id": "subjects",
+            "term": "categories",
+        },
     ),
     (
         "richie.apps.search.filter_definitions.IndexableFilterDefinition",
-        {"name": "organizations", "human_name": _("Organizations"), "position": 3},
+        {
+            "name": "levels",
+            "human_name": _("Levels"),
+            "position": 3,
+            "reverse_id": "levels",
+            "term": "categories",
+        },
+    ),
+    (
+        "richie.apps.search.filter_definitions.IndexableFilterDefinition",
+        {
+            "name": "organizations",
+            "human_name": _("Organizations"),
+            "position": 4,
+            "reverse_id": "organizations",
+        },
     ),
 ]

--- a/src/richie/apps/search/filter_definitions/base.py
+++ b/src/richie/apps/search/filter_definitions/base.py
@@ -186,8 +186,11 @@ class BaseChoicesFilterDefinition(BaseFilterDefinition):
     def get_form_fields(self):
         """Choice filters are validated with a MultipleChoiceField."""
         return {
-            self.name: forms.MultipleChoiceField(
-                required=False, choices=self.get_values().items()
+            self.name: (
+                forms.MultipleChoiceField(
+                    required=False, choices=self.get_values().items()
+                ),
+                True,  # a MultipleChoiceField expects list values
             )
         }
 

--- a/src/richie/apps/search/filter_definitions/courses.py
+++ b/src/richie/apps/search/filter_definitions/courses.py
@@ -66,11 +66,20 @@ class IndexableFilterDefinition(TermsAggsMixin, TermsQueryMixin, BaseFilterDefin
         return super().aggs_include
 
     def get_form_fields(self):
-        """Indexables are filtered via a list of their Elasticsearch ids i.e strings."""
+        """
+        Indexables are filtered via:
+        - a list of their Elasticsearch ids i.e strings,
+        - a regex to eventually limit which terms are facetted.
+        """
         return {
-            self.name: ArrayField(
-                required=False, base_type=forms.CharField(max_length=50)
-            )
+            self.name: (
+                ArrayField(required=False, base_type=forms.CharField(max_length=50)),
+                True,  # an ArrayField expects list values
+            ),
+            f"{self.name:s}_include": (
+                forms.CharField(max_length=20, required=False),
+                False,  # a CharField expects string values
+            ),
         }
 
     def get_i18n_names(self, keys):

--- a/src/richie/apps/search/filter_definitions/mixins.py
+++ b/src/richie/apps/search/filter_definitions/mixins.py
@@ -28,18 +28,20 @@ class TermsAggsMixin:
         return ".*"
 
     # pylint: disable=unused-argument
-    def get_aggs_fragment(self, queries, *args, **kwargs):
+    def get_aggs_fragment(self, queries, data, *args, **kwargs):
         """
         Build the aggregations as a term query that counts all the different values assigned
         to the field.
         """
+        # Look for an include parameter in the form data and default to the regex returned
+        # by the `aggs_include` property:
+        include = data[f"{self.name:s}_include"] or self.aggs_include
+
         return {
             self.name: {
                 # Rely on the built-in "terms" aggregation to get everything we need
                 "aggregations": {
-                    self.name: {
-                        "terms": {"field": self.term, "include": self.aggs_include}
-                    }
+                    self.name: {"terms": {"field": self.term, "include": include}}
                 },
                 "filter": {
                     "bool": {

--- a/src/richie/apps/search/filter_definitions/mixins.py
+++ b/src/richie/apps/search/filter_definitions/mixins.py
@@ -19,6 +19,14 @@ class TermsQueryMixin:
 class TermsAggsMixin:
     """A mixin for filter definitions that need to apply aggregations as term queries."""
 
+    @property
+    def aggs_include(self):
+        """
+        Return a regex to limit the terms on which the field will be faceted. We return ".*" by
+        default (no limitation) but it can be overriden in children classes.
+        """
+        return ".*"
+
     # pylint: disable=unused-argument
     def get_aggs_fragment(self, queries, *args, **kwargs):
         """
@@ -28,7 +36,11 @@ class TermsAggsMixin:
         return {
             self.name: {
                 # Rely on the built-in "terms" aggregation to get everything we need
-                "aggregations": {self.name: {"terms": {"field": self.term}}},
+                "aggregations": {
+                    self.name: {
+                        "terms": {"field": self.term, "include": self.aggs_include}
+                    }
+                },
                 "filter": {
                     "bool": {
                         # Use all the query fragments from the queries *but* the one(s) that

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -39,9 +39,14 @@ FILTER_FIELDS = {
 class SearchForm(forms.Form):
     """Validate the query string params in a search request."""
 
+    OBJECTS, FILTERS = "objects", "filters"
+
+    SCOPE_CHOICES = ((OBJECTS, "Objects"), (FILTERS, "Filters"))
+
     limit = forms.IntegerField(required=False, min_value=1, initial=10)
     query = forms.CharField(required=False, min_length=3, max_length=100)
     offset = forms.IntegerField(required=False, min_value=0, initial=0)
+    scope = forms.ChoiceField(required=False, choices=SCOPE_CHOICES)
 
 
 class CourseSearchForm(SearchForm):

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -55,6 +55,20 @@ class CategoriesIndexer:
         "title.*",
     ]
 
+    @staticmethod
+    def get_es_id(page):
+        """
+        An ID built with the node path and the position of this category in the taxonomy:
+            - P: parent, the category has children
+            - L: leaf, the category has no children
+
+        For example: a parent category `P_00010002` and its child `L_000100020001`.
+        """
+        return "{type:s}-{path:s}".format(
+            type="L" if page.node.is_leaf() else "P",  # Leaf or Parent?
+            path=page.node.path,
+        )
+
     @classmethod
     def get_es_document_for_category(cls, category, index=None, action="index"):
         """Build an Elasticsearch document from the category instance."""
@@ -90,7 +104,7 @@ class CategoriesIndexer:
         node = category.extended_object.node
 
         return {
-            "_id": str(category.extended_object_id),
+            "_id": cls.get_es_id(category.extended_object),
             "_index": index,
             "_op_type": action,
             "_type": cls.document_type,

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -401,7 +401,7 @@ class CoursesIndexer:
                     queryset=Title.objects.filter(published=True),
                 )
             )
-            .only("extended_object")
+            .only("extended_object__node")
             .distinct()
         )
 
@@ -456,11 +456,8 @@ class CoursesIndexer:
             "description": {l: " ".join(st) for l, st in syllabus_texts.items()},
             "is_new": len(course_runs) == 1,
             "organizations": [
-                str(id)
-                for id in course.get_organizations().values_list(
-                    "public_extension__extended_object", flat=True
-                )
-                if id is not None
+                ES_INDICES.organizations.get_es_id(o.extended_object)
+                for o in organizations
             ],
             # Index the names of organizations to surface them in full text searches
             "organizations_names": reduce(

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -45,6 +45,20 @@ class OrganizationsIndexer:
     scripts = {}
     display_fields = ["absolute_url", "logo", "title.*"]
 
+    @staticmethod
+    def get_es_id(page):
+        """
+        An ID built with the node path and the position of this organization in the taxonomy:
+            - P: parent, the organization has children
+            - L: leaf, the organization has no children
+
+        For example: a parent organization `P_00010002` and its child `L_000100020001`.
+        """
+        return "{type:s}-{path:s}".format(
+            type="L" if page.node.is_leaf() else "P",  # Leaf or Parent?
+            path=page.node.path,
+        )
+
     @classmethod
     def get_es_document_for_organization(cls, organization, index=None, action="index"):
         """Build an Elasticsearch document from the category instance."""
@@ -79,7 +93,7 @@ class OrganizationsIndexer:
             description[simple_text.cmsplugin_ptr.language].append(simple_text.body)
 
         return {
-            "_id": str(organization.extended_object_id),
+            "_id": cls.get_es_id(organization.extended_object),
             "_index": index,
             "_op_type": action,
             "_type": cls.document_type,

--- a/tests/apps/search/test_filter_definitions.py
+++ b/tests/apps/search/test_filter_definitions.py
@@ -1,0 +1,75 @@
+"""
+Tests for environment ElasticSearch support
+"""
+from django.test import TestCase
+
+from richie.apps.courses.factories import CategoryFactory
+from richie.apps.search.filter_definitions import FILTERS, IndexableFilterDefinition
+
+
+class FilterDefintionsTestCase(TestCase):
+    """
+    Unit tests for parts of the filter definitions that are not sufficiently tested by
+    integration tests in test_query_courses.py
+    """
+
+    def test_filter_definitions_indexable_filter_aggs_include_no_page(self):
+        """
+        The indexable filters (subjects, levels and organizations) should return a regex matching
+        nothing if the corresponding filter pages have not been created.
+        """
+        for filter_name in ["levels", "subjects", "organizations"]:
+            with self.assertNumQueries(1):
+                self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
+
+            with self.assertNumQueries(0):
+                self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
+
+            # Reset cache for subsequent tests...
+            del FILTERS[filter_name].aggs_include
+
+    def test_filter_definitions_indexable_filter_aggs_include_draft_page(self):
+        """
+        The indexable filters (subjects, levels and organizations) should return a regex matching
+        nothing if the corresponding filter pages are not published.
+        """
+        for filter_name in ["levels", "subjects", "organizations"]:
+            CategoryFactory(page_reverse_id=filter_name)
+
+            with self.assertNumQueries(1):
+                self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
+
+            with self.assertNumQueries(0):
+                self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
+
+            # Reset cache for subsequent tests...
+            del FILTERS[filter_name].aggs_include
+
+    def test_filter_definitions_indexable_filter_aggs_include_published_page(self):
+        """
+        The indexable filters (subjects, levels and organizations) should return a regex matching
+        only the parent objects if the corresponding filter pages exist and are published.
+        """
+        for index, filter_name in enumerate(["levels", "subjects", "organizations"]):
+            CategoryFactory(page_reverse_id=filter_name, should_publish=True)
+
+            with self.assertNumQueries(1):
+                self.assertEqual(
+                    FILTERS[filter_name].aggs_include, f".*-000{index+1:d}.{{4}}"
+                )
+
+            with self.assertNumQueries(0):
+                self.assertEqual(
+                    FILTERS[filter_name].aggs_include, f".*-000{index+1:d}.{{4}}"
+                )
+
+            # Reset cache for subsequent tests...
+            del FILTERS[filter_name].aggs_include
+
+    def test_filter_definitions_indexable_filter_aggs_include_no_reverse_id(self):
+        """
+        An indexable filter instantiated with no `reverse_id` should return a match all aggs
+        include regex.
+        """
+        indexable_filter_definition = IndexableFilterDefinition("name")
+        self.assertEqual(indexable_filter_definition.aggs_include, ".*")

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -37,6 +37,7 @@ class CourseSearchFormTestCase(TestCase):
                 "organizations": [],
                 "organizations_include": "",
                 "query": "",
+                "scope": "",
                 "subjects": [],
                 "subjects_include": "",
             },
@@ -113,7 +114,7 @@ class CourseSearchFormTestCase(TestCase):
                 query_string=(
                     "availability=coming_soon&levels=1&levels_include=.*&languages=fr&limit=9&"
                     "offset=3&organizations=10&organizations_include=.*&query=maths&new=new&"
-                    "subjects=1&subjects_include=.*"
+                    "scope=objects&subjects=1&subjects_include=.*"
                 )
             )
         )
@@ -131,6 +132,7 @@ class CourseSearchFormTestCase(TestCase):
                 "organizations": ["10"],
                 "organizations_include": ".*",
                 "query": "maths",
+                "scope": "objects",
                 "subjects": ["1"],
                 "subjects_include": ".*",
             },
@@ -147,7 +149,7 @@ class CourseSearchFormTestCase(TestCase):
                     "availability=coming_soon&availability=ongoing&levels=1&levels=2&"
                     "languages=fr&languages=en&limit=9&limit=11&offset=3&offset=17&"
                     "organizations=10&organizations=11&query=maths&query=physics&new=new&"
-                    "subjects=1&subjects=2"
+                    "scope=objects&scope=filters&subjects=1&subjects=2"
                 )
             )
         )
@@ -166,6 +168,7 @@ class CourseSearchFormTestCase(TestCase):
                 "organizations": ["10", "11"],
                 "organizations_include": "",
                 "query": "maths",
+                "scope": "objects",
                 "subjects": ["1", "2"],
                 "subjects_include": "",
             },

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -23,18 +23,22 @@ class CourseSearchFormTestCase(TestCase):
         """The empty query string should be a valid search form."""
         form = CourseSearchForm(data=QueryDict())
         self.assertTrue(form.is_valid())
+
         self.assertEqual(
             form.cleaned_data,
             {
                 "availability": [],
                 "languages": [],
                 "levels": [],
+                "levels_include": "",
                 "limit": None,
                 "new": [],
                 "offset": None,
                 "organizations": [],
+                "organizations_include": "",
                 "query": "",
                 "subjects": [],
+                "subjects_include": "",
             },
         )
 
@@ -107,8 +111,9 @@ class CourseSearchFormTestCase(TestCase):
         form = CourseSearchForm(
             data=QueryDict(
                 query_string=(
-                    "availability=coming_soon&levels=1&subjects=1&languages=fr&limit=9&"
-                    "offset=3&organizations=10&query=maths&new=new"
+                    "availability=coming_soon&levels=1&levels_include=.*&languages=fr&limit=9&"
+                    "offset=3&organizations=10&organizations_include=.*&query=maths&new=new&"
+                    "subjects=1&subjects_include=.*"
                 )
             )
         )
@@ -119,18 +124,21 @@ class CourseSearchFormTestCase(TestCase):
                 "availability": ["coming_soon"],
                 "languages": ["fr"],
                 "levels": ["1"],
+                "levels_include": ".*",
                 "limit": 9,
                 "new": ["new"],
                 "offset": 3,
                 "organizations": ["10"],
+                "organizations_include": ".*",
                 "query": "maths",
                 "subjects": ["1"],
+                "subjects_include": ".*",
             },
         )
 
     def test_forms_courses_multi_values_in_querystring(self):
         """
-        The fields from filter defintions should allow multiple values. The fields defined
+        The fields from filter definitions should allow multiple values. The fields defined
         on the form should ignore repeated values (limit, offset and query).
         """
         form = CourseSearchForm(
@@ -151,12 +159,15 @@ class CourseSearchFormTestCase(TestCase):
                 "availability": ["coming_soon", "ongoing"],
                 "languages": ["fr", "en"],
                 "levels": ["1", "2"],
+                "levels_include": "",
                 "limit": 9,
                 "new": ["new"],
                 "offset": 3,
                 "organizations": ["10", "11"],
+                "organizations_include": "",
                 "query": "maths",
                 "subjects": ["1", "2"],
+                "subjects_include": "",
             },
         )
 

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -27,13 +27,14 @@ class CourseSearchFormTestCase(TestCase):
             form.cleaned_data,
             {
                 "availability": [],
-                "categories": [],
                 "languages": [],
+                "levels": [],
                 "limit": None,
                 "new": [],
                 "offset": None,
                 "organizations": [],
                 "query": "",
+                "subjects": [],
             },
         )
 
@@ -106,7 +107,7 @@ class CourseSearchFormTestCase(TestCase):
         form = CourseSearchForm(
             data=QueryDict(
                 query_string=(
-                    "availability=coming_soon&categories=1&languages=fr&limit=9&"
+                    "availability=coming_soon&levels=1&subjects=1&languages=fr&limit=9&"
                     "offset=3&organizations=10&query=maths&new=new"
                 )
             )
@@ -116,13 +117,14 @@ class CourseSearchFormTestCase(TestCase):
             form.cleaned_data,
             {
                 "availability": ["coming_soon"],
-                "categories": ["1"],
                 "languages": ["fr"],
+                "levels": ["1"],
                 "limit": 9,
                 "new": ["new"],
                 "offset": 3,
                 "organizations": ["10"],
                 "query": "maths",
+                "subjects": ["1"],
             },
         )
 
@@ -134,9 +136,10 @@ class CourseSearchFormTestCase(TestCase):
         form = CourseSearchForm(
             data=QueryDict(
                 query_string=(
-                    "availability=coming_soon&availability=ongoing&categories=1&categories=2&"
+                    "availability=coming_soon&availability=ongoing&levels=1&levels=2&"
                     "languages=fr&languages=en&limit=9&limit=11&offset=3&offset=17&"
-                    "organizations=10&organizations=11&query=maths&query=physics&new=new"
+                    "organizations=10&organizations=11&query=maths&query=physics&new=new&"
+                    "subjects=1&subjects=2"
                 )
             )
         )
@@ -146,13 +149,14 @@ class CourseSearchFormTestCase(TestCase):
             form.cleaned_data,
             {
                 "availability": ["coming_soon", "ongoing"],
-                "categories": ["1", "2"],
                 "languages": ["fr", "en"],
+                "levels": ["1", "2"],
                 "limit": 9,
                 "new": ["new"],
                 "offset": 3,
                 "organizations": ["10", "11"],
                 "query": "maths",
+                "subjects": ["1", "2"],
             },
         )
 

--- a/tests/apps/search/test_forms_search_items.py
+++ b/tests/apps/search/test_forms_search_items.py
@@ -24,7 +24,7 @@ class ItemSearchFormTestCase(TestCase):
         form = ItemSearchForm(data=QueryDict())
         self.assertTrue(form.is_valid())
         self.assertEqual(
-            form.cleaned_data, {"limit": None, "offset": None, "query": ""}
+            form.cleaned_data, {"limit": None, "offset": None, "query": "", "scope": ""}
         )
 
     def test_forms_courses_limit_greater_than_1(self):
@@ -97,7 +97,9 @@ class ItemSearchFormTestCase(TestCase):
             data=QueryDict(query_string=("limit=9&offset=3&query=maths"))
         )
         self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data, {"limit": 9, "offset": 3, "query": "maths"})
+        self.assertEqual(
+            form.cleaned_data, {"limit": 9, "offset": 3, "query": "maths", "scope": ""}
+        )
 
     def test_forms_items_build_es_query_search_by_match_text(self):
         """

--- a/tests/apps/search/test_indexers_categories.py
+++ b/tests/apps/search/test_indexers_categories.py
@@ -30,7 +30,7 @@ class CategoriesIndexersTestCase(TestCase):
             fill_logo=True,
             should_publish=True,
         )
-        category2 = CategoryFactory(
+        CategoryFactory(
             page_parent=category1.extended_object,
             page_title={"en": "my second category", "fr": "ma deuxième thématique"},
             should_publish=True,
@@ -54,7 +54,7 @@ class CategoriesIndexersTestCase(TestCase):
             ),
             [
                 {
-                    "_id": str(category2.public_extension.extended_object_id),
+                    "_id": "L-00010001",
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "category",
@@ -81,7 +81,7 @@ class CategoriesIndexersTestCase(TestCase):
                     },
                 },
                 {
-                    "_id": str(category1.public_extension.extended_object_id),
+                    "_id": "P-0001",
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "category",

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -114,20 +114,20 @@ class CoursesIndexersTestCase(TestCase):
         ]
         draft_category = CategoryFactory()  # L-0003
 
-        main_organization = OrganizationFactory(
+        main_organization = OrganizationFactory(  # L-0004
             page_title={
                 "en": "english main organization title",
                 "fr": "titre organisation principale français",
             },
             should_publish=True,
         )
-        other_draft_organization = OrganizationFactory(
+        other_draft_organization = OrganizationFactory(  # L-0005
             page_title={
                 "en": "english other organization title",
                 "fr": "titre autre organisation français",
             }
         )
-        other_published_organization = OrganizationFactory(
+        other_published_organization = OrganizationFactory(  # L-0006
             page_title={
                 "en": "english other organization title",
                 "fr": "titre autre organisation français",
@@ -209,10 +209,7 @@ class CoursesIndexersTestCase(TestCase):
                 "fr": "syllabus français ligne 1. syllabus français ligne 2.",
             },
             "is_new": False,
-            "organizations": [
-                str(main_organization.public_extension.extended_object_id),
-                str(other_published_organization.public_extension.extended_object_id),
-            ],
+            "organizations": ["L-0004", "L-0006"],
             "organizations_names": {
                 "en": [
                     "english main organization title",

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -103,16 +103,16 @@ class CoursesIndexersTestCase(TestCase):
         """
         # Create a course with a page in both english and french
         published_categories = [
-            CategoryFactory(
+            CategoryFactory(  # L-0001
                 page_title={"en": "Open-architected radical application"},
                 should_publish=True,
             ),
-            CategoryFactory(
+            CategoryFactory(  # L-0002
                 page_title={"en": "Public-key transitional solution"},
                 should_publish=True,
             ),
         ]
-        draft_category = CategoryFactory()
+        draft_category = CategoryFactory()  # L-0003
 
         main_organization = OrganizationFactory(
             page_title={
@@ -172,9 +172,7 @@ class CoursesIndexersTestCase(TestCase):
                 "en": "/en/an-english-course-title/",
                 "fr": "/fr/un-titre-cours-francais/",
             },
-            "categories": [
-                str(s.public_extension.extended_object_id) for s in published_categories
-            ],
+            "categories": ["L-0001", "L-0002"],
             "categories_names": {
                 "en": [
                     "Open-architected radical application",

--- a/tests/apps/search/test_indexers_organizations.py
+++ b/tests/apps/search/test_indexers_organizations.py
@@ -33,7 +33,7 @@ class OrganizationsIndexersTestCase(TestCase):
             fill_logo=True,
             should_publish=True,
         )
-        organization2 = OrganizationFactory(
+        OrganizationFactory(
             page_title={
                 "en": "my second organization",
                 "fr": "ma deuxième organisation",
@@ -60,7 +60,7 @@ class OrganizationsIndexersTestCase(TestCase):
             ),
             [
                 {
-                    "_id": str(organization2.public_extension.extended_object_id),
+                    "_id": "L-0002",
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "organization",
@@ -88,7 +88,7 @@ class OrganizationsIndexersTestCase(TestCase):
                     },
                 },
                 {
-                    "_id": str(organization1.public_extension.extended_object_id),
+                    "_id": "L-0001",
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "organization",

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -1,6 +1,4 @@
-"""
-Tests for environment ElasticSearch support
-"""
+"""Tests for environment ElasticSearch support."""
 import json
 import random
 from unittest import mock
@@ -618,6 +616,14 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 {"count": 1, "human_name": "#L-00020003", "key": "L-00020003"},
             ],
         )
+        self.assertEqual(
+            content["filters"]["organizations"]["values"],
+            [
+                {"count": 2, "human_name": "#P-00030001", "key": "P-00030001"},
+                {"count": 1, "human_name": "#P-00030003", "key": "P-00030003"},
+                {"count": 1, "human_name": "#P-00030004", "key": "P-00030004"},
+            ],
+        )
 
     def test_query_courses_course_runs_filter_ongoing_courses(self, *_):
         """
@@ -714,6 +720,8 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 {"count": 2, "human_name": "On-going", "key": "ongoing"},
             ],
         )
+        # A, D and F course runs are in French
+        # So only courses 0, 2 and 3 are selected
         self.assertEqual(
             content["filters"]["subjects"]["values"],
             [
@@ -728,6 +736,15 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             [
                 {"count": 2, "human_name": "#L-00020001", "key": "L-00020001"},
                 {"count": 1, "human_name": "#L-00020002", "key": "L-00020002"},
+            ],
+        )
+        self.assertEqual(
+            content["filters"]["organizations"]["values"],
+            [
+                {"count": 2, "human_name": "#P-00030002", "key": "P-00030002"},
+                {"count": 2, "human_name": "#P-00030004", "key": "P-00030004"},
+                {"count": 1, "human_name": "#P-00030001", "key": "P-00030001"},
+                {"count": 1, "human_name": "#P-00030003", "key": "P-00030003"},
             ],
         )
 
@@ -818,6 +835,14 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 {"count": 1, "human_name": "#L-00020002", "key": "L-00020002"},
             ],
         )
+        self.assertEqual(
+            content["filters"]["organizations"]["values"],
+            [
+                {"count": 2, "human_name": "#P-00030004", "key": "P-00030004"},
+                {"count": 1, "human_name": "#P-00030001", "key": "P-00030001"},
+                {"count": 1, "human_name": "#P-00030002", "key": "P-00030002"},
+            ],
+        )
 
     def test_query_courses_filter_new(self, *_):
         """
@@ -836,6 +861,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering by an organization.
         """
+        self.create_filter_pages()
         courses_definition, content = self.execute_query("organizations=P-00030002")
         # Keep only the courses that are linked to organization 00030002:
         courses_definition = filter(lambda c: c[0] in [2, 3], courses_definition)
@@ -843,6 +869,15 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             list([int(c["id"]) for c in content["objects"]]),
             self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+        )
+        self.assertEqual(
+            content["filters"]["organizations"]["values"],
+            [
+                {"count": 2, "human_name": "#P-00030001", "key": "P-00030001"},
+                {"count": 2, "human_name": "#P-00030002", "key": "P-00030002"},
+                {"count": 2, "human_name": "#P-00030003", "key": "P-00030003"},
+                {"count": 2, "human_name": "#P-00030004", "key": "P-00030004"},
+            ],
         )
 
     def test_query_courses_filter_multiple_organizations(self, *_):
@@ -858,6 +893,24 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             list([int(c["id"]) for c in content["objects"]]),
             self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+        )
+
+    def test_query_courses_filter_organization_include(self, *_):
+        """
+        It should be possible to limit faceting on an organization to specific values by
+        passing a regex in the querystring.
+        """
+        self.create_filter_pages()
+        _courses_definition, content = self.execute_query(
+            "organizations_include=.*-00030001.{4}"
+        )
+
+        self.assertEqual(
+            content["filters"]["organizations"]["values"],
+            [
+                {"count": 1, "human_name": "#L-000300010001", "key": "L-000300010001"},
+                {"count": 1, "human_name": "#L-000300010002", "key": "L-000300010002"},
+            ],
         )
 
     def test_query_courses_filter_subject(self, *_):
@@ -886,6 +939,24 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             list([int(c["id"]) for c in content["objects"]]),
             self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+        )
+
+    def test_query_courses_filter_subject_include(self, *_):
+        """
+        It should be possible to limit faceting on a subject to specific values by
+        passing a regex in the querystring.
+        """
+        self.create_filter_pages()
+        _courses_definition, content = self.execute_query(
+            "subjects_include=.*-00010001.{4}"
+        )
+
+        self.assertEqual(
+            content["filters"]["subjects"]["values"],
+            [
+                {"count": 1, "human_name": "#L-000100010001", "key": "L-000100010001"},
+                {"count": 1, "human_name": "#L-000100010002", "key": "L-000100010002"},
+            ],
         )
 
     def test_query_courses_filter_level(self, *_):

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -1,4 +1,5 @@
 """Tests for environment ElasticSearch support."""
+# pylint: disable=too-many-lines
 import json
 import random
 from unittest import mock
@@ -551,6 +552,22 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             list([int(c["id"]) for c in content["objects"]]),
             self.get_expected_courses(courses_definition, ["A", "B", "C"]),
         )
+
+    def test_query_courses_match_all_scope_objects(self, *_):
+        """
+        The scope can be limited to objects via the querystring.
+        """
+        _courses_definition, content = self.execute_query("scope=objects")
+        self.assertEqual(len(content["objects"]), 4)
+        self.assertFalse("filters" in content)
+
+    def test_query_courses_match_all_scope_filters(self, *_):
+        """
+        The scope can be limited to filters via the querystring.
+        """
+        _courses_definition, content = self.execute_query("scope=filters")
+        self.assertEqual(len(content["filters"]), 6)
+        self.assertFalse("objects" in content)
 
     def test_query_courses_course_runs_filter_availability_facets(self, *_):
         """

--- a/tests/apps/search/test_signals.py
+++ b/tests/apps/search/test_signals.py
@@ -131,9 +131,7 @@ class CoursesSignalsTestCase(TestCase):
             actions[0]["_id"], str(published_course.public_extension.extended_object_id)
         )
         self.assertEqual(actions[0]["_type"], "course")
-        self.assertEqual(
-            actions[1]["_id"], str(organization.public_extension.extended_object_id)
-        )
+        self.assertEqual(actions[1]["_id"], "L-0001")
         self.assertEqual(actions[1]["_type"], "organization")
 
     def test_signals_categories(self, mock_bulk, *_):

--- a/tests/apps/search/test_signals.py
+++ b/tests/apps/search/test_signals.py
@@ -164,7 +164,5 @@ class CoursesSignalsTestCase(TestCase):
             actions[0]["_id"], str(published_course.public_extension.extended_object_id)
         )
         self.assertEqual(actions[0]["_type"], "course")
-        self.assertEqual(
-            actions[1]["_id"], str(category.public_extension.extended_object_id)
-        )
+        self.assertEqual(actions[1]["_id"], "L-0001")
         self.assertEqual(actions[1]["_type"], "category")

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -105,8 +105,8 @@ class CoursesViewsetsTestCase(TestCase):
                             "languages@en": {"doc_count": 33},
                             "languages@fr": {"doc_count": 55},
                             "new@new": {"doc_count": 66},
-                            "categories": {
-                                "categories": {
+                            "levels": {
+                                "levels": {
                                     "buckets": [
                                         {"key": "2", "doc_count": 15},
                                         {"key": "1", "doc_count": 13},
@@ -121,6 +121,14 @@ class CoursesViewsetsTestCase(TestCase):
                                     ]
                                 }
                             },
+                            "subjects": {
+                                "subjects": {
+                                    "buckets": [
+                                        {"key": "22", "doc_count": 23},
+                                        {"key": "21", "doc_count": 21},
+                                    ]
+                                }
+                            },
                         }
                     },
                 }
@@ -128,8 +136,10 @@ class CoursesViewsetsTestCase(TestCase):
                 return {
                     "hits": {
                         "hits": [
-                            {"_id": "1", "_source": {"title": {"en": "Category 1"}}},
-                            {"_id": "2", "_source": {"title": {"en": "Category 2"}}},
+                            {"_id": "1", "_source": {"title": {"en": "Level 1"}}},
+                            {"_id": "2", "_source": {"title": {"en": "Level 2"}}},
+                            {"_id": "21", "_source": {"title": {"en": "Subject 1"}}},
+                            {"_id": "22", "_source": {"title": {"en": "Subject 2"}}},
                         ]
                     }
                 }
@@ -190,21 +200,31 @@ class CoursesViewsetsTestCase(TestCase):
                             {"count": 66, "human_name": "First session", "key": "new"}
                         ],
                     },
-                    "categories": {
-                        "human_name": "Categories",
+                    "subjects": {
+                        "human_name": "Subjects",
                         "is_drilldown": False,
-                        "name": "categories",
+                        "name": "subjects",
                         "position": 2,
                         "values": [
-                            {"count": 15, "human_name": "Category 2", "key": "2"},
-                            {"count": 13, "human_name": "Category 1", "key": "1"},
+                            {"count": 23, "human_name": "Subject 2", "key": "22"},
+                            {"count": 21, "human_name": "Subject 1", "key": "21"},
+                        ],
+                    },
+                    "levels": {
+                        "human_name": "Levels",
+                        "is_drilldown": False,
+                        "name": "levels",
+                        "position": 3,
+                        "values": [
+                            {"count": 15, "human_name": "Level 2", "key": "2"},
+                            {"count": 13, "human_name": "Level 1", "key": "1"},
                         ],
                     },
                     "organizations": {
                         "human_name": "Organizations",
                         "is_drilldown": False,
                         "name": "organizations",
-                        "position": 3,
+                        "position": 4,
                         "values": [
                             {"count": 19, "human_name": "Organization 12", "key": "12"},
                             {"count": 17, "human_name": "Organization 11", "key": "11"},
@@ -214,7 +234,7 @@ class CoursesViewsetsTestCase(TestCase):
                         "human_name": "Languages",
                         "is_drilldown": False,
                         "name": "languages",
-                        "position": 4,
+                        "position": 5,
                         "values": [
                             {"count": 55, "human_name": "French", "key": "fr"},
                             {"count": 33, "human_name": "English", "key": "en"},


### PR DESCRIPTION
## Purpose

For the moment, the category filter includes all categories. But since categories are now a taxonomy, we want to be able to declare several filter blocks that each target a specific part of the category taxonomy.

We also need to be able to render the taxonomy with its nested parents and children.

## Proposal

- [x] Build ES documents ID with the path and parental status of a category's related page node (we need the ID to carry information about a category's place in the taxonomy so that facet counts have all the information),
- [x] refactor organizations to use the same ids so that they work the same eventhough we don't specifically need to nest organizations,
- [x] allow targeting different portions of the category taxonomy from different filters,
- [x] allow limiting what facets are computed by the filters. By default we will only facet the top level categories and the frontend will need to send separated queries to get facet counts for children categories,
- [x] allow limiting the scope of a response to just the objects or just the filters. This will make the query lighter when requesting facet counts to display the children of a filter box.