### PR TITLE
🐛(search) improve caching of include regex on indexable filters

### DIFF
--- a/tests/apps/search/test_filter_definitions.py
+++ b/tests/apps/search/test_filter_definitions.py
@@ -22,11 +22,9 @@ class FilterDefintionsTestCase(TestCase):
             with self.assertNumQueries(1):
                 self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
 
-            with self.assertNumQueries(0):
+            # The result is not set in cache when a page was not found
+            with self.assertNumQueries(1):
                 self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
-
-            # Reset cache for subsequent tests...
-            del FILTERS[filter_name].aggs_include
 
     def test_filter_definitions_indexable_filter_aggs_include_draft_page(self):
         """
@@ -39,11 +37,9 @@ class FilterDefintionsTestCase(TestCase):
             with self.assertNumQueries(1):
                 self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
 
-            with self.assertNumQueries(0):
+            # The result is not set in cache when a published page was not found
+            with self.assertNumQueries(1):
                 self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
-
-            # Reset cache for subsequent tests...
-            del FILTERS[filter_name].aggs_include
 
     def test_filter_definitions_indexable_filter_aggs_include_published_page(self):
         """
@@ -64,7 +60,22 @@ class FilterDefintionsTestCase(TestCase):
                 )
 
             # Reset cache for subsequent tests...
-            del FILTERS[filter_name].aggs_include
+            # pylint: disable=protected-access
+            FILTERS[filter_name]._aggs_include = None
+
+            with self.assertNumQueries(1):
+                self.assertEqual(
+                    FILTERS[filter_name].aggs_include, f".*-000{index+1:d}.{{4}}"
+                )
+
+            with self.assertNumQueries(0):
+                self.assertEqual(
+                    FILTERS[filter_name].aggs_include, f".*-000{index+1:d}.{{4}}"
+                )
+
+            # Reset cache for subsequent tests...
+            # pylint: disable=protected-access
+            FILTERS[filter_name]._aggs_include = None
 
     def test_filter_definitions_indexable_filter_aggs_include_no_reverse_id(self):
         """

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -146,10 +146,8 @@ class CourseRunsCoursesQueryTestCase(TestCase):
     def reset_filter_definitions_cache():
         """Reset indexable filters cache on the `aggs_include` field."""
         for filter_name in ["levels", "subjects", "organizations"]:
-            try:
-                del FILTERS[filter_name].aggs_include
-            except AttributeError:
-                pass
+            # pylint: disable=protected-access
+            FILTERS[filter_name]._aggs_include = None
 
     @staticmethod
     def create_filter_pages():


### PR DESCRIPTION
## Purpose

The include regex on indexable filters was cached on the first execution, whatever the result. 

In cases where the setting was set before the page was created and published, it could cause the method to cache the empty regex. In this case, we had to restart the app (on all pods in case of scaled deployments) for the include regex to be updated and for the filters to show correctly.

## Proposal

The solution applied here is to cache the result only when the page pointed by the setting is found. Until then, the cache is not set and we keep looking for the page.

