### PR TITLE
Fix category selection from autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Translations are loaded dynamically in frontend application,
 - Optimized frontend build in our official Docker image.
 
-## Fixed
+### Fixed
 
 - Remove possibility to edit course title from the course run page as it breaks publishing.
+- Fix an issue that crashed the app when a category was selected in search autocomplete.
 
 ## [1.0.0-beta.4] - 2019-04-08
 

--- a/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
@@ -29,18 +29,19 @@ describe('components/SearchFilterGroup', () => {
       >
         <SearchFilterGroup
           filter={{
+            base_path: '0001',
             human_name: 'Organizations',
             name: 'organizations',
             values: [
               {
                 count: 4,
                 human_name: 'Value One',
-                key: 'P-value-1',
+                key: 'P-00010001',
               },
               {
                 count: 7,
                 human_name: 'Value Two',
-                key: 'L-value-2',
+                key: 'L-00010002',
               },
             ],
           }}

--- a/src/frontend/js/components/SearchFilterValueLeaf/SearchFilterValueLeaf.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/SearchFilterValueLeaf.spec.tsx
@@ -16,6 +16,7 @@ describe('components/SearchFilterValueLeaf', () => {
       >
         <SearchFilterValueLeaf
           filter={{
+            base_path: null,
             human_name: 'Filter name',
             name: 'filter_name',
             values: [],
@@ -44,6 +45,7 @@ describe('components/SearchFilterValueLeaf', () => {
       >
         <SearchFilterValueLeaf
           filter={{
+            base_path: null,
             human_name: 'Filter name',
             name: 'filter_name',
             values: [],
@@ -74,6 +76,7 @@ describe('components/SearchFilterValueLeaf', () => {
       >
         <SearchFilterValueLeaf
           filter={{
+            base_path: null,
             human_name: 'Filter name',
             name: 'filter_name',
             values: [],
@@ -89,7 +92,12 @@ describe('components/SearchFilterValueLeaf', () => {
 
     fireEvent.click(getByText('Human name'));
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
-      filter: { human_name: 'Filter name', name: 'filter_name', values: [] },
+      filter: {
+        base_path: null,
+        human_name: 'Filter name',
+        name: 'filter_name',
+        values: [],
+      },
       payload: '43',
       type: 'FILTER_ADD',
     });
@@ -106,6 +114,7 @@ describe('components/SearchFilterValueLeaf', () => {
       >
         <SearchFilterValueLeaf
           filter={{
+            base_path: null,
             human_name: 'Filter name',
             name: 'filter_name',
             values: [],
@@ -121,7 +130,12 @@ describe('components/SearchFilterValueLeaf', () => {
 
     fireEvent.click(getByText('Human name'));
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
-      filter: { human_name: 'Filter name', name: 'filter_name', values: [] },
+      filter: {
+        base_path: null,
+        human_name: 'Filter name',
+        name: 'filter_name',
+        values: [],
+      },
       payload: '44',
       type: 'FILTER_REMOVE',
     });

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
@@ -27,6 +27,7 @@ describe('<SearchFilterValueParent />', () => {
       >
         <SearchFilterValueParent
           filter={{
+            base_path: '00010002',
             human_name: 'Subjects',
             name: 'subjects',
             values: [],
@@ -80,6 +81,7 @@ describe('<SearchFilterValueParent />', () => {
       >
         <SearchFilterValueParent
           filter={{
+            base_path: '00010002',
             human_name: 'Subjects',
             name: 'subjects',
             values: [],
@@ -133,6 +135,7 @@ describe('<SearchFilterValueParent />', () => {
       >
         <SearchFilterValueParent
           filter={{
+            base_path: '00010002',
             human_name: 'Subjects',
             name: 'subjects',
             values: [],
@@ -190,6 +193,7 @@ describe('<SearchFilterValueParent />', () => {
       >
         <SearchFilterValueParent
           filter={{
+            base_path: '0009',
             human_name: 'Filter name',
             name: 'filter_name',
             values: [],
@@ -221,6 +225,7 @@ describe('<SearchFilterValueParent />', () => {
       >
         <SearchFilterValueParent
           filter={{
+            base_path: '0009',
             human_name: 'Filter name',
             name: 'filter_name',
             values: [],
@@ -251,6 +256,7 @@ describe('<SearchFilterValueParent />', () => {
       >
         <SearchFilterValueParent
           filter={{
+            base_path: '0009',
             human_name: 'Filter name',
             name: 'filter_name',
             values: [],
@@ -266,7 +272,12 @@ describe('<SearchFilterValueParent />', () => {
 
     fireEvent.click(getByText('Human name'));
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
-      filter: { human_name: 'Filter name', name: 'filter_name', values: [] },
+      filter: {
+        base_path: '0009',
+        human_name: 'Filter name',
+        name: 'filter_name',
+        values: [],
+      },
       payload: 'P-00040005',
       type: 'FILTER_ADD',
     });
@@ -283,6 +294,7 @@ describe('<SearchFilterValueParent />', () => {
       >
         <SearchFilterValueParent
           filter={{
+            base_path: '0009',
             human_name: 'Filter name',
             name: 'filter_name',
             values: [],
@@ -298,7 +310,12 @@ describe('<SearchFilterValueParent />', () => {
 
     fireEvent.click(getByText('Human name'));
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
-      filter: { human_name: 'Filter name', name: 'filter_name', values: [] },
+      filter: {
+        base_path: '0009',
+        human_name: 'Filter name',
+        name: 'filter_name',
+        values: [],
+      },
       payload: 'P-00040005',
       type: 'FILTER_REMOVE',
     });

--- a/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.spec.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.spec.tsx
@@ -19,11 +19,13 @@ describe('components/SearchFiltersPane', () => {
       <SearchFiltersPane
         filters={{
           categories: {
+            base_path: '0001',
             human_name: 'Categories',
             name: 'categories',
             values: [],
           },
           organizations: {
+            base_path: '0002',
             human_name: 'Organizations',
             name: 'organizations',
             values: [],

--- a/src/frontend/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -274,7 +274,7 @@ describe('components/SearchSuggestField', () => {
         },
       });
 
-      expect(mockAddFilter).toHaveBeenCalledWith(modelName.CATEGORIES, '43');
+      expect(mockAddFilter).toHaveBeenCalledWith('43');
       expect(mockSetValue).toHaveBeenCalledWith('');
       expect(mockSetSuggestions).toHaveBeenCalledWith([]);
       expect(mockLocation.href).not.toBeDefined();
@@ -287,7 +287,7 @@ describe('components/SearchSuggestField', () => {
         },
       });
 
-      expect(mockAddFilter).toHaveBeenCalledWith(modelName.ORGANIZATIONS, '44');
+      expect(mockAddFilter).toHaveBeenCalledWith('44');
       expect(mockSetValue).toHaveBeenCalledWith('');
       expect(mockSetSuggestions).toHaveBeenCalledWith([]);
       expect(mockLocation.href).not.toBeDefined();

--- a/src/frontend/js/components/SearchSuggestField/SearchSuggestField.tsx
+++ b/src/frontend/js/components/SearchSuggestField/SearchSuggestField.tsx
@@ -150,10 +150,7 @@ export const onSuggestionsFetchRequested = (
 export const onSuggestionSelected = (
   setValue: valueSetter,
   setSuggestions: suggestionsSetter,
-  addFilter: (
-    filterName: modelName.CATEGORIES | modelName.ORGANIZATIONS,
-    payload: string,
-  ) => void,
+  addFilter: (payload: string) => void,
   updateFullTextSearch: (query: string) => void,
 ) => (
   event: React.FormEvent,
@@ -167,7 +164,7 @@ export const onSuggestionSelected = (
     case modelName.ORGANIZATIONS:
     case modelName.CATEGORIES:
       // Update the search with the newly selected filter
-      addFilter(suggestion.model, String(suggestion.data.id));
+      addFilter(String(suggestion.data.id));
       // Reset the search field state: the task has been completed
       setValue('');
       setSuggestions([]);
@@ -218,14 +215,18 @@ export const SearchSuggestFieldBase = ({
       query,
       type: 'QUERY_UPDATE',
     });
-  // When the user selects a filter from one of our autocomplete APIs, we add a filter to the
-  // current search and query string parameters
-  const addFilter = (
-    filterName: modelName.CATEGORIES | modelName.ORGANIZATIONS,
-    payload: string,
-  ) => {
+
+  // Helper to add a filter to the current search and query string parameters when the user selects a
+  // filter value from one of our autocomplete APIs.
+  const addFilter = (payload: string) => {
+    // Pick the filter to update based on the payload's path: it contains the relevant filter's page path
+    // (for eg. a meta-category or the "organizations" root page)
+    const filter = Object.values(filters).find(
+      fltr => !!fltr.base_path && payload.substr(2).startsWith(fltr.base_path),
+    )!;
+
     dispatchCourseSearchParamsUpdate({
-      filter: filters[filterName],
+      filter,
       payload,
       type: 'FILTER_ADD',
     });
@@ -277,6 +278,6 @@ export const SearchSuggestFieldBase = ({
 
 /**
  * Component. Displays the main search field alon with any suggestions organized in relevant sections.
- * @param addFilter Store helper to add a new active value for a filter.
+ * @param filters Filter definitions for all the potential suggestable filters.
  */
 export const SearchSuggestField = injectIntl(SearchSuggestFieldBase);

--- a/src/frontend/js/data/useFilterValue/useFilterValue.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/useFilterValue.spec.tsx
@@ -36,6 +36,7 @@ describe('data/useFilterValue', () => {
       >
         <TestComponent
           filter={{
+            base_path: '0003',
             human_name: 'Organizations',
             name: 'organizations',
             values: [],
@@ -53,6 +54,7 @@ describe('data/useFilterValue', () => {
     toggle();
     expect(mockDispatchCourseSearchParamsAction).toHaveBeenCalledWith({
       filter: {
+        base_path: '0003',
         human_name: 'Organizations',
         name: 'organizations',
         values: [],
@@ -73,6 +75,7 @@ describe('data/useFilterValue', () => {
       >
         <TestComponent
           filter={{
+            base_path: '0003',
             human_name: 'Organizations',
             name: 'organizations',
             values: [],
@@ -90,6 +93,7 @@ describe('data/useFilterValue', () => {
     toggle();
     expect(mockDispatchCourseSearchParamsAction).toHaveBeenCalledWith({
       filter: {
+        base_path: '0003',
         human_name: 'Organizations',
         name: 'organizations',
         values: [],

--- a/src/frontend/js/types/filters.ts
+++ b/src/frontend/js/types/filters.ts
@@ -1,10 +1,30 @@
+import { Nullable } from '../utils/types';
+
+/**
+ * Filter values are specific choices that are available for a given filter, eg. `Mathematics` and `Social sciences`
+ * for `Subjects`.
+ * @property `count` — Faceted count of matching results for the filter value, given the current search parameters.
+ * @property `human_name` — Internationalized human name for the filter value.
+ * @property `key` — ID for the filter. This is the MPTT path of the CMS page for this filter value, prefixed with
+ * `P-` if it has children, or with `L-` otherwise.
+ */
 export interface FilterValue {
   count: number;
   human_name: string;
   key: string;
 }
 
+/**
+ * Filter definitions give us information on a type of filter, eg. `organizations`, `availabilities`
+ * @property `base_path` — MPTT path of the CMS page that matches the filter. This is useful here because
+ * it appears in the path the pages for all filter values that are under that filter in the taxonomy.
+ * @property `human_name` — Internationalized human name for the filter.
+ * @property `is_drilldown` — Whether the filter is limited to one active value at a time.
+ * @property `name` — Machine name for the filter (for use in API calls, query strings, etc.).
+ * @property `values` — List of (faceted) available values for the filter.
+ */
 export interface FilterDefinition {
+  base_path: Nullable<string>;
   human_name: string;
   is_drilldown?: boolean;
   name: string;


### PR DESCRIPTION
## Purpose

Selecting a category in the autocomplete suggestions caused the app to crash. This was due to a mismatch between the filters object, that contained definitions for meta-categories, and the autocomplete code, which was looking for a "category" definition.

## Proposal

This can be fixed by adding the path to filter definitions and searching in the filters object for a definition that matches the beginning of the filter we're attempting to add.


Closes #582 