### PR TITLE
Simplify Richie settings by declaring as defaults those that are unlikely to require customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Changed
+
+- Simplify search settings and provide defaults for those unlikely to be
+  customized.
+
 ## [1.0.0-beta.5] - 2019-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## Changed
 
 - Simplify Richie settings and provide defaults for those unlikely to be
-  customized.
+  customized (search, languages, plugins, general).
 
 ## [1.0.0-beta.5] - 2019-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
-- Simplify search settings and provide defaults for those unlikely to be
+- Simplify Richie settings and provide defaults for those unlikely to be
   customized.
 
 ## [1.0.0-beta.5] - 2019-04-11

--- a/env.d/ci/common
+++ b/env.d/ci/common
@@ -4,6 +4,5 @@ DJANGO_CONFIGURATION=Test
 DJANGO_SECRET_KEY=ThisIsAnExampleKeyForTestPurposeOnly
 PYTHONPATH=/app/sandbox
 
-# Elastic search
-ES_CLIENT=elasticsearch
+# Elasticsearch
 bootstrap.memory_lock=true

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -3,8 +3,5 @@ DJANGO_SETTINGS_MODULE=settings
 DJANGO_CONFIGURATION=Development
 DJANGO_SECRET_KEY=ThisIsAnExampleKeyForDevPurposeOnly
 
-# Elastic search
-ES_CLIENT=elasticsearch
-
 # Python
 PYTHONUNBUFFERED=1

--- a/env.d/test/common
+++ b/env.d/test/common
@@ -4,5 +4,3 @@ DJANGO_CONFIGURATION=Test
 DJANGO_SECRET_KEY=ThisIsAnExampleKeyForTestPurposeOnly
 PYTHONPATH=/app/sandbox
 
-# Elastic search
-ES_CLIENT=elasticsearch

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -212,9 +212,6 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
         "rest_framework",
     )
 
-    # Group to add plugin to placeholder "Content"
-    RICHIE_PLUGINS_GROUP = "Richie Plugins"
-
     LANGUAGE_CODE = "en"
 
     # Django sets `LANGUAGES` by default with all supported languages. Let's save it to a

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -51,8 +51,6 @@ class ElasticSearchMixin:
     ES_CLIENT = Elasticsearch(
         [values.Value("localhost", environ_name="ES_CLIENT", environ_prefix=None)]
     )
-    ES_CHUNK_SIZE = 500
-    ES_DEFAULT_PAGE_SIZE = 10
 
 
 class DRFMixin:

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -484,16 +484,6 @@ class Base(DRFMixin, Configuration):
         "easy_thumbnails.processors.background",
     )
 
-    RICHIE_SECTION_TEMPLATES = [
-        ("richie/section/section.html", _("Default")),
-        ("richie/section/highlighted_items.html", _("Highlighted items")),
-    ]
-
-    RICHIE_LARGEBANNER_TEMPLATES = [
-        ("richie/large_banner/large_banner.html", _("Default")),
-        ("richie/large_banner/hero-intro.html", _("Hero introduction")),
-    ]
-
     LOGGING = {
         "version": 1,
         "disable_existing_loggers": True,

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -82,10 +82,10 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
 
     * DJANGO_SENTRY_DSN
     * ES_CLIENT
-    * POSTGRES_DB
-    * POSTGRES_HOST
-    * POSTGRES_PASSWORD
-    * POSTGRES_USER
+    * DB_NAME
+    * DB_HOST
+    * DB_PASSWORD
+    * DB_USER
     """
 
     SECRET_KEY = values.Value(None)
@@ -231,7 +231,6 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
     # when their preferred language, whatever it is, is unavailable
     LANGUAGES = (("en", _("English")), ("fr", _("French")))
     LANGUAGES_DICT = dict(LANGUAGES)
-    LANGUAGE_NAME = LANGUAGES_DICT[LANGUAGE_CODE]
 
     # Django CMS settings
     CMS_LANGUAGES = {

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -198,20 +198,11 @@ class Base(DRFMixin, Configuration):
 
     LANGUAGE_CODE = "en"
 
-    # Django sets `LANGUAGES` by default with all supported languages. Let's save it to a
-    # different setting before overriding it with the languages active in the CMS. We can use it
-    # for example for the choice of languages on the course run which should not be limited to
-    # the few languages active in the CMS.
-    # pylint: disable=no-member
-    ALL_LANGUAGES = [(language, _(name)) for language, name in Configuration.LANGUAGES]
-    ALL_LANGUAGES_DICT = dict(ALL_LANGUAGES)
-
     # Careful! Languages should be ordered by priority, as this tuple is used to get
     # fallback/default languages throughout the app.
     # Use "en" as default as it is the language that is most likely to be spoken by any visitor
     # when their preferred language, whatever it is, is unavailable
     LANGUAGES = (("en", _("English")), ("fr", _("French")))
-    LANGUAGES_DICT = dict(LANGUAGES)
 
     # Django CMS settings
     CMS_LANGUAGES = {

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -9,7 +9,6 @@ from django.utils.translation import ugettext_lazy as _
 # pylint: disable=ungrouped-imports
 import sentry_sdk
 from configurations import Configuration, values
-from elasticsearch import Elasticsearch
 from sentry_sdk.integrations.django import DjangoIntegration
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -38,21 +37,6 @@ def get_release():
     return "NA"
 
 
-class ElasticSearchMixin:
-    """
-    Elastic Search configuration mixin
-
-    You may want to override default configuration by setting the following environment
-    variable:
-
-    * ES_CLIENT
-    """
-
-    ES_CLIENT = Elasticsearch(
-        [values.Value("localhost", environ_name="ES_CLIENT", environ_prefix=None)]
-    )
-
-
 class DRFMixin:
     """
     Django Rest Framework configuration mixin.
@@ -67,7 +51,7 @@ class DRFMixin:
     }
 
 
-class Base(DRFMixin, ElasticSearchMixin, Configuration):
+class Base(DRFMixin, Configuration):
     """
     This is the base configuration every configuration (aka environnement) should inherit from. It
     is recommended to configure third-party applications by creating a configuration mixins in
@@ -81,7 +65,7 @@ class Base(DRFMixin, ElasticSearchMixin, Configuration):
     variables:
 
     * DJANGO_SENTRY_DSN
-    * ES_CLIENT
+    * RICHIE_ES_HOST
     * DB_NAME
     * DB_HOST
     * DB_PASSWORD

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     djangocms-text-ckeditor # pyup: ignore
     djangocms-video # pyup: ignore
     djangorestframework # pyup: ignore
-    elasticsearch # pyup: ignore
+    elasticsearch>=6.0.0,<7.0.0 # pyup: ignore
 package_dir =
     =src
 packages = find:

--- a/src/richie/apps/core/defaults.py
+++ b/src/richie/apps/core/defaults.py
@@ -1,5 +1,23 @@
 """Default settings for the core app of Richie."""
+from django.conf import global_settings, settings
 from django.utils.translation import ugettext_lazy as _
 
 # Group to add plugin to placeholder "Content"
 PLUGINS_GROUP = _("Richie Plugins")
+
+# Django sets `LANGUAGES` by default with all supported languages. We can use it for example for
+# the choice of languages on the course run which should not be limited to the few languages
+# active in the CMS.
+# pylint: disable=no-member
+ALL_LANGUAGES = getattr(
+    settings,
+    "ALL_LANGUAGES",
+    [(language, _(name)) for language, name in global_settings.LANGUAGES],
+)
+ALL_LANGUAGES_DICT = dict(ALL_LANGUAGES)
+
+# Careful! Languages should be ordered by priority, as this tuple is used to get
+# fallback/default languages throughout the app.
+# Use "en" as default as it is the language that is most likely to be spoken by any visitor
+# when their preferred language, whatever it is, is unavailable
+LANGUAGES_DICT = dict(settings.LANGUAGES)

--- a/src/richie/apps/core/defaults.py
+++ b/src/richie/apps/core/defaults.py
@@ -1,0 +1,5 @@
+"""Default settings for the core app of Richie."""
+from django.utils.translation import ugettext_lazy as _
+
+# Group to add plugin to placeholder "Content"
+PLUGINS_GROUP = _("Richie Plugins")

--- a/src/richie/apps/courses/cms_plugins.py
+++ b/src/richie/apps/courses/cms_plugins.py
@@ -2,11 +2,12 @@
 Courses CMS plugins
 """
 
