### PR TITLE
🚸(courses) simplify page title frontend editing

### DIFF
--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -14,7 +14,7 @@
     {% endwith %}
   </div>
 
-  <h1 class="category-detail__title">{% render_model request.current_page "titles" %}</h1>
+  <h1 class="category-detail__title">{% render_model request.current_page "title" %}</h1>
 
   <div class="category-detail__content">
     <div class="category-detail__content__description">

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -29,7 +29,7 @@
         {% if request.current_page.parent_page.course %}
           {{ request.current_page.parent_page.get_title }}
         {% else %}
-          {% render_model request.current_page "titles" %}
+          {% render_model request.current_page "title" %}
         {% endif %}
       </h1>
 

--- a/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
@@ -18,12 +18,12 @@
   <div class="course-detail__content course-detail__content--one">
     <h1 class="course-detail__content__title">
       {% if request.current_page.parent_page.parent_page.course %}
-        {% render_model request.current_page.parent_page.parent_page "titles" %}
+        {% render_model request.current_page.parent_page.parent_page "title" %}
       {% else %}
-        {% render_model request.current_page.parent_page "titles" %}
+        {% render_model request.current_page.parent_page "title" %}
       {% endif %}
       <br />
-      {% render_model request.current_page "titles" %}
+      {% render_model request.current_page "title" %}
     </h1>
 
     <div class="course-detail__content__row course-detail__content__categories">

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -16,7 +16,7 @@
     {% endwith %}
   </div>
 
-  <h1 class="organization-detail__title">{% render_model request.current_page "titles" %}</h1>
+  <h1 class="organization-detail__title">{% render_model request.current_page "title" %}</h1>
 
   <div class="organization-detail__content">
     <div class="organization-detail__content__description">


### PR DESCRIPTION
## Purpose

Our support team reported that having 3 titles is confusing for teachers/marketers editing the page in frontend. Also, it is very rare that you will need to modify the html title and menu title specifically...

## Proposal

I propose to reduce to the main `title` field. For power users, it is still possible to edit the other titles via the "page settings" menu item...
