### PR TITLE
💄(layout) improve styling images and CKEditor usage

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -446,7 +446,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
         "language": "{{ language }}",
         "skin": "moono-lisa",
         "toolbarCanCollapse": False,
-        "contentsCss": "/static/css/ckeditor.css",
+        "contentsCss": "/static/richie/css/ckeditor.css",
         # Enabled showblocks as default behavior
         "startupOutlineBlocks": True,
         # Enable some plugins
@@ -471,17 +471,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
             ["Bold", "Italic", "Underline", "-", "Subscript", "Superscript"],
             ["JustifyLeft", "JustifyCenter", "JustifyRight"],
             ["Link", "Unlink"],
-            [
-                "Image",
-                "-",
-                "NumberedList",
-                "BulletedList",
-                "-",
-                "Table",
-                "-",
-                "CreateDiv",
-                "HorizontalRule",
-            ],
+            ["NumberedList", "BulletedList", "-", "HorizontalRule"],
             ["Source"],
         ],
     }

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -35,6 +35,9 @@
 @import 'bootstrap/scss/utilities/text';
 @import 'bootstrap/scss/utilities/embed';
 
+// Some basic element styling
+@import './elements/images';
+
 // PORTAL STYLES
 // Objects from Partials (eg. styles for templates produced by dependencies)
 @import './objects/react-autosuggest';
@@ -69,7 +72,7 @@
 @import './templates/search/search';
 @import './templates/richie/large_banner/large_banner';
 @import './templates/richie/large_banner/hero-intro';
-@import './templates/richie/section/highlighted_items';
+@import './templates/richie/section/section';
 
 // Page component styles
 @import './components/header';

--- a/src/frontend/scss/elements/_images.scss
+++ b/src/frontend/scss/elements/_images.scss
@@ -1,0 +1,54 @@
+// Common basic rules on image elements
+
+img {
+  // Image should NEVER go beyond its container
+  max-width: 100%;
+
+  // Horizontal alignments
+  &.align-center {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    float: none;
+    clear: both;
+  }
+  &.align-left {
+    float: left;
+    @include media-breakpoint-down(md) {
+      margin-left: auto;
+      margin-right: auto;
+      float: none;
+    }
+  }
+  &.align-right {
+    float: right;
+    @include media-breakpoint-down(md) {
+      margin-left: auto;
+      margin-right: auto;
+      float: none;
+    }
+  }
+}
+
+figure {
+  // Float clearfix is included inside figure
+  @include clearfix();
+
+  img {
+    &.align-center + figcaption {
+      text-align: center;
+    }
+    &.align-left + figcaption {
+      text-align: left;
+      @include media-breakpoint-down(md) {
+        text-align: center;
+      }
+    }
+    &.align-right + figcaption {
+      text-align: right;
+      @include media-breakpoint-down(md) {
+        text-align: center;
+      }
+    }
+  }
+}

--- a/src/frontend/scss/templates/richie/section/_section.scss
+++ b/src/frontend/scss/templates/richie/section/_section.scss
@@ -9,6 +9,9 @@ $richie-section-highlights-title-textalign: center !default;
 $richie-section-highlights-item-gutter: 0.625rem !default;
 
 .section {
+  // Include clearfix since section is a hard fullwidth block
+  @include clearfix();
+
   &--highlights {
     padding: $richie-section-highlights-padding;
     background: $richie-section-highlights-background-even;
@@ -39,6 +42,12 @@ $richie-section-highlights-item-gutter: 0.625rem !default;
       @include media-breakpoint-up(md) {
         @include make-container();
         @include make-container-max-widths();
+      }
+
+      // Some have to take 100% on default behavior
+      & > p,
+      & > figure {
+        @include sv-flex(1, 0, 100%);
       }
 
       .course-plugin-container {

--- a/src/richie/static/richie/css/ckeditor.css
+++ b/src/richie/static/richie/css/ckeditor.css
@@ -1,0 +1,18 @@
+/*
+CSS for CKEditor content
+*/
+
+/*
+ * Add alignment classes required for alignment buttons to work right according
+ * to CKEditor configuration option "justifyClasses" */
+.text-left {
+  text-align: left;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-center {
+  text-align: center;
+}


### PR DESCRIPTION
## Purpose

Some configuration is missing to allow controlling the positioning
of images and image element (img and figure) behaviors are not
correct.

Related to issue #567

## Proposal

Here we add some basic image element styles so image have correct
basic behaviors on its alignments and with its container. Also we
disable some useless CKEditor features and fixed alignment buttons.

Note than since CKEditor edit render have its own CSS file to
customize render and since we need to use it to fix text alignment,
we forced its addition to the repository in richie static directory.