-from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
+
+from richie.apps.core.defaults import PLUGINS_GROUP
 
 from .forms import LicencePluginForm
 from .models import (
@@ -25,11 +26,10 @@ class OrganizationPlugin(CMSPluginBase):
     Organization plugin displays an organization's information on other pages
     """
 
-    model = OrganizationPluginModel
-    module = _("Courses")
-    render_template = "courses/plugins/organization.html"
     cache = True
-    module = settings.RICHIE_PLUGINS_GROUP
+    model = OrganizationPluginModel
+    module = PLUGINS_GROUP
+    render_template = "courses/plugins/organization.html"
 
     def render(self, context, instance, placeholder):
         context.update(
@@ -48,11 +48,10 @@ class CategoryPlugin(CMSPluginBase):
     Category plugin displays a category's information on other pages
     """
 
-    model = CategoryPluginModel
-    module = _("Courses")
-    render_template = "courses/plugins/category_plugin.html"
     cache = True
-    module = settings.RICHIE_PLUGINS_GROUP
+    model = CategoryPluginModel
+    module = PLUGINS_GROUP
+    render_template = "courses/plugins/category_plugin.html"
 
     def render(self, context, instance, placeholder):
         context.update(
@@ -71,11 +70,10 @@ class CoursePlugin(CMSPluginBase):
     Course plugin displays a course's information on other pages
     """
 
-    model = CoursePluginModel
-    module = _("Courses")
-    render_template = "courses/plugins/course_plugin.html"
     cache = True
-    module = settings.RICHIE_PLUGINS_GROUP
+    model = CoursePluginModel
+    module = PLUGINS_GROUP
+    render_template = "courses/plugins/course_plugin.html"
 
     def render(self, context, instance, placeholder):
         context.update(
@@ -94,10 +92,10 @@ class PersonPlugin(CMSPluginBase):
     Person plugin displays a person's information on other pages
     """
 
-    model = PersonPluginModel
-    module = _("Persons")
-    render_template = "courses/plugins/person.html"
     cache = True
+    model = PersonPluginModel
+    module = PLUGINS_GROUP
+    render_template = "courses/plugins/person.html"
 
     def render(self, context, instance, placeholder):
         context.update(
@@ -117,15 +115,14 @@ class LicencePlugin(CMSPluginBase):
     with an additional free text.
     """
 
-    model = LicencePluginModel
+    allow_children = False
+    cache = True
+    fieldsets = ((None, {"fields": ["licence", "description"]}),)
     form = LicencePluginForm
+    model = LicencePluginModel
+    module = PLUGINS_GROUP
     name = _("Licence")
     render_template = "courses/plugins/licence_plugin.html"
-    cache = True
-    module = settings.RICHIE_PLUGINS_GROUP
-    allow_children = False
-
-    fieldsets = ((None, {"fields": ["licence", "description"]}),)
 
     def render(self, context, instance, placeholder):
         context.update({"instance": instance, "placeholder": placeholder})
@@ -138,11 +135,10 @@ class BlogPostPlugin(CMSPluginBase):
     BlogPost plugin displays a Blog post overview on other pages
     """
 
-    model = BlogPostPluginModel
-    module = _("Courses")
-    render_template = "courses/plugins/blogpost.html"
     cache = True
-    module = settings.RICHIE_PLUGINS_GROUP
+    model = BlogPostPluginModel
+    module = PLUGINS_GROUP
+    render_template = "courses/plugins/blogpost.html"
 
     def render(self, context, instance, placeholder):
         context.update(

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -5,7 +5,6 @@ import random
 from collections import namedtuple
 from datetime import datetime, timedelta
 
-from django.conf import settings
 from django.core.files import File
 from django.utils import timezone
 from django.utils.translation import get_language
@@ -15,6 +14,7 @@ import pytz
 from cms.api import add_plugin
 from filer.models.imagemodels import Image
 
+from ..core.defaults import ALL_LANGUAGES
 from ..core.factories import FilerImageFactory, PageExtensionDjangoModelFactory
 from ..core.helpers import create_text_plugin
 from ..core.utils import file_getter
@@ -380,10 +380,7 @@ class CourseRunFactory(PageExtensionDjangoModelFactory):
         return (
             self.parent.get_languages()
             if getattr(self, "parent", None)
-            else [
-                l[0]
-                for l in random.sample(settings.ALL_LANGUAGES, random.randint(1, 5))
-            ]
+            else [l[0] for l in random.sample(ALL_LANGUAGES, random.randint(1, 5))]
         )
 
     # pylint: disable=no-self-use

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping
 from datetime import MAXYEAR, datetime
 
 from django import forms
-from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -20,6 +19,7 @@ from cms.extensions.extension_pool import extension_pool
 from cms.models.pluginmodel import CMSPlugin
 from filer.fields.image import FilerImageField
 
+from ...core.defaults import ALL_LANGUAGES
 from ...core.fields.multiselect import MultiSelectField
 from ...core.models import BasePageExtension, PagePluginMixin
 from .category import Category
@@ -334,7 +334,7 @@ class CourseRun(BasePageExtension):
         # Language choices are made lazy so that we can override them in our tests.
         # When set directly, they are evaluated too early and can't be changed with the
         # "override_settings" utility.
-        choices=lazy(lambda: settings.ALL_LANGUAGES, tuple)(),
+        choices=lazy(lambda: ALL_LANGUAGES, tuple)(),
         help_text=_("The list of languages in which the course content is available."),
     )
 

--- a/src/richie/apps/search/__init__.py
+++ b/src/richie/apps/search/__init__.py
@@ -1,3 +1,9 @@
 """Define SearchConfig as the default app configuration."""
+from django.conf import settings
+
+from elasticsearch import Elasticsearch
+
 # pylint: disable=invalid-name
 default_app_config = "richie.apps.search.apps.SearchConfig"
+
+ES_CLIENT = Elasticsearch([getattr(settings, "RICHIE_ES_HOST", "elasticsearch")])

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -33,20 +33,21 @@ ORGANIZATIONS_LOGO_IMAGE_HEIGHT = getattr(
     settings, "ORGANIZATIONS_LOGO_IMAGE_HEIGHT", 216
 )
 
+# Elasticsearch
+ES_CHUNK_SIZE = 500
+ES_PAGE_SIZE = 10
+
 # Define the scoring boost (in ElasticSearch) related value names receive when using
 # full-text search.
 # For example, when a user searches for "Science" in full-text, it should match any
 # course whose category contains "Science" or a related word, albeit with a lower
 # score than courses that include it in their title or description.
 # This lower score factor is the boost value we get or set here.
-RELATED_CONTENT_MATCHING_BOOST = getattr(
-    settings, "RELATED_CONTENT_MATCHING_BOOST", 0.05
-)
+RELATED_CONTENT_BOOST = 0.05
 
-# Facet sorting mode
-SEARCH_SORTING_DEFAULT = getattr(settings, "RICHIE_SEARCH_SORTING", "conf")
+FACET_SORTING_DEFAULT = "conf"
 
-FILTERS_DEFAULT = [
+FILTERS_CONFIGURATION = [
     (
         "richie.apps.search.filter_definitions.StaticChoicesFilterDefinition",
         {

--- a/src/richie/apps/search/filter_definitions/__init__.py
+++ b/src/richie/apps/search/filter_definitions/__init__.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 
 # pylint: disable=unused-import
-from ..defaults import FILTERS_DEFAULT
+from ..defaults import FILTERS_CONFIGURATION
 from .base import NestingWrapper  # noqa
 from .courses import (  # noqa
     AvailabilityFilterDefinition,
@@ -14,5 +14,7 @@ from .courses import (  # noqa
 
 FILTERS = {
     params["name"]: import_string(path)(**params)
-    for path, params in getattr(settings, "RICHIE_SEARCH_FILTERS", FILTERS_DEFAULT)
+    for path, params in getattr(
+        settings, "RICHIE_FILTERS_CONFIGURATION", FILTERS_CONFIGURATION
+    )
 }

--- a/src/richie/apps/search/filter_definitions/base.py
+++ b/src/richie/apps/search/filter_definitions/base.py
@@ -10,7 +10,7 @@ from django import forms
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
-from ..defaults import SEARCH_SORTING_DEFAULT
+from ..defaults import FACET_SORTING_DEFAULT
 
 
 class BaseFilterDefinition:
@@ -29,7 +29,7 @@ class BaseFilterDefinition:
         is_drilldown=False,
         min_doc_count=0,
         position=0,
-        sorting=SEARCH_SORTING_DEFAULT,
+        sorting=FACET_SORTING_DEFAULT,
     ):
         """Set common attributes with sensible defaults (only name is required)."""
         self.name = name

--- a/src/richie/apps/search/filter_definitions/courses.py
+++ b/src/richie/apps/search/filter_definitions/courses.py
@@ -2,11 +2,12 @@
 from functools import reduce
 
 from django import forms
-from django.conf import settings
 from django.utils import timezone, translation
 from django.utils.translation import gettext as _
 
 from cms.api import Page
+
+from richie.apps.core.defaults import ALL_LANGUAGES_DICT
 
 from .. import ES_CLIENT
 from ..fields.array import ArrayField
@@ -271,11 +272,11 @@ class LanguagesFilterDefinition(
 
     def get_values(self):
         """Return the language values defined in the project's settings."""
-        return settings.ALL_LANGUAGES_DICT
+        return ALL_LANGUAGES_DICT
 
     def get_fragment_map(self):
         """Compute query fragments for each language defined in the project's settings."""
         return {
             language: [{"term": {"course_runs.languages": language}}]
-            for language in settings.ALL_LANGUAGES_DICT
+            for language in ALL_LANGUAGES_DICT
         }

--- a/src/richie/apps/search/filter_definitions/courses.py
+++ b/src/richie/apps/search/filter_definitions/courses.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 
 from cms.api import Page
 
+from .. import ES_CLIENT
 from ..fields.array import ArrayField
 from ..indexers import ES_INDICES
 from ..utils.i18n import get_best_field_language
@@ -109,7 +110,8 @@ class IndexableFilterDefinition(TermsAggsMixin, TermsQueryMixin, BaseFilterDefin
         indexer = getattr(ES_INDICES, self.term)
 
         # Get just the documents we need from ElasticSearch
-        search_query_response = settings.ES_CLIENT.search(
+        # pylint: disable=unexpected-keyword-arg
+        search_query_response = ES_CLIENT.search(
             # We only need the titles to get the i18n names
             _source=["title.*"],
             index=indexer.index_name,

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -5,10 +5,11 @@ from datetime import MAXYEAR
 from functools import reduce
 
 from django import forms
+from django.conf import settings
 
 import arrow
 
-from .defaults import RELATED_CONTENT_MATCHING_BOOST
+from .defaults import RELATED_CONTENT_BOOST
 from .filter_definitions import FILTERS, AvailabilityFilterDefinition
 
 # Instantiate filter fields for each filter defined in settings
@@ -207,7 +208,11 @@ class CourseSearchForm(SearchForm):
                                     },
                                     {
                                         "multi_match": {
-                                            "boost": RELATED_CONTENT_MATCHING_BOOST,
+                                            "boost": getattr(
+                                                settings,
+                                                "RICHIE_RELATED_CONTENT_BOOST",
+                                                RELATED_CONTENT_BOOST,
+                                            ),
                                             "fields": [
                                                 "categories_names.*",
                                                 "organizations_names.*",

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -10,6 +10,7 @@ from elasticsearch.client import IndicesClient
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch.helpers import bulk
 
+from . import ES_CLIENT
 from .defaults import ES_CHUNK_SIZE
 from .indexers import ES_INDICES
 from .text_indexing import ANALYSIS_SETTINGS
@@ -20,7 +21,7 @@ def richie_bulk(actions):
     return bulk(
         actions=actions,
         chunk_size=getattr(settings, "RICHIE_ES_CHUNK_SIZE", ES_CHUNK_SIZE),
-        client=settings.ES_CLIENT,
+        client=ES_CLIENT,
         stats_only=True,
     )
 
@@ -39,7 +40,7 @@ def perform_create_index(indexable, logger):
     """
     Create a new index in ElasticSearch from an indexable instance
     """
-    indices_client = IndicesClient(client=settings.ES_CLIENT)
+    indices_client = IndicesClient(client=ES_CLIENT)
     # Create a new index name, suffixing its name with a timestamp
     new_index = "{:s}_{:s}".format(
         indexable.index_name, timezone.now().strftime("%Y-%m-%d-%Hh%Mm%S.%fs")
@@ -70,7 +71,7 @@ def regenerate_indexes(logger):
     a new one only once it has successfully built it.
     """
     # Prepare the client we'll be using to handle indexes
-    indices_client = IndicesClient(client=settings.ES_CLIENT)
+    indices_client = IndicesClient(client=ES_CLIENT)
 
     # Get all existing indexes once; we'll look up into this list many times
     try:
@@ -137,4 +138,4 @@ def store_es_scripts(logger):
         for script_id, script_body in indexer.scripts.items():
             if logger:
                 logger.info('Storing script "{:s}"...'.format(script_id))
-            settings.ES_CLIENT.put_script(id=script_id, body=script_body)
+            ES_CLIENT.put_script(id=script_id, body=script_body)

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -10,6 +10,7 @@ from elasticsearch.client import IndicesClient
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch.helpers import bulk
 
+from .defaults import ES_CHUNK_SIZE
 from .indexers import ES_INDICES
 from .text_indexing import ANALYSIS_SETTINGS
 
@@ -18,7 +19,7 @@ def richie_bulk(actions):
     """Wrap bulk helper to set default parameters."""
     return bulk(
         actions=actions,
-        chunk_size=settings.ES_CHUNK_SIZE,
+        chunk_size=getattr(settings, "RICHIE_ES_CHUNK_SIZE", ES_CHUNK_SIZE),
         client=settings.ES_CLIENT,
         stats_only=True,
     )

--- a/src/richie/apps/search/utils/viewsets.py
+++ b/src/richie/apps/search/utils/viewsets.py
@@ -1,11 +1,12 @@
 """
 Helpers to enable reuse for needs that are shared between viewsets.
 """
-from django.conf import settings
 from django.utils.translation import get_language_from_request
 
 from rest_framework.decorators import action
 from rest_framework.response import Response
+
+from .. import ES_CLIENT
 
 
 class ViewSetMetadata:
@@ -40,7 +41,7 @@ class AutocompleteMixin:
         indexer = self._meta.indexer
 
         # Query our specific ES completion field
-        autocomplete_query_response = settings.ES_CLIENT.search(
+        autocomplete_query_response = ES_CLIENT.search(
             index=indexer.index_name,
             doc_type=indexer.document_type,
             body={

--- a/src/richie/apps/search/viewsets/categories.py
+++ b/src/richie/apps/search/viewsets/categories.py
@@ -8,6 +8,7 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from .. import ES_CLIENT
 from ..defaults import ES_PAGE_SIZE
 from ..indexers import ES_INDICES
 from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
@@ -36,7 +37,8 @@ class CategoriesViewSet(AutocompleteMixin, ViewSet):
 
         limit, offset, query = params_form.build_es_query()
 
-        query_response = settings.ES_CLIENT.search(
+        # pylint: disable=unexpected-keyword-arg
+        query_response = ES_CLIENT.search(
             _source=getattr(self._meta.indexer, "display_fields", "*"),
             index=self._meta.indexer.index_name,
             doc_type=self._meta.indexer.document_type,
@@ -75,7 +77,7 @@ class CategoriesViewSet(AutocompleteMixin, ViewSet):
         # Wrap the ES get in a try/catch to we control the exception we emit — it would
         # raise and end up in a 500 error otherwise
         try:
-            query_response = settings.ES_CLIENT.get(
+            query_response = ES_CLIENT.get(
                 index=self._meta.indexer.index_name,
                 doc_type=self._meta.indexer.document_type,
                 id=pk,

--- a/src/richie/apps/search/viewsets/categories.py
+++ b/src/richie/apps/search/viewsets/categories.py
@@ -8,6 +8,7 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from ..defaults import ES_PAGE_SIZE
 from ..indexers import ES_INDICES
 from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
 
@@ -42,7 +43,7 @@ class CategoriesViewSet(AutocompleteMixin, ViewSet):
             body=query,
             # Directly pass meta-params through as arguments to the ES client
             from_=offset,
-            size=limit or settings.ES_DEFAULT_PAGE_SIZE,
+            size=limit or getattr(settings, "RICHIE_ES_PAGE_SIZE", ES_PAGE_SIZE),
         )
 
         # Format the response in a consumer-friendly way

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -7,6 +7,7 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from ..defaults import ES_PAGE_SIZE
 from ..filter_definitions import FILTERS
 from ..indexers import ES_INDICES
 from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
@@ -56,7 +57,7 @@ class CoursesViewSet(AutocompleteMixin, ViewSet):
             body=body,
             # Directly pass meta-params through as arguments to the ES client
             from_=offset,
-            size=limit or settings.ES_DEFAULT_PAGE_SIZE,
+            size=limit or getattr(settings, "RICHIE_ES_PAGE_SIZE", ES_PAGE_SIZE),
         )
 
         response_object = {

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -7,6 +7,7 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from .. import ES_CLIENT
 from ..defaults import ES_PAGE_SIZE
 from ..filter_definitions import FILTERS
 from ..indexers import ES_INDICES
@@ -50,7 +51,8 @@ class CoursesViewSet(AutocompleteMixin, ViewSet):
         if form_class.FILTERS in scope or not scope:
             body["aggs"] = aggs
 
-        course_query_response = settings.ES_CLIENT.search(
+        # pylint: disable=unexpected-keyword-arg
+        course_query_response = ES_CLIENT.search(
             _source=getattr(self._meta.indexer, "display_fields", "*"),
             index=self._meta.indexer.index_name,
             doc_type=self._meta.indexer.document_type,
@@ -96,7 +98,7 @@ class CoursesViewSet(AutocompleteMixin, ViewSet):
         # Wrap the ES get in a try/catch to we control the exception we emit — it would
         # raise and end up in a 500 error otherwise
         try:
-            query_response = settings.ES_CLIENT.get(
+            query_response = ES_CLIENT.get(
                 index=self._meta.indexer.index_name,
                 doc_type=self._meta.indexer.document_type,
                 id=pk,

--- a/src/richie/apps/search/viewsets/organizations.py
+++ b/src/richie/apps/search/viewsets/organizations.py
@@ -8,6 +8,7 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from ..defaults import ES_PAGE_SIZE
 from ..indexers import ES_INDICES
 from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
 
@@ -42,7 +43,7 @@ class OrganizationsViewSet(AutocompleteMixin, ViewSet):
             body=query,
             # Directly pass meta-params through as arguments to the ES client
             from_=offset,
-            size=limit or settings.ES_DEFAULT_PAGE_SIZE,
+            size=limit or getattr(settings, "RICHIE_ES_PAGE_SIZE", ES_PAGE_SIZE),
         )
 
         # Format the response in a consumer-friendly way

--- a/src/richie/apps/search/viewsets/organizations.py
+++ b/src/richie/apps/search/viewsets/organizations.py
@@ -8,6 +8,7 @@ from elasticsearch.exceptions import NotFoundError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from .. import ES_CLIENT
 from ..defaults import ES_PAGE_SIZE
 from ..indexers import ES_INDICES
 from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
@@ -36,7 +37,8 @@ class OrganizationsViewSet(AutocompleteMixin, ViewSet):
 
         limit, offset, query = params_form.build_es_query()
 
-        search_query_response = settings.ES_CLIENT.search(
+        # pylint: disable=unexpected-keyword-arg
+        search_query_response = ES_CLIENT.search(
             _source=getattr(self._meta.indexer, "display_fields", "*"),
             index=self._meta.indexer.index_name,
             doc_type=self._meta.indexer.document_type,
@@ -74,7 +76,7 @@ class OrganizationsViewSet(AutocompleteMixin, ViewSet):
         # Wrap the ES get in a try/catch so we control the exception we emit — it would
         # raise and end up in a 500 error otherwise
         try:
-            query_response = settings.ES_CLIENT.get(
+            query_response = ES_CLIENT.get(
                 index=self._meta.indexer.index_name,
                 doc_type=self._meta.indexer.document_type,
                 id=pk,

--- a/src/richie/plugins/large_banner/cms_plugins.py
+++ b/src/richie/plugins/large_banner/cms_plugins.py
@@ -1,11 +1,12 @@
 """
 Large banner CMS plugin
 """
-from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
+
+from richie.apps.core.defaults import PLUGINS_GROUP
 
 from .defaults import LARGEBANNER_TEMPLATES
 from .forms import LargeBannerForm
@@ -18,11 +19,11 @@ class LargeBannerPlugin(CMSPluginBase):
     CMSPlugin to customize a home page header.
     """
 
-    module = settings.RICHIE_PLUGINS_GROUP
-    name = _("Large Banner")
-    model = LargeBanner
-    form = LargeBannerForm
     cache = True
+    form = LargeBannerForm
+    model = LargeBanner
+    module = PLUGINS_GROUP
+    name = _("Large Banner")
     # Required from CMSPluginBase signature but not used since we override it
     # from render()
     render_template = LARGEBANNER_TEMPLATES[0][0]

--- a/src/richie/plugins/large_banner/defaults.py
+++ b/src/richie/plugins/large_banner/defaults.py
@@ -7,5 +7,8 @@ from django.utils.translation import ugettext_lazy as _
 LARGEBANNER_TEMPLATES = getattr(
     settings,
     "RICHIE_LARGEBANNER_TEMPLATES",
-    [("richie/large_banner/large_banner.html", _("Default"))],
+    [
+        ("richie/large_banner/large_banner.html", _("Default")),
+        ("richie/large_banner/hero-intro.html", _("Hero introduction")),
+    ],
 )

--- a/src/richie/plugins/plain_text/cms_plugins.py
+++ b/src/richie/plugins/plain_text/cms_plugins.py
@@ -1,11 +1,12 @@
 """
 Plain text CMS plugin
 """
-from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
+
+from richie.apps.core.defaults import PLUGINS_GROUP
 
 from .models import PlainText
 
@@ -21,7 +22,7 @@ class PlainTextPlugin(CMSPluginBase):
     disable_child_plugins = True
     fieldsets = ((None, {"fields": ["body"]}),)
     model = PlainText
-    module = settings.RICHIE_PLUGINS_GROUP
+    module = PLUGINS_GROUP
     name = _("Plain text")
     render_template = "richie/plain_text/plain_text.html"
 

--- a/src/richie/plugins/section/cms_plugins.py
+++ b/src/richie/plugins/section/cms_plugins.py
@@ -1,11 +1,12 @@
 """
 Section CMS plugin
 """
-from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
+
+from richie.apps.core.defaults import PLUGINS_GROUP
 
 from .defaults import SECTION_TEMPLATES
 from .models import Section
@@ -17,16 +18,15 @@ class SectionPlugin(CMSPluginBase):
     CMSPlugin to add a content section with a distinct title from content.
     """
 
-    module = settings.RICHIE_PLUGINS_GROUP
-    name = _("Section")
+    allow_children = True
+    cache = True
+    fieldsets = ((None, {"fields": ["title", "template"]}),)
     model = Section
+    module = PLUGINS_GROUP
+    name = _("Section")
     # Required from CMSPluginBase signature but not used since we override it
     # from render()
     render_template = SECTION_TEMPLATES[0][0]
-    cache = True
-    allow_children = True
-
-    fieldsets = ((None, {"fields": ["title", "template"]}),)
 
     def render(self, context, instance, placeholder):
         context.update({"instance": instance, "placeholder": placeholder})

--- a/src/richie/plugins/section/defaults.py
+++ b/src/richie/plugins/section/defaults.py
@@ -7,5 +7,8 @@ from django.utils.translation import ugettext_lazy as _
 SECTION_TEMPLATES = getattr(
     settings,
     "RICHIE_SECTION_TEMPLATES",
-    [("richie/section/section.html", _("Default"))],
+    [
+        ("richie/section/section.html", _("Default")),
+        ("richie/section/highlighted_items.html", _("Highlighted items")),
+    ],
 )

--- a/src/richie/plugins/simple_text_ckeditor/cms_plugins.py
+++ b/src/richie/plugins/simple_text_ckeditor/cms_plugins.py
@@ -1,11 +1,12 @@
 """
 Simple text CMS plugin
 """
-from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
+
+from richie.apps.core.defaults import PLUGINS_GROUP
 
 from .forms import CKEditorPluginForm
 from .models import SimpleText
@@ -17,14 +18,14 @@ class CKEditorPlugin(CMSPluginBase):
     A plugin to add text with CKEditor widget.
     """
 
-    model = SimpleText
+    allow_children = False
+    cache = True
+    disable_child_plugins = True
     form = CKEditorPluginForm
+    model = SimpleText
+    module = PLUGINS_GROUP
     name = _("Simple text")
     render_template = "richie/simple_text_ckeditor/simple_text.html"
-    cache = True
-    module = settings.RICHIE_PLUGINS_GROUP
-    allow_children = False
-    disable_child_plugins = True
 
     fieldsets = ((None, {"fields": ["body"]}),)
 

--- a/tests/apps/courses/test_models_course_run.py
+++ b/tests/apps/courses/test_models_course_run.py
@@ -5,7 +5,6 @@ import random
 from datetime import datetime, timedelta
 from unittest import mock
 
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -13,6 +12,7 @@ from django.utils import timezone
 
 import pytz
 
+from richie.apps.core.defaults import ALL_LANGUAGES
 from richie.apps.core.helpers import create_i18n_page
 from richie.apps.courses.factories import CourseFactory, CourseRunFactory
 
@@ -418,7 +418,7 @@ class CourseRunModelsTestCase(TestCase):
         """
         The languages field should not accept more than 50 choices.
         """
-        languages = [l[0] for l in settings.ALL_LANGUAGES[:51]]
+        languages = [l[0] for l in ALL_LANGUAGES[:51]]
 
         # 50 languages should be fine
         CourseRunFactory(languages=languages[:-1])

--- a/tests/apps/search/test_autocomplete_categories.py
+++ b/tests/apps/search/test_autocomplete_categories.py
@@ -89,11 +89,7 @@ class AutocompleteCategoriesTestCase(TestCase):
             }
             for category in categories
         ]
-        bulk(
-            actions=actions,
-            chunk_size=settings.ES_CHUNK_SIZE,
-            client=settings.ES_CLIENT,
-        )
+        bulk(actions=actions, chunk_size=500, client=settings.ES_CLIENT)
         indices_client.refresh()
 
         response = self.client.get(

--- a/tests/apps/search/test_autocomplete_categories.py
+++ b/tests/apps/search/test_autocomplete_categories.py
@@ -4,12 +4,12 @@ Tests for category autocomplete
 import json
 from unittest import mock
 
-from django.conf import settings
 from django.test import TestCase
 
 from elasticsearch.client import IndicesClient
 from elasticsearch.helpers import bulk
 
+from richie.apps.search import ES_CLIENT
 from richie.apps.search.indexers.categories import CategoriesIndexer
 from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
 from richie.apps.search.utils.indexers import slice_string_for_completion
@@ -59,7 +59,7 @@ class AutocompleteCategoriesTestCase(TestCase):
             },
         ]
 
-        indices_client = IndicesClient(client=settings.ES_CLIENT)
+        indices_client = IndicesClient(client=ES_CLIENT)
         # Delete any existing indexes so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
@@ -89,7 +89,7 @@ class AutocompleteCategoriesTestCase(TestCase):
             }
             for category in categories
         ]
-        bulk(actions=actions, chunk_size=500, client=settings.ES_CLIENT)
+        bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
         indices_client.refresh()
 
         response = self.client.get(

--- a/tests/apps/search/test_autocomplete_courses.py
+++ b/tests/apps/search/test_autocomplete_courses.py
@@ -103,11 +103,7 @@ class AutocompleteCoursesTestCase(TestCase):
             }
             for course in courses
         ]
-        bulk(
-            actions=actions,
-            chunk_size=settings.ES_CHUNK_SIZE,
-            client=settings.ES_CLIENT,
-        )
+        bulk(actions=actions, chunk_size=500, client=settings.ES_CLIENT)
         indices_client.refresh()
 
         response = self.client.get(f"/api/v1.0/courses/autocomplete/?{querystring:s}")

--- a/tests/apps/search/test_autocomplete_organizations.py
+++ b/tests/apps/search/test_autocomplete_organizations.py
@@ -4,12 +4,12 @@ Tests for organization autocomplete
 import json
 from unittest import mock
 
-from django.conf import settings
 from django.test import TestCase
 
 from elasticsearch.client import IndicesClient
 from elasticsearch.helpers import bulk
 
+from richie.apps.search import ES_CLIENT
 from richie.apps.search.indexers.organizations import OrganizationsIndexer
 from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
 from richie.apps.search.utils.indexers import slice_string_for_completion
@@ -61,7 +61,7 @@ class AutocompleteOrganizationsTestCase(TestCase):
             },
         ]
 
-        indices_client = IndicesClient(client=settings.ES_CLIENT)
+        indices_client = IndicesClient(client=ES_CLIENT)
         # Delete any existing indexes so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
@@ -92,7 +92,7 @@ class AutocompleteOrganizationsTestCase(TestCase):
             }
             for organization in organizations
         ]
-        bulk(actions=actions, chunk_size=500, client=settings.ES_CLIENT)
+        bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
         indices_client.refresh()
 
         response = self.client.get(

--- a/tests/apps/search/test_autocomplete_organizations.py
+++ b/tests/apps/search/test_autocomplete_organizations.py
@@ -92,11 +92,7 @@ class AutocompleteOrganizationsTestCase(TestCase):
             }
             for organization in organizations
         ]
-        bulk(
-            actions=actions,
-            chunk_size=settings.ES_CHUNK_SIZE,
-            client=settings.ES_CLIENT,
-        )
+        bulk(actions=actions, chunk_size=500, client=settings.ES_CLIENT)
         indices_client.refresh()
 
         response = self.client.get(

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -1,25 +1,27 @@
 """
 Tests for the course search form.
 """
+from unittest import mock
+
 from django.http.request import QueryDict
 from django.test import TestCase
-from django.test.utils import override_settings
 
+from richie.apps.core.defaults import ALL_LANGUAGES_DICT
 from richie.apps.search.forms import CourseSearchForm
 
 
-@override_settings(ALL_LANGUAGES_DICT={"fr": "French", "en": "English"})
+@mock.patch.dict(ALL_LANGUAGES_DICT, {"fr": "French", "en": "English"})
 class CourseSearchFormTestCase(TestCase):
     """
     Test the course search form.
     """
 
-    def test_forms_courses_params_not_required(self):
+    def test_forms_courses_params_not_required(self, *_):
         """No params are required for the search form."""
         form = CourseSearchForm()
         self.assertTrue(form.is_valid())
 
-    def test_forms_courses_empty_querystring(self):
+    def test_forms_courses_empty_querystring(self, *_):
         """The empty query string should be a valid search form."""
         form = CourseSearchForm(data=QueryDict())
         self.assertTrue(form.is_valid())
@@ -43,7 +45,7 @@ class CourseSearchFormTestCase(TestCase):
             },
         )
 
-    def test_forms_courses_limit_greater_than_1(self):
+    def test_forms_courses_limit_greater_than_1(self, *_):
         """The `limit` param should be greater than 1."""
         form = CourseSearchForm(data=QueryDict(query_string="limit=0"))
         self.assertFalse(form.is_valid())
@@ -51,7 +53,7 @@ class CourseSearchFormTestCase(TestCase):
             form.errors, {"limit": ["Ensure this value is greater than or equal to 1."]}
         )
 
-    def test_forms_courses_limit_integer(self):
+    def test_forms_courses_limit_integer(self, *_):
         """The `limit` param should be an integer."""
         form = CourseSearchForm(data=QueryDict(query_string="limit=a"))
         self.assertFalse(form.is_valid())
@@ -60,7 +62,7 @@ class CourseSearchFormTestCase(TestCase):
         form = CourseSearchForm(data=QueryDict(query_string="limit=1"))
         self.assertTrue(form.is_valid())
 
-    def test_forms_courses_offset_greater_than_0(self):
+    def test_forms_courses_offset_greater_than_0(self, *_):
         """The `offset` param should be greater than 0."""
         form = CourseSearchForm(data=QueryDict(query_string="offset=-1"))
         self.assertFalse(form.is_valid())
@@ -69,7 +71,7 @@ class CourseSearchFormTestCase(TestCase):
             {"offset": ["Ensure this value is greater than or equal to 0."]},
         )
 
-    def test_forms_courses_offset_integer(self):
+    def test_forms_courses_offset_integer(self, *_):
         """The `offset` param should be an integer."""
         form = CourseSearchForm(data=QueryDict(query_string="offset=a"))
         self.assertFalse(form.is_valid())
@@ -78,7 +80,7 @@ class CourseSearchFormTestCase(TestCase):
         form = CourseSearchForm(data=QueryDict(query_string="offset=1"))
         self.assertTrue(form.is_valid())
 
-    def test_forms_courses_query_between_3_and_100_characters_long(self):
+    def test_forms_courses_query_between_3_and_100_characters_long(self, *_):
         """The `query` param should be between 3 and 100 characters long."""
         form = CourseSearchForm(data=QueryDict(query_string="query=aa"))
         self.assertFalse(form.is_valid())
@@ -104,7 +106,7 @@ class CourseSearchFormTestCase(TestCase):
             {"query": ["Ensure this value has at most 100 characters (it has 101)."]},
         )
 
