### PR TITLE
🌐(search) replace gettext by ugettext_lazy in the defaults file

### DIFF
--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -3,7 +3,7 @@ Import custom settings and set up defaults for values the Search app needs
 """
 from django.conf import settings
 from django.utils.functional import lazy
-from django.utils.translation import gettext as _
+from django.utils.translation import ugettext_lazy as _
 
 # The React i18n library only works with ISO15897 locales (e.g. fr_FR)
 # Django also supports ISO639-1 language codes without a region (e.g. fr) which is sufficient

--- a/tests/apps/search/test_query_courses_edge_cases.py
+++ b/tests/apps/search/test_query_courses_edge_cases.py
@@ -1,7 +1,7 @@
 """Tests for environment ElasticSearch support."""
-# pylint: disable=too-many-lines
 import json
 import random
+from http.cookies import SimpleCookie
 from unittest import mock
 
 from django.conf import settings
@@ -103,6 +103,28 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
             client=settings.ES_CLIENT,
         )
         indices_client.refresh()
+
+    def test_query_courses_filter_box_titles_french(self, *_):
+        """
+        Filter box titles should be in french when the language cookie is set.
+        """
+
+        self.prepare_index([])
+        self.client.cookies = SimpleCookie({"django_language": "fr"})
+        response = self.client.get(f"/api/v1.0/courses/")
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(
+            [v["human_name"] for v in content["filters"].values()],
+            [
+                "Nouveaux cours",
+                "Disponibilité",
+                "Sujets",
+                "Niveaux",
+                "Établissements",
+                "Langues",
+            ],
+        )
 
     def test_query_courses_rare_facet_force(self, *_):
         """


### PR DESCRIPTION
## Purpose
The section titles on the search page are not translating properly with gettext. 

You can see it on:
https://richie.education/fr/cours/?limit=999&offset=0
and this screenshot from my localhost:
![Screenshot_2019-04-04 Cours](https://user-images.githubusercontent.com/17911549/55587343-22ab2e00-56f9-11e9-8b05-8bb3a9f58c4d.jpg)

## Proposal
Using ugettext_lazy instead fixes the problem.
