### PR TITLE
✨(search) implement parent & children filters in the frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Enable parent/children filters in the filters pane in Search.
+
 ### Changed
 
 - Translations are loaded dynamically in frontend application.
-- Optimized frontend build in our official Docker image
+- Optimized frontend build in our official Docker image.
 
 ## [1.0.0-beta.4] - 2019-04-08
 

--- a/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
@@ -8,9 +8,13 @@ import { SearchFilterGroup } from './SearchFilterGroup';
 
 jest.mock('../SearchFilterValueLeaf/SearchFilterValueLeaf', () => ({
   SearchFilterValueLeaf: ({ value }: any) => (
-    <span data-testid="search-filter">{`Received: filter - ${
-      value.human_name
-    }`}</span>
+    <span>{`Received leaf: filter - ${value.human_name}`}</span>
+  ),
+}));
+
+jest.mock('../SearchFilterValueParent/SearchFilterValueParent', () => ({
+  SearchFilterValueParent: ({ value }: any) => (
+    <span>{`Received parent: filter - ${value.human_name}`}</span>
   ),
 }));
 
@@ -31,22 +35,21 @@ describe('components/SearchFilterGroup', () => {
               {
                 count: 4,
                 human_name: 'Value One',
-                key: 'value-1',
+                key: 'P-value-1',
               },
               {
                 count: 7,
                 human_name: 'Value Two',
-                key: 'value-2',
+                key: 'L-value-2',
               },
             ],
           }}
         />
       </CourseSearchParamsContext.Provider>,
     );
-
     // The filter group title and all filters are shown
     getByText('Organizations');
-    getByText('Received: filter - Value One');
-    getByText('Received: filter - Value Two');
+    getByText('Received parent: filter - Value One');
+    getByText('Received leaf: filter - Value Two');
   });
 });

--- a/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.tsx
@@ -13,14 +13,16 @@ export const SearchFilterGroup = ({ filter }: SearchFilterGroupProps) => (
     <h3 className="search-filter-group__title">{filter.human_name}</h3>
     <div className="search-filter-group__list">
       {filter.values.map(value =>
-        value.children && value.children.length ? (
+        value.key.startsWith(
+          'P-',
+        ) /* Values with children have a key that starts with `P-` by convention */ ? (
           <SearchFilterValueParent
             filter={filter}
             value={value}
             key={value.key}
           />
         ) : (
-          <SearchFilterValueLeaf
+          /* Other values' keys start with `L-` */ <SearchFilterValueLeaf
             filter={filter}
             value={value}
             key={value.key}

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
@@ -1,8 +1,13 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { defineMessages, InjectedIntlProps, injectIntl } from 'react-intl';
 
+import { fetchList } from '../../data/getResourceList/getResourceList';
+import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
 import { useFilterValue } from '../../data/useFilterValue/useFilterValue';
+import { requestStatus } from '../../types/api';
 import { FilterDefinition, FilterValue } from '../../types/filters';
+import { modelName } from '../../types/models';
+import { useAsyncEffect } from '../../utils/useAsyncEffect';
 import { CloseIcon } from '../icons/CloseIcon';
 import { SearchFilterValueLeaf } from '../SearchFilterValueLeaf/SearchFilterValueLeaf';
 
@@ -32,13 +37,56 @@ export const SearchFilterValueParent = injectIntl(
     intl,
     value,
   }: SearchFilterValueParentProps & InjectedIntlProps) => {
+    // Get the current values for the filter definition so we know if any children of this parent
+    // filter are active (and we therefore need to get them and unfold the children).
+    const [coursesSearchParams] = useContext(CourseSearchParamsContext);
+    // Default to an array of strings no matter the current value so we can easily check for active values
+    const activeFilterValues =
+      coursesSearchParams[filter.name] || ([] as string[]);
+    const activeValuesList =
+      typeof activeFilterValues === 'string'
+        ? [activeFilterValues]
+        : activeFilterValues;
+
+    // We can easily determine if any children are active without having to GET them first through our
+    // path key convention.
+    // If this parent filter has a key (path) `P-00040005`, all of its children will have with a matching
+    // path such as `P-000400050001` or `L-000400050003`.
+    const childrenPathMatch = `.-${value.key.substr(2)}[0-9]+`;
+    const childrenPathMatchRegexp = new RegExp(childrenPathMatch);
     // Hide children by default, unless at least one of them is currently active
     const [showChildren, setShowChildren] = useState(
-      value.children!.some(childValue => useFilterValue(filter, childValue)[0]),
+      activeValuesList.some(activeValueKey =>
+        childrenPathMatchRegexp.test(activeValueKey),
+      ),
     );
 
-    const [isActive, toggle] = useFilterValue(filter, value);
+    const [children, setChildren] = useState([] as FilterValue[]);
+    useAsyncEffect(async () => {
+      if (showChildren) {
+        // Get only the filters & facet counts for the children of the current parent
+        const childrenResponse = await fetchList(modelName.COURSES, {
+          ...coursesSearchParams,
+          [`${filter.name}_include`]: childrenPathMatch,
+          scope: 'filters',
+        });
 
+        if (childrenResponse.status === requestStatus.FAILURE) {
+          throw new Error(
+            `Failed to get children filters for ${
+              filter.name
+            }/${childrenPathMatch}`,
+          );
+        }
+
+        setChildren(childrenResponse.content.filters[filter.name].values);
+      }
+      // Be sure to include courseSearchParams in the dependencies so the children counts are re-fetched whenever
+      // the user applies new filters or queries
+    }, [showChildren, value, coursesSearchParams]);
+
+    // We also need to know if the current filter is active itself and let the user toggle it directly
+    const [isActive, toggle] = useFilterValue(filter, value);
     return (
       <div className="search-filter-value-parent">
         <div className="search-filter-value-parent__self">
@@ -77,7 +125,7 @@ export const SearchFilterValueParent = injectIntl(
         </div>
         {showChildren && (
           <div className="search-filter-value-parent__children">
-            {value.children!.map(childValue => (
+            {children.map(childValue => (
               <SearchFilterValueLeaf
                 filter={filter}
                 key={childValue.key}

--- a/src/frontend/js/types/filters.ts
+++ b/src/frontend/js/types/filters.ts
@@ -1,8 +1,7 @@
 export interface FilterValue {
   count: number;
-  children?: FilterValue[];
   human_name: string;
-  key: string; // Either a machine name or a stringified ID
+  key: string;
 }
 
 export interface FilterDefinition {


### PR DESCRIPTION
## Purpose

The existing implementation of parent & children filters in the frontend expected filter values to have a "children" value that directly contained their own children values.

We decided to go another way with standard formatted paths that give us many benefits in terms of search but needed a different implementation in the frontend as parent filters need to fetch their children when the user requests them.

This also improves scalability.

## Proposal

Update the frontend to use the paths & make the appropriate requests.

WIP: missing tests

Fixes https://github.com/openfun/richie/issues/582