### PR TITLE
Simplify page creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Simplify the page creation wizard by reducing possibilities and automating object relations
   based on the navigation context:
+  * Create nested categories automatically when visiting the parent category page,
   * Show button to create course runs only when visiting a course page and automatically link
     the course run to the current course,
-  * Hide button to create normal pages/subpages from wizard in sections governed by Richie,
+  * Hide button to create normal pages/subpages from wizard in sections governed by Richie.
 - Translations are loaded dynamically in frontend application,
 - Optimized frontend build in our official Docker image.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Enable parent/children filters in the filters pane in Search,
+- Add a template filter to check if a placeholder is empty,
 - Add a new "Assessment" section in the course page.
 
 ### Changed
 
+- Hide empty placeholders from the course public page,
 - Simplify the page creation wizard by reducing possibilities and automating object relations
   based on the navigation context:
   * ensure we are not creating duplicate slugs when creating a page,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Simplify the page creation wizard by reducing possibilities and automating object relations
   based on the navigation context:
-  * Automatically link courses with an organization when created from this organization's page,
-  * Create nested categories automatically when visiting the parent category page,
-  * Show button to create course runs only when visiting a course page and automatically link
+  * reduce number of fields on form to create a new course run (languages and resource_link),
+  * automatically link courses with an organization when created from this organization's page,
+  * create nested categories automatically when visiting the parent category page,
+  * show button to create course runs only when visiting a course page and automatically link
     the course run to the current course,
-  * Hide button to create normal pages/subpages from wizard in sections governed by Richie.
+  * hide button to create normal pages/subpages from wizard in sections governed by Richie.
 - Translations are loaded dynamically in frontend application,
 - Optimized frontend build in our official Docker image.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Hide button to create normal pages/subpages from wizard in sections governed by Richie,
+- Simplify the page creation wizard by reducing possibilities and automating object relations
+  based on the navigation context:
+  * Show button to create course runs only when visiting a course page and automatically link
+    the course run to the current course,
+  * Hide button to create normal pages/subpages from wizard in sections governed by Richie,
 - Translations are loaded dynamically in frontend application,
 - Optimized frontend build in our official Docker image.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Simplify the page creation wizard by reducing possibilities and automating object relations
   based on the navigation context:
+  * Automatically link courses with an organization when created from this organization's page,
   * Create nested categories automatically when visiting the parent category page,
   * Show button to create course runs only when visiting a course page and automatically link
     the course run to the current course,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Enable parent/children filters in the filters pane in Search.
+- Enable parent/children filters in the filters pane in Search,
+- Add a new "Assessment" section in the course page.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Simplify the page creation wizard by reducing possibilities and automating object relations
   based on the navigation context:
-  * reduce number of fields on form to create a new course run (languages and resource_link),
+  * reduce number of fields on form to create a new course run (remove languages and
+    resource_link) and add a checkbox to easily snapshot the course when creating the course run,
   * automatically link courses with an organization when created from this organization's page,
   * create nested categories automatically when visiting the parent category page,
   * show button to create course runs only when visiting a course page and automatically link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Simplify the page creation wizard by reducing possibilities and automating object relations
   based on the navigation context:
+  * ensure we are not creating duplicate slugs when creating a page,
   * reduce number of fields on form to create a new course run (remove languages and
     resource_link) and add a checkbox to easily snapshot the course when creating the course run,
   * automatically link courses with an organization when created from this organization's page,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Translations are loaded dynamically in frontend application,
 - Optimized frontend build in our official Docker image.
 
+## Fixed
+
+- Remove possibility to edit course title from the course run page as it breaks publishing.
+
 ## [1.0.0-beta.4] - 2019-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Translations are loaded dynamically in frontend application.
+- Hide button to create normal pages/subpages from wizard in sections governed by Richie,
+- Translations are loaded dynamically in frontend application,
 - Optimized frontend build in our official Docker image.
 
 ## [1.0.0-beta.4] - 2019-04-08

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -330,7 +330,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
             "plugins": ["VideoPlayerPlugin", "PicturePlugin"],
             "limits": {"VideoPlayerPlugin": 1, "PicturePlugin": 1},
         },
-        "courses/cms/course_detail.html course_syllabus": {
+        "courses/cms/course_detail.html course_description": {
             "name": _("About the course"),
             "plugins": ["CKEditorPlugin"],
         },

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -372,6 +372,10 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
             "name": _("Organizations"),
             "plugins": ["OrganizationPlugin"],
         },
