### PR TITLE
🐛(search) make sure selected filter values are included in the result

### DIFF
--- a/tests/apps/search/test_filter_definitions.py
+++ b/tests/apps/search/test_filter_definitions.py
@@ -20,11 +20,11 @@ class FilterDefintionsTestCase(TestCase):
         """
         for filter_name in ["levels", "subjects", "organizations"]:
             with self.assertNumQueries(1):
-                self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
+                self.assertEqual(FILTERS[filter_name].aggs_include, "")
 
             # The result is not set in cache when a page was not found
             with self.assertNumQueries(1):
-                self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
+                self.assertEqual(FILTERS[filter_name].aggs_include, "")
 
     def test_filter_definitions_indexable_filter_aggs_include_draft_page(self):
         """
@@ -35,11 +35,11 @@ class FilterDefintionsTestCase(TestCase):
             CategoryFactory(page_reverse_id=filter_name)
 
             with self.assertNumQueries(1):
-                self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
+                self.assertEqual(FILTERS[filter_name].aggs_include, "")
 
             # The result is not set in cache when a published page was not found
             with self.assertNumQueries(1):
-                self.assertEqual(FILTERS[filter_name].aggs_include, "^$")
+                self.assertEqual(FILTERS[filter_name].aggs_include, "")
 
     def test_filter_definitions_indexable_filter_aggs_include_published_page(self):
         """

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -12,7 +12,7 @@ import arrow
 from elasticsearch.client import IndicesClient
 from elasticsearch.helpers import bulk
 
-from richie.apps.courses.factories import CategoryFactory
+from richie.apps.courses.factories import CategoryFactory, OrganizationFactory
 from richie.apps.search.filter_definitions import FILTERS, IndexableFilterDefinition
 from richie.apps.search.indexers.courses import CoursesIndexer
 
@@ -128,8 +128,8 @@ COURSE_RUNS = {
 )
 class CourseRunsCoursesQueryTestCase(TestCase):
     """
-    Test edge case search queries on underlying course runs to make sure filtering and sorting
-    works as we expect.
+    Test search queries on courses and underlying course runs to make sure filtering and sorting
+    works as expected.
     """
 
     def setUp(self):
@@ -158,8 +158,9 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             - levels page path: 0002
             - organizations page path: 0003
         """
-        for filter_name in ["subjects", "levels", "organizations"]:
-            CategoryFactory(page_reverse_id=filter_name, should_publish=True)
+        CategoryFactory(page_reverse_id="subjects", should_publish=True)
+        CategoryFactory(page_reverse_id="levels", should_publish=True)
+        OrganizationFactory(page_reverse_id="organizations", should_publish=True)
 
     @staticmethod
     def get_expected_courses(courses_definition, course_run_ids):

