### PR TITLE
Improve frontend editing for person and blog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ compilemessages: ## compile the gettext files
 	@$(COMPOSE_RUN) -w /app/src/richie app python /app/sandbox/manage.py compilemessages
 
 demo-site:  ## create a demo site
+	@$(MANAGE) flush
 	@$(MANAGE) create_demo_site
 	@${MAKE} search-index;
 .PHONY: demo-site

--- a/src/richie/apps/core/management/commands/create_demo_site.py
+++ b/src/richie/apps/core/management/commands/create_demo_site.py
@@ -11,7 +11,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.test.utils import override_settings
 
 import factory
-from cms import models as cms_models
 from cms.api import add_plugin
 from filer.models.imagemodels import Image
 
@@ -27,16 +26,7 @@ from richie.apps.courses.factories import (
     PersonTitleTranslationFactory,
 )
 from richie.apps.courses.helpers import create_categories
-from richie.apps.courses.models import (
-    BlogPost,
-    Category,
-    Course,
-    Licence,
-    Organization,
-    Person,
-    PersonTitle,
-    PersonTitleTranslation,
-)
+from richie.apps.courses.models import BlogPost, Category, Course, Organization, Person
 
 from ...helpers import create_text_plugin, recursive_page_creation
 from ...utils import file_getter
@@ -323,24 +313,6 @@ def get_number_of_course_runs():
 # Looks like pylint is not relevant at guessing object types when cascading
 # methods over querysets: Instance of 'list' has no 'delete' member (no-member).
 # We choose to ignore this false positive warning.
-
-
-def clear_cms_data():
-    """Clear all CMS data (CMS models + apps models)"""
-
-    cms_models.Page.objects.all().delete()
-    cms_models.Title.objects.all().delete()
-    cms_models.CMSPlugin.objects.all().delete()
-    cms_models.Placeholder.objects.all().delete()
-    Course.objects.all().delete()  # Deletes the associated course runs as well by cascading
-    Organization.objects.all().delete()
-    Category.objects.all().delete()
-    Person.objects.all().delete()
-    PersonTitle.objects.all().delete()
-    PersonTitleTranslation.objects.all().delete()
-    Licence.objects.all().delete()
-    BlogPost.objects.all().delete()
-
 
 # pylint: disable=too-many-locals,too-many-statements
 @override_settings(RICHIE_KEEP_SEARCH_UPDATED=False)
@@ -785,7 +757,6 @@ class Command(BaseCommand):
                 )
             )
 
-        clear_cms_data()
         create_demo_site()
 
         logger.info("done")

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% spaceless %}
 <div class="blogpost-detail">
-  <h1 class="blogpost-detail__title">{{ current_page.get_title }}</h1>
+  <h1 class="blogpost-detail__title">{% render_model current_page "title" %}</h1>
 
   <div class="blogpost-detail__subhead">
     <p class="blogpost-detail__subhead__date">

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -1,6 +1,10 @@
 {% extends "richie/fullwidth.html" %} {% load cms_tags i18n %} {% block content %}
 <div class="person-detail">
-  <h1 class="person-detail__title">{{ current_page.get_title }}</h1>
+  <h1 class="person-detail__title">
+    {% render_model_block current_page.person %}
+      {{ instance.person_title.title }} {{ instance.first_name }} {{ instance.last_name }}
+    {% endrender_model_block %}
+  </h1>
 
   <div class="person-detail__card">
     {% with header_level=2 %}

--- a/tests/apps/core/test_commands_create_demo_site.py
+++ b/tests/apps/core/test_commands_create_demo_site.py
@@ -25,13 +25,10 @@ class CreateDemoSiteCommandsTestCase(CMSTestCase):
 
     @override_settings(DEBUG=True)
     @mock.patch.object(Logger, "info")
-    @mock.patch("richie.apps.core.management.commands.create_demo_site.clear_cms_data")
     @mock.patch(
         "richie.apps.core.management.commands.create_demo_site.create_demo_site"
     )
-    def test_commands_create_demo_site_success(
-        self, mock_create, mock_clear, mock_logger
-    ):
+    def test_commands_create_demo_site_success(self, mock_create, mock_logger):
         """
         The command should delete and recreate the sample site when DEBUG is True
         The result should be posted to an info logger
@@ -43,6 +40,5 @@ class CreateDemoSiteCommandsTestCase(CMSTestCase):
         """
         self.assertTrue(settings.DEBUG)
         call_command("create_demo_site")
-        mock_clear.assert_called_once_with()
         mock_create.assert_called_once_with()
         mock_logger.assert_called_once_with("done")


### PR DESCRIPTION
## Purpose

It was not possible to edit the title of the blog post and person pages as easily as on the other types of pages.

## Proposal

- [x] add frontend editing of the page title on a blog post
- [x] replace the page title, on the top of a person page, by the concatenation of her title, first name and last name. Make them editable in frontend.