### PR TITLE
Fix statics in docker and package builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,17 +454,11 @@ jobs:
   #   * you have define both the TWINE_USERNAME & TWINE_PASSWORD secret
   #     environment variables in CircleCI UI (with your PyPI credentials)
   pypi:
-    machine: true
+    docker:
+      - image: circleci/python:3.7-stretch
     working_directory: ~/fun
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - docker-debian-images-ci-{{ .Revision }}
-      - run:
-          name: Load images to docker engine
-          command: |
-            docker load < docker/images/dev/richie.tar
       # Restore built python packages
       - attach_workspace:
           at: ~/fun
@@ -472,19 +466,11 @@ jobs:
           name: List built packages
           command: ls dist/*
       - run:
+          name: Install base requirements (twine)
+          command: pip install .[ci]
+      - run:
           name: Upload built packages to PyPI
-          command: |
-            docker-compose \
-              -p richie-ci \
-              -f docker/compose/ci/postgresql/docker-compose.yml \
-              --project-directory . \
-              run --rm --no-deps \
-                --user="$(id -u)" \
-                --volume="$PWD:/app" \
-                -e TWINE_USERNAME \
-                -e TWINE_PASSWORD \
-                app \
-                twine upload dist/*
+          command: twine upload dist/*
 
   # ---- DockerHub publication job ----
   hub:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,35 +428,24 @@ jobs:
 
   # ---- Packaging jobs ----
   package-back:
-    machine: true
+    docker:
+      - image: circleci/python:3.7-stretch
     working_directory: ~/fun
     steps:
       - checkout
+      # Ensure we restore frontend production builds in Richie's static
+      # directory
       - attach_workspace:
           at: ~/fun
-      - restore_cache:
-          keys:
-            - docker-debian-images-ci-{{ .Revision }}
-      - run:
-          name: Load images to docker engine
-          command: |
-            docker load < docker/images/dev/richie.tar
-      # Run commands using CircleCI's user and mount the app volume to have
-      # write permission on it, and thus, being able to create the package.
       - run:
           name: Build python package
-          command: |
-            docker run --rm \
-              --user="$(id -u)" \
-              --volume "$PWD:/app" \
-              "richie:${CIRCLE_SHA1}-ci" \
-              python setup.py sdist bdist_wheel
+          command: python setup.py sdist bdist_wheel
       # Persist build packages to the workspace
       - persist_to_workspace:
           root: ~/fun
           paths:
             - dist
-      # Store packages as artifacts
+      # Store packages as artifacts to download/test them
       - store_artifacts:
           path: ~/fun/dist
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,6 +432,8 @@ jobs:
     working_directory: ~/fun
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/fun
       - restore_cache:
           keys:
             - docker-debian-images-ci-{{ .Revision }}
@@ -603,6 +605,36 @@ jobs:
             - ./node_modules
           key: v5-front-dependencies-{{ checksum "yarn.lock" }}
 
+  build-front-production:
+    docker:
+      - image: circleci/node:10
+    working_directory: ~/fun/src/frontend
+    steps:
+      - checkout:
+          path: ~/fun
+      - restore_cache:
+          keys:
+            - v5-front-dependencies-{{ checksum "yarn.lock" }}
+            - v5-front-dependencies-
+      - run:
+          name: Build front-end application in production mode
+          command: yarn build-production
+      - run:
+          name: Build application styles in production mode
+          command: yarn sass-production
+      - run:
+          name: List builds
+          command: |
+            echo "== Javascript =="
+            ls ../richie/static/richie/js/*.js
+            echo "== CSS =="
+            ls ../richie/static/richie/css/*.css
+      - persist_to_workspace:
+          root: ~/fun
+          paths:
+            - src/richie/static/richie/js/*.js
+            - src/richie/static/richie/css/*.css
+
   lint-front-tslint:
     docker:
       - image: circleci/node:10
@@ -696,6 +728,12 @@ workflows:
       #
       # Build, lint and test the front-end apps
       - build-front:
+          filters:
+            tags:
+              only: /.*/
+      - build-front-production:
+          requires:
+            - build-front
           filters:
             tags:
               only: /.*/
@@ -822,6 +860,7 @@ workflows:
             - test-back-mysql
             - test-back-postgresql
             - test-alpine
+            - build-front-production
           filters:
             tags:
               only: /.*/

--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,7 @@ data
 sandbox/build
 sandbox/static/css
 src/richie/static/richie/css
+!src/richie/static/richie/css/ckeditor.css
 src/richie/static/richie/js
 
 # Font-end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Remove possibility to edit course title from the course run page as it breaks publishing.
 - Fix an issue that crashed the app when a category was selected in search autocomplete.
 - Committed CSS files are now included in the Docker image
+- The python package now includes statics build in production mode
 
 ## [1.0.0-beta.4] - 2019-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Remove possibility to edit course title from the course run page as it breaks publishing.
 - Fix an issue that crashed the app when a category was selected in search autocomplete.
+- Committed CSS files are now included in the Docker image
 
 ## [1.0.0-beta.4] - 2019-04-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,17 @@ FROM base as back-builder
 
 WORKDIR /builder
 
-# Copy distributed application's statics
-COPY --from=front-builder /builder/src/richie/static/richie /builder/src/richie/static/richie
-
 # Copy required python dependencies
 COPY setup.py setup.cfg MANIFEST.in /builder/
 COPY ./src/richie /builder/src/richie/
+
+# Copy distributed application's statics
+COPY --from=front-builder \
+    /builder/src/richie/static/richie/js/*.js \
+    /builder/src/richie/static/richie/js/
+COPY --from=front-builder \
+    /builder/src/richie/static/richie/css/main.css \
+    /builder/src/richie/static/richie/css/main.css
 
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN pip install --upgrade pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ dev =
     pytest-cov==2.6.1
     pytest-django==3.4.8
     responses==0.10.6
+ci =
     twine==1.13.0
 sandbox =
     django-configurations==2.1


### PR DESCRIPTION
## Purpose

We've detected multiple issues related to static files packaging (Docker + Python):

- `ckeditor.css` file is missing in the Docker image
- `statics` & `locale` contents are not distributed with the python package

## Proposal

- [x] add an exception to the `.dockerignorefile` for the `ckeditor.css` particular case
- [x] persist/attach frontend builds for the backend packaging
- [x] ensure locale are also packaged