-    def test_forms_courses_single_values_in_querystring(self):
+    def test_forms_courses_single_values_in_querystring(self, *_):
         """
         The fields from filter definitions should be normalized as lists. The fields defined
         on the form should be single values (limit, offset and query)
@@ -138,7 +140,7 @@ class CourseSearchFormTestCase(TestCase):
             },
         )
 
-    def test_forms_courses_multi_values_in_querystring(self):
+    def test_forms_courses_multi_values_in_querystring(self, *_):
         """
         The fields from filter definitions should allow multiple values. The fields defined
         on the form should ignore repeated values (limit, offset and query).
@@ -174,7 +176,7 @@ class CourseSearchFormTestCase(TestCase):
             },
         )
 
-    def test_forms_courses_build_es_query_search_by_match_text(self):
+    def test_forms_courses_build_es_query_search_by_match_text(self, *_):
         """
         Happy path: build a query that filters courses by matching text
         """

--- a/tests/apps/search/test_forms_search_items.py
+++ b/tests/apps/search/test_forms_search_items.py
@@ -1,25 +1,27 @@
 """
 Tests for the course search form.
 """
+from unittest import mock
+
 from django.http.request import QueryDict
 from django.test import TestCase
-from django.test.utils import override_settings
 
+from richie.apps.core.defaults import ALL_LANGUAGES_DICT
 from richie.apps.search.forms import ItemSearchForm
 
 
