### PR TITLE
💄(layout) improve how empty pages look

### DIFF
--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -6,6 +6,7 @@
 @import './variables';
 @import './mixins/shapes';
 @import './mixins/flexbox';
+@import './mixins/empty';
 @import './mixins/cards';
 @import './mixins/hero';
 @import './mixins/list-group';

--- a/src/frontend/scss/mixins/_empty.scss
+++ b/src/frontend/scss/mixins/_empty.scss
@@ -1,0 +1,45 @@
+@mixin m-o-media_empty(
+  $width: null,
+  $height: null,
+  $margin: 0,
+  $padding: 1rem,
+  $fontsize: null,
+  $fontstyle: italic,
+  $fontcolor: $gray20,
+  $textalign: center,
+  $border: null,
+  $background: null,
+  $absolute: true,
+  $selector: '&__empty'
+) {
+  #{$selector} {
+    width: $width;
+    min-height: $height;
+    margin: $margin;
+    padding: $padding;
+    font-size: $fontsize;
+    font-style: $fontstyle;
+    text-align: $textalign;
+    color: $fontcolor;
+    border: $border;
+    background: $background;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-content: center;
+    text-decoration: none;
+
+    @if ($absolute) {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+
+    &:hover {
+      color: $fontcolor;
+      text-decoration: none;
+    }
+  }
+}

--- a/src/frontend/scss/templates/courses/cms/_blogpost_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_blogpost_detail.scss
@@ -17,7 +17,7 @@ $richie-blogpost-detail-title-textalign: center !default;
 
   &__subhead {
     display: flex;
-    margin-bottom: 0.5rem;
+    margin-bottom: 2rem;
     flex-wrap: wrap;
     justify-content: center;
 
@@ -93,6 +93,13 @@ $richie-blogpost-detail-title-textalign: center !default;
       margin: 0 auto;
       max-width: 100%;
     }
+
+    @include m-o-media_empty(
+      $width: 100%,
+      $height: 30vh,
+      $background: $gray97,
+      $absolute: false
+    );
   }
 
   &__excerpt {

--- a/src/frontend/scss/templates/courses/cms/_category_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_category_detail.scss
@@ -34,14 +34,17 @@ $richie-category-detail-banner-logo-sizing-xl: 25rem !default;
       bottom: -1000%;
       left: -1000%;
       min-width: 100%;
-      min-height: 100%;
       margin: auto;
     }
+
+    @include m-o-media_empty($background: $gray97);
   }
 
   &__logo {
     position: relative;
     overflow: hidden;
+    background: $white;
+    border: 1px solid darken($light, 20%);
 
     width: $richie-category-detail-banner-logo-sizing * 0.75;
     height: $richie-category-detail-banner-logo-sizing * 0.75;
@@ -75,8 +78,9 @@ $richie-category-detail-banner-logo-sizing-xl: 25rem !default;
       width: 100%;
       min-height: 100%;
       margin: auto;
-      border: 1px solid darken($light, 20%);
     }
