### PR TITLE
🐛(frontend) fix scss relative imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,6 +636,25 @@ jobs:
           # (https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server)
           command: yarn test --runInBand
 
+  test-front-package:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/wrk
+    steps:
+      - checkout:
+          path: ~/fun
+      - run:
+          name: Check SCSS library
+          command: |
+            # Install the sass library/compiler
+            yarn add node-sass
+            # Install the package locally
+            yarn add file:/home/circleci/fun/src/frontend
+            # Create a scss file to compile that imports the package main entry
+            echo -e "@import 'richie-education/scss/main';\n" > main.scss
+            # Compile it!
+            yarn node-sass --include-path node_modules main.scss main.css
+
   # Publishing to npm requires that:
   #   * you already registered to pypi.org
   #   * you have define the NPM_TOKEN secret environment variables in CircleCI
@@ -684,6 +703,10 @@ workflows:
       - test-front:
           requires:
             - build-front
+          filters:
+            tags:
+              only: /.*/
+      - test-front-package:
           filters:
             tags:
               only: /.*/
@@ -823,6 +846,7 @@ workflows:
             - lint-front-tslint
             - lint-prettier
             - test-front
+            - test-front-package
           filters:
             branches:
               ignore: /.*/

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -16,7 +16,7 @@
 
 // TWITTER BOOTSTRAP V4
 // Required
-@import '../node_modules/bootstrap/scss/bootstrap-reboot.scss';
+@import 'bootstrap/scss/bootstrap-reboot.scss';
 
 // Icomoon font
 @import './vendor/icomoon';

--- a/src/frontend/scss/_variables.scss
+++ b/src/frontend/scss/_variables.scss
@@ -1,5 +1,5 @@
-@import '../node_modules/bootstrap/scss/functions';
-@import '../node_modules/bootstrap/scss/variables';
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
 
 // Design color palette
 @import 'colors';


### PR DESCRIPTION
## Purpose

When using `richie-education` package as a library to build upon, having relative imports breaks derivated builds compilation. 

## Proposal

Since `node_modules` is in the `SASS_PATH`, we should derive dependency imports from this location.