+        "courses/cms/course_detail.html course_assessment": {
+            "name": _("Assessment and Certification"),
+            "plugins": ["CKEditorPlugin"],
+        },
         # Organization detail
         "courses/cms/organization_detail.html banner": {
             "name": _("Banner"),

--- a/src/richie/apps/core/management/commands/create_demo_site.py
+++ b/src/richie/apps/core/management/commands/create_demo_site.py
@@ -400,7 +400,7 @@ def create_demo_site():
                 organizations, NB_COURSES_ORGANIZATION_RELATIONS
             ),
             fill_texts=[
-                "course_syllabus",
+                "course_description",
                 "course_format",
                 "course_prerequisites",
                 "course_plan",

--- a/src/richie/apps/courses/admin.py
+++ b/src/richie/apps/courses/admin.py
@@ -1,10 +1,9 @@
 """
 Courses application admin
 """
-import time
-
 from django.conf.urls import url
 from django.contrib import admin
+from django.core.exceptions import PermissionDenied
 from django.db import models, transaction
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
 from django.utils.decorators import method_decorator
@@ -13,14 +12,14 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_POST
 
 from cms.admin.placeholderadmin import FrontendEditableAdminMixin
-from cms.api import Page, create_title
+from cms.api import Page
 from cms.extensions import PageExtensionAdmin
-from cms.utils import page_permissions
 from cms.utils.admin import jsonify_request
 from parler.admin import TranslatableAdmin
 
 from .fields import CourseRunSplitDateTimeField
 from .forms import LicenceFormAdmin
+from .helpers import snapshot_course
 from .models import Course, CourseRun, Licence, Organization, Person, PersonTitle
 from .widgets import CourseRunSplitDateTimeWidget
 
@@ -67,72 +66,13 @@ class CourseAdmin(PageExtensionAdmin):
             )
         except Page.DoesNotExist:
             return jsonify_request(
-                HttpResponseBadRequest(
-                    force_text(_("Error! Course could not be found."))
-                )
+                HttpResponseBadRequest(force_text(_("Course could not be found.")))
             )
 
-        # If the page has a parent that is a course page, it is a snapshot and should therefore
-        # not be allowed to be itself snapshotted.
-        if page.parent_page:
-            try:
-                page.parent_page.course
-            except Course.DoesNotExist:
-                pass
-            else:
-                return jsonify_request(
-                    HttpResponseForbidden(
-                        force_text(_("Error! You can't snapshot a snapshot."))
-                    )
-                )
-
-        site = page.node.site
-
-        # User can only snapshot pages he can see
-        can_snapshot = page_permissions.user_can_change_page(request.user, page, site)
-
-        if can_snapshot:
-            # User can only snapshot a page if he has the permission to add a page under it.
-            can_snapshot = page_permissions.user_can_add_subpage(
-                request.user, page, site
-            )
-
-        if not can_snapshot:
-            return jsonify_request(
-                HttpResponseForbidden(
-                    force_text(
-                        _("Error! You don't have permissions to snapshot this page.")
-                    )
-                )
-            )
-
-        # Copy the page as its own child with its extension.
-        # Titles are set to a timestamp in each language of the original page
-        new_page = page.copy(
-            site, parent_node=page.node, translations=False, extensions=True
-        )
-
-        # The snapshot title and slug is set to a timestamp of the time of snapshot. It is
-        # published only in languages for which the original course page was published.
-        for language in page.get_languages():
-            base = page.get_path(language)
-            timestamp = str(int(time.time()))
-            snapshot_title = _("Snapshot of {:s}").format(page.get_title(language))
-            create_title(
-                language=language,
-                menu_title=timestamp,
-                title="{:s} - {:s}".format(timestamp, snapshot_title),
-                slug=timestamp,
-                path="{:s}/{:s}".format(base, timestamp) if base else timestamp,
-                page=new_page,
-            )
-            if page.is_published(language) is True:
-                new_page.publish(language)
-
-        # Move the existing course run subpages as children of the snapshot
-        # Their publication status will be respected
-        for subpage in page.get_child_pages().filter(courserun__isnull=False):
-            subpage.move_page(new_page.node, position="last-child")
+        try:
+            new_page = snapshot_course(page, request.user, simulate_only=False)
+        except PermissionDenied as context:
+            return jsonify_request(HttpResponseForbidden(force_text(context)))
 
         return JsonResponse({"id": new_page.course.id})
 

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -2,7 +2,6 @@
 CMS Wizard to add a course page
 """
 from django import forms
-from django.conf import settings
 from django.template.defaultfilters import slugify
 from django.utils.functional import cached_property
 from django.utils.translation import get_language
@@ -222,15 +221,6 @@ class CourseRunWizardForm(BaseWizardForm):
     A related CourseRun model is created for each course run page.
     """
 
-    languages = forms.MultipleChoiceField(
-        required=True,
-        label=_("Languages"),
-        choices=settings.ALL_LANGUAGES,
-        help_text=_(
-            "Select all the languages in which the course content is available."
-        ),
-    )
-    resource_link = forms.URLField(label=_("Resource link"), required=False)
 
     model = CourseRun
 