-@override_settings(ALL_LANGUAGES_DICT={"fr": "French", "en": "English"})
+@mock.patch.dict(ALL_LANGUAGES_DICT, {"fr": "French", "en": "English"})
 class ItemSearchFormTestCase(TestCase):
     """
     Test the course search form.
     """
 
-    def test_forms_items_params_not_required(self):
+    def test_forms_items_params_not_required(self, *_):
         """No params are required for the search form."""
         form = ItemSearchForm()
         self.assertTrue(form.is_valid())
 
-    def test_forms_items_empty_querystring(self):
+    def test_forms_items_empty_querystring(self, *_):
         """The empty query string should be a valid search form."""
         form = ItemSearchForm(data=QueryDict())
         self.assertTrue(form.is_valid())
@@ -27,7 +29,7 @@ class ItemSearchFormTestCase(TestCase):
             form.cleaned_data, {"limit": None, "offset": None, "query": "", "scope": ""}
         )
 
-    def test_forms_courses_limit_greater_than_1(self):
+    def test_forms_courses_limit_greater_than_1(self, *_):
         """The `limit` param should be greater than 1."""
         form = ItemSearchForm(data=QueryDict(query_string="limit=0"))
         self.assertFalse(form.is_valid())
@@ -35,7 +37,7 @@ class ItemSearchFormTestCase(TestCase):
             form.errors, {"limit": ["Ensure this value is greater than or equal to 1."]}
         )
 
