### PR TITLE
🔧(pyup) ignore direct dependencies pinning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,17 +25,17 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    arrow
-    django-cms>=3.6.0
-    django-parler
-    djangocms-file
-    djangocms-googlemap
-    djangocms-link
-    djangocms-picture
-    djangocms-text-ckeditor
-    djangocms-video
-    djangorestframework
-    elasticsearch
+    arrow # pyup: ignore
+    django-cms>=3.6.0 # pyup: ignore
+    django-parler # pyup: ignore
+    djangocms-file # pyup: ignore
+    djangocms-googlemap # pyup: ignore
+    djangocms-link # pyup: ignore
+    djangocms-picture # pyup: ignore
+    djangocms-text-ckeditor # pyup: ignore
+    djangocms-video # pyup: ignore
+    djangorestframework # pyup: ignore
+    elasticsearch # pyup: ignore
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
## Purpose

During our latest refactoring of dependencies management, we thought unpinning direct dependencies would be enough for `pyup` to ignore them. We were wrong.

## Proposal

- [x] explicitly ask `pyup` to **ignore** direct dependencies pinning.