@@ -261,11 +251,7 @@ class CourseRunWizardForm(BaseWizardForm):
         This method creates the associated course run page extension.
         """
         page = super().save()
-        CourseRun.objects.create(
-            extended_object=page,
-            resource_link=self.cleaned_data["resource_link"],
-            languages=self.cleaned_data["languages"],
-        )
+        CourseRun.objects.create(extended_object=page, languages=[get_language()])
         return page
 
 

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -110,10 +110,10 @@ class BaseWizardForm(forms.Form):
         if cleaned_data.get("title") and not cleaned_data.get("slug"):
             cleaned_data["slug"] = slugify(cleaned_data["title"])[:200]
 
-        # Check that the length of the slug is compatible with its parent page:
-        #  a page `path` is limited to 255 chars, therefore the course page slug should
-        # always be shorter than (255 - length of parent page path - 1 character for the "/")
         if self.parent_page:
+            # Check that the length of the slug is compatible with its parent page:
+            #  a page `path` is limited to 255 chars, therefore the course page slug should
+            # always be shorter than (255 - length of parent page path - 1 character for the "/")
             length = len(self.parent_page.get_path()) + 1 + len(cleaned_data["slug"])
             if length > 255:
                 raise forms.ValidationError(
@@ -126,6 +126,15 @@ class BaseWizardForm(forms.Form):
                             )
                         ]
                     }
+                )
+
+            if (
+                self.parent_page.get_child_pages()
+                .filter(title_set__slug=cleaned_data["slug"])
+                .exists()
+            ):
+                raise forms.ValidationError(
+                    {"slug": [_("This slug is already in use")]}
                 )
 
         return cleaned_data

--- a/src/richie/apps/courses/helpers.py
+++ b/src/richie/apps/courses/helpers.py
@@ -1,7 +1,82 @@
 """
 Helpers that can be useful throughout Richie's courses app
 """
+import time
+
+from django.core.exceptions import PermissionDenied
+from django.utils.translation import ugettext_lazy as _
+
+from cms.api import create_title
+from cms.utils import page_permissions
+
 from .factories import CategoryFactory
+from .models import Course
+
+
+def snapshot_course(page, user, simulate_only=False):
+    """
+    Snapshotting a course is making a copy of the course page with all its permissions and
+    extensions, and placing the copy as the first child of the page being snapshotted, then
+    moving all the course run of the page being snapshotted as children of the new snapshot
+    so we keep record of the course as it was when these course runs were played.
+    """
+    assert page.publisher_is_draft is True
+
+    # If the page has a parent that is a course page, it is a snapshot and should therefore
+    # not be allowed to be itself snapshotted.
+    if page.parent_page:
+        try:
+            page.parent_page.course
+        except Course.DoesNotExist:
+            pass
+        else:
+            raise PermissionDenied(_("You can't snapshot a snapshot."))
+
+    site = page.node.site
+
+    # User can only snapshot pages he can see
+    can_snapshot = page_permissions.user_can_change_page(user, page, site)
+
+    if can_snapshot:
+        # User can only snapshot a page if he has the permission to add a page under it.
+        can_snapshot = page_permissions.user_can_add_subpage(user, page, site)
+
+    if not can_snapshot:
+        raise PermissionDenied(
+            _("You don't have sufficient permissions to snapshot this page.")
+        )
+    if simulate_only:
+        return None
+
+    # Copy the page as its own child with its extension.
+    # Titles are set to a timestamp in each language of the original page
+    snapshot_page = page.copy(
+        site, parent_node=page.node, translations=False, extensions=True
+    )
+
+    # The snapshot title and slug is set to a timestamp of the time of snapshot. It is
+    # published only in languages for which the original course page was published.
+    for language in page.get_languages():
+        base = page.get_path(language)
+        timestamp = str(int(time.time()))
+        snapshot_title = _("Snapshot of {:s}").format(page.get_title(language))
+        create_title(
+            language=language,
+            menu_title=timestamp,
+            title="{:s} - {:s}".format(timestamp, snapshot_title),
+            slug=timestamp,
+            path="{:s}/{:s}".format(base, timestamp) if base else timestamp,
+            page=snapshot_page,
+        )
+        if page.is_published(language) is True:
+            snapshot_page.publish(language)
+
+    # Move the existing course run subpages as children of the snapshot
+    # Their publication status will be respected
+    for subpage in page.get_child_pages().filter(courserun__isnull=False):
+        subpage.move_page(snapshot_page.node, position="last-child")
+
+    return snapshot_page
 
 
 # pylint: disable=too-many-arguments

--- a/src/richie/apps/courses/models/__init__.py
+++ b/src/richie/apps/courses/models/__init__.py
@@ -7,3 +7,8 @@ from .category import *
 from .course import *
 from .organization import *
 from .person import *
+
+ROOT_REVERSE_IDS = [
+    model.ROOT_REVERSE_ID
+    for model in [BlogPost, Category, Course, Organization, Person]
+]

--- a/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
@@ -18,9 +18,9 @@
   <div class="course-detail__content course-detail__content--one">
     <h1 class="course-detail__content__title">
       {% if request.current_page.parent_page.parent_page.course %}
-        {% render_model request.current_page.parent_page.parent_page "title" %}
+        {{ current_page.parent_page.parent_page.get_title }}
       {% else %}
-        {% render_model request.current_page.parent_page "title" %}
+        {{ current_page.parent_page.get_title }}
       {% endif %}
       <br />
       {% render_model request.current_page "title" %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
@@ -60,6 +60,17 @@
   {% endpage_placeholder %}
 </div>
 
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_assessment" %}
+<div class="course-detail__content__row course-detail__content__assessment">
+  <h2 class="course-detail__content__row__title">{% trans 'Assessment and certification' %}</h2>
+  {% page_placeholder "course_assessment" page or %}
+    <p class="course-detail__content__assessment__placeholder">
+      {% trans "How is progress evaluated and/or certified?" %}
+    </p>
+  {% endpage_placeholder %}
+</div>
+{% endif %}
+
 <div class="course-detail__content__row course-detail__content__license">
   <h2 class="course-detail__content__row__title course-detail__content__license__title">{% trans 'License' %}</h2>
 

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
@@ -6,6 +6,7 @@
   {% endpage_placeholder %}
 </div>
 
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_description" %}
 <div class="course-detail__content__row course-detail__content__description">
   <h2 class="course-detail__content__row__title">{% trans 'About the course...' %}</h2>
   {% with header_level=3 %}
@@ -14,51 +15,63 @@
     {% endpage_placeholder %}
   {% endwith %}
 </div>
+{% endif %}
 
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_format" %}
 <div class="course-detail__content__row course-detail__content__format">
   <h2 class="course-detail__content__row__title">{% trans 'Format' %}</h2>
   {% page_placeholder "course_format" page or %}
     <p>{% trans 'How is the course structured?' %}</p>
   {% endpage_placeholder %}
 </div>
+{% endif %}
 
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_prerequisites" %}
 <div class="course-detail__content__row course-detail__content__prerequisites">
   <h2 class="course-detail__content__row__title">{% trans 'Prerequisites' %}</h2>
   {% page_placeholder "course_prerequisites" page or %}
     <p>{% trans 'What are the prerequisites to follow this course?' %}</p>
   {% endpage_placeholder %}
 </div>
+{% endif %}
 
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_plan" %}
 <div class="course-detail__content__row course-detail__content__plan">
   <h2 class="course-detail__content__row__title">{% trans 'Course plan' %}</h2>
   {% page_placeholder "course_plan" page or %}
-  <p>{% trans 'Enter here the detailed course plan' %}</p>
+    <p>{% trans 'Enter here the detailed course plan.' %}</p>
   {% endpage_placeholder %}
-</div>
-
-{% page_placeholder "course_information" page as course_information %}
-{% if course_information or page.publisher_is_draft %}
-<div class="course-detail__content__row course-detail__content__information">
-  {{ course_information }}
 </div>
 {% endif %}
 
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_information" %}
+<div class="course-detail__content__row course-detail__content__information">
+  {% page_placeholder "course_information" page %}
+</div>
+{% endif %}
+
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_team" %}
 <div class="course-detail__content__row course-detail__content__team">
-  <h2 class="course-detail__content__row__title course-detail__content__team__title">{% trans 'Course team' %}</h2>
+  <h2 class="course-detail__content__row__title course-detail__content__team__title">
+    {% trans 'Course team' %}
+  </h2>
   {% with header_level=3 %}
-      {% page_placeholder "course_team" page or %}
+    {% page_placeholder "course_team" page or %}
       <p>{% trans 'Who are the teachers in the course team?' %}</p>
-      {% endpage_placeholder %}
+    {% endpage_placeholder %}
   {% endwith %}
 </div>
+{% endif %}
 
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_organizations" %}
 <div class="course-detail__content__row course-detail__content__organizations">
   {% page_placeholder "course_organizations" page or %}
     <p class="course-detail__content__organizations__placeholder">
-      {% trans "No associated organizations" %}
+      {% trans "What are the organizations publishing this course?" %}
     </p>
   {% endpage_placeholder %}
 </div>
+{% endif %}
 
 {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_assessment" %}
 <div class="course-detail__content__row course-detail__content__assessment">
@@ -77,9 +90,9 @@
   <div class="course-detail__content__license__item">
     <h3 class="course-detail__content__license__item__title">{% trans 'License for the course content' %}</h3>
     {% with header_level=4 %}
-        {% page_placeholder "course_license_content" page or %}
+      {% page_placeholder "course_license_content" page or %}
         <p>{% trans 'What is the license for the course content?' %}</p>
-        {% endpage_placeholder %}
+      {% endpage_placeholder %}
     {% endwith %}
   </div>
 

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
@@ -6,10 +6,10 @@
   {% endpage_placeholder %}
 </div>
 
-<div class="course-detail__content__row course-detail__content__syllabus">
-  <h2 class="course-detail__content__row__title">{% trans 'About the course' %}</h2>
+<div class="course-detail__content__row course-detail__content__description">
+  <h2 class="course-detail__content__row__title">{% trans 'About the course...' %}</h2>
   {% with header_level=3 %}
-    {% page_placeholder "course_syllabus" page or %}
+    {% page_placeholder "course_description" page or %}
       <p>{% trans 'Enter here a short description of your course.' %}</p>
     {% endpage_placeholder %}
   {% endwith %}

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -16,6 +16,7 @@ from cms.utils.placeholder import validate_placeholder_name
 register = template.Library()
 
 
+@register.tag("page_placeholder")
 class PagePlaceholder(Placeholder):
     """
     This template node is used to output page content and