-    def test_forms_courses_limit_integer(self):
+    def test_forms_courses_limit_integer(self, *_):
         """The `limit` param should be an integer."""
         form = ItemSearchForm(data=QueryDict(query_string="limit=a"))
         self.assertFalse(form.is_valid())
@@ -44,7 +46,7 @@ class ItemSearchFormTestCase(TestCase):
         form = ItemSearchForm(data=QueryDict(query_string="limit=1"))
         self.assertTrue(form.is_valid())
 
-    def test_forms_courses_offset_greater_than_0(self):
+    def test_forms_courses_offset_greater_than_0(self, *_):
         """The `offset` param should be greater than 0."""
         form = ItemSearchForm(data=QueryDict(query_string="offset=-1"))
         self.assertFalse(form.is_valid())
@@ -53,7 +55,7 @@ class ItemSearchFormTestCase(TestCase):
             {"offset": ["Ensure this value is greater than or equal to 0."]},
         )
 
-    def test_forms_courses_offset_integer(self):
+    def test_forms_courses_offset_integer(self, *_):
         """The `offset` param should be an integer."""
         form = ItemSearchForm(data=QueryDict(query_string="offset=a"))
         self.assertFalse(form.is_valid())
@@ -62,7 +64,7 @@ class ItemSearchFormTestCase(TestCase):
         form = ItemSearchForm(data=QueryDict(query_string="offset=1"))
         self.assertTrue(form.is_valid())
 
