### PR TITLE
Add categories to a person

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Allow tagging persons with categories
 - A "Clear x active filters" button in the search filters pane lets the user
   remove all active filters with one click
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Simplify Richie settings and provide defaults for those unlikely to be
   customized (search, languages, plugins, general).
 
+### Fixed
+
+- Fix links between objects managed via plugins (e.g. categories on a course)
+  that allowed draft links to display objects on public pages.
+
 ## [1.0.0-beta.5] - 2019-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Harmonize how cards look on the site (grey border and white background),
 - Activating a filter that is a parent or child of a current active filter
   removes this active relative. This makes the experience of adding those
   relative filters more intuitive.

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -379,6 +379,10 @@ class Base(DRFMixin, Configuration):
             "limits": {"CKEditorPlugin": 1},
         },
         # Person detail
+        "courses/cms/person_detail.html categories": {
+            "name": _("Categories"),
+            "plugins": ["CategoryPlugin"],
+        },
         "courses/cms/person_detail.html portrait": {
             "name": _("Portrait"),
             "plugins": ["PicturePlugin"],

--- a/src/frontend/scss/objects/_blogpost_glimpses.scss
+++ b/src/frontend/scss/objects/_blogpost_glimpses.scss
@@ -15,7 +15,7 @@ $richie-blogpost-glimpse-container-width-lg: 33.3333% !default;
 $richie-blogpost-glimpse-container-width-xl: 25% !default;
 $richie-blogpost-glimpse-container-gutter: 0.5rem !default;
 $richie-blogpost-glimpse-container-background: $white !default;
-$richie-blogpost-glimpse-container-border: 1px solid transparent !default;
+$richie-blogpost-glimpse-container-border: 1px solid $gray80 !default;
 $richie-blogpost-glimpse-container-border-hover: 1px solid $firebrick6 !default;
 
 $richie-blogpost-glimpse-media-width: null !default;

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -15,7 +15,7 @@ $richie-course-glimpse-container-width-lg: 33.3333% !default;
 $richie-course-glimpse-container-width-xl: 25% !default;
 $richie-course-glimpse-container-gutter: 0.5rem !default;
 $richie-course-glimpse-container-background: $white !default;
-$richie-course-glimpse-container-border: 1px solid transparent !default;
+$richie-course-glimpse-container-border: 1px solid $gray80 !default;
 $richie-course-glimpse-container-border-hover: 1px solid $firebrick6 !default;
 
 $richie-course-glimpse-media-margin: 0 0 1rem 0 !default;

--- a/src/frontend/scss/objects/_person_glimpses.scss
+++ b/src/frontend/scss/objects/_person_glimpses.scss
@@ -87,7 +87,7 @@ $richie-person-glimpse-caption-background: $gray80 !default;
     );
   }
 
