### PR TITLE
📦(dependencies) refactor app/sandbox dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY ./src/richie /builder/src/richie/
 RUN pip install --upgrade pip
 
 RUN mkdir /install && \
-    pip install --prefix=/install .
+    pip install --prefix=/install .[sandbox]
 
 # ---- final application image ----
 FROM base

--- a/docker/images/alpine/Dockerfile
+++ b/docker/images/alpine/Dockerfile
@@ -50,9 +50,7 @@ RUN apk --no-cache add --update \
     tk-dev \
     zlib-dev \
     # psycopg2 dependencies
-    postgresql-dev \
-    # MySQL dependencies
-    mariadb-connector-c-dev && \
+    postgresql-dev && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /builder
@@ -68,7 +66,7 @@ COPY ./src/richie /builder/src/richie/
 RUN pip install --upgrade pip
 
 RUN mkdir /install && \
-    pip install --prefix=/install .
+    pip install --prefix=/install .[sandbox]
 
 # ---- final application image ----
 FROM base

--- a/docker/images/alpine/ci/Dockerfile
+++ b/docker/images/alpine/ci/Dockerfile
@@ -15,7 +15,9 @@ RUN apk --no-cache add --update \
         curl \
         gcc \
         libffi-dev \
-        musl-dev
+        musl-dev \
+        # MySQL dependencies
+        mariadb-connector-c-dev
 
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN pip install --upgrade pip

--- a/docker/images/alpine/dev/Dockerfile
+++ b/docker/images/alpine/dev/Dockerfile
@@ -16,7 +16,9 @@ RUN apk --no-cache add --update \
         gcc \
         libffi-dev \
         musl-dev \
-        vim
+        vim \
+        # MySQL dependencies
+        mariadb-connector-c-dev
 
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN pip install --upgrade pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,54 +25,17 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    arrow==0.13.1
-    Babel==2.6.0
-    decorator==4.4.0
-    dj-database-url==0.5.0
-    Django>=1.11,<2.2
-    django-appconf==1.0.3
-    django-classy-tags==0.8.0
-    django-cms==3.6.0
-    django-configurations==2.1
-    django-formtools==2.1
-    django-mptt==0.9.1
-    django-reversion==1.10.2  # pyup: >=1.8.2,<1.11
-    django-sekizai==0.10.0
-    djangocms-admin-style==1.3.0
-    djangocms-attributes-field==1.0.0
-    djangocms-file==2.2.0
-    djangocms-googlemap==1.2.0
-    djangocms-link==2.3.1
-    django-parler==1.9.2
-    djangocms-text-ckeditor==3.7.0
-    djangocms-video==2.1.1
-    djangocms-picture==2.1.3
-    djangorestframework==3.9.2
-    dockerflow==2018.4.0
-    easy-thumbnails==2.6
-    elasticsearch==6.3.1
-    gunicorn==19.9.0
-    lxml==4.3.3
-    mysqlclient==1.4.2.post1
-    pexpect==4.6.0
-    pickleshare==0.7.5
-    Pillow==5.4.1
-    prompt-toolkit==2.0.9
-    psycopg2==2.7.7
-    ptyprocess==0.6.0
-    Pygments==2.3.1
-    python-dateutil==2.8.0
-    pytz==2018.9
-    requests==2.21.0
-    sentry-sdk==0.7.9
-    simplegeneric==0.8.1
-    six==1.12.0
-    text-unidecode==1.2
-    traitlets==4.3.2
-    tzlocal==1.5.1
-    urllib3==1.24.1
-    wcwidth==0.1.7
-    YURL==0.13
+    arrow
+    django-cms>=3.6.0
+    django-parler
+    djangocms-file
+    djangocms-googlemap
+    djangocms-link
+    djangocms-picture
+    djangocms-text-ckeditor
+    djangocms-video
+    djangorestframework
+    elasticsearch
 package_dir =
     =src
 packages = find:
@@ -80,15 +43,13 @@ zip_safe = True
 
 [options.extras_require]
 dev =
-    astroid==2.2.5
     black==19.3b0
-    Faker==1.0.4
-    factory-boy[django]==2.11.1
+    factory-boy==2.11.1
     flake8==3.7.7
     ipdb==0.12
     ipython==7.4.0
-    ipython-genutils==0.2.0
     isort==4.3.16
+    mysqlclient==1.4.2.post1
     pylint==2.3.1
     pylint-django==2.0.6
     pytest==4.4.0
@@ -96,6 +57,12 @@ dev =
     pytest-django==3.4.8
     responses==0.10.6
     twine==1.13.0
+sandbox =
+    django-configurations==2.1
+    dockerflow==2018.4.0
+    gunicorn==19.9.0
+    psycopg2-binary==2.7.7
+    sentry-sdk==0.7.9
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Purpose

Richie is supposed to be distributed as a django third-party application, we needed to separate direct dependencies from runtime dependencies (sandbox).

Also, pinning direct dependencies for the app is not a good idea since we do not need to force a particular release when it's not required. This will ease the app installation by avoiding unresolvable dependencies.

Finally secondary dependencies should not be listed nor pinned as their constraints should be declared in primary dependencies' package.

## Proposal

- [x] move runtime dependencies to the `sandbox` extra requirements
- [x] remove secondary dependencies
- [x] unpin primary dependencies

Fixes #257, #259 