### PR TITLE
💄(search) fix search filters glitch on click

### DIFF
--- a/src/frontend/js/components/SearchFilterGroup/_SearchFilterGroup.scss
+++ b/src/frontend/js/components/SearchFilterGroup/_SearchFilterGroup.scss
@@ -21,5 +21,7 @@ $richie-search-filters-group-title-fontcolor: $white !default;
 
   &__list {
     @include m-o-list-group__container;
+    height: 7rem;
+    overflow-y: scroll;
   }
 }

--- a/src/frontend/scss/objects/_search-filter-value.scss
+++ b/src/frontend/scss/objects/_search-filter-value.scss
@@ -61,6 +61,7 @@ $richie-search-filter-value-active-divider-border: 1px solid $white !default;
   display: flex;
   border-top: $richie-search-filter-value-divider-border;
   padding: $richie-search-filter-value-padding;
+  font-size: 0.85rem;
 }
 
 .search-filter-value-parent {


### PR DESCRIPTION
## Purpose

When clicking on a search filter to toggle it, search filters lists are updated producing a glitch in the search filters column.

## Proposal

We've decided to make each search filter group list a block with a fixed height to avoid this disturbing glitch (blocks jump).

An alternative would have been to define a max-height, but this would just limit the jump phenomenon that will still be disturbing when only a few filters are still available.

## Sneak peek

![richie-search-filters-height](https://user-images.githubusercontent.com/956157/55148034-c881fa00-5147-11e9-9e82-3309efe0bd75.gif)
