### PR TITLE
🐳(front) build frontend in production mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ COPY ./src /app/src/
 WORKDIR /app/src/frontend
 
 RUN yarn install --frozen-lockfile && \
-    yarn build && \
-    yarn sass
+    yarn build-production && \
+    yarn sass-production
 
 # ---- back-end builder image ----
 FROM base as back-builder

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -5,11 +5,13 @@
   "main": "sandbox/manage.py",
   "scripts": {
     "build": "tsc --noEmit && webpack",
+    "build-production": "tsc --noEmit && webpack --mode=production",
     "generate-l10n-template": "rip json2pot 'i18n/js/**/*.json' -o i18n/frontend.pot",
     "generate-translations": "rip po2json './js/translations/*.po' -o './js/translations' -m './i18n/**/*.json'",
     "lint": "tslint -c tslint.json 'js/**/*.ts?(x)'",
     "prettier-write": "prettier --write 'js/**/*.+(ts|tsx|json|js|jsx)' '*.+(ts|tsx|json|js|jsx)' '**/*.+(css|scss)'",
     "sass": "node-sass --include-path node_modules scss/_main.scss ../richie/static/richie/css/main.css",
+    "sass-production": "node-sass --include-path node_modules scss/_main.scss --output-style compressed ../richie/static/richie/css/main.css",
     "test": "jest",
     "watch-sass": "nodemon -e scss -x 'yarn sass'"
   },


### PR DESCRIPTION
## Purpose

The Dockerfile at root project is used to build the production image. We
should build the frontend application in production mode.


## Proposal

- [x] add `--mode=production` to `yarn build` in Dockerfile.