-    def test_forms_courses_query_between_3_and_100_characters_long(self):
+    def test_forms_courses_query_between_3_and_100_characters_long(self, *_):
         """The `query` param should be between 3 and 100 characters long."""
         form = ItemSearchForm(data=QueryDict(query_string="query=aa"))
         self.assertFalse(form.is_valid())
@@ -88,7 +90,7 @@ class ItemSearchFormTestCase(TestCase):
             {"query": ["Ensure this value has at most 100 characters (it has 101)."]},
         )
 
-    def test_forms_items_single_values_in_querystring(self):
+    def test_forms_items_single_values_in_querystring(self, *_):
         """
         The fields from filter definitions should be normalized as lists. The fields defined
         on the form should be single values (limit, offset and query)
@@ -101,7 +103,7 @@ class ItemSearchFormTestCase(TestCase):
             form.cleaned_data, {"limit": 9, "offset": 3, "query": "maths", "scope": ""}
         )
 
-    def test_forms_items_build_es_query_search_by_match_text(self):
+    def test_forms_items_build_es_query_search_by_match_text(self, *_):
         """
         Happy path: build a query that filters items by matching text
         """
@@ -127,7 +129,7 @@ class ItemSearchFormTestCase(TestCase):
             ),
         )
 
-    def test_forms_items_build_es_query_search_all(self):
+    def test_forms_items_build_es_query_search_all(self, *_):
         """
         Happy path: a match all query is returned
         """

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -91,7 +91,7 @@ class IndexManagerTestCase(TestCase):
         self.assertEqual(list(get_indexes_by_alias(existing_indexes, alias)), [])
 
     # Make sure indexing still works when the number of records is higher than chunk size
-    @override_settings(ES_CHUNK_SIZE=2)
+    @override_settings(RICHIE_ES_CHUNK_SIZE=2)
     def test_index_manager_perform_create_index(self):
         """
         Perform all side-effects through the ES client and return the index name (incl. timestamp)

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -4,7 +4,6 @@ Tests for the index_manager utilities
 from datetime import datetime
 from unittest import mock
 
