### PR TITLE
👷(circleci) add check CHANGELOG job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,17 @@ jobs:
           command: |
             gitlint --commits origin/master..HEAD
 
+  # Check that the CHANGELOG has been updated in the current branch
+  check-changelog:
+    machine: true
+    working_directory: ~/fun
+    steps:
+      - checkout
+      - run:
+          name: Check that the CHANGELOG has been modified in the current branch
+          command: |
+            git whatchanged --name-only --pretty="" origin..HEAD | grep CHANGELOG
+
   # Docker/back-end jobs
   # Build job
   # Build the Docker image ready for production
@@ -716,6 +727,13 @@ workflows:
       # Check validity of git history
       - lint-git:
           filters:
+            tags:
+              only: /.*/
+      # Check CHANGELOG update
+      - check-changelog:
+          filters:
+            branches:
+              ignore: master
             tags:
               only: /.*/
 


### PR DESCRIPTION
## Purpose

We need a way to remind us to update the project's `CHANGELOG` when we submitting a PR.

## Proposal

- [x] add a `check-changelog` job to the CI

One may believe that this is another annoying task, but the experience we had with Arnold's repository shows that it drastically speeds up the release cycle since almost everything has already been prepared upfront.

You may have noticed that this job **is not required** to merge a PR since the `CHANGELOG` does not have to be updated for every submitted changes.