### PR TITLE
🐛(manifest) add missing extensions in MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.md
-recursive-include src/richie *.html *.png *.gif *.js *.css *.jpg *.jpeg *.po *.mo
+recursive-include src/richie *.html *.png *.gif *.js *.css *.jpg *.jpeg *.po *.mo *.eot *.svg *.ttf *.woff
+include src/richie/apps/core/static/fonts/icomoon/selection.json


### PR DESCRIPTION
## Purpose

Some extensions were missing in MANIFEST.in file. Without them it is not
possible anymore to run collecstatic command.

## Proposal

- [x] Add missing extensions in MANIFEST.in file

