### PR TITLE
Fix webpack publicpath

### DIFF
--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -54,7 +54,10 @@ document.addEventListener('DOMContentLoaded', event => {
         }
 
         try {
-          addLocaleData(await import(`react-intl/locale-data/${localeCode}`));
+          const localeData = await import(`react-intl/locale-data/${localeCode}`);
+          // async import returns an object of getters containing the value we want. We have to fetch them
+          // by calling Object.values
+          addLocaleData(Object.values(localeData));
         } catch (e) {}
 
         let translatedMessages = null;

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
   ],
   output: {
     filename: 'index.js',
+    publicPath: '/static/richie/js/',
     path: __dirname + '/../richie/static/richie/js',
   },
 


### PR DESCRIPTION
## Purpose

public path of splitted files in generated bundle by webpack is missing so the current url is used as a prefix and chunk are never loaded.
There is an other bug, the value returned by dynamic import was not the one expected. It returns an
object having only getters to lazy load what was imported. addLocaleData
function was excepting an array so we have to rebuild it by
extracting all the value of the returned object.

Description...

- [x] fix webpack config
- [x] fix imported locale data value.
