### PR TITLE
🐛(circleci) fix PyPI package upload job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,10 +479,10 @@ jobs:
           command: ls dist/*
       - run:
           name: Install base requirements (twine)
-          command: pip install .[ci]
+          command: pip install --user .[ci]
       - run:
           name: Upload built packages to PyPI
-          command: twine upload dist/*
+          command: ~/.local/bin/twine upload dist/*
 
   # ---- DockerHub publication job ----
   hub:


### PR DESCRIPTION
## Purpose

We (I mean I :grin:) forgot that CircleCI Docker images use a non-privileged user, so we need to perform a local twine install and invoke this local script.

## Proposal

- [x] install CI dependencies in the current user home directory
