### PR TITLE
Update course glimpse to match template in CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add template and styling for persons list page,
 - Add template and styling for categories list page,
 - Add sub categories in category detail page.
+  remove all active filters with one click.
+- Show CTAs to Enroll on course glimpses in Search.
 
 ## Changed
 
@@ -33,6 +35,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix links between objects managed via plugins (e.g. categories on a course)
   that allowed draft links to display objects on public pages.
+
+### Fixed
+
+- Show the highlighted organization on course glimpses in Search.
+- Show a placeholder image on course glimpses in Search when the
+  cover for the course is missing.
 
 ## [1.0.0-beta.5] - 2019-04-11
 

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
@@ -57,7 +57,7 @@ describe('components/CourseGlimpse', () => {
       },
       title: 'Course 42',
     } as Course;
-    const { getByAltText, getByText, getByTitle } = render(
+    const { getByText, getByTitle } = render(
       <IntlProvider locale="en">
         <CourseGlimpse course={course} />
       </IntlProvider>,
@@ -66,5 +66,26 @@ describe('components/CourseGlimpse', () => {
     // Make sure the component renders and shows the state
     getByTitle('Details page for Course 42.');
     getByText('Archived');
+  });
+
+  it('shows the "Cover" placeholder div when the course is missing a cover image', () => {
+    const course = {
+      cover_image: null,
+      organization_highlighted: 'Some Organization',
+      state: {
+        call_to_action: 'Enroll now',
+        datetime: '2019-03-14T10:35:47.823Z',
+        text: 'starts on',
+      },
+      title: 'Course 42',
+    } as Course;
+    const { getByText, getByTitle } = render(
+      <IntlProvider locale="en">
+        <CourseGlimpse course={course} />
+      </IntlProvider>,
+    );
+
+    getByTitle('Details page for Course 42.');
+    getByText('Cover');
   });
 });

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
@@ -5,7 +5,6 @@ import { IntlProvider } from 'react-intl';
 import { cleanup, render } from 'react-testing-library';
 
 import { Course } from '../../types/Course';
