### PR TITLE
Fix minor glitches

### DIFF
--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -449,7 +449,7 @@ class PersonWizardForm(BaseWizardForm):
     """
 
     person_title = forms.ModelChoiceField(
-        required=True,
+        required=False,
         queryset=PersonTitle.objects.all(),
         label=_("Title"),
         help_text=_("Choose this person's title among existing ones"),

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
@@ -1,22 +1,22 @@
 {% load i18n cms_tags %}{% spaceless %}
 <div class="course-detail__aside__main-org-logo">
-{% if organization %}
+  {% if organization %}
     {% with organization_page=organization.extended_object %}
-    <a href="{{ organization.get_absolute_url }}" title="{{ organization_page.get_title }}">
+      <a href="{{ organization_page.get_absolute_url }}" title="{{ organization_page.get_title }}">
         {% show_placeholder "logo" organization_page as logo %}
         {% if logo %}
-            {{ logo }}
+          {{ logo }}
         {% else %}
-            <div class="course-detail__aside__main-org-logo__empty">
+          <div class="course-detail__aside__main-org-logo__empty">
             {% trans "Main organization" %}
-            </div>
+          </div>
         {% endif %}
-    </a>
+      </a>
     {% endwith %}
-{% else %}
+  {% else %}
     <div class="course-detail__aside__main-org-logo__empty">
-    {% trans "Main organization" %}
+      {% trans "Main organization" %}
     </div>
-{% endif %}
+  {% endif %}
 </div>
 {% endspaceless %}

--- a/tests/apps/courses/test_cms_wizards_person.py
+++ b/tests/apps/courses/test_cms_wizards_person.py
@@ -289,9 +289,9 @@ class PersonCMSWizardTestCase(CMSTestCase):
         # Check that missing last_name field is a cause for the invalid form
         self.assertEqual(form.errors["last_name"], ["This field is required."])
 
-    def test_cms_wizards_person_submit_form_person_title_required(self):
+    def test_cms_wizards_person_submit_form_person_title_not_required(self):
         """
-        The `person_title` field should be required
+        The `person_title` field should not be required
         """
         # A parent page should pre-exist
         create_page(
@@ -301,16 +301,14 @@ class PersonCMSWizardTestCase(CMSTestCase):
             reverse_id=Person.ROOT_REVERSE_ID,
         )
 
-        invalid_data = {
+        no_title_data = {
             "title": "A person",
             "first_name": "First name",
             "last_name": "Last name",
         }
 
-        form = PersonWizardForm(data=invalid_data)
-        self.assertFalse(form.is_valid())
-        # Check that missing last_name field is a cause for the invalid form
-        self.assertEqual(form.errors["person_title"], ["This field is required."])
+        form = PersonWizardForm(data=no_title_data)
+        self.assertTrue(form.is_valid())
 
     def test_cms_wizards_person_parent_page_should_exist(self):
         """


### PR DESCRIPTION
## Purpose

Our support department reported 2 small glitches:

- The link on the main organization logo was broken,
- The person title field should not be required when creating a new person page.

## Proposal

- [x] Compute url from the organization page and not the organization page extension,
- [x] Change to `required=False` on the `person_title` form field and change related test.