+
+    @include m-o-media_empty();
   }
 
   &__title {

--- a/src/frontend/scss/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_course_detail.scss
@@ -1,61 +1,63 @@
-$richie-course-detail-breakpoint: lg;
-// TODO: Change every value below to 'null !default' after copying it to settings
-$richie-course-detail-title-margin: 0 0 1rem 0;
-$richie-course-detail-title-padding: 1rem;
-$richie-course-detail-title-fontsize: 2.6rem;
-$richie-course-detail-title-fontsize-large: 3rem;
-$richie-course-detail-title-fontweight: normal;
-$richie-course-detail-title-lineheight: 1.1;
-$richie-course-detail-title-textalign: center;
-$richie-course-detail-title-underline-width: 10rem;
-$richie-course-detail-title-underline-border: 1px solid $gray40;
+$richie-course-detail-breakpoint: lg !default;
 
-$richie-course-detail-content-width-large: 70%;
-$richie-course-detail-content-margin: 0;
-$richie-course-detail-content-padding: 0;
+$richie-course-detail-title-margin: 0 0 1rem 0 !default;
+$richie-course-detail-title-padding: 1rem !default;
+$richie-course-detail-title-fontsize: 2.6rem !default;
+$richie-course-detail-title-fontsize-large: 3rem !default;
+$richie-course-detail-title-fontweight: normal !default;
+$richie-course-detail-title-lineheight: 1.1 !default;
+$richie-course-detail-title-textalign: center !default;
+$richie-course-detail-title-underline-width: 10rem !default;
+$richie-course-detail-title-underline-border: 1px solid $gray40 !default;
 
-$richie-course-detail-row-margin: 0;
-$richie-course-detail-row-padding: 0.5rem 1rem 0;
-$richie-course-detail-row-fontsize: 0.95rem;
-$richie-course-detail-row-title-fontcolor: $dodgerblue3;
+$richie-course-detail-content-width-large: 70% !default;
+$richie-course-detail-content-margin: 0 !default;
+$richie-course-detail-content-padding: 0 !default;
 
-$richie-course-detail-categories-justify: center;
-$richie-course-detail-categories-empty-fontcolor: $gray40;
-$richie-course-detail-categories-empty-textalign: center;
+$richie-course-detail-row-margin: 0 !default;
+$richie-course-detail-row-padding: 0.5rem 1rem 0 !default;
+$richie-course-detail-row-fontsize: 0.95rem !default;
+$richie-course-detail-row-title-fontcolor: $dodgerblue3 !default;
 
-$richie-course-detail-teaser-margin: 0;
-$richie-course-detail-teaser-padding: 0;
-$richie-course-detail-teaser-object-padding-vertical: 1.5rem;
-$richie-course-detail-teaser-object-padding-horizontal: 1rem;
+$richie-course-detail-categories-justify: center !default;
+$richie-course-detail-categories-empty-fontcolor: $gray40 !default;
+$richie-course-detail-categories-empty-textalign: center !default;
 
-$richie-course-detail-run-background: $dodgerblue1;
-$richie-course-detail-run-gutter: 0.5rem;
-$richie-course-detail-run-width-large: 33.33%;
+$richie-course-detail-organizations-item-gutter: 0.625rem !default;
+
+$richie-course-detail-teaser-margin: 0 !default;
+$richie-course-detail-teaser-padding: 0 !default;
+$richie-course-detail-teaser-object-padding-vertical: 1.5rem !default;
+$richie-course-detail-teaser-object-padding-horizontal: 1rem !default;
+
+$richie-course-detail-run-background: $dodgerblue1 !default;
+$richie-course-detail-run-gutter: 0.5rem !default;
+$richie-course-detail-run-width-large: 33.33% !default;
 $richie-course-detail-run-margin: 0 !default;
 $richie-course-detail-run-padding: 1rem !default;
 $richie-course-detail-run-fontcolor: $white !default;
 
-$richie-course-detail-socialnetworks-background: $dodgerblue1;
+$richie-course-detail-socialnetworks-background: $dodgerblue1 !default;
 $richie-course-detail-socialnetworks-margin: 0 !default;
 $richie-course-detail-socialnetworks-padding: 1rem !default;
 $richie-course-detail-socialnetworks-fontcolor: $white !default;
 
-$richie-course-detail-team-gutter: 0.5rem;
-$richie-course-detail-team-width-large: 100%;
-$richie-course-detail-team-title-fontsize: 1.4rem;
-$richie-course-detail-team-title-fontcolor: $dodgerblue5;
+$richie-course-detail-team-gutter: 0.5rem !default;
+$richie-course-detail-team-width-large: 100% !default;
+$richie-course-detail-team-title-fontsize: 1.4rem !default;
+$richie-course-detail-team-title-fontcolor: $dodgerblue5 !default;
 
-$richie-course-detail-license-margin: 1rem 0 0 0;
-$richie-course-detail-license-title-margin: 0 0 0.75rem 0;
-$richie-course-detail-license-title-fontcolor: $dodgerblue3;
+$richie-course-detail-license-margin: 1rem 0 0 0 !default;
+$richie-course-detail-license-title-margin: 0 0 0.75rem 0 !default;
+$richie-course-detail-license-title-fontcolor: $dodgerblue3 !default;
 
-$richie-course-detail-aside-with-large: 30%;
-$richie-course-detail-aside-margin: 0;
-$richie-course-detail-aside-padding: 0;
+$richie-course-detail-aside-with-large: 30% !default;
+$richie-course-detail-aside-margin: 0 !default;
+$richie-course-detail-aside-padding: 0 !default;
 
-$richie-course-detail-aside-main-org-margin: 0;
-$richie-course-detail-aside-main-org-padding: 1rem;
-$richie-course-detail-aside-main-org-background: $white;
+$richie-course-detail-aside-main-org-margin: 0 !default;
+$richie-course-detail-aside-main-org-padding: 1rem !default;
+$richie-course-detail-aside-main-org-background: $white !default;
 
 .course-detail {
   @include make-container-max-widths();
@@ -282,6 +284,8 @@ $richie-course-detail-aside-main-org-background: $white;
         );
         border: 0;
       }