@@ -94,4 +95,12 @@ class PagePlaceholder(Placeholder):
         return content
 
 
-register.tag("page_placeholder", PagePlaceholder)
+@register.filter("is_empty_placeholder")
+def is_empty_placeholder(page, slot):
+    """A template filter to determine if a placeholder is empty.
+
+    This is useful when we don't want to include any wrapper markup in our template unless
+    the placeholder unless it actually contains plugins.
+    """
+    placeholder = page.placeholders.get(slot=slot)
+    return not placeholder.cmsplugin_set.exists()

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -366,13 +366,13 @@ class CoursesIndexer:
             cover_image.height = COURSES_COVER_IMAGE_HEIGHT
             cover_images[cover_image.cmsplugin_ptr.language] = cover_image.img_src
 
-        # Prepare syllabus texts
-        syllabus_texts = defaultdict(list)
+        # Prepare description texts
+        descriptions = defaultdict(list)
         for simple_text in SimpleText.objects.filter(
             cmsplugin_ptr__placeholder__page=course.extended_object,
-            cmsplugin_ptr__placeholder__slot="course_syllabus",
+            cmsplugin_ptr__placeholder__slot="course_description",
         ):
-            syllabus_texts[simple_text.cmsplugin_ptr.language].append(simple_text.body)
+            descriptions[simple_text.cmsplugin_ptr.language].append(simple_text.body)
 
         # Prepare categories, making sure we get title information for categories
         # in the same query