-from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
@@ -12,6 +11,7 @@ from django.utils import timezone
 import pytz
 from elasticsearch.client import IndicesClient
 
+from richie.apps.search import ES_CLIENT
 from richie.apps.search.index_manager import (
     get_indexes_by_alias,
     perform_create_index,
@@ -30,7 +30,7 @@ class IndexManagerTestCase(TestCase):
         Make sure all indexes are deleted before each new test is run.
         """
         super().setUp()
-        self.indices_client = IndicesClient(client=settings.ES_CLIENT)
+        self.indices_client = IndicesClient(client=ES_CLIENT)
         self.indices_client.delete(index="_all")
 
     def test_index_manager_get_indexes_by_alias(self):
@@ -137,7 +137,7 @@ class IndexManagerTestCase(TestCase):
         self.indices_client.refresh()
 
         self.assertEqual(new_index, "richie_courses_2016-05-04-03h12m33.123456s")
-        self.assertEqual(settings.ES_CLIENT.count()["count"], 10)
+        self.assertEqual(ES_CLIENT.count()["count"], 10)
         self.assertEqual(
             self.indices_client.get_mapping(),
             {
@@ -301,7 +301,7 @@ class IndexManagerTestCase(TestCase):
         "richie.apps.search.indexers.categories.CategoriesIndexer.scripts",
         new={"script_id_C": "script body C"},
     )
-    @mock.patch("settings.ES_CLIENT.put_script")
+    @mock.patch.object(ES_CLIENT, "put_script")
     def test_index_manager_store_es_scripts(self, mock_put_script, *args):
         """
         Make sure store_es_scripts iterates over all indexers to store their scripts and

--- a/tests/apps/search/test_partial_mappings.py
+++ b/tests/apps/search/test_partial_mappings.py
@@ -1,11 +1,11 @@
 """
 Test for our partial mappings
 """
-from django.conf import settings
 from django.test import TestCase
 
 from elasticsearch.client import IndicesClient
 
+from richie.apps.search import ES_CLIENT
 from richie.apps.search.text_indexing import ANALYSIS_SETTINGS, MULTILINGUAL_TEXT
 
 
@@ -19,7 +19,7 @@ class PartialMappingsTestCase(TestCase):
         Instantiate our ES client and make sure all indexes are deleted before each test
         """
         super().setUp()
-        self.indices_client = IndicesClient(client=settings.ES_CLIENT)
+        self.indices_client = IndicesClient(client=ES_CLIENT)
         self.indices_client.delete(index="_all")
 
     def test_partial_mappings_multilingual_text(self):
@@ -51,7 +51,7 @@ class PartialMappingsTestCase(TestCase):
         )
 
         # Index an object that should trigger a match for our dynamic template
-        settings.ES_CLIENT.index(
+        ES_CLIENT.index(
             index=index_name,
             doc_type=document_type,
             body={"title": {"fr": "Un titre en français à titre d'exemple"}},
@@ -86,7 +86,7 @@ class PartialMappingsTestCase(TestCase):
         )
 
         # Index an object that should trigger a different match for our dynamic template
-        settings.ES_CLIENT.index(
+        ES_CLIENT.index(
             index=index_name,
             doc_type=document_type,
             body={"title": {"en": "An English title as an example"}},

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -5,7 +5,6 @@ import random
 from unittest import mock
 
 from django.test import TestCase
-from django.test.utils import override_settings
 
 import arrow
 from elasticsearch.client import IndicesClient
@@ -14,6 +13,7 @@ from elasticsearch.helpers import bulk
 from richie.apps.courses.factories import CategoryFactory, OrganizationFactory
 from richie.apps.search import ES_CLIENT
 from richie.apps.search.filter_definitions import FILTERS, IndexableFilterDefinition
+from richie.apps.search.filter_definitions.courses import ALL_LANGUAGES_DICT
 from richie.apps.search.indexers.courses import CoursesIndexer
 from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
 
@@ -152,10 +152,10 @@ COURSE_RUNS = {
 
 
 # pylint: disable=too-many-public-methods
-@override_settings(  # Reduce the number of languages
-    ALL_LANGUAGES_DICT={
-        l: "#{:s}".format(l) for cr in COURSE_RUNS.values() for l in cr["languages"]
-    }
+@mock.patch.dict(  # Reduce the number of languages
+    ALL_LANGUAGES_DICT,
+    {l: "#{:s}".format(l) for cr in COURSE_RUNS.values() for l in cr["languages"]},
+    clear=True,
 )
 @mock.patch.object(  # Avoid having to build the categories and organizations indices
     IndexableFilterDefinition, "get_i18n_names", return_value=INDEXABLE_IDS

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -291,11 +291,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             }
             for course_id, course_run_ids in courses_definition
         ]
-        bulk(
-            actions=actions,
-            chunk_size=settings.ES_CHUNK_SIZE,
-            client=settings.ES_CLIENT,
-        )
+        bulk(actions=actions, chunk_size=500, client=settings.ES_CLIENT)
         indices_client.refresh()
 
         response = self.client.get(f"/api/v1.0/courses/?{querystring:s}")

--- a/tests/apps/search/test_query_courses_edge_cases.py
+++ b/tests/apps/search/test_query_courses_edge_cases.py
@@ -97,11 +97,7 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
             }
             for course in courses
         ]
-        bulk(
-            actions=actions,
-            chunk_size=settings.ES_CHUNK_SIZE,
-            client=settings.ES_CLIENT,
-        )
+        bulk(actions=actions, chunk_size=500, client=settings.ES_CLIENT)
         indices_client.refresh()
 
     def test_query_courses_filter_box_titles_french(self, *_):

--- a/tests/apps/search/test_query_courses_edge_cases.py
+++ b/tests/apps/search/test_query_courses_edge_cases.py
@@ -4,13 +4,13 @@ import random
 from http.cookies import SimpleCookie
 from unittest import mock
 
-from django.conf import settings
 from django.test import TestCase
 
 from elasticsearch.client import IndicesClient
 from elasticsearch.helpers import bulk
 
 from richie.apps.courses.factories import CategoryFactory, OrganizationFactory
+from richie.apps.search import ES_CLIENT
 from richie.apps.search.filter_definitions import FILTERS, IndexableFilterDefinition
 from richie.apps.search.indexers.courses import CoursesIndexer
 from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
@@ -71,7 +71,7 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
         """
         self.create_filter_pages()
         # Index these 4 courses in Elasticsearch
-        indices_client = IndicesClient(client=settings.ES_CLIENT)
+        indices_client = IndicesClient(client=ES_CLIENT)
         # Delete any existing indexes so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
@@ -85,7 +85,7 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
             body=CoursesIndexer.mapping, doc_type="course", index="test_courses"
         )
         # Add the sorting script