+
+      @include m-o-media_empty($background: $gray97);
     }
 
     &__team {
@@ -320,6 +324,42 @@ $richie-course-detail-aside-main-org-background: $white;
       }
     }
 
+    &__organizations {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      .organization-plugin-container {
+        @include sv-flex(
+          1,
+          0,
+          calc(100% - #{$richie-course-detail-organizations-item-gutter * 2})
+        );
+        display: flex;
+        min-width: auto;
+        margin: $richie-course-detail-organizations-item-gutter;
+        padding: 0;
+        @include media-breakpoint-up(sm) {
+          @include sv-flex(
+            1,
+            0,
+            calc(50% - #{$richie-course-detail-organizations-item-gutter * 2})
+          );
+        }
+        @include media-breakpoint-up(md) {
+          @include sv-flex(
+            1,
+            0,
+            calc(25% - #{$richie-course-detail-organizations-item-gutter * 2})
+          );
+        }
+
+        .organization-plugin {
+          @include sv-flex(1, 0, 100%);
+          margin: 0;
+        }
+      }
+    }
+
     &__license {
       &__item {
         margin: $richie-course-detail-license-margin;
@@ -353,6 +393,8 @@ $richie-course-detail-aside-main-org-background: $white;
         max-width: 100%;
         margin: auto;
       }
+
+      @include m-o-media_empty($width: 100%, $height: 20vh, $absolute: false);
     }
 
     &__cover {
@@ -363,6 +405,13 @@ $richie-course-detail-aside-main-org-background: $white;
         width: 100%;
         max-width: 100%;
       }
+
+      @include m-o-media_empty(
+        $width: 100%,
+        $height: 15vh,
+        $background: $gray97,
+        $absolute: false
+      );
     }
 
     &__social-networks {
@@ -386,6 +435,14 @@ $richie-course-detail-aside-main-org-background: $white;
         text-align: center;
       }
 
+      @include m-o-media_empty(
+        $width: 100%,
+        $height: 10vh,
+        $fontcolor: $white,
+        $background: null,
+        $absolute: false
+      );
+
       &__block {
         $block-selector: &;
 
@@ -394,7 +451,7 @@ $richie-course-detail-aside-main-org-background: $white;
         padding: 2rem 0;
 
         a {
-          color: white;
+          color: $white;
         }
 
         dt {

--- a/src/frontend/scss/templates/courses/cms/_organization_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_organization_detail.scss
@@ -34,24 +34,16 @@ $richie-org-detail-banner-logo-height-xl: 25rem !default;
       bottom: -1000%;
       left: -1000%;
       min-width: 100%;
-      min-height: 100%;
       margin: auto;
     }
 
-    &__empty {
-      width: 100%;
-      background: $gray97;
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-    }
+    @include m-o-media_empty($background: $gray97);
   }
 
   &__logo {
     position: relative;
     overflow: hidden;
+    background: $white;
     border: 1px solid darken($light, 20%);
 
     width: $richie-org-detail-banner-logo-height * 0.75;
@@ -88,15 +80,7 @@ $richie-org-detail-banner-logo-height-xl: 25rem !default;
       margin: auto;
     }
 
-    &__empty {
-      width: 100%;
-      background: $white;
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-    }
+    @include m-o-media_empty();
   }
 
   &__title {

--- a/src/frontend/scss/templates/courses/cms/_organization_list.scss
+++ b/src/frontend/scss/templates/courses/cms/_organization_list.scss
@@ -41,9 +41,9 @@ $richie-org-list-item-empty-textalign: center;
       display: flex;
       margin: $richie-org-list-item-gutter;
       padding: 1.25rem;
-      flex-direction: row;
-      flex-wrap: wrap;
-      align-content: stretch;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      align-content: space-between;
       border: 1px solid rgba($black, 0.125);
       border-radius: 0.25rem;
       @include media-breakpoint-up(md) {
@@ -51,8 +51,9 @@ $richie-org-list-item-empty-textalign: center;
       }
 
       &__logo {
-        @include sv-flex(1, 0, 100%);
+        @include sv-flex(1, 0, auto);
         display: flex;
+        position: relative;
         flex-direction: row;
         justify-content: center;
         align-content: center;
@@ -62,10 +63,12 @@ $richie-org-list-item-empty-textalign: center;
           @include sv-flex(0, 0, auto);
           max-width: 100%;
         }
+
+        @include m-o-media_empty($background: $gray97);
       }
 
       &__title {
-        @include sv-flex(1, 0, 100%);
+        @include sv-flex(0, 0, auto);
         display: flex;
         justify-content: center;
         font-size: $richie-org-list-item-title-fontsize;

--- a/src/frontend/scss/templates/courses/cms/_person_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_person_detail.scss
@@ -45,6 +45,17 @@ $richie-person-detail-media-width: 120px;
         max-width: $richie-person-detail-media-width;
         border-radius: 100%;
       }
+
+      @include m-o-media_empty(
+        $width: 100%,
+        $height: 13vh,
+        $background: $gray97,
+        $absolute: false
+      );
+    }
+
+    &__content__wrapper {
+      @include m-o-media_empty($width: 100%, $height: 13vh, $absolute: false);
     }
   }
 }