@@ -453,7 +453,7 @@ class CoursesIndexer:
             },
             "course_runs": course_runs,
             "cover_image": cover_images,
-            "description": {l: " ".join(st) for l, st in syllabus_texts.items()},
+            "description": {l: " ".join(st) for l, st in descriptions.items()},
             "is_new": len(course_runs) == 1,
             "organizations": [
                 ES_INDICES.organizations.get_es_id(o.extended_object)

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -84,7 +84,7 @@ class OrganizationsIndexer:
             logo_image.height = defaults.ORGANIZATIONS_LOGO_IMAGE_HEIGHT
             logo_images[logo_image.cmsplugin_ptr.language] = logo_image.img_src
 
-        # Get syllabus texts
+        # Get description texts
         description = defaultdict(list)
         for simple_text in SimpleText.objects.filter(
             cmsplugin_ptr__placeholder__page=organization.extended_object,

--- a/tests/apps/courses/test_admin_page_snapshot.py
+++ b/tests/apps/courses/test_admin_page_snapshot.py
@@ -139,7 +139,7 @@ class SnapshotPageAdminTestCase(CMSTestCase):
             content,
             {
                 "status": 403,
-                "content": "Error! You don't have permissions to snapshot this page.",
+                "content": "You don't have sufficient permissions to snapshot this page.",
             },
         )
         # No additional courses should have been created
@@ -170,7 +170,7 @@ class SnapshotPageAdminTestCase(CMSTestCase):
             content,
             {
                 "status": 403,
-                "content": "Error! You don't have permissions to snapshot this page.",
+                "content": "You don't have sufficient permissions to snapshot this page.",
             },
         )
         # No additional courses should have been created
@@ -235,7 +235,7 @@ class SnapshotPageAdminTestCase(CMSTestCase):
             content,
             {
                 "status": 403,
-                "content": "Error! You don't have permissions to snapshot this page.",
+                "content": "You don't have sufficient permissions to snapshot this page.",
             },
         )
         # No additional courses should have been created
@@ -294,7 +294,7 @@ class SnapshotPageAdminTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         self.assertEqual(
-            content, {"status": 403, "content": "Error! You can't snapshot a snapshot."}
+            content, {"status": 403, "content": "You can't snapshot a snapshot."}
         )
 
     @override_settings(CMS_PERMISSION=False)
