### PR TITLE
🐛(layout) did remaining minor feedbacks from PR#609

### DIFF
--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -77,10 +77,6 @@
         {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
       </a>
     {% endif %}
-  {% empty %}
-    <div class="course-glimpse course-glimpse--empty">
-      {% trans "No associated courses" %}
-    </div>
   {% endfor %}
 </div>
 {% endif %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -50,10 +50,6 @@
           {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
         </a>
       {% endif %}
-    {% empty %}
-      <p class="course-glimpse course-glimpse--empty">
-        {% trans "No associated courses" %}
-      </p>
     {% endfor %}
   </div>
   {% endif %}


### PR DESCRIPTION
## Purpose

Just after PR #609 has been merged, two minor feedbacks about
useless '{% empty %}' blocks have been submitted.

## Proposal

This tiny commit just remove this useless tag inside category detail
and organizations detail templates.