--- a/src/frontend/scss/templates/courses/plugins/_category_plugin.scss
+++ b/src/frontend/scss/templates/courses/plugins/_category_plugin.scss
@@ -1,24 +1,89 @@
-$richie-category-plugin-categories-margin: 0 0 0.3rem 0;
-$richie-category-plugin-categories-padding: 0.25rem 0.4rem;
-$richie-category-plugin-categories-fontsize: 0.7rem;
-$richie-category-plugin-categories-fontcolor: $white;
-$richie-category-plugin-categories-background: $gray7;
-$richie-category-plugin-categories-divider-margin: 0.3rem;
+$richie-category-plugin-tag-margin: 0 0 0.3rem 0;
+$richie-category-plugin-tag-padding: 0.25rem 0.4rem;
+$richie-category-plugin-tag-fontsize: 0.7rem;
+$richie-category-plugin-tag-fontcolor: $white;
+$richie-category-plugin-tag-background: $gray7;
+$richie-category-plugin-tag-divider-margin: 0.3rem;
+
+$richie-category-plugin-title-fontsize: small !default;
+$richie-category-plugin-title-fontcolor: $black !default;
+$richie-category-plugin-title-textalign: center !default;
 
 .category-plugin-tag {
   @include sv-flex(0, 0, auto);
-  margin: $richie-category-plugin-categories-margin;
-  padding: $richie-category-plugin-categories-padding;
-  font-size: $richie-category-plugin-categories-fontsize;
-  color: $richie-category-plugin-categories-fontcolor;
-  background: $richie-category-plugin-categories-background;
+  margin: $richie-category-plugin-tag-margin;
+  padding: $richie-category-plugin-tag-padding;
+  font-size: $richie-category-plugin-tag-fontsize;
+  color: $richie-category-plugin-tag-fontcolor;
+  background: $richie-category-plugin-tag-background;
   text-decoration: none;
 
   &:hover {
-    color: $richie-category-plugin-categories-fontcolor;
+    color: $richie-category-plugin-tag-fontcolor;
   }
 
   & + & {
-    margin-left: $richie-category-plugin-categories-divider-margin;
+    margin-left: $richie-category-plugin-tag-divider-margin;
+  }
+}
+
+.category-plugin-container {
+  @include make-col-ready();
+  @include media-breakpoint-up(sm) {
+    @include make-col(6);
+  }
+  @include media-breakpoint-up(md) {
+    @include make-col(4);
+  }
+  @include media-breakpoint-up(lg) {
+    @include make-col(2);
+  }
+  display: flex;
+}
+
+.category-plugin {
+  display: flex;
+  padding: 1.25rem;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-content: space-between;
+  border: 1px solid rgba($black, 0.125);
+  border-radius: 0.25rem;
+
+  &__body {
+    @include sv-flex(1, 0, 100%);
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    color: $richie-category-plugin-title-fontcolor;
+    font-size: $richie-category-plugin-title-fontsize;
+  }
+
+  &__logo {
+    @include sv-flex(1, 0, auto);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    @include m-o-media_empty(
+      $width: 100%,
+      $background: $gray97,
+      $absolute: false
+    );
+
+    &__empty {
+      @include sv-flex(1, 0, auto);
+    }
+
+    img {
+      @include sv-flex(0, 0, auto);
+    }
+  }
+
+  &__title {
+    @include sv-flex(0, 0, auto);
+    word-wrap: break-word;
+    text-align: $richie-category-plugin-title-textalign;
   }
 }

--- a/src/frontend/scss/templates/courses/plugins/_organization_plugin.scss
+++ b/src/frontend/scss/templates/courses/plugins/_organization_plugin.scss
@@ -3,47 +3,65 @@ $richie-organization-plugin-border-hover: 1px solid $firebrick6 !default;
 $richie-organization-plugin-title-fontsize: small !default;
 $richie-organization-plugin-title-fontcolor: $black !default;
 $richie-organization-plugin-title-textalign: center !default;
