### PR TITLE
refactor paths for frontend tasks in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -595,10 +595,10 @@ jobs:
   lint-front-tslint:
     docker:
       - image: circleci/node:10
-    working_directory: ~/richie/src/frontend
+    working_directory: ~/fun/src/frontend
     steps:
       - checkout:
-          path: ~/richie
+          path: ~/fun
       - restore_cache:
           keys:
             - v4-front-dependencies-{{ checksum "yarn.lock" }}
@@ -609,10 +609,10 @@ jobs:
   lint-prettier:
     docker:
       - image: circleci/node:10
-    working_directory: ~/richie/src/frontend
+    working_directory: ~/fun/src/frontend
     steps:
       - checkout:
-          path: ~/richie
+          path: ~/fun
       - restore_cache:
           keys:
             - v4-front-dependencies-{{ checksum "yarn.lock" }}
@@ -623,10 +623,10 @@ jobs:
   test-front:
     docker:
       - image: circleci/node:10
-    working_directory: ~/richie/src/frontend
+    working_directory: ~/fun/src/frontend
     steps:
       - checkout:
-          path: ~/richie
+          path: ~/fun
       - restore_cache:
           keys:
             - v4-front-dependencies-{{ checksum "yarn.lock" }}
@@ -643,16 +643,16 @@ jobs:
   npm:
     docker:
       - image: circleci/node:10
-    working_directory: ~/richie
+    working_directory: ~/fun
     steps:
       - checkout:
-          path: ~/richie
+          path: ~/fun
       - restore_cache:
           keys:
             - v4-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Authenticate with registry
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/richie/.npmrc
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/fun/.npmrc
       - run:
           name: Publish package
           command: npm publish src/frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,8 +567,8 @@ jobs:
           path: ~/fun
       - restore_cache:
           keys:
-            - v4-front-dependencies-{{ checksum "yarn.lock" }}
-            - v4-front-dependencies-
+            - v5-front-dependencies-{{ checksum "yarn.lock" }}
+            - v5-front-dependencies-
       # If the yarn.lock file is not up-to-date with the package.json file,
       # using the --frozen-lockfile should fail.
       - run:
@@ -590,7 +590,7 @@ jobs:
       - save_cache:
           paths:
             - ./node_modules
-          key: v4-front-dependencies-{{ checksum "yarn.lock" }}
+          key: v5-front-dependencies-{{ checksum "yarn.lock" }}
 
   lint-front-tslint:
     docker:
@@ -601,7 +601,7 @@ jobs:
           path: ~/fun
       - restore_cache:
           keys:
-            - v4-front-dependencies-{{ checksum "yarn.lock" }}
+            - v5-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Lint code with tslint
           command: yarn lint
@@ -615,7 +615,7 @@ jobs:
           path: ~/fun
       - restore_cache:
           keys:
-            - v4-front-dependencies-{{ checksum "yarn.lock" }}
+            - v5-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Lint JS/TS/JSON and CSS/SCSS code with prettier
           command: yarn prettier --list-different "js/**/*.+(ts|tsx|json|js|jsx)" "*.+(ts|tsx|json|js|jsx)" "**/*.+(css|scss)"
@@ -629,7 +629,7 @@ jobs:
           path: ~/fun
       - restore_cache:
           keys:
-            - v4-front-dependencies-{{ checksum "yarn.lock" }}
+            - v5-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Run tests
           # Circle CI needs the tests to be ran sequentially, otherwise it hangs. See Jest docs below:
@@ -649,7 +649,7 @@ jobs:
           path: ~/fun
       - restore_cache:
           keys:
-            - v4-front-dependencies-{{ checksum "yarn.lock" }}
+            - v5-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/fun/.npmrc


### PR DESCRIPTION
## Purpose

In the i18n PR I changed the path where the code is checkout and also the working directory. Doing this I break how the `node_modules` path is stored in cache.


## Proposal

- [x] change the base path from `richie` to `fun` on every frontend tasks. This is also the base path used in all other tasks
- [x] change cache key name.