@@ -316,5 +316,5 @@ class SnapshotPageAdminTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         self.assertEqual(
-            content, {"status": 400, "content": "Error! Course could not be found."}
+            content, {"status": 400, "content": "Course could not be found."}
         )

--- a/tests/apps/courses/test_cms_wizards_blogpost.py
+++ b/tests/apps/courses/test_cms_wizards_blogpost.py
@@ -9,6 +9,7 @@ from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.cms_wizards import BlogPostWizardForm
+from richie.apps.courses.factories import BlogPostFactory
 from richie.apps.courses.models import BlogPost
 
 
@@ -174,6 +175,28 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             form.errors["slug"],
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
+
+    def test_cms_wizards_blogpost_submit_form_slug_duplicate(self):
+        """
+        Trying to create a blog post with a slug that would lead to a duplicate path should
+        raise a validation error.
+        """
+        # A parent page should pre-exist
+        parent_page = create_page(
+            "News",
+            "richie/single_column.html",
+            "en",
+            reverse_id=BlogPost.ROOT_REVERSE_ID,
+        )
+        # Create an existing page with a known slug
+        BlogPostFactory(page_parent=parent_page, page_title="My title")
+
+        # Submit a title that will lead to the same slug
+        data = {"title": "my title"}
+
+        form = BlogPostWizardForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {"slug": ["This slug is already in use"]})
 
     def test_cms_wizards_blogpost_parent_page_should_exist(self):
         """

--- a/tests/apps/courses/test_cms_wizards_blogpost.py
+++ b/tests/apps/courses/test_cms_wizards_blogpost.py
@@ -15,15 +15,17 @@ from richie.apps.courses.models import BlogPost
 class BlogPostCMSWizardTestCase(CMSTestCase):
     """Testing the wizard that is used to create new blogpost pages from the CMS"""
 
-    def test_cms_wizards_blogpost_create_wizards_list(self):
+    def test_cms_wizards_blogpost_create_wizards_list_superuser(self):
         """
         The wizard to create a new blogpost page should be present on the wizards list page
+        for a superuser.
         """
+        page = create_page("page", "richie/single_column.html", "en")
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
         # Let the authorized user get the page with all wizards listed
-        url = reverse("cms_wizard_create")
+        url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
         response = self.client.get(url)
 
         # Check that our wizard to create blogposts is on this page
@@ -34,6 +36,22 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             html=True,
         )
         self.assertContains(response, "<strong>New blog post</strong>", html=True)
+
+    def test_cms_wizards_blogpost_create_wizards_list_staff(self):
+        """
+        The wizard to create a new blogpost page should not be present on the wizards list page
+        for a simple staff user.
+        """
+        page = create_page("page", "richie/single_column.html", "en")
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Let the authorized user get the page with all wizards listed
+        url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
+        response = self.client.get(url)
+
+        # Check that our wizard to create blogposts is not on this page
+        self.assertNotContains(response, "new blog post", status_code=200, html=True)
 
     def test_cms_wizards_blogpost_submit_form(self):
         """

--- a/tests/apps/courses/test_cms_wizards_category.py
+++ b/tests/apps/courses/test_cms_wizards_category.py
@@ -15,18 +15,20 @@ from richie.apps.courses.models import Category
 class CategoryCMSWizardTestCase(CMSTestCase):
     """Testing the wizard that is used to create new category pages from the CMS"""
 
-    def test_cms_wizards_category_create_wizards_list(self):
+    def test_cms_wizards_category_create_wizards_list_superuser(self):
         """
         The wizard to create a new category page should be present on the wizards list page
+        for a superuser.
         """
+        page = create_page("page", "richie/single_column.html", "en")
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
         # Let the authorized user get the page with all wizards listed
-        url = reverse("cms_wizard_create")
+        url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
         response = self.client.get(url)
 
-        # Check that our wizard to create courses is on this page
+        # Check that our wizard to create categories is on this page
         self.assertContains(
             response,
             '<span class="info">Create a new category page</span>',
@@ -34,6 +36,22 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             html=True,
         )
         self.assertContains(response, "<strong>New category page</strong>", html=True)