--- a/tests/apps/search/test_query_courses_edge_cases.py
+++ b/tests/apps/search/test_query_courses_edge_cases.py
@@ -1,0 +1,213 @@
+"""Tests for environment ElasticSearch support."""
+# pylint: disable=too-many-lines
+import json
+import random
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+
+from elasticsearch.client import IndicesClient
+from elasticsearch.helpers import bulk
+
+from richie.apps.courses.factories import CategoryFactory, OrganizationFactory
+from richie.apps.search.filter_definitions import FILTERS, IndexableFilterDefinition
+from richie.apps.search.indexers.courses import CoursesIndexer
+
+
+@mock.patch.object(  # Avoid having to build the categories and organizations indices
+    IndexableFilterDefinition,
+    "get_i18n_names",
+    side_effect=lambda o: {key: f"#{key:s}" for key in o},
+)
+@mock.patch.object(  # Avoid messing up the development Elasticsearch index
+    CoursesIndexer,
+    "index_name",
+    new_callable=mock.PropertyMock,
+    return_value="test_courses",
+)
+class EdgeCasesCoursesQueryTestCase(TestCase):
+    """
+    Test edge case search queries to make sure facetting works as we expect.
+    """
+
+    def setUp(self):
+        """Reset indexable filters cache before each test so the context is as expected."""
+        super().setUp()
+        self.reset_filter_definitions_cache()
+
+    def tearDown(self):
+        """Reset indexable filters cache after each test to avoid impacting subsequent tests."""
+        super().tearDown()
+        self.reset_filter_definitions_cache()
+
+    @staticmethod
+    def reset_filter_definitions_cache():
+        """Reset indexable filters cache on the `aggs_include` field."""
+        for filter_name in ["levels", "subjects", "organizations"]:
+            # pylint: disable=protected-access
+            FILTERS[filter_name]._aggs_include = None
+
+    @staticmethod
+    def create_filter_pages():
+        """
+        Create pages for each filter based on an indexable. We must create them in the same order
+        as they are instantiated in order to match the node paths we expect:
+            - subjects page path: 0001
+            - levels page path: 0002
+            - organizations page path: 0003
+        """
+        CategoryFactory(page_reverse_id="subjects", should_publish=True)
+        CategoryFactory(page_reverse_id="levels", should_publish=True)
+        OrganizationFactory(page_reverse_id="organizations", should_publish=True)
+
+    def prepare_index(self, courses):
+        """
+        Not a test.
+        This method is doing the heavy lifting for the tests in this class:
+        - prepare the Elasticsearch index,
+        - execute the query.
+        """
+        self.create_filter_pages()
+        # Index these 4 courses in Elasticsearch
+        indices_client = IndicesClient(client=settings.ES_CLIENT)
+        # Delete any existing indexes so we get a clean slate
+        indices_client.delete(index="_all")
+        # Create an index we'll use to test the ES features
+        indices_client.create(index="test_courses")
+        # Use the default courses mapping from the Indexer
+        indices_client.put_mapping(
+            body=CoursesIndexer.mapping, doc_type="course", index="test_courses"
+        )
+        # Add the sorting script
+        settings.ES_CLIENT.put_script(id="state", body=CoursesIndexer.scripts["state"])
+        # Actually insert our courses in the index
+        actions = [
+            {
+                "_id": course["id"],
+                "_index": "test_courses",
+                "_op_type": "create",
+                "_type": "course",
+                **course,
+            }
+            for course in courses
+        ]
+        bulk(
+            actions=actions,
+            chunk_size=settings.ES_CHUNK_SIZE,
+            client=settings.ES_CLIENT,
+        )
+        indices_client.refresh()
+
+    def test_query_courses_rare_facet_force(self, *_):
+        """
+        A facet that is selected in the querystring should always be included in the result's
+        facet counts, even if it is not in the top 10.
+        """
+        organizations = [
+            "L-0003{:04d}".format(o + 1) for o in range(10)
+        ] * 2  # 10 organizations with 2 occurences
+        organizations.append("L-00030011")  # 1 organization with only 1 occurence
+        # => organization with ID "L-00030011" is not in the top ten facets.
+
+        self.prepare_index(
+            [
+                {
+                    "id": index,
+                    "organizations": [id],
+                    "categories": [],
+                    "is_new": False,
+                    "absolute_url": {"en": "url"},
+                    "cover_image": {"en": "image"},
+                    "title": {"en": "title"},
+                    "course_runs": [],
+                }
+                for index, id in enumerate(organizations)
+            ]
+        )
+
+        # If not filter is applied, the 10 top facets should be returned
+        response = self.client.get(f"/api/v1.0/courses/")
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(
+            content["filters"]["organizations"]["values"],
+            [
+                {"count": 2, "human_name": "#L-00030001", "key": "L-00030001"},
+                {"count": 2, "human_name": "#L-00030002", "key": "L-00030002"},
+                {"count": 2, "human_name": "#L-00030003", "key": "L-00030003"},
+                {"count": 2, "human_name": "#L-00030004", "key": "L-00030004"},
+                {"count": 2, "human_name": "#L-00030005", "key": "L-00030005"},
+                {"count": 2, "human_name": "#L-00030006", "key": "L-00030006"},
+                {"count": 2, "human_name": "#L-00030007", "key": "L-00030007"},
+                {"count": 2, "human_name": "#L-00030008", "key": "L-00030008"},
+                {"count": 2, "human_name": "#L-00030009", "key": "L-00030009"},
+                {"count": 2, "human_name": "#L-00030010", "key": "L-00030010"},
+            ],
+        )
+
+        # If organizations are selected, they should be included in the facet counts:
+        # - at its place for the one that is in the top 10
+        # - at the end for the one that is not in the top 10 and should not be included
+        #   if it wasn't forced...
+        response = self.client.get(
+            f"/api/v1.0/courses/?organizations=L-00030002&organizations=L-00030011"
+        )
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+
+        self.assertEqual(
+            content["filters"]["organizations"]["values"],
+            [
+                {"count": 2, "human_name": "#L-00030001", "key": "L-00030001"},
+                {"count": 2, "human_name": "#L-00030002", "key": "L-00030002"},
+                {"count": 2, "human_name": "#L-00030003", "key": "L-00030003"},
+                {"count": 2, "human_name": "#L-00030004", "key": "L-00030004"},
+                {"count": 2, "human_name": "#L-00030005", "key": "L-00030005"},
+                {"count": 2, "human_name": "#L-00030006", "key": "L-00030006"},
+                {"count": 2, "human_name": "#L-00030007", "key": "L-00030007"},
+                {"count": 2, "human_name": "#L-00030008", "key": "L-00030008"},
+                {"count": 2, "human_name": "#L-00030009", "key": "L-00030009"},
+                {"count": 2, "human_name": "#L-00030010", "key": "L-00030010"},
+                {"count": 1, "human_name": "#L-00030011", "key": "L-00030011"},
+            ],
+        )
+
+    def test_query_courses_rare_facet_no_include_match(self, *_):
+        """
+        A facet that is selected in the querystring should not be included in the result's
+        facet counts if it does not match the include regex.
+        """
+        organizations = [
+            "L-0003{:04d}".format(o + 1) for o in range(10)
+        ]  # 10 organizations matching the include regex
+        organizations.append(
+            "L-000300010001"
+        )  # 1 organization not matching the include regex
+
+        self.prepare_index(
+            [
+                {
+                    "id": index,
+                    "organizations": random.sample(
+                        organizations, random.randint(1, len(organizations))
+                    ),
+                    "categories": [],
+                    "is_new": False,
+                    "absolute_url": {"en": "url"},
+                    "cover_image": {"en": "image"},
+                    "title": {"en": "title"},
+                    "course_runs": [],
+                }
+                for index, id in enumerate(organizations)
+            ]
+        )
+
+        response = self.client.get(f"/api/v1.0/courses/?organizations=L-000300010001")
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+
+        self.assertNotIn(
+            "L-000300010001",
+            [o["key"] for o in content["filters"]["organizations"]["values"]],
+        )


### PR DESCRIPTION
## Purpose

On indexable filters that are using a terms aggregation with a limit of 10 facet results, we could end up with a selected filter value not being included in the top 10 facets. Since the frontend now relies on the query result to display the filter boxes, the selected facet was not visible on the site anymore and could not be unselected...

Fixes https://github.com/openfun/richie/issues/504

## Proposal

We fix this problem by forcing specific facetting on the selected filter values. We choose to merge them with the facets returned by the terms aggregation. 

Note that it can lead to more than 10 facets but we think this allows keeping a significant number of new available choices.