-import { Organization } from '../../types/Organization';
 import { CourseGlimpse } from './CourseGlimpse';
 
 describe('components/CourseGlimpse', () => {
@@ -14,18 +13,16 @@ describe('components/CourseGlimpse', () => {
   it('renders a course glimpse with its data', () => {
     const course = {
       cover_image: '/thumbs/small.png',
+      organization_highlighted: 'Some Organization',
       state: {
         datetime: '2019-03-14T10:35:47.823Z',
         text: 'starts on',
       },
       title: 'Course 42',
     } as Course;
-    const organization = {
-      title: 'Some Organization',
-    } as Organization;
     const { getByAltText, getByText, getByTitle } = render(
       <IntlProvider locale="en">
-        <CourseGlimpse course={course} organizationMain={organization} />
+        <CourseGlimpse course={course} />
       </IntlProvider>,
     );
 

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
@@ -15,6 +15,7 @@ describe('components/CourseGlimpse', () => {
       cover_image: '/thumbs/small.png',
       organization_highlighted: 'Some Organization',
       state: {
+        call_to_action: 'Enroll now',
         datetime: '2019-03-14T10:35:47.823Z',
         text: 'starts on',
       },
@@ -37,10 +38,33 @@ describe('components/CourseGlimpse', () => {
         element.innerHTML.startsWith('Starts on') &&
         element.innerHTML.includes('Mar 14, 2019'),
     );
+    getByText('Enroll now');
     // The logo is rendered along with alternate text
     expect(getByAltText('Logo for Course 42')).toHaveAttribute(
       'src',
       '/thumbs/small.png',
     );
+  });
+
+  it('works when there is no call to action or datetime on the state (eg. an archived course)', () => {
+    const course = {
+      cover_image: '/thumbs/small.png',
+      organization_highlighted: 'Some Organization',
+      state: {
+        call_to_action: null,
+        datetime: null,
+        text: 'archived',
+      },
+      title: 'Course 42',
+    } as Course;
+    const { getByAltText, getByText, getByTitle } = render(
+      <IntlProvider locale="en">
+        <CourseGlimpse course={course} />
+      </IntlProvider>,
+    );
+
+    // Make sure the component renders and shows the state
+    getByTitle('Details page for Course 42.');
+    getByText('Archived');
   });
 });

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpse.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpse.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   defineMessages,
   FormattedDate,
-  FormattedMessage,
   InjectedIntlProps,
   injectIntl,
 } from 'react-intl';
@@ -13,7 +12,6 @@ import { Nullable } from '../../utils/types';
 
 export interface CourseGlimpseProps {
   course: Course;
-  organizationMain: Nullable<Organization>;
 }
 
 const messages = defineMessages({
@@ -36,11 +34,7 @@ const messages = defineMessages({
 });
 
 export const CourseGlimpse = injectIntl(
-  ({
-    course,
-    intl,
-    organizationMain,
-  }: CourseGlimpseProps & InjectedIntlProps) => (
+  ({ course, intl }: CourseGlimpseProps & InjectedIntlProps) => (
     <a
       className="course-glimpse course-glimpse--link"
       href={course.absolute_url}
@@ -59,7 +53,7 @@ export const CourseGlimpse = injectIntl(
       <div className="course-glimpse__content">
         <div className="course-glimpse__content__wrapper">
           <p className="course-glimpse__content__title">{course.title}</p>
-          <p>{(organizationMain && organizationMain.title) || ''}</p>
+          <p>{course.organization_highlighted}</p>
         </div>
       </div>
       <div className="course-glimpse__footer">

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpse.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpse.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 import {
   defineMessages,
   FormattedDate,
+  FormattedMessage,
   InjectedIntlProps,
   injectIntl,
 } from 'react-intl';
 
 import { Course } from '../../types/Course';
-import { Organization } from '../../types/Organization';
-import { Nullable } from '../../utils/types';
 
 export interface CourseGlimpseProps {
   course: Course;
@@ -19,6 +18,12 @@ const messages = defineMessages({
     defaultMessage: 'Logo for {courseTitle}',
     description: 'Alternate text for the course logo in a course glimpse.',
     id: 'components.CourseGlimpse.logoAltText',
+  },
+  cover: {
+    defaultMessage: 'Cover',
+    description:
+      'Placeholder text when the course we are glimpsing at is missing a cover image',
+    id: 'components.CourseGlimpse.cover',
   },
   date: {
     defaultMessage: 'Starts on {date}',
@@ -43,12 +48,18 @@ export const CourseGlimpse = injectIntl(
       })}
     >
       <div className="course-glimpse__media">
-        <img
-          src={course.cover_image}
-          alt={intl.formatMessage(messages.altText, {
-            courseTitle: course.title,
-          })}
-        />
+        {course.cover_image ? (
+          <img
+            src={course.cover_image}
+            alt={intl.formatMessage(messages.altText, {
+              courseTitle: course.title,
+            })}
+          />
+        ) : (
+          <div className="course-glimpse__media__empty">
+            <FormattedMessage {...messages.cover} />
+          </div>
+        )}
       </div>
       <div className="course-glimpse__content">
         <div className="course-glimpse__content__wrapper">

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpse.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpse.tsx
@@ -60,14 +60,26 @@ export const CourseGlimpse = injectIntl(
         <p className="course-glimpse__footer__date">
           {course.state.text.charAt(0).toUpperCase() +
             course.state.text.substr(1)}
-          &nbsp;
-          <FormattedDate
-            value={new Date(course.state.datetime)}
-            year="numeric"
-            month="short"
-            day="numeric"
-          />
+          {course.state.datetime ? (
+            <React.Fragment>
+              <br />
+              <FormattedDate
+                value={new Date(course.state.datetime)}
+                year="numeric"
+                month="short"
+                day="numeric"
+              />
+            </React.Fragment>
+          ) : null}
         </p>
+        {course.state.call_to_action ? (
+          <div className="course-glimpse__footer__cta">
+            <button className="button">
+              {course.state.call_to_action.charAt(0).toUpperCase() +
+                course.state.call_to_action.substr(1)}
+            </button>
+          </div>
+        ) : null}
       </div>
     </a>
   ),

--- a/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.tsx
@@ -11,14 +11,7 @@ export const CourseGlimpseList = ({ courses }: CourseGlimpseListProps) => {
   return (
     <div className="course-glimpse-list">
       {courses.map(
-        course =>
-          course && (
-            <CourseGlimpse
-              course={course}
-              key={course.id}
-              organizationMain={null}
-            />
-          ),
+        course => course && <CourseGlimpse course={course} key={course.id} />,
       )}
     </div>
   );

--- a/src/frontend/js/types/Course.ts
+++ b/src/frontend/js/types/Course.ts
@@ -4,6 +4,7 @@ export interface Course extends Resource {
   absolute_url: string;
   categories: string[];
   cover_image: string;
+  organization_highlighted: string;
   organizations: string[];
   state: {
     call_to_action: string;

--- a/src/frontend/js/types/Course.ts
+++ b/src/frontend/js/types/Course.ts
@@ -1,3 +1,4 @@
+import { Nullable } from '../utils/types';
 import { Resource } from './Resource';
 
 export interface Course extends Resource {
@@ -7,8 +8,8 @@ export interface Course extends Resource {
   organization_highlighted: string;
   organizations: string[];
   state: {
-    call_to_action: string;
-    datetime: string;
+    call_to_action: Nullable<string>;
+    datetime: Nullable<string>;
     priority: number;
     text: string;
   };

--- a/src/frontend/js/types/Course.ts
+++ b/src/frontend/js/types/Course.ts
@@ -4,7 +4,7 @@ import { Resource } from './Resource';
 export interface Course extends Resource {
   absolute_url: string;
   categories: string[];
-  cover_image: string;
+  cover_image: Nullable<string>;
   organization_highlighted: string;
   organizations: string[];
   state: {

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -139,7 +139,6 @@ $richie-course-glimpse-foot-cta-background-hover: $firebrick6 !default;
 
     &__date {
       @include sv-flex-cell-width(auto);
-      display: flex;
       margin: 0;
       padding: $richie-course-glimpse-foot-date-padding;
       font-size: $richie-course-glimpse-foot-date-fontsize;

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -66,6 +66,7 @@ class CoursesIndexer:
         "categories",
         "cover_image",
         "organizations",
+        "organizations_names",
         "title.*",
     ]
     form = CourseSearchForm
@@ -512,6 +513,9 @@ class CoursesIndexer:
             "absolute_url": get_best_field_language(source["absolute_url"], language),
             "categories": source["categories"],
             "cover_image": get_best_field_language(source["cover_image"], language),
+            "organization_highlighted": get_best_field_language(
+                source["organizations_names"], language
+            )[0],
             "organizations": source["organizations"],
             "state": CourseState(**state),
             "title": get_best_field_language(source["title"], language),

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -325,9 +325,10 @@ class CoursesIndexersTestCase(TestCase):
             "_id": 93,
             "_source": {
                 "absolute_url": {"en": "campo-qui-format-do"},
+                "categories": [43, 86],
                 "cover_image": {"en": "image.jpg"},
                 "organizations": [42, 84],
-                "categories": [43, 86],
+                "organizations_names": {"en": ["Org 42", "Org 84"]},
                 "title": {"en": "Duis eu arcu erat"},
             },
             "fields": {
@@ -341,9 +342,10 @@ class CoursesIndexersTestCase(TestCase):
             {
                 "id": 93,
                 "absolute_url": "campo-qui-format-do",
-                "cover_image": "image.jpg",
-                "organizations": [42, 84],
                 "categories": [43, 86],
+                "cover_image": "image.jpg",
+                "organization_highlighted": "Org 42",
+                "organizations": [42, 84],
                 "title": "Duis eu arcu erat",
                 "state": CourseState(
                     0, datetime(2019, 3, 17, 21, 25, 52, 179667, pytz.utc)

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -31,6 +31,7 @@ COURSES = [
         },
         "is_new": True,
         "organizations": ["P-00030001", "P-00030004", "L-000300010001"],
+        "organizations_names": {"en": ["Org 31", "Org 34", "Org 311"]},
         "title": {"en": "Artificial intelligence for mushroom picking"},
     },
     {
@@ -46,6 +47,7 @@ COURSES = [
         },
         "is_new": True,
         "organizations": ["P-00030001", "P-00030003", "L-000300010002"],
+        "organizations_names": {"en": ["Org 31", "Org 33", "Org 312"]},
         "title": {"en": "Click-farms: managing the autumn harvest"},
     },
     {
@@ -61,6 +63,7 @@ COURSES = [
         },
         "is_new": False,
         "organizations": ["P-00030002", "P-00030003", "L-000300020001"],
+        "organizations_names": {"en": ["Org 32", "Org 33", "Org 321"]},
         "title": {"en": "Building a data lake out of mountain springs"},
     },
     {
@@ -75,6 +78,7 @@ COURSES = [
         },
         "is_new": False,
         "organizations": ["P-00030002", "P-00030004", "L-000300020002"],
+        "organizations_names": {"en": ["Org 32", "Org 34", "Org 322"]},
         "title": {"en": "Kung-fu moves for cloud infrastructure security"},
     },
 ]
@@ -323,6 +327,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                             "L-00020001",
                         ],
                         "cover_image": "image",
+                        "organization_highlighted": "Org 31",
                         "organizations": ["P-00030001", "P-00030004", "L-000300010001"],
                         "state": {
                             "priority": 0,
@@ -344,6 +349,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                             "L-00020001",
                         ],
                         "cover_image": "image",
+                        "organization_highlighted": "Org 32",
                         "organizations": ["P-00030002", "P-00030003", "L-000300020001"],
                         "state": {
                             "priority": 0,
@@ -365,6 +371,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                             "L-00020002",
                         ],
                         "cover_image": "image",
+                        "organization_highlighted": "Org 32",
                         "organizations": ["P-00030002", "P-00030004", "L-000300020002"],
                         "state": {
                             "priority": 1,
@@ -386,6 +393,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                             "L-00020003",
                         ],
                         "cover_image": "image",
+                        "organization_highlighted": "Org 31",
                         "organizations": ["P-00030001", "P-00030003", "L-000300010002"],
                         "state": {
                             "priority": 4,

--- a/tests/apps/search/test_query_courses_edge_cases.py
+++ b/tests/apps/search/test_query_courses_edge_cases.py
@@ -136,14 +136,15 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
         self.prepare_index(
             [
                 {
-                    "id": index,
-                    "organizations": [id],
-                    "categories": [],
-                    "is_new": False,
                     "absolute_url": {"en": "url"},
-                    "cover_image": {"en": "image"},
-                    "title": {"en": "title"},
+                    "categories": [],
                     "course_runs": [],
+                    "cover_image": {"en": "image"},
+                    "id": index,
+                    "is_new": False,
+                    "organizations": [id],
+                    "organizations_names": {"en": ["Org #{:s}".format(id)]},
+                    "title": {"en": "title"},
                 }
                 for index, id in enumerate(organizations)
             ]
@@ -211,16 +212,17 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
         self.prepare_index(
             [
                 {
+                    "absolute_url": {"en": "url"},
+                    "categories": [],
+                    "course_runs": [],
+                    "cover_image": {"en": "image"},
                     "id": index,
+                    "is_new": False,
                     "organizations": random.sample(
                         organizations, random.randint(1, len(organizations))
                     ),
-                    "categories": [],
-                    "is_new": False,
-                    "absolute_url": {"en": "url"},
-                    "cover_image": {"en": "image"},
+                    "organizations_names": {"en": ["Org #{:s}".format(id)]},
                     "title": {"en": "title"},
-                    "course_runs": [],
                 }
                 for index, id in enumerate(organizations)
             ]

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -253,6 +253,7 @@ class CoursesViewsetsTestCase(TestCase):
                 "categories",
                 "cover_image",
                 "organizations",
+                "organizations_names",
                 "title.*",
             ],
             body={


### PR DESCRIPTION
## Purpose

Course glimpses in the search results were missing elements and cases when compared to the ones in the CMS.

## Proposal

Bring them up-to-speed:

- [x] add the highlighted organization for a course on the API;
- [x] show this organization on course glimpses in search results;
- [x] add CTAs on glimpses when it is relevant;
- [x] add a placeholder when a course is missing a cover image (Closes #638)
