### PR TITLE
🔍(SEO) configure meta and opengraph tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a new page type for programs as a collection of courses.
 - New dependency "dj-pagination" to enable pagination on blogpost list
   and person list.
+- Add basic SEO tags with some more relevant ones in page details.
 
 ### Changed
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -1,10 +1,29 @@
 {% load i18n cms_tags menu_tags static sekizai_tags %}
 <!doctype html>
-<html>
+<html lang="{{ LANGUAGE_CODE }}">
     <head>
+        {% spaceless %}
         <title>{% block title %}{{ SITE.name }}{% endblock title %}</title>
         <meta name="viewport" content="width=device-width,initial-scale=1">
-        {% block meta %}{% endblock meta %}
+        {% block meta %}
+            {% block meta_index_rules %}
+                <meta name="robots" content="index,follow,all">
+            {% endblock meta_index_rules %}
+
+            {% block meta_html %}
+                {% page_attribute "meta_description" as meta_description %}
+                <meta name="description" content="{% block meta-description %}{% if meta_description and meta_description != "None" %}{{ meta_description }}{% endif %}{% endblock %}">
+                <meta name="keywords" content="{% block meta-keywords %}{% endblock %}">
+            {% endblock meta_html %}
+
+            {% block meta_opengraph %}
+                <meta property="og:title" content="{{ SITE.name }}">
+                <meta property="og:url" content="{{ SITE.web_url }}">
+                <meta property="og:image" content="{{ SITE.web_url }}{% static "images/logo.png" %}">
+                <meta property="og:type" content="website">
+            {% endblock meta_opengraph %}
+        {% endblock meta %}
+        {% endspaceless %}
 
         {% render_block "css" %}
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -12,15 +12,28 @@
 
             {% block meta_html %}
                 {% page_attribute "meta_description" as meta_description %}
-                <meta name="description" content="{% block meta-description %}{% if meta_description and meta_description != "None" %}{{ meta_description }}{% endif %}{% endblock %}">
-                <meta name="keywords" content="{% block meta-keywords %}{% endblock %}">
+                {% if meta_description and meta_description != "None" %}<meta name="description" content="{% block meta-description %}{{ meta_description }}{% endblock %}">{% endif %}
             {% endblock meta_html %}
 
             {% block meta_opengraph %}
-                <meta property="og:title" content="{{ SITE.name }}">
-                <meta property="og:url" content="{{ SITE.web_url }}">
-                <meta property="og:image" content="{{ SITE.web_url }}{% static "images/logo.png" %}">
-                <meta property="og:type" content="website">
+                {% block meta_opengraph_locale %}
+                    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
+                {% endblock meta_opengraph_locale %}
+                {% block meta_opengraph_type %}
+                    <meta property="og:type" content="website">
+                {% endblock meta_opengraph_type %}
+                {% block meta_opengraph_sitename %}
+                    <meta property="og:site_name" content="{{ SITE.name }}">
+                {% endblock meta_opengraph_sitename %}
+                {% comment %}Since we are not able yet to get relevant image contextually for each content kind, we
+                keep the logo as the ressource image for all{% endcomment %}
+                {% block meta_opengraph_image %}
+                    <meta property="og:image" content="{{ SITE.web_url }}{% static "images/logo.png" %}">
+                {% endblock meta_opengraph_image %}
+                {% block meta_opengraph_contextuals %}
+                    <meta property="og:title" content="{{ SITE.name }}">
+                    <meta property="og:url" content="{{ SITE.web_url }}">
+                {% endblock meta_opengraph_contextuals %}
             {% endblock meta_opengraph %}
         {% endblock meta %}
         {% endspaceless %}

--- a/src/richie/apps/core/templates/richie/fullwidth.html
+++ b/src/richie/apps/core/templates/richie/fullwidth.html
@@ -5,6 +5,12 @@
     {% page_attribute "page_title" %}
 {% endblock title %}
 
+{% block meta_opengraph_contextuals %}
+    {% page_attribute "page_title" as page_title %}
+    <meta property="og:title" content="{{ page_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+{% endblock meta_opengraph_contextuals %}
+
 {% block content %}
     {% placeholder "maincontent" %}
 {% endblock content %}