-  &__content__title {
+  &__content__wrapper__title {
     color: $richie-person-glimpse-content-title-fontcolor;
     text-align: $richie-person-glimpse-content-title-textalign;
     @include media-breakpoint-up(lg) {
@@ -95,7 +95,15 @@ $richie-person-glimpse-caption-background: $gray80 !default;
     }
   }
 
-  &__content__text {
+  &__content__wrapper__categories {
+    margin-bottom: 0.6rem;
+    text-align: $richie-person-glimpse-content-title-textalign;
+    @include media-breakpoint-up(lg) {
+      text-align: $richie-person-glimpse-content-title-textalign-lg;
+    }
+  }
+
+  &__content__wrapper__resume {
     @include m-o-media_empty($width: 100%, $height: 13vh, $absolute: false);
   }
 

--- a/src/frontend/scss/objects/_person_glimpses.scss
+++ b/src/frontend/scss/objects/_person_glimpses.scss
@@ -4,13 +4,13 @@
 // Available objects settings
 $richie-person-glimpse-list-maxwidth-constraint: true !default;
 $richie-person-glimpse-list-margin: 0 auto !default;
-$richie-person-glimpse-list-padding: 1rem !default;
+$richie-person-glimpse-list-padding: 1rem 0 !default;
 $richie-person-glimpse-list-title-margin: null !default;
 $richie-person-glimpse-list-title-padding: 0.5rem !default;
-$richie-person-glimpse-list-title-textalign: center !default;
+$richie-person-glimpse-list-title-textalign: left !default;
 
-$richie-person-glimpse-container-padding: 1rem 0 !default;
-$richie-person-glimpse-container-border: null !default;
+$richie-person-glimpse-container-padding: 1rem !default;
+$richie-person-glimpse-container-border: 1px solid $gray80 !default;
 $richie-person-glimpse-container-background: $white !default;
 $richie-person-glimpse-container-divider: 1rem !default;
 
@@ -18,7 +18,7 @@ $richie-person-glimpse-content-title-fontcolor: $dodgerblue5 !default;
 $richie-person-glimpse-content-title-textalign: center !default;
 $richie-person-glimpse-content-title-textalign-lg: left !default;
 
-$richie-person-glimpse-wrapper-padding: 0.2rem 0.6rem 0.6rem !default;
+$richie-person-glimpse-wrapper-padding: 0 0 0 1rem !default;
 
 $richie-person-glimpse-media-width: 100px;
 
@@ -33,9 +33,11 @@ $richie-person-glimpse-caption-background: $gray80 !default;
   @if $richie-person-glimpse-list-maxwidth-constraint {
     @include make-container-max-widths();
   }
-  margin: $richie-person-glimpse-list-margin;
-  padding: $richie-person-glimpse-list-padding;
-  background: $white;
+  display: flex;
+  margin: $richie-blogpost-glimpse-list-margin;
+  padding: $richie-blogpost-glimpse-list-padding;
+  flex-direction: row;
+  flex-wrap: wrap;
 
   &__title {
     @include sv-flex(1, 0, 100%);
@@ -88,6 +90,7 @@ $richie-person-glimpse-caption-background: $gray80 !default;
   }
 
   &__content__wrapper__title {
+    margin-bottom: 0.3rem;
     color: $richie-person-glimpse-content-title-fontcolor;
     text-align: $richie-person-glimpse-content-title-textalign;
     @include media-breakpoint-up(lg) {

--- a/src/frontend/scss/templates/courses/cms/_person_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_person_detail.scss
@@ -16,7 +16,6 @@ $richie-person-detail-media-width: 120px;
   &__card {
     @include m-o-card(
       $padding: 1rem 0,
-      $border: $richie-course-glimpse-container-border,
       $background: $richie-course-glimpse-container-background,
       $media-margin: 0,
       $caption-width: $richie-course-glimpse-caption-width,
@@ -25,7 +24,7 @@ $richie-person-detail-media-width: 120px;
       $caption-fontsize: $richie-course-glimpse-caption-fontsize,
       $caption-background: $richie-course-glimpse-caption-background,
       $content-flex-justify: flex-start,
-      $wrapper-padding: $richie-course-glimpse-wrapper-padding,
+      $wrapper-padding: 0 0 0 1rem,
       $foot-divider: $richie-course-glimpse-foot-divider,
       $methodology: 'bem'
     );

--- a/src/frontend/scss/templates/courses/plugins/_category_plugin.scss
+++ b/src/frontend/scss/templates/courses/plugins/_category_plugin.scss
@@ -49,6 +49,7 @@ $richie-category-plugin-title-textalign: center !default;
   align-content: space-between;
   border: 1px solid rgba($black, 0.125);
   border-radius: 0.25rem;
+  background-color: white;
 
   &__body {
     @include sv-flex(1, 0, 100%);

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -708,6 +708,22 @@ class PersonFactory(PageExtensionDjangoModelFactory):
 
     @factory.post_generation
     # pylint: disable=unused-argument
+    def fill_categories(self, create, extracted, **kwargs):
+        """Add categories plugin to person from a given list of category instances."""
+        if create and extracted:
+            for language in self.extended_object.get_languages():
+                placeholder = self.extended_object.placeholders.get(slot="categories")
+
+                for category in extracted:
+                    add_plugin(
+                        language=language,
+                        placeholder=placeholder,
+                        plugin_type="CategoryPlugin",
+                        **{"page": category.extended_object},
+                    )
+
+    @factory.post_generation
+    # pylint: disable=unused-argument
     def fill_portrait(self, create, extracted, **kwargs):
         """
         Add a portrait with a random image

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -50,21 +50,19 @@ class Category(BasePageExtension):
         Return a query to get the courses related to this category ie for which a plugin for
         this category is linked to the course page on the "course_categories" placeholder.
         """
-        page = (
-            self.extended_object
-            if self.extended_object.publisher_is_draft
-            else self.draft_extension.extended_object
-        )
+        is_draft = self.extended_object.publisher_is_draft
+        category = self if is_draft else self.draft_extension
         language = language or translation.get_language()
+
         bfs = "extended_object__placeholders__cmsplugin__courses_categorypluginmodel__page"
         filter_dict = {
             "extended_object__node__parent__cms_pages__course__isnull": True,
-            "extended_object__publisher_is_draft": True,
+            "extended_object__publisher_is_draft": is_draft,
             "extended_object__placeholders__slot": "course_categories",
             "extended_object__placeholders__cmsplugin__language": language,
-            bfs: page,
-            "{:s}__publisher_is_draft".format(bfs): True,
+            bfs: category.extended_object,
         }
+
         course_model = apps.get_model(app_label="courses", model_name="course")
         # pylint: disable=no-member
         return (
@@ -86,20 +84,16 @@ class Category(BasePageExtension):
         plugin for this category is linked to the blogpost page on the "categories"
         placeholder.
         """
-        page = (
-            self.extended_object
-            if self.extended_object.publisher_is_draft
-            else self.draft_extension.extended_object
-        )
+        is_draft = self.extended_object.publisher_is_draft
+        blog_post = self if is_draft else self.draft_extension
         language = language or translation.get_language()
+
         bfs = "extended_object__placeholders__cmsplugin__courses_categorypluginmodel__page"
         filter_dict = {
-            "extended_object__node__parent__cms_pages__course__isnull": True,
-            "extended_object__publisher_is_draft": True,
+            "extended_object__publisher_is_draft": is_draft,
             "extended_object__placeholders__slot": "categories",
             "extended_object__placeholders__cmsplugin__language": language,
-            bfs: page,
-            f"{bfs:s}__publisher_is_draft": True,
+            bfs: blog_post.extended_object,
         }
 
         blogpost_model = apps.get_model(app_label="courses", model_name="blogpost")

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -91,21 +91,19 @@ class Organization(BasePageExtension):
         Return a query to get the courses related to this organization ie for which a plugin for
         this organization is linked to the course page on the "course_organizations" placeholder.
         """
-        page = (
-            self.extended_object
-            if self.extended_object.publisher_is_draft
-            else self.draft_extension.extended_object
-        )
+        is_draft = self.extended_object.publisher_is_draft
+        organization = self if is_draft else self.draft_extension
         language = language or translation.get_language()
+
         bfs = "extended_object__placeholders__cmsplugin__courses_organizationpluginmodel__page"
         filter_dict = {
             "extended_object__node__parent__cms_pages__course__isnull": True,
-            "extended_object__publisher_is_draft": True,
+            "extended_object__publisher_is_draft": is_draft,
             "extended_object__placeholders__slot": "course_organizations",
             "extended_object__placeholders__cmsplugin__language": language,
-            bfs: page,
-            "{:s}__publisher_is_draft".format(bfs): True,
+            bfs: organization.extended_object,
         }
+
         course_model = apps.get_model(app_label="courses", model_name="course")
         # pylint: disable=no-member
         return (

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
@@ -6,9 +6,11 @@
   <h1 class="blogpost-glimpse-list__title">{{ current_page.get_title }}</h1>
 
   {% for page in current_page.get_child_pages %}
+    {% if page.blogpost %}
     <a class="blogpost-glimpse blogpost-glimpse--link" href="{{ page.get_absolute_url }}">
-      {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=page %}
+      {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=page.blogpost %}
     </a>
+    {% endif %}
   {% empty %}
     <p class="blogpost-glimpse blogpost-glimpse--empty">
     {% trans "No associated blogposts" %}

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -2,7 +2,7 @@
 {% load cms_tags i18n %}
 
 {% block content %}{% spaceless %}
-{% with category=current_page.category header_level=2 blogposts=current_page.category.get_blogposts courses=current_page.category.get_courses %}
+{% with category=current_page.category header_level=2 %}
 <div class="category-detail">
   <div class="category-detail__banner">
     {% placeholder "banner" or %}
@@ -27,59 +27,43 @@
   </div>
 </div>
 
-{% if blogposts %}
-<div class="blogpost-glimpse-list">
-  <h2 class="blogpost-glimpse-list__title">{% trans "Related news" %}</h2>
-  {% for blogpost in blogposts %}
-    {# If the current page is a draft, show draft courses with a class annotation for styling #}
-    {% if current_page.publisher_is_draft %}
-      {% if blogpost.check_publication is True %}
-      <a class="blogpost-glimpse blogpost-glimpse--link" href="{{ blogpost.public_extension.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=blogpost.public_extension.extended_object %}
-      </a>
-      {% else %}
-      <a class="blogpost-glimpse blogpost-glimpse--link blogpost-glimpse--draft" href="{{ blogpost.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=blogpost.extended_object %}
-      </a>
+{% with courses=category.get_courses %}
+  {% if courses %}
+  <div class="course-glimpse-list">
+    <h2 class="course-glimpse-list__title">{% trans "Related courses" %}</h2>
+    {% for course in courses %}
+      {% if course.extended_object.publisher_is_draft %}
+        <a class="course-glimpse course-glimpse--link course-glimpse--draft" href="{{ course.extended_object.get_absolute_url }}">
+          {% include "courses/cms/fragment_course_glimpse.html" %}
+        </a>
+      {% elif course.check_publication %}
+        <a class="course-glimpse course-glimpse--link" href="{{ course.extended_object.get_absolute_url }}">
+          {% include "courses/cms/fragment_course_glimpse.html" %}
+        </a>
       {% endif %}
-    {# If the current blogpost page is the published version, show only the blogposts that are published #}
-    {% elif blogpost.check_publication is True %}
-      <a class="blogpost-glimpse blogpost-glimpse--link" href="{{ blogpost.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=blogpost.public_extension.extended_object %}
-      </a>
-    {% endif %}
-  {% empty %}
-    <div class="blogpost-glimpse blogpost-glimpse--empty">
-      {% trans "No associated blogposts" %}
+    {% endfor %}
     </div>
-  {% endfor %}
-</div>
-{% endif %}
+  {% endif %}
+{% endwith %}
 
-{% if courses %}
-<div class="course-glimpse-list">
-  <h2 class="course-glimpse-list__title">{% trans "Related courses" %}</h2>
-  {% for course in courses %}
-    {# If the current page is a draft, show draft courses with a class annotation for styling #}
-    {% if current_page.publisher_is_draft %}
-      {% if course.check_publication is True %}
-      <a class="course-glimpse course-glimpse--link" href="{{ course.public_extension.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
-      </a>
-      {% else %}
-      <a class="course-glimpse course-glimpse--link course-glimpse--draft" href="{{ course.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
-      </a>
+{% with blogposts=category.get_blogposts %}
+  {% if blogposts %}
+  <div class="blogpost-glimpse-list">
+    <h2 class="blogpost-glimpse-list__title">{% trans "Related blogposts" %}</h2>
+    {% for blogpost in blogposts %}
+      {% if blogpost.extended_object.publisher_is_draft %}
+        <a class="blogpost-glimpse blogpost-glimpse--link blogpost-glimpse--draft" href="{{ blogpost.extended_object.get_absolute_url }}">
+          {% include "courses/cms/fragment_blogpost_glimpse.html" %}
+        </a>
+      {% elif blogpost.check_publication %}
+        <a class="blogpost-glimpse blogpost-glimpse--link" href="{{ blogpost.extended_object.get_absolute_url }}">
+          {% include "courses/cms/fragment_blogpost_glimpse.html" %}
+        </a>
       {% endif %}
-    {# If the current course page is the published version, show only the courses that are published #}
-    {% elif course.check_publication is True %}
-      <a class="course-glimpse course-glimpse--link" href="{{ course.extended_object.get_absolute_url }}">
-        {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
-      </a>
-    {% endif %}
-  {% endfor %}
-</div>
-{% endif %}
+    {% endfor %}
+    </div>
+  {% endif %}
+{% endwith %}
 
 {% with persons=category.get_persons %}
   {% if persons %}

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -81,5 +81,20 @@
 </div>
 {% endif %}
 
+{% with persons=category.get_persons %}
+  {% if persons %}
+  <div class="person-glimpse-list">
+    <h2 class="person-glimpse-list__title">{% trans "Related persons" %}</h2>
+    {% for person in persons %}
+      {% if person.extended_object.publisher_is_draft %}
+        {% include "courses/cms/fragment_person_glimpse.html" %}
+      {% elif person.check_publication %}
+        {% include "courses/cms/fragment_person_glimpse.html" %}
+      {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+{% endwith %}
+
 {% endwith %}
 {% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -60,13 +60,13 @@
         {% if main_organization %}
           {% if current_page.publisher_is_draft %}
               {% if main_organization.check_publication is True %}
-                  {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension.extended_object %}
+                  {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
               {% else %}
-                  {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.extended_object %}
+                  {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization %}
               {% endif %}
           {# If the current page is the published version, show only the organizations that are published #}
           {% elif main_organization.check_publication is True %}
-              {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension.extended_object %}
+              {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
           {% endif %}
         {% else %}
           {% include "courses/cms/fragment_organization_main_logo.html" with organization=None %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
@@ -1,18 +1,20 @@
 {% load i18n cms_tags %}
 {% comment %}Obviously, the context template variable "blogpost" is required and must be a BlogPost page extension{% endcomment %}
+{% with blogpost_page=blogpost.extended_object %}
 <div class="blogpost-glimpse__media">
-    {% show_placeholder "cover" blogpost %}
+    {% show_placeholder "cover" blogpost_page %}
 </div>
 <div class="blogpost-glimpse__content">
     <div class="blogpost-glimpse__content__wrapper">
-        <p class="blogpost-glimpse__content__title">{{ blogpost.get_title }}</p>
+        <p class="blogpost-glimpse__content__title">{{ blogpost_page.get_title }}</p>
         <p>
-            {% show_placeholder "excerpt" blogpost %}
+            {% show_placeholder "excerpt" blogpost_page %}
         </p>
     </div>
     <div class="blogpost-glimpse__footer">
         <p class="blogpost-glimpse__footer__date">
-            {{ blogpost.creation_date|date:"DATE_FORMAT" }}
+            {{ blogpost_page.creation_date|date:"DATE_FORMAT" }}
         </p>
     </div>
 </div>
+{% endwith %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -1,8 +1,8 @@
 {% load i18n cms_tags %}
 {% comment %}Obviously, the context template variable "course" is required and must be a Course page extension{% endcomment %}
-{% with course_state=course.state main_org_title=course.get_main_organization.extended_object.get_title %}
+{% with course_page=course.extended_object course_state=course.state main_org_title=course.get_main_organization.extended_object.get_title %}
 <div class="course-glimpse__media">
-    {% show_placeholder "course_cover" course.extended_object as cover %}
+    {% show_placeholder "course_cover" course_page as cover %}
     {% if cover %}
         {{ cover }}
     {% else %}
@@ -13,7 +13,7 @@
 </div>
 <div class="course-glimpse__content">
     <div class="course-glimpse__content__wrapper">
-        <p class="course-glimpse__content__title">{{ course.extended_object.get_title }}</p>
+        <p class="course-glimpse__content__title">{{ course_page.get_title }}</p>
         {% if main_org_title %}
         <p>{{ main_org_title }}</p>
         {% endif %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
@@ -1,8 +1,9 @@
 {% load i18n cms_tags %}{% spaceless %}
 <div class="course-detail__aside__main-org-logo">
 {% if organization %}
-    <a href="{{ organization.get_absolute_url }}" title="{{ organization.get_title }}">
-        {% show_placeholder "logo" organization as logo %}
+    {% with organization_page=organization.extended_object %}
+    <a href="{{ organization.get_absolute_url }}" title="{{ organization_page.get_title }}">
+        {% show_placeholder "logo" organization_page as logo %}
         {% if logo %}
             {{ logo }}
         {% else %}
@@ -11,6 +12,7 @@
             </div>
         {% endif %}
     </a>
+    {% endwith %}
 {% else %}
     <div class="course-detail__aside__main-org-logo__empty">
     {% trans "Main organization" %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
@@ -1,10 +1,11 @@
-{% load i18n cms_tags %}
-{% comment %}Obviously, the context template variable "person" is required and must be a Person page{% endcomment %}
+{% load i18n cms_tags extra_tags %}
+{% comment %}Obviously, the context template variable "person" is required and must be a Person page extension{% endcomment %}
+{% with person_page=person.extended_object %}
 <div class="person-glimpse">
-  <a class="person-glimpse__media" href="{{ person.get_absolute_url }}"
-      title="{{ person.person.get_full_name }} {% trans "avatar" %}">
+  <a class="person-glimpse__media" href="{{ person_page.get_absolute_url }}"
+      title="{{ person.get_full_name }} {% trans "avatar" %}">
     {% with width=200 height=200 %}
-      {% show_placeholder "portrait" person as portrait %}
+      {% page_placeholder "portrait" person_page as portrait %}
       {% if portrait %}
           {{ portrait }}
       {% else %}
@@ -16,14 +17,20 @@
   </a>
   <div class="person-glimpse__content">
     <div class="person-glimpse__content__wrapper">
-      <a href="{{ person.get_absolute_url }}" title="{{ person.person.get_full_name }}">
-        <h{{ header_level|default:2 }} class="person-glimpse__content__title">
-          {{ person.person.get_full_name }}
+      <a href="{{ person_page.get_absolute_url }}" title="{{ person.get_full_name }}">
+        <h{{ header_level|default:2 }} class="person-glimpse__content__wrapper__title">
+          {{ person.get_full_name }}
         </h{{ header_level|default:2 }}>
       </a>
-      <div class="person-glimpse__content__text">
-        {% show_placeholder "resume" person %}
+      <div class="person-glimpse__content__wrapper__categories">
+        {% with form_factor="tag" %}
+          {% page_placeholder "categories" person_page %}
+        {% endwith %}
+      </div>
+      <div class="person-glimpse__content__wrapper__resume">
+        {% page_placeholder "resume" person_page %}
       </div>
     </div>
   </div>
 </div>
+{% endwith %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -32,26 +32,17 @@
   <div class="course-glimpse-list">
     <h2 class="course-glimpse-list__title">{% trans "Related courses" %}</h2>
     {% for course in courses %}
-
-      {# If the current page is a draft, show draft courses with a class annotation for styling #}
-      {% if current_page.publisher_is_draft %}
-        {% if course.check_publication is True %}
-        <a class="course-glimpse course-glimpse--link" href="{{ course.public_extension.extended_object.get_absolute_url }}">
-          {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
-        </a>
-        {% else %}
+      {% if course.extended_object.publisher_is_draft is True %}
         <a class="course-glimpse course-glimpse--link course-glimpse--draft" href="{{ course.extended_object.get_absolute_url }}">
-          {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
+          {% include "courses/cms/fragment_course_glimpse.html" %}
         </a>
-        {% endif %}
-      {# If the current course page is the published version, show only the courses that are published #}
       {% elif course.check_publication is True %}
         <a class="course-glimpse course-glimpse--link" href="{{ course.extended_object.get_absolute_url }}">
-          {% include "courses/cms/fragment_course_glimpse.html" with course=course.public_extension %}
+          {% include "courses/cms/fragment_course_glimpse.html" %}
         </a>
       {% endif %}
     {% endfor %}
-  </div>
+    </div>
   {% endif %}
 {% endwith %}
 

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -1,10 +1,22 @@
-{% extends "richie/fullwidth.html" %} {% load cms_tags i18n %} {% block content %}
+{% extends "richie/fullwidth.html" %} {% load cms_tags extra_tags i18n %} {% block content %}
 <div class="person-detail">
   <h1 class="person-detail__title">
     {% render_model_block current_page.person %}
       {{ instance.person_title.title }} {{ instance.first_name }} {{ instance.last_name }}
     {% endrender_model_block %}
   </h1>
+
+  {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"categories" %}
+  <div class="person-detail__categories">
+    {% with form_factor="tag" %}
+      {% placeholder "categories" or %}
+        <p class="person-detail__categories__empty">
+          {% trans "No associated categories" %}
+        </p>
+      {% endplaceholder %}
+    {% endwith %}
+  </div>
+  {% endif %}
 
   <div class="person-detail__card">
     {% with header_level=2 %}

--- a/src/richie/apps/courses/templates/courses/cms/person_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_list.html
@@ -6,10 +6,12 @@
   <h1 class="person-glimpse-list__title">{{ current_page.get_title }}</h1>
 
   {% for page in current_page.get_child_pages %}
-      {% include "courses/cms/fragment_person_glimpse.html" with person=page %}
+    {% if page.person %}
+      {% include "courses/cms/fragment_person_glimpse.html" with person=page.person %}
+    {% endif %}
   {% empty %}
     <p class="person-glimpse person-glimpse--empty">
-    {% trans "No persons" %}
+      {% trans "No persons" %}
     </p>
   {% endfor %}
 </div>

--- a/src/richie/apps/courses/templates/courses/plugins/blogpost.html
+++ b/src/richie/apps/courses/templates/courses/plugins/blogpost.html
@@ -3,7 +3,7 @@
 {% if current_page.publisher_is_draft or instance.check_publication is True %}
   <div class="blogpost-plugin-container{% if relevant_page.check_publication is False %} blogpost-plugin-container--draft{% endif %}">
       <a class="blogpost-plugin" href="{{ relevant_page.get_absolute_url }}" title="{{ relevant_page.get_title }}">
-        {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=relevant_page %}
+        {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=relevant_page.blogpost %}
       </a>
   </div>
 {% endif %}

--- a/src/richie/apps/courses/templates/courses/plugins/person.html
+++ b/src/richie/apps/courses/templates/courses/plugins/person.html
@@ -7,7 +7,7 @@
       {{ relevant_page.person.get_full_name }}
     </a>
   {% else %}
-    {% include "courses/cms/fragment_person_glimpse.html" with person=relevant_page %}
+    {% include "courses/cms/fragment_person_glimpse.html" with person=relevant_page.person %}
   {% endif %}
 {% endif %}
 {% endspaceless %}

--- a/src/richie/apps/search/signals.py
+++ b/src/richie/apps/search/signals.py
@@ -46,10 +46,8 @@ def update_organization(instance, language):
     """
     organization = Organization.objects.get(draft_extension__extended_object=instance)
     actions = [
-        ES_INDICES.courses.get_es_document_for_course(course.public_extension)
-        # get_courses always returns the draft course instance
+        ES_INDICES.courses.get_es_document_for_course(course)
         for course in organization.get_courses(language)
-        if course.public_extension
     ]
     actions.append(
         ES_INDICES.organizations.get_es_document_for_organization(organization)
@@ -81,10 +79,8 @@ def update_category(instance, language):
     """
     category = Category.objects.get(draft_extension__extended_object=instance)
     actions = [
-        ES_INDICES.courses.get_es_document_for_course(course.public_extension)
-        # get_courses always returns the draft course instance
+        ES_INDICES.courses.get_es_document_for_course(course)
         for course in category.get_courses(language)
-        if course.public_extension
     ]
     actions.append(ES_INDICES.categories.get_es_document_for_category(category))
 

--- a/tests/apps/courses/test_cms_plugins_person.py
+++ b/tests/apps/courses/test_cms_plugins_person.py
@@ -128,7 +128,7 @@ class PersonPluginTestCase(CMSTestCase):
         # The person's full name should be wrapped in a h2
         self.assertContains(
             response,
-            '<h2 class="person-glimpse__content__title">{:s}</h2>'.format(
+            '<h2 class="person-glimpse__content__wrapper__title">{:s}</h2>'.format(
                 person.public_extension.get_full_name()
             ),
             html=True,
@@ -139,11 +139,10 @@ class PersonPluginTestCase(CMSTestCase):
         # Person's portrait and its properties should be present
         # pylint: disable=no-member
         self.assertContains(response, image.file.name)
-
         # Short resume should be present
         self.assertContains(
             response,
-            '<div class="person-glimpse__content__text">public resume</div>',
+            '<div class="person-glimpse__content__wrapper__resume">public resume</div>',
             html=True,
         )
         self.assertNotContains(response, "draft resume")
@@ -162,7 +161,7 @@ class PersonPluginTestCase(CMSTestCase):
         self.assertContains(response, image.file.name)
         self.assertContains(
             response,
-            '<div class="person-glimpse__content__text">résumé public</div>',
+            '<div class="person-glimpse__content__wrapper__resume">résumé public</div>',
             html=True,
         )
 

--- a/tests/apps/courses/test_models_category.py
+++ b/tests/apps/courses/test_models_category.py
@@ -74,6 +74,30 @@ class CategoryModelsTestCase(TestCase):
                     course.extended_object.prefetched_titles[0].title, "my title"
                 )
 
+    def test_models_category_get_courses_public_category_page(self):
+        """
+        When a category is added on a draft course, the course should not be visible on
+        the public category page until the course is published.
+        """
+        category = CategoryFactory(should_publish=True)
+        category_page = category.extended_object
+        course = CourseFactory(page_title="my title", should_publish=True)
+        course_page = course.extended_object
+
+        # Add a category to the course but don't publish the modification
+        placeholder = course_page.placeholders.get(slot="course_categories")
+        add_plugin(placeholder, CategoryPlugin, "en", page=category_page)
+
+        self.assertEqual(list(category.get_courses()), [course])
+        self.assertEqual(list(category.public_extension.get_courses()), [])
+
+        # Now publish the modification and check that the course is displayed
+        # on the public category page
+        course.extended_object.publish("en")
+        self.assertEqual(
+            list(category.public_extension.get_courses()), [course.public_extension]
+        )
+
     def test_models_category_get_courses_several_languages(self):
         """
         The courses should not be duplicated if they exist in several languages.
@@ -134,6 +158,31 @@ class CategoryModelsTestCase(TestCase):
                 self.assertEqual(
                     blogpost.extended_object.prefetched_titles[0].title, "my title"
                 )
+
+    def test_models_category_get_blogposts_public_category_page(self):
+        """
+        When a category is added on a draft blog post, the blog post should not be visible on
+        the public category page until the blog post is published.
+        """
+        category = CategoryFactory(should_publish=True)
+        category_page = category.extended_object
+        blog_post = BlogPostFactory(page_title="my title", should_publish=True)
+        blog_post_page = blog_post.extended_object
+
+        # Add a category to the blog post but don't publish the modification
+        placeholder = blog_post_page.placeholders.get(slot="categories")
+        add_plugin(placeholder, CategoryPlugin, "en", page=category_page)
+
+        self.assertEqual(list(category.get_blogposts()), [blog_post])
+        self.assertEqual(list(category.public_extension.get_blogposts()), [])
+
+        # Now publish the modification and check that the blog post is displayed
+        # on the public category page
+        blog_post.extended_object.publish("en")
+        self.assertEqual(
+            list(category.public_extension.get_blogposts()),
+            [blog_post.public_extension],
+        )
 
     def test_models_category_get_blogposts_several_languages(self):
         """

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -1,0 +1,143 @@
+"""
+End-to-end tests for the person detail view
+"""
+from django.test import TestCase
+
+from cms.api import add_plugin
+
+from richie.apps.core.factories import UserFactory
+from richie.apps.courses.cms_plugins import CategoryPlugin
+from richie.apps.courses.factories import CategoryFactory, PersonFactory
+
+
+class PersonCMSTestCase(TestCase):
+    """
+    End-to-end test suite to validate the content and Ux of the person detail view
+    """
+
+    def test_templates_person_detail_cms_published_content(self):
+        """
+        Validate that the important elements are displayed on a published person page
+        """
+        published_category, extra_published_category = CategoryFactory.create_batch(
+            2, should_publish=True
+        )
+        unpublished_category = CategoryFactory()
+
+        # Then modify its draft version
+        title_obj = published_category.extended_object.title_set.get(language="en")
+        title_obj.title = "modified title"
+        title_obj.save()
+
+        person = PersonFactory(
+            page_title="My page title",
+            fill_portrait=True,
+            fill_resume=True,
+            fill_categories=[published_category, unpublished_category],
+        )
+        page = person.extended_object
+
+        # The page should not be visible before it is published
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+        # Publish the person
+        page.publish("en")
+
+        # Add a new category to the draft person page but don't publish the modification
+        placeholder = page.placeholders.get(slot="categories")
+        add_plugin(
+            placeholder,
+            CategoryPlugin,
+            "en",
+            page=extra_published_category.extended_object,
+        )
+
+        # Ensure the published page content is correct
+        response = self.client.get(url)
+        self.assertContains(
+            response, "<title>My page title</title>", html=True, status_code=200
+        )
+        full_name = person.get_full_name()
+        self.assertContains(
+            response, f'<h1 class="person-detail__title">{full_name:s}</h1>', html=True
+        )
+        # The published category should be on the page in its published version
+        self.assertContains(
+            response,
+            '<a class="category-plugin-tag" href="{:s}">{:s}</a>'.format(
+                published_category.public_extension.extended_object.get_absolute_url(),
+                published_category.public_extension.extended_object.get_title(),
+            ),
+            html=True,
+        )
+        # The other categories should not be leaked:
+        # - new_category linked only on the draft person page
+        self.assertNotContains(
+            response, extra_published_category.extended_object.get_title(), html=True
+        )
+        # - unpublished category
+        self.assertNotContains(
+            response, unpublished_category.extended_object.get_title(), html=True
+        )
+        # - modified draft version of the published category
+        self.assertNotContains(response, "modified title")
+
+    def test_templates_person_detail_cms_draft_content(self):
+        """
+        A superuser should see a draft person including its draft elements with an
+        annotation.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        published_category = CategoryFactory(should_publish=True)
+        unpublished_category = CategoryFactory()
+
+        # Then modify its draft version
+        title_obj = published_category.extended_object.title_set.get(language="en")
+        title_obj.title = "modified title"
+        title_obj.save()
+
+        person = PersonFactory(
+            page_title="My page title",
+            fill_portrait=True,
+            fill_resume=True,
+            fill_categories=[published_category, unpublished_category],
+        )
+        page = person.extended_object
+
+        # The page should be visible as draft to the superuser
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+        self.assertContains(
+            response, "<title>My page title</title>", html=True, status_code=200
+        )
+        full_name = person.get_full_name()
+        self.assertContains(
+            response, f'<h1 class="person-detail__title">{full_name:s}</h1>', html=True
+        )
+        # The published category should be on the page in its published version
+        self.assertContains(
+            response,
+            '<a class="category-plugin-tag" href="{:s}">{:s}</a>'.format(
+                published_category.public_extension.extended_object.get_absolute_url(),
+                published_category.public_extension.extended_object.get_title(),
+            ),
+            html=True,
+        )
+        # The unpublished category should be on the page, mark as draft
+        self.assertContains(
+            response,
+            (
+                '<a class="category-plugin-tag category-plugin-tag--draft" '
+                'href="{:s}">{:s}</a>'
+            ).format(
+                unpublished_category.extended_object.get_absolute_url(),
+                unpublished_category.extended_object.get_title(),
+            ),
+            html=True,
+        )
+        # The modified draft version of the published category should not be visible
+        self.assertNotContains(response, "modified title")


### PR DESCRIPTION
## Purpose

We want to allow tagging a person with categories.

## Proposal

- [x] Add a template placeholder on the person detail page to add category plugins,
- [x] Add a `get_persons` method on the category model to display the list of related persons on a category page,
- [x] Add missing end-to-end tests on the person detail template,
- [x] Harmonize how boxes look throughout the site (borders and backgrounds).

While doing this PR I found a bug that allowed plugins added to a draft page to be displayed on the public page so I fixed it everywhere:

- on the category page:
    - [x] related courses
    - [x] related blog posts
- on the organization page:
    - [x] related courses

## Screenshots

<img src="https://user-images.githubusercontent.com/1427165/56147699-0a64ca00-5fa9-11e9-8af8-b9c29b1bf029.png" width="700">

<img src="https://user-images.githubusercontent.com/1427165/56147926-85c67b80-5fa9-11e9-8c84-b3109ee802d2.png" width="700">