-        settings.ES_CLIENT.put_script(id="state", body=CoursesIndexer.scripts["state"])
+        ES_CLIENT.put_script(id="state", body=CoursesIndexer.scripts["state"])
         # Actually insert our courses in the index
         actions = [
             {
@@ -97,7 +97,7 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
             }
             for course in courses
         ]
-        bulk(actions=actions, chunk_size=500, client=settings.ES_CLIENT)
+        bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
         indices_client.refresh()
 
     def test_query_courses_filter_box_titles_french(self, *_):

--- a/tests/apps/search/test_viewsets_categories.py
+++ b/tests/apps/search/test_viewsets_categories.py
@@ -3,12 +3,12 @@ Tests for the category viewset
 """
 from unittest import mock
 
-from django.conf import settings
 from django.test import TestCase
 
 from elasticsearch.exceptions import NotFoundError
 from rest_framework.test import APIRequestFactory
 
+from richie.apps.search import ES_CLIENT
 from richie.apps.search.viewsets.categories import CategoriesViewSet
 
 
@@ -25,7 +25,7 @@ class CategoriesViewsetsTestCase(TestCase):
         request = factory.get("/api/v1.0/categories/42")
 
         with mock.patch.object(
-            settings.ES_CLIENT,
+            ES_CLIENT,
             "get",
             return_value={
                 "_id": 42,
@@ -65,7 +65,7 @@ class CategoriesViewsetsTestCase(TestCase):
         request = factory.get("/api/v1.0/categories/43")
 
         # Act like the ES client would when we attempt to get a non-existent document
-        with mock.patch.object(settings.ES_CLIENT, "get", side_effect=NotFoundError):
+        with mock.patch.object(ES_CLIENT, "get", side_effect=NotFoundError):
             response = CategoriesViewSet.as_view({"get": "retrieve"})(
                 request, 43, version="1.0"
             )
@@ -77,7 +77,7 @@ class CategoriesViewsetsTestCase(TestCase):
         "richie.apps.search.forms.ItemSearchForm.build_es_query",
         lambda x: (2, 0, {"query": "example"}),
     )
-    @mock.patch.object(settings.ES_CLIENT, "search")
+    @mock.patch.object(ES_CLIENT, "search")
     def test_viewsets_categories_search(self, mock_search):
         """
         Happy path: the category is filtering the categories by name

--- a/tests/apps/search/test_viewsets_organizations.py
+++ b/tests/apps/search/test_viewsets_organizations.py
@@ -3,12 +3,12 @@ Tests for the organization viewset
 """
 from unittest import mock
 
-from django.conf import settings
 from django.test import TestCase
 
 from elasticsearch.exceptions import NotFoundError
 from rest_framework.test import APIRequestFactory
 
+from richie.apps.search import ES_CLIENT
 from richie.apps.search.viewsets.organizations import OrganizationsViewSet
 
 
@@ -25,7 +25,7 @@ class OrganizationsViewsetsTestCase(TestCase):
         request = factory.get("/api/v1.0/organizations/42")
 
         with mock.patch.object(
-            settings.ES_CLIENT,
+            ES_CLIENT,
             "get",
             return_value={
                 "_id": 42,
@@ -55,7 +55,7 @@ class OrganizationsViewsetsTestCase(TestCase):
         request = factory.get("/api/v1.0/organizations/43")
 
         # Act like the ES client would when we attempt to get a non-existent document
-        with mock.patch.object(settings.ES_CLIENT, "get", side_effect=NotFoundError):
+        with mock.patch.object(ES_CLIENT, "get", side_effect=NotFoundError):
             response = OrganizationsViewSet.as_view({"get": "retrieve"})(
                 request, 43, version="1.0"
             )
@@ -67,7 +67,7 @@ class OrganizationsViewsetsTestCase(TestCase):
         "richie.apps.search.forms.ItemSearchForm.build_es_query",
         lambda x: (2, 0, {"query": "something"}),
     )
-    @mock.patch.object(settings.ES_CLIENT, "search")
+    @mock.patch.object(ES_CLIENT, "search")
     def test_viewsets_organizations_search(self, mock_search):
         """
         Happy path: the consumer is filtering the organizations by title


### PR DESCRIPTION
## Purpose

We want to simplify Richie's settings as much as possible while still maintaining configurability.

## Proposal

I'm proposing to move the settings that are unlikely to be customized to a default pattern inside Richie.

- [x] move search settings to Richie as defaults,
- [x] refactor how the Elasticsearch client is instantiated,
- [x] move specific languages settings to Richie as defaults,
- [x] declare as defaults the settings related to Richie plugins,
- [x] minor typos and removing useless settings.