--- a/src/richie/apps/core/templates/richie/homepage.html
+++ b/src/richie/apps/core/templates/richie/homepage.html
@@ -3,6 +3,12 @@
 
 {% block breadcrumbs %}{% endblock breadcrumbs %}
 
+{% block meta_opengraph_contextuals %}
+    {% page_attribute "page_title" as page_title %}
+    <meta property="og:title" content="{{ page_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}">
+{% endblock meta_opengraph_contextuals %}
+
 {% block title %}
     {% page_attribute "page_title" %}
 {% endblock title %}

--- a/src/richie/apps/core/templates/richie/single_column.html
+++ b/src/richie/apps/core/templates/richie/single_column.html
@@ -5,6 +5,12 @@
     {% page_attribute "page_title" %}
 {% endblock title %}
 
+{% block meta_opengraph_contextuals %}
+    {% page_attribute "page_title" as page_title %}
+    <meta property="og:title" content="{{ page_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+{% endblock meta_opengraph_contextuals %}
+
 {% block content %}
 <div class="single-column">
 

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -1,15 +1,15 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n thumbnail %}
 
-{% block meta_opengraph %}
-    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
-    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
-    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
-    <meta property="og:site_name" content="{{ SITE.name }}">
-    <meta property="og:type" content="article, article:published_time, article:author, article:tag">
-    {% comment %}<meta property="og:image" content="Should be filled from cover url">{% endcomment %}
-    {% comment %}<meta property="og:description" content="Should be filled from excerpt, limited to 300char and HTML stripped">{% endcomment %}
-{% endblock meta_opengraph %}
+{% block meta_opengraph_type %}
+    <meta property="og:type" content="article">
+{% endblock meta_opengraph_type %}
+
+{% block meta_opengraph_contextuals %}
+    <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+    <meta property="article:published_time" content="{{ current_page.creation_date|date:"c" }}">
+{% endblock meta_opengraph_contextuals %}
 
 {% block content %}
 {% spaceless %}

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -1,5 +1,16 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n thumbnail %}
+
+{% block meta_opengraph %}
+    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
+    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
+    <meta property="og:site_name" content="{{ SITE.name }}">
+    <meta property="og:type" content="article, article:published_time, article:author, article:tag">
+    {% comment %}<meta property="og:image" content="Should be filled from cover url">{% endcomment %}
+    {% comment %}<meta property="og:description" content="Should be filled from excerpt, limited to 300char and HTML stripped">{% endcomment %}
+{% endblock meta_opengraph %}
+
 {% block content %}
 {% spaceless %}
 <div class="blogpost-detail">

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -1,6 +1,18 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n thumbnail %}
 
+{% comment %}{% block meta-keywords %}{{ request.current_page.get_title|lower }} + comma separated list of children{% endblock %}{% endcomment %}
+
+{% block meta_opengraph %}
+    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
+    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
+    <meta property="og:site_name" content="{{ SITE.name }}">
+    {% comment %}<meta property="og:type" content="???">{% endcomment %}
+    {% comment %}<meta property="og:image" content="Should be filled from logo url">{% endcomment %}
+    {% comment %}<meta property="og:description" content="Should be filled from description, limited to 300char and HTML stripped">{% endcomment %}
+{% endblock meta_opengraph %}
+
 {% block content %}{% spaceless %}
 {% with category=current_page.category header_level=2 %}
 <div class="category-detail">

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -1,17 +1,10 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n thumbnail %}
 
