### PR TITLE
🔧(blog) allow adding blog post plugins on the home page

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -289,11 +289,12 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
             "plugins": ["LargeBannerPlugin", "SectionPlugin"],
             "child_classes": {
                 "SectionPlugin": [
+                    "BlogPostPlugin",
                     "CoursePlugin",
-                    "OrganizationPlugin",
                     "CategoryPlugin",
-                    "PersonPlugin",
                     "LinkPlugin",
+                    "OrganizationPlugin",
+                    "PersonPlugin",
                 ]
             },
         },


### PR DESCRIPTION
## Purpose

When we added the blog post plugin, we forgot to add it as a possible option on the home page.

## Proposal

- [x] Add BlogPostPlugin as a possible option on the home page.