### PR TITLE
Refactor dynamic import in frontend application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Translations are loaded dynamically in frontend application.
+
 ## [1.0.0-beta.4] - 2019-04-08
 
 ### Added

--- a/src/frontend/babel.config.js
+++ b/src/frontend/babel.config.js
@@ -6,6 +6,7 @@ module.exports = {
         messagesDir: './i18n',
       },
     ],
+    ['@babel/plugin-syntax-dynamic-import'],
   ],
   presets: [
     [

--- a/src/frontend/babel.config.js
+++ b/src/frontend/babel.config.js
@@ -13,6 +13,7 @@ module.exports = {
       {
         forceAllTransforms: true,
         useBuiltIns: 'usage',
+        corejs: 3,
       },
     ],
     '@babel/preset-typescript',

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', event => {
   // Find all the elements that need React to render a component
   Array.prototype.forEach.call(
     document.querySelectorAll('.fun-react'),
-    (element: Element) => {
+    async (element: Element) => {
       // Generate a component name. It should be a key of the componentLibrary object / ComponentLibrary interface
       const componentName = startCase(
         get(element.className.match(/fun-react--([a-zA-Z-]*)/), '[1]') || '',
@@ -54,12 +54,12 @@ document.addEventListener('DOMContentLoaded', event => {
         }
 
         try {
-          addLocaleData(require(`react-intl/locale-data/${localeCode}`));
+          addLocaleData(await import(`react-intl/locale-data/${localeCode}`));
         } catch (e) {}
 
         let translatedMessages = null;
         try {
-          translatedMessages = require(`./translations/${locale}.json`);
+          translatedMessages = await import(`./translations/${locale}.json`);
         } catch (e) {}
 
         // Do get the component dynamically. We know this WILL produce a valid component thanks to the type guard

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -35,6 +35,7 @@
   ],
   "devDependencies": {
     "@babel/core": "7.4.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/polyfill": "7.4.0",
     "@babel/preset-env": "7.4.2",
     "@babel/preset-typescript": "7.3.3",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "bootstrap": "4.3.1",
+    "core-js": "3",
     "lodash-es": "4.17.11",
     "query-string": "6.4.0",
     "react": "16.8.5",

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -12,7 +12,7 @@
       "es2016",
       "es2017"
     ],
-    "module": "es6",
+    "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -6,9 +6,14 @@ module.exports = {
   // webpack config for production.
   mode: 'development',
 
-  // Include whatwg fetch as an entry point (and not an import) as it's replacing (when necessary)
-  // a globally available browser-provided function
-  entry: ['./js/index.tsx'],
+  // Currently, @babel/preset-env is unaware that using import() with Webpack relies on Promise internally.
+  // Environments which do not have builtin support for Promise, like Internet Explorer, will require both
+  // the promise and iterator polyfills be added manually.
+  entry: [
+    'core-js/modules/es.promise',
+    'core-js/modules/es.array.iterator',
+    './js/index.tsx',
+  ],
   output: {
     filename: 'index.js',
     path: __dirname + '/../richie/static/richie/js',

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -329,6 +329,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-dynamic-import@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612"
+  integrity sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470"

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2122,7 +2122,7 @@ core-js-pure@3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.0.0.tgz#a5679adb4875427c8c0488afc93e6f5b7125859b"
   integrity sha512-yPiS3fQd842RZDgo/TAKGgS0f3p2nxssF1H65DIZvZv0Od5CygP8puHXn3IQiM/39VAvgCbdaMQpresrbGgt9g==
 
-core-js@3.0.0:
+core-js@3, core-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.0.tgz#a8dbfa978d29bfc263bfb66c556d0ca924c28957"
   integrity sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==


### PR DESCRIPTION
## Purpose

I'm not confident with what I made in my [PR managing i18n](https://github.com/openfun/richie/pull/566) and I don't know if we can really rely with this kind of dynamic require.
So I look for an other solution using dynamic import in a more "typescript" way.


## Proposal

- [x] use core-js 3 to have a more recent version of core-js, this is not really realted with the main purpose of this PR but it's I think better to use this new version.
- [x] use @babel/plugin-syntax-dynamic-import to have dynamic import 
- [x] refactor `index.tsx` file

There are maybe negative points here :warning:  :

- the build now have lot of files and not only one `index.js`. This is because the build import every possible file "importable" and react-intl as a lot of `locale-data` files.
- I have switch the module resolution use in the typescript config, so I don't really know with which browser our code will work now, I found nothing about this in the documentation, but with babel maybe we have no compatibility regression.