+
+    def test_cms_wizards_category_create_wizards_list_staff(self):
+        """
+        The wizard to create a new category page should not be present on the wizards list page
+        for a simple staff user.
+        """
+        page = create_page("page", "richie/single_column.html", "en")
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        # Let the authorized user get the page with all wizards listed
+        url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
+        response = self.client.get(url)
+
+        # Check that our wizard to create categories is not on this page
+        self.assertNotContains(response, "new category", status_code=200, html=True)
 
     def test_cms_wizards_category_submit_form(self):
         """

--- a/tests/apps/courses/test_cms_wizards_category.py
+++ b/tests/apps/courses/test_cms_wizards_category.py
@@ -216,6 +216,29 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
 
+    def test_cms_wizards_category_submit_form_slug_duplicate(self):
+        """
+        Trying to create a category with a slug that would lead to a duplicate path should
+        raise a validation error.
+        """
+        # A parent page should pre-exist
+        parent_page = create_page(
+            "Categories",
+            "richie/single_column.html",
+            "en",
+            reverse_id=Category.ROOT_REVERSE_ID,
+        )
+        # Create an existing page with a known slug
+        CategoryFactory(page_parent=parent_page, page_title="My title")
+
+        # Submit a title that will lead to the same slug
+        data = {"title": "my title"}
+
+        form = CategoryWizardForm(data=data)
+        form.page = parent_page
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {"slug": ["This slug is already in use"]})
+
     def test_cms_wizards_category_root_page_should_exist(self):
         """
         We should not be able to create a category page if the root page does not exist

--- a/tests/apps/courses/test_cms_wizards_course.py
+++ b/tests/apps/courses/test_cms_wizards_course.py
@@ -9,7 +9,7 @@ from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.cms_wizards import CourseWizardForm
-from richie.apps.courses.factories import OrganizationFactory
+from richie.apps.courses.factories import CourseFactory, OrganizationFactory
 from richie.apps.courses.models import Course, OrganizationPluginModel
 
 
@@ -235,6 +235,28 @@ class CourseCMSWizardTestCase(CMSTestCase):
             form.errors["slug"],
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
+
+    def test_cms_wizards_course_submit_form_slug_duplicate(self):
+        """
+        Trying to create a course with a slug that would lead to a duplicate path should
+        raise a validation error.
+        """
+        # A parent page should pre-exist
+        parent_page = create_page(
+            "Courses",
+            "richie/single_column.html",
+            "en",
+            reverse_id=Course.ROOT_REVERSE_ID,
+        )
+        # Create an existing page with a known slug
+        CourseFactory(page_parent=parent_page, page_title="My title")
+
+        # Submit a title that will lead to the same slug
+        data = {"title": "my title"}
+
+        form = CourseWizardForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {"slug": ["This slug is already in use"]})
 
     def test_cms_wizards_course_parent_page_should_exist(self):
         """

--- a/tests/apps/courses/test_cms_wizards_organization.py
+++ b/tests/apps/courses/test_cms_wizards_organization.py
@@ -17,15 +17,17 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
     Unit test suite to validate the behavior of the Wizard to create organization pages
     """
 
-    def test_cms_wizards_organization_create_wizards_list(self):
+    def test_cms_wizards_organization_create_wizards_list_superuser(self):
         """
         The wizard to create a new Organization page should be present on the wizards list page
+        for a superuser.
         """
+        page = create_page("page", "richie/single_column.html", "en")
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
         # Let the authorized user get the page with all wizards listed
-        url = reverse("cms_wizard_create")
+        url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
         response = self.client.get(url)
 
         # Check that our wizard to create organizations is on this page
@@ -38,6 +40,22 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
         self.assertContains(
             response, "<strong>New Organization page</strong>", html=True
         )
+
+    def test_cms_wizards_organization_create_wizards_list_staff(self):
+        """
+        The wizard to create a new Organization page should be present on the wizards list page
+        for a simple staff.
+        """
+        page = create_page("page", "richie/single_column.html", "en")
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Let the authorized user get the page with all wizards listed
+        url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
+        response = self.client.get(url)
+
+        # Check that our wizard to create organizations is on this page
+        self.assertNotContains(response, "new Organization", status_code=200, html=True)
 
     def test_cms_wizards_organization_submit_form(self):
         """

--- a/tests/apps/courses/test_cms_wizards_organization.py
+++ b/tests/apps/courses/test_cms_wizards_organization.py
@@ -9,6 +9,7 @@ from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.cms_wizards import OrganizationWizardForm
+from richie.apps.courses.factories import OrganizationFactory
 from richie.apps.courses.models import Organization
 
 
@@ -166,6 +167,28 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
             form.errors["slug"],
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
+
+    def test_cms_wizards_organization_submit_form_slug_duplicate(self):
+        """
+        Trying to create an organization with a slug that would lead to a duplicate path should
+        raise a validation error.
+        """
+        # A parent page should pre-exist
+        parent_page = create_page(
+            "Organizations",
+            "richie/single_column.html",
+            "en",
+            reverse_id=Organization.ROOT_REVERSE_ID,
+        )
+        # Create an existing page with a known slug
+        OrganizationFactory(page_parent=parent_page, page_title="My title")
+
+        # Submit a title that will lead to the same slug
+        data = {"title": "my title"}
+
+        form = OrganizationWizardForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {"slug": ["This slug is already in use"]})
 
     def test_cms_wizards_organization_parent_page_should_exist(self):
         """

