### PR TITLE
🎨(project) rename plugin group to richie

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -215,7 +215,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
     )
 
     # Group to add plugin to placeholder "Content"
-    FUN_PLUGINS_GROUP = "Fun Plugins"
+    RICHIE_PLUGINS_GROUP = "Richie Plugins"
 
     LANGUAGE_CODE = "en"
 

--- a/src/richie/apps/courses/cms_plugins.py
+++ b/src/richie/apps/courses/cms_plugins.py
@@ -29,7 +29,7 @@ class OrganizationPlugin(CMSPluginBase):
     module = _("Courses")
     render_template = "courses/plugins/organization.html"
     cache = True
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
 
     def render(self, context, instance, placeholder):
         context.update(
@@ -52,7 +52,7 @@ class CategoryPlugin(CMSPluginBase):
     module = _("Courses")
     render_template = "courses/plugins/category_plugin.html"
     cache = True
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
 
     def render(self, context, instance, placeholder):
         context.update(
@@ -75,7 +75,7 @@ class CoursePlugin(CMSPluginBase):
     module = _("Courses")
     render_template = "courses/plugins/course_plugin.html"
     cache = True
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
 
     def render(self, context, instance, placeholder):
         context.update(
@@ -122,7 +122,7 @@ class LicencePlugin(CMSPluginBase):
     name = _("Licence")
     render_template = "courses/plugins/licence_plugin.html"
     cache = True
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
     allow_children = False
 
     fieldsets = ((None, {"fields": ["licence", "description"]}),)
@@ -142,7 +142,7 @@ class BlogPostPlugin(CMSPluginBase):
     module = _("Courses")
     render_template = "courses/plugins/blogpost.html"
     cache = True
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
 
     def render(self, context, instance, placeholder):
         context.update(

--- a/src/richie/plugins/large_banner/cms_plugins.py
+++ b/src/richie/plugins/large_banner/cms_plugins.py
@@ -18,7 +18,7 @@ class LargeBannerPlugin(CMSPluginBase):
     CMSPlugin to customize a home page header.
     """
 
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
     name = _("Large Banner")
     model = LargeBanner
     form = LargeBannerForm

--- a/src/richie/plugins/plain_text/cms_plugins.py
+++ b/src/richie/plugins/plain_text/cms_plugins.py
@@ -21,7 +21,7 @@ class PlainTextPlugin(CMSPluginBase):
     disable_child_plugins = True
     fieldsets = ((None, {"fields": ["body"]}),)
     model = PlainText
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
     name = _("Plain text")
     render_template = "richie/plain_text/plain_text.html"
 

--- a/src/richie/plugins/section/cms_plugins.py
+++ b/src/richie/plugins/section/cms_plugins.py
@@ -17,7 +17,7 @@ class SectionPlugin(CMSPluginBase):
     CMSPlugin to add a content section with a distinct title from content.
     """
 
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
     name = _("Section")
     model = Section
     # Required from CMSPluginBase signature but not used since we override it

--- a/src/richie/plugins/simple_text_ckeditor/cms_plugins.py
+++ b/src/richie/plugins/simple_text_ckeditor/cms_plugins.py
@@ -22,7 +22,7 @@ class CKEditorPlugin(CMSPluginBase):
     name = _("Simple text")
     render_template = "richie/simple_text_ckeditor/simple_text.html"
     cache = True
-    module = settings.FUN_PLUGINS_GROUP
+    module = settings.RICHIE_PLUGINS_GROUP
     allow_children = False
     disable_child_plugins = True
 


### PR DESCRIPTION

## Purpose

We were using the name FUN for the plugin group but it should be Richie as FUN is now just one of the websites we will build with Richie.

## Proposal

Rename `FUN_PLUGIN_GROUP` setting to `RICHIE_PLUGIN_GROUP`.