-// Set a standard height that caps titles at 1 lines
-$richie-organization-plugin-title-height: 1.1 * $headings-line-height *
-  $h5-font-size !default;
 
 .organization-plugin-container {
-  @include make-col-ready();
+  @include sv-flex(1, 0, 100%);
+
   @include media-breakpoint-up(sm) {
-    @include make-col(6);
+    @include sv-flex(1, 0, 50%);
   }
   @include media-breakpoint-up(md) {
-    @include make-col(4);
+    @include sv-flex(1, 0, 33.3333%);
   }
   @include media-breakpoint-up(lg) {
-    @include make-col(3);
+    @include sv-flex(1, 0, 25%);
   }
-  display: inline-block;
-  min-height: 100%;
+  display: flex;
 }
+
 .organization-plugin {
-  @extend .card;
-  // Use margin bottom to match side spacing
-  margin-bottom: $richie-organization-plugin-margin-bottom;
-  &:hover,
-  &:focus {
-    border: $richie-organization-plugin-border-hover;
-    cursor: pointer;
-  }
+  @include sv-flex(1, 0, 100%);
+  display: flex;
+  padding: 1.25rem;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-content: space-between;
+  border: 1px solid rgba($black, 0.125);
+  border-radius: 0.25rem;
+
   &__body {
-    @extend .card-body;
-    @extend .text-center;
-    & > img {
-      max-width: 100%;
+    @include sv-flex(1, 0, 100%);
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    color: $richie-organization-plugin-title-fontcolor;
+    font-size: $richie-organization-plugin-title-fontsize;
+  }
+
+  &__logo {
+    @include sv-flex(1, 0, auto);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    @include m-o-media_empty(
+      $width: 100%,
+      $background: $gray97,
+      $absolute: false
+    );
+
+    &__empty {
+      @include sv-flex(1, 0, auto);
+    }
+
+    img {
+      @include sv-flex(0, 0, auto);
     }
   }
+
   &__title {
-    @extend .card-title;
-    // Set a standard height that caps titles at x lines
-    font-size: $richie-organization-plugin-title-fontsize;
-    color: $richie-organization-plugin-title-fontcolor;
+    @include sv-flex(0, 0, auto);
     text-align: $richie-organization-plugin-title-textalign;
-    height: $richie-organization-plugin-title-height;
-    overflow: visible;
   }
 }

--- a/src/frontend/scss/templates/richie/section/_section.scss
+++ b/src/frontend/scss/templates/richie/section/_section.scss
@@ -113,11 +113,36 @@ $richie-section-highlights-item-gutter: 0.625rem !default;
       }
 
       .category-plugin-container {
-        @include sv-flex(1, 0, auto);
+        @include sv-flex(
+          1,
+          0,
+          calc(50% - #{$richie-section-highlights-item-gutter * 2})
+        );
         display: flex;
         min-width: auto;
         margin: $richie-section-highlights-item-gutter;
         padding: 0;
+        @include media-breakpoint-up(sm) {
+          @include sv-flex(
+            1,
+            0,
+            calc(33.3333% - #{$richie-section-highlights-item-gutter * 2})
+          );
+        }
+        @include media-breakpoint-up(md) {
+          @include sv-flex(
+            1,
+            0,
+            calc(25% - #{$richie-section-highlights-item-gutter * 2})
+          );
+        }
+        @include media-breakpoint-up(lg) {
+          @include sv-flex(
+            1,
+            0,
+            calc(16.6667% - #{$richie-section-highlights-item-gutter * 2})
+          );
+        }
 
         .category-plugin {
           @include sv-flex(1, 0, 100%);

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -1,5 +1,5 @@
 {% extends "richie/fullwidth.html" %}
-{% load cms_tags i18n %}
+{% load cms_tags i18n extra_tags %}
 {% block content %}
 {% spaceless %}
 <div class="blogpost-detail">
@@ -10,34 +10,30 @@
       {{ current_page.creation_date|date:"SHORT_DATE_FORMAT" }}
     </p>
 
-    <p class="blogpost-detail__subhead__author">
-      {% with form_factor="tag" %}
-        {% placeholder "author" or %}
-          <span class="blogpost-detail__author__empty">
-            {% trans "No associated author" %}
-          </span>
-        {% endplaceholder %}
-      {% endwith %}
-    </p>
+    {% with form_factor="tag" %}
+      {% page_placeholder "author" current_page as blogpost_author_content %}
+      {% if blogpost_author_content %}
+      <div class="blogpost-detail__subhead__author">
+        {{ blogpost_author_content }}
+      </div>
+      {% endif %}
+    {% endwith %}
 
     {% include "social-networks/blogpost-badges.html" with page_title=request.current_page.get_title page_url=request.current_page.get_absolute_url %}
   </div>
 
-  <div class="blogpost-detail__categories">
-    {% with form_factor="tag" %}
-      {% placeholder "categories" or %}
-        <p class="blogpost-detail__categories__empty">
-          {% trans "No associated categories" %}
-        </p>
-      {% endplaceholder %}
-    {% endwith %}
-  </div>
+  {% with form_factor="tag" %}
+    {% page_placeholder "categories" current_page as blogpost_categories_content %}
+    {% if blogpost_categories_content %}
+    <div class="blogpost-detail__categories">
+      {{ blogpost_categories_content }}
+    </div>
+    {% endif %}
+  {% endwith %}
 
   <div class="blogpost-detail__cover">
     {% placeholder "cover" or %}
-      <p class="blogpost-detail__cover__empty">
-        {% trans "No cover" %}
-      </p>
+      <p class="blogpost-detail__cover__empty">{% trans "Cover" %}</p>
     {% endplaceholder %}
   </div>
 

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -2,15 +2,19 @@
 {% load cms_tags i18n %}
 
 {% block content %}{% spaceless %}
-{% with category=current_page.category header_level=2 %}
+{% with category=current_page.category header_level=2 blogposts=current_page.category.get_blogposts courses=current_page.category.get_courses %}
 <div class="category-detail">
   <div class="category-detail__banner">
-    {% placeholder "banner" %}
+    {% placeholder "banner" or %}
+      <div class="category-detail__banner__empty">{% trans "Banner" %}</div>
+    {% endplaceholder %}
   </div>
 
   <div class="category-detail__logo">
     {% with width=216 height=120 %}
-      {% placeholder "logo" %}
+      {% placeholder "logo" or %}
+        <div class="category-detail__logo__empty">{% trans "Logo" %}</div>
+      {% endplaceholder %}
     {% endwith %}
   </div>
 
@@ -23,10 +27,10 @@
   </div>
 </div>
 
-
+{% if blogposts %}
 <div class="blogpost-glimpse-list">
   <h2 class="blogpost-glimpse-list__title">{% trans "Related news" %}</h2>
-  {% for blogpost in category.get_blogposts %}
+  {% for blogpost in blogposts %}
     {# If the current page is a draft, show draft courses with a class annotation for styling #}
     {% if current_page.publisher_is_draft %}
       {% if blogpost.check_publication is True %}
@@ -45,15 +49,17 @@
       </a>
     {% endif %}
   {% empty %}
-    <p class="blogpost-glimpse blogpost-glimpse--empty">
+    <div class="blogpost-glimpse blogpost-glimpse--empty">
       {% trans "No associated blogposts" %}
-    </p>
+    </div>
   {% endfor %}
 </div>
+{% endif %}
 
+{% if courses %}
 <div class="course-glimpse-list">
   <h2 class="course-glimpse-list__title">{% trans "Related courses" %}</h2>
-  {% for course in category.get_courses %}
+  {% for course in courses %}
     {# If the current page is a draft, show draft courses with a class annotation for styling #}
     {% if current_page.publisher_is_draft %}
       {% if course.check_publication is True %}
@@ -72,11 +78,12 @@
       </a>
     {% endif %}
   {% empty %}
-    <p class="course-glimpse course-glimpse--empty">
+    <div class="course-glimpse course-glimpse--empty">
       {% trans "No associated courses" %}
-    </p>
+    </div>
   {% endfor %}
 </div>
+{% endif %}
 
 {% endwith %}
 {% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -51,14 +51,27 @@
       <div class="course-detail__aside__cover">
         {% if current_page.publisher_is_draft %}
           {% placeholder "course_cover" or %}
-          <p>{% trans 'Add an image for course cover on its glimpse.' %}</p>
+          <p class="course-detail__aside__cover__empty">{% trans 'Add an image for course cover on its glimpse.' %}</p>
           {% endplaceholder %}
         {% endif %}
       </div>
 
-      <div class="course-detail__aside__main-org-logo">
-        {% include "courses/cms/fragment_organization_main_logo.html" with organization=course.get_main_organization %}
-      </div>
+      {% with main_organization=course.get_main_organization %}
+        {% if main_organization %}
+          {% if current_page.publisher_is_draft %}
+              {% if main_organization.check_publication is True %}
+                  {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension.extended_object %}
+              {% else %}
+                  {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.extended_object %}
+              {% endif %}
+          {# If the current page is the published version, show only the organizations that are published #}
+          {% elif main_organization.check_publication is True %}
+              {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension.extended_object %}
+          {% endif %}
+        {% else %}
+          {% include "courses/cms/fragment_organization_main_logo.html" with organization=None %}
+        {% endif %}
+      {% endwith %}
 
       <div class="course-detail__aside__social-networks">
         {% include "social-networks/course-badges.html" with page_title=request.current_page.get_title page_url=request.current_page.get_absolute_url %}
@@ -102,7 +115,7 @@
           {% endif %}
         </div>
         {% empty %}
-          {% trans "No associated course runs" %}
+          <div class="course-detail__aside__run__empty">{% trans "No associated course runs" %}</div>
         {% endfor %}
       </div>
     </div>

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
@@ -2,7 +2,7 @@
 
 <div class="course-detail__content__row course-detail__content__teaser">
   {% page_placeholder "course_teaser" page or %}
-    <p>{% trans 'Add a video or teaser.' %}</p>
+    <div class="course-detail__content__row course-detail__content__teaser__empty">{% trans 'Add a video or teaser.' %}</div>
   {% endpage_placeholder %}
 </div>
 

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
@@ -1,19 +1,20 @@
-{% load cms_tags static %}{% spaceless %}
+{% load i18n cms_tags %}{% spaceless %}
+<div class="course-detail__aside__main-org-logo">
 {% if organization %}
-    {% if current_page.publisher_is_draft %}
-        {% if organization.check_publication is True %}
-            {% show_placeholder "logo" organization.public_extension.extended_object as logo %}
+    <a href="{{ organization.get_absolute_url }}" title="{{ organization.get_title }}">
+        {% show_placeholder "logo" organization as logo %}
+        {% if logo %}
+            {{ logo }}
         {% else %}
-            {% show_placeholder "logo" organization.extended_object as logo %}
+            <div class="course-detail__aside__main-org-logo__empty">
+            {% trans "Main organization" %}
+            </div>
         {% endif %}
-    {# If the current page is the published version, show only the organizations that are published #}
-    {% elif organization.check_publication is True %}
-        {% show_placeholder "logo" organization.public_extension.extended_object as logo %}
-    {% endif %}
-    {% if logo %}
-        {{ logo }}
-    {% else %}
-        <img src="{% static "images/samples/main-organization.png" %}" alt="">
-    {% endif %}
+    </a>
+{% else %}
+    <div class="course-detail__aside__main-org-logo__empty">
+    {% trans "Main organization" %}
+    </div>
 {% endif %}
+</div>
 {% endspaceless %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -6,14 +6,14 @@
 <div class="organization-detail">
   <div class="organization-detail__banner">
     {% placeholder "banner" or %}
-      <div class="organization-detail__banner__empty"></div>
+      <div class="organization-detail__banner__empty">{% trans "Banner" %}</div>
     {% endplaceholder %}
   </div>
 
   <div class="organization-detail__logo">
     {% with width=216 height=120 %}
       {% placeholder "logo" or %}
-        <div class="organization-detail__logo__empty"></div>
+        <div class="organization-detail__logo__empty">{% trans "Logo" %}</div>
       {% endplaceholder %}
     {% endwith %}
   </div>
@@ -27,31 +27,37 @@
   </div>
 </div>
 
-<div class="course-glimpse-list">
-  {% for course in organization.get_courses %}
+{% with courses=organization.get_courses %}
+  {% if courses %}
+  <div class="course-glimpse-list">
+    <h2 class="course-glimpse-list__title">{% trans "Related courses" %}</h2>
+    {% for course in courses %}
 
-    {# If the current page is a draft, show draft courses with a class annotation for styling #}
-    {% if current_page.publisher_is_draft %}
-      {% if course.check_publication is True %}
-      <a class="course-glimpse course-glimpse--link" href="{{ course.public_extension.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
-      </a>
-      {% else %}
-      <a class="course-glimpse course-glimpse--link course-glimpse--draft" href="{{ course.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
-      </a>
+      {# If the current page is a draft, show draft courses with a class annotation for styling #}
+      {% if current_page.publisher_is_draft %}
+        {% if course.check_publication is True %}
+        <a class="course-glimpse course-glimpse--link" href="{{ course.public_extension.extended_object.get_absolute_url }}">
+          {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
+        </a>
+        {% else %}
+        <a class="course-glimpse course-glimpse--link course-glimpse--draft" href="{{ course.extended_object.get_absolute_url }}">
+          {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
+        </a>
+        {% endif %}
+      {# If the current course page is the published version, show only the courses that are published #}
+      {% elif course.check_publication is True %}
+        <a class="course-glimpse course-glimpse--link" href="{{ course.extended_object.get_absolute_url }}">
+          {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
+        </a>
       {% endif %}
-    {# If the current course page is the published version, show only the courses that are published #}
-    {% elif course.check_publication is True %}
-      <a class="course-glimpse course-glimpse--link" href="{{ course.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
-      </a>
-    {% endif %}
-  {% empty %}
-    <p class="course-glimpse course-glimpse--empty">
-      {% trans "No associated courses" %}
-    </p>
-  {% endfor %}
-</div>
+    {% empty %}
+      <p class="course-glimpse course-glimpse--empty">
+        {% trans "No associated courses" %}
+      </p>
+    {% endfor %}
+  </div>
+  {% endif %}
+{% endwith %}
+
 {% endwith %}
 {% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_list.html
@@ -7,9 +7,14 @@
 
     <div class="organization-list__content">
     {% for page in current_page.get_child_pages %}
+        {% show_placeholder "logo" page as logo %}
         <a class="organization-list__content__item" href="{{ page.get_absolute_url }}" title="{{ page.get_title }}" alt="{{ page.get_title }} {% trans 'logo' %}">
             <div class="organization-list__content__item__logo">
-                {% with width=216 height=120 %}{% show_placeholder "logo" page %}{% endwith %}
+                {% if logo %}
+                {% with width=216 height=120 %}{{ logo }}{% endwith %}
+                {% else %}
+                <div class="organization-list__content__item__logo__empty">{% trans "Logo" %}</div>
+                {% endif %}
             </div>
             <div class="organization-list__content__item__title">
                 {{ page.get_title }}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -10,14 +10,19 @@
     {% with header_level=2 %}
       <div class="person-detail__card__media">
         {% with width=216 height=120 %}
-          {% placeholder "portrait" %}
+          {% placeholder "portrait" or %}
+            <div class="person-detail__card__media__empty">{% trans "Portrait" %}</div>
+          {% endplaceholder %}
         {% endwith %}
       </div>
 
       <div class="person-detail__card__content">
         <div class="person-detail__card__content__wrapper">
-        {% placeholder "resume" %}
-        {% placeholder "maincontent" %}
+          {% placeholder "resume" or %}
+            <p class="person-detail__card__content__wrapper__empty">{% trans "Enter your bio here..." %}</p>
+          {% endplaceholder %}
+
+          {% placeholder "maincontent" %}
         </div>
       </div>
 

--- a/src/richie/apps/courses/templates/courses/plugins/organization.html
+++ b/src/richie/apps/courses/templates/courses/plugins/organization.html
@@ -4,9 +4,18 @@
   <div class="organization-plugin-container{% if instance.check_publication is False %} organization-plugin-container--draft{% endif %}">
     <div class="organization-plugin">
       <a class="organization-plugin__body" href="{{ relevant_page.get_absolute_url }}" title="{{ relevant_page.get_title }}" alt="{{ relevant_page.get_title }} {% trans 'logo' %}">
+        <div class="organization-plugin__logo">
         {% with width=216 height=120 %}
-          {% show_placeholder "logo" relevant_page %}
+          {% show_placeholder "logo" relevant_page as logo %}
+          {% if logo %}
+              {{ logo }}
+          {% else %}
+              <div class="organization-plugin__logo__empty">
+              {% trans "Logo" %}
+              </div>
+          {% endif %}
         {% endwith %}
+        </div>
         <div class="organization-plugin__title">
           {{ relevant_page.get_title }}
         </div>


### PR DESCRIPTION
## Purpose

Empty pages must look good. More importantly, it should be obvious
how to fill them.

This is related to #542

## Proposal

This commit add some styles for media placeholders which don't have
any content, making them more consistent visually and without
perturbing layout. It cover categories, courses, blogposts,
organizations and persons.

## Previews

### Blogpost

![empty_blogpost](https://user-images.githubusercontent.com/1572165/55622147-b0d9ef80-579f-11e9-8818-623510c95f64.png)

### Category

![empty_category](https://user-images.githubusercontent.com/1572165/55630459-05886500-57b6-11e9-9c11-f2901094aa59.png)

### Course

![empty_course](https://user-images.githubusercontent.com/1572165/55622204-d8c95300-579f-11e9-8e86-f5e40658c120.png)

### Organization

![empty_org](https://user-images.githubusercontent.com/1572165/55630402-e558a600-57b5-11e9-9d60-235d5f1de4cf.png)

### Person

![empty_person](https://user-images.githubusercontent.com/1572165/55630410-e984c380-57b5-11e9-9918-26280c399306.png)