-{% comment %}{% block meta-keywords %}{{ request.current_page.get_title|lower }} + comma separated list of children{% endblock %}{% endcomment %}
-
-{% block meta_opengraph %}
-    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
-    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
-    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
-    <meta property="og:site_name" content="{{ SITE.name }}">
-    {% comment %}<meta property="og:type" content="???">{% endcomment %}
-    {% comment %}<meta property="og:image" content="Should be filled from logo url">{% endcomment %}
-    {% comment %}<meta property="og:description" content="Should be filled from description, limited to 300char and HTML stripped">{% endcomment %}
-{% endblock meta_opengraph %}
+{% block meta_opengraph_contextuals %}
+    <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+{% endblock meta_opengraph_contextuals %}
 
 {% block content %}{% spaceless %}
 {% with category=current_page.category header_level=2 %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -12,16 +12,10 @@
     {% endif %}
 {% endblock meta_index_rules %}
 
-{% block meta_opengraph %}
-    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
-    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
-    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
-    <meta property="og:site_name" content="{{ SITE.name }}">
-    {% comment %}<meta property="og:type" content="Unknow">{% endcomment %}
-    {% comment %}<meta property="og:image" content="Should be filled from cover url">{% endcomment %}
-    {% comment %}<meta property="og:video" content="Should be filled from teaser url">{% endcomment %}
-    {% comment %}<meta property="og:description" content="Should be filled from about, limited to 300char and HTML stripped">{% endcomment %}
-{% endblock meta_opengraph %}
+{% block meta_opengraph_contextuals %}
+    <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+{% endblock meta_opengraph_contextuals %}
 
 {% block content %}{% spaceless %}
 <div class="course-detail">

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -3,10 +3,25 @@
 
 {% block breadcrumbs %}{% endblock breadcrumbs %}
 
-{% block meta %}
-{# Make sure course snapshot pages are not indexed by search engines #}
-{% if current_page.parent_page.course %}<meta name="robots" content="noindex">{% endif %}
-{% endblock meta %}
+{% block meta_index_rules %}
+    {# Make sure course snapshot pages are not indexed by search engines #}
+    {% if current_page.parent_page.course %}
+        <meta name="robots" content="noindex">
+    {% else %}
+        {{ block.super }}
+    {% endif %}
+{% endblock meta_index_rules %}
+
+{% block meta_opengraph %}
+    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
+    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
+    <meta property="og:site_name" content="{{ SITE.name }}">
+    {% comment %}<meta property="og:type" content="Unknow">{% endcomment %}
+    {% comment %}<meta property="og:image" content="Should be filled from cover url">{% endcomment %}
+    {% comment %}<meta property="og:video" content="Should be filled from teaser url">{% endcomment %}
+    {% comment %}<meta property="og:description" content="Should be filled from about, limited to 300char and HTML stripped">{% endcomment %}
+{% endblock meta_opengraph %}
 
 {% block content %}{% spaceless %}
 <div class="course-detail">

--- a/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
@@ -8,7 +8,7 @@
 {% endspaceless %}{% endblock title %}
 
 {# Make sure the course run pages are not indexed by search engines #}
-{% block meta %}<meta name="robots" content="noindex">{% endblock meta %}
+{% block meta_index_rules %}<meta name="robots" content="noindex">{% endblock meta_index_rules %}
 
 {% block content %}{% spaceless %}
 <div class="course-detail">
@@ -35,7 +35,7 @@
         {% endpage_placeholder %}
       {% endwith %}
     </div>
-    
+
     <div class="course-detail__content__run">
       <h2 class="course-detail__content__run__title">{% trans 'Details' %}</h2>
       <div class="course-detail__content__run__block">
@@ -75,12 +75,12 @@
         <dd>
           <a href="{{ course_run.resource_link }}">
             {% render_model course_run "resource_link" "resource_link" "" "default:'...'" %}
-          </a> 
+          </a>
         </dd>
       </dl>
       {% endif %}
     </div>
-    
+
     {% include "courses/cms/fragment_course_content.html" with page=current_page.parent_page %}
 
   </div>

--- a/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
@@ -10,6 +10,13 @@
 {# Make sure the course run pages are not indexed by search engines #}
 {% block meta_index_rules %}<meta name="robots" content="noindex">{% endblock meta_index_rules %}
 
+{% block meta_opengraph_contextuals %}
+    {% page_attribute "page_title" as course_run_title %}
+    {% page_attribute "page_title" current_page.parent_page as course_title %}
+    <meta property="og:title" content="{{ course_run_title|capfirst }} - {{ course_title|capfirst|truncatechars:53 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+{% endblock meta_opengraph_contextuals %}
+
 {% block content %}{% spaceless %}
 <div class="course-detail">
 

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -1,6 +1,18 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n static thumbnail %}
 
+{% block meta-keywords %}{{ request.current_page.get_title|lower }}{% endblock %}
+
+{% block meta_opengraph %}
+    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
+    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
+    <meta property="og:site_name" content="{{ SITE.name }}">
+    {% comment %}<meta property="og:type" content="???">{% endcomment %}
+    {% comment %}<meta property="og:image" content="Should be filled from logo url">{% endcomment %}
+    {% comment %}<meta property="og:description" content="Should be filled from description, limited to 300char and HTML stripped">{% endcomment %}
+{% endblock meta_opengraph %}
+
 {% block content %}{% spaceless %}
 {% with organization=current_page.organization header_level=2 %}
 <div class="organization-detail">

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -1,17 +1,10 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n static thumbnail %}
 
-{% block meta-keywords %}{{ request.current_page.get_title|lower }}{% endblock %}
-
-{% block meta_opengraph %}
-    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
-    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
-    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
-    <meta property="og:site_name" content="{{ SITE.name }}">
-    {% comment %}<meta property="og:type" content="???">{% endcomment %}
-    {% comment %}<meta property="og:image" content="Should be filled from logo url">{% endcomment %}
-    {% comment %}<meta property="og:description" content="Should be filled from description, limited to 300char and HTML stripped">{% endcomment %}
-{% endblock meta_opengraph %}
+{% block meta_opengraph_contextuals %}
+    <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+{% endblock meta_opengraph_contextuals %}
 
 {% block content %}{% spaceless %}
 {% with organization=current_page.organization header_level=2 %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -1,17 +1,12 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n thumbnail %}
 
-{% block meta_opengraph %}
-    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
-    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
-    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
-    <meta property="og:site_name" content="{{ SITE.name }}">
-    <meta property="og:type" content="profile, profile:first_name, profile:last_name">
-    {% comment %}<meta property="og:image" content="Should be filled from portrait url">{% endcomment %}
-    {% comment %}<meta property="og:description" content="Should be filled from resume, limited to 300char and HTML stripped">{% endcomment %}
-{% endblock meta_opengraph %}
+{% block meta_opengraph_contextuals %}
+    <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+{% endblock meta_opengraph_contextuals %}
 
-{% block content %}
+{% block content %}{% spaceless %}
 {% with header_level=2 person=current_page.person %}
 <div class="person-detail">
   <div class="person-detail__card">
@@ -94,4 +89,4 @@
 
 </div>
 {% endwith %}
-{% endblock content %}
+{% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -1,6 +1,16 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n thumbnail %}
 
+{% block meta_opengraph %}
+    <meta property="og:title" content="{{ request.current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ request.current_page.get_absolute_url }}">
+    <meta property="og:locale" content="{{ LANGUAGE_CODE }}">
+    <meta property="og:site_name" content="{{ SITE.name }}">
+    <meta property="og:type" content="profile, profile:first_name, profile:last_name">
+    {% comment %}<meta property="og:image" content="Should be filled from portrait url">{% endcomment %}
+    {% comment %}<meta property="og:description" content="Should be filled from resume, limited to 300char and HTML stripped">{% endcomment %}
+{% endblock meta_opengraph %}
+
 {% block content %}
 {% with header_level=2 person=current_page.person %}
 <div class="person-detail">

--- a/src/richie/apps/courses/templates/courses/cms/program_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_detail.html
@@ -1,7 +1,12 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n thumbnail %}
-{% block content %}
-{% spaceless %}
+
+{% block meta_opengraph_contextuals %}
+    <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
+    <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
+{% endblock meta_opengraph_contextuals %}
+
+{% block content %}{% spaceless %}
 <div class="program-detail">
   <h1 class="program-detail__title">{% render_model current_page "title" %}</h1>
 
@@ -47,5 +52,4 @@
     <h2 class="course-glimpse-list__title">{% trans "Related courses" %}</h2>
     {% placeholder "program_courses" %}
 </section>
-{% endspaceless %}
-{% endblock content %}
+{% endspaceless %}{% endblock content %}


### PR DESCRIPTION
## Purpose

There is currently no meta tags in pages, which is an issue for SEO.

This is related to #568.

## Proposal

Here we add and define meta tags as meaningfully as possible for home and detail pages. To do so we add new dedicated blocks in the base template with some basic information then page templates can fill
or override them to define relevant meta information.

## Todo

- [x] homepage
- [x] course detail
- [x] organization detail
- [x] person detail
- [x] categories detail
- [x] blog post detail