--- a/tests/apps/courses/test_cms_wizards_person.py
+++ b/tests/apps/courses/test_cms_wizards_person.py
@@ -16,15 +16,17 @@ from richie.apps.courses.models import Person
 class PersonCMSWizardTestCase(CMSTestCase):
     """Testing the wizard that is used to create new person pages from the CMS"""
 
-    def test_cms_wizards_person_create_wizards_list(self):
+    def test_cms_wizards_person_create_wizards_list_superuser(self):
         """
         The wizard to create a new person page should be present on the wizards list page
+        for a superuser.
         """
+        page = create_page("page", "richie/single_column.html", "en")
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
         # Let the authorized user get the page with all wizards listed
-        url = reverse("cms_wizard_create")
+        url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
         response = self.client.get(url)
 
         # Check that our wizard to create persons is on this page
@@ -35,6 +37,22 @@ class PersonCMSWizardTestCase(CMSTestCase):
             html=True,
         )
         self.assertContains(response, "<strong>New person page</strong>", html=True)
+
+    def test_cms_wizards_person_create_wizards_list_staff(self):
+        """
+        The wizard to create a new person page should be present on the wizards list page
+        for a simple staff user.
+        """
+        page = create_page("page", "richie/single_column.html", "en")
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Let the authorized user get the page with all wizards listed
+        url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
+        response = self.client.get(url)
+
+        # Check that our wizard to create persons is not on this page
+        self.assertNotContains(response, "new person page", status_code=200, html=True)
 
     def test_cms_wizards_person_submit_form(self):
         """

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -152,15 +152,15 @@ class CoursesIndexersTestCase(TestCase):
             2, page_parent=course.extended_object, should_publish=True
         )
 
-        # Add a syllabus in several languages
+        # Add a description in several languages
         placeholder = course.public_extension.extended_object.placeholders.get(
-            slot="course_syllabus"
+            slot="course_description"
         )
         plugin_params = {"placeholder": placeholder, "plugin_type": "CKEditorPlugin"}
-        add_plugin(body="english syllabus line 1.", language="en", **plugin_params)
-        add_plugin(body="english syllabus line 2.", language="en", **plugin_params)
-        add_plugin(body="syllabus français ligne 1.", language="fr", **plugin_params)
-        add_plugin(body="syllabus français ligne 2.", language="fr", **plugin_params)
+        add_plugin(body="english description line 1.", language="en", **plugin_params)
+        add_plugin(body="english description line 2.", language="en", **plugin_params)
+        add_plugin(body="a propos français ligne 1.", language="fr", **plugin_params)
+        add_plugin(body="a propos français ligne 2.", language="fr", **plugin_params)
 
         # The results were properly formatted and passed to the consumer
         expected_course = {
@@ -205,8 +205,8 @@ class CoursesIndexersTestCase(TestCase):
             ],
             "cover_image": {"en": "123.jpg", "fr": "123.jpg"},
             "description": {
-                "en": "english syllabus line 1. english syllabus line 2.",
-                "fr": "syllabus français ligne 1. syllabus français ligne 2.",
+                "en": "english description line 1. english description line 2.",
+                "fr": "a propos français ligne 1. a propos français ligne 2.",
             },
             "is_new": False,
             "organizations": ["L-0004", "L-0006"],


### PR DESCRIPTION
## Purpose

Our support team gave a lot of feedback last week. The main point was that, because the page creation wizard proposes to create any type of page from anywhere on the site, they ended-up with wrong pages at the wrong place... They also felt that it was making things unnecessarily complicated to understand.

## Proposal

The idea of this PR is to make page creation contextual ie take into account the position on the site from which a page is created to:

- customize what buttons are shown or hidden on the page creation wizard,
- automatically place pages in the CMS tree or create plugins.

More precisely:

- [x] automatically link courses with an organization when created from this organization's page,
- [x] automatically nest a category when created from another category page (the parent),
- [x] show button to create course runs only when visiting a course page and automatically link the course run to the current course,
- [x] hide button to create normal pages/subpages from wizard in sections governed by Richie.

Other related improvements made on the basis of their feedback:

- [x] reduce number of fields on form to create a new course run (remove languages and resource_link) and add a checkbox to easily snapshot the course when creating the course run,
- [x] ensure we are not creating duplicate slugs when creating a page,
- [x] Hide empty placeholders from the course public page (done thanks to a new template filter that checks if a placeholder is empty),
- [x] Add a new "Assessment" section in the course page,
- [x] Rename the "Syllabus" section to "Description" on the course page,
- [x] Remove possibility to edit course title from the course run page as it breaks publishing.

### Related issues

Fixes https://github.com/openfun/richie/issues/607
Fixes https://github.com/openfun/richie/issues/573