### PR TITLE
🐳(frontend) improve build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Translations are loaded dynamically in frontend application.
+- Optimized frontend build in our official Docker image
 
 ## [1.0.0-beta.4] - 2019-04-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,10 @@ FROM python:3.7-stretch as base
 # ---- front-end builder image ----
 FROM node:10 as front-builder
 
-# FIXME: we should only copy src/frontend, but for now compiling scss files
-# requires files from the backend sources
-COPY ./src /app/src/
+# Copy frontend app sources
+COPY ./src/frontend /builder/src/frontend
 
-WORKDIR /app/src/frontend
+WORKDIR /builder/src/frontend
 
 RUN yarn install --frozen-lockfile && \
     yarn build-production && \
@@ -36,7 +35,7 @@ FROM base as back-builder
 WORKDIR /builder
 
 # Copy distributed application's statics
-COPY --from=front-builder /app/src/richie/static/richie /builder/src/richie/static/richie
+COPY --from=front-builder /builder/src/richie/static/richie /builder/src/richie/static/richie
 
 # Copy required python dependencies
 COPY setup.py setup.cfg MANIFEST.in /builder/


### PR DESCRIPTION
## Purpose

Now that we've packaged the frontend application, we no longer require to copy the whole repository sources to compile the frontend.

## Proposal

- [x] only copy what is required to build the frontend application
- [x] improve build path consistency
