### PR TITLE
🔖(chore) bump release to 1.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0-beta.6] - 2019-04-17
+
 ### Added
 
 - Allow tagging persons with categories,
@@ -16,14 +18,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add template and styling for persons list page,
 - Add template and styling for categories list page,
 - Add sub categories in category detail page.
-  remove all active filters with one click.
 - Show CTAs to Enroll on course glimpses in Search.
 - Make the `RICHIE_ES_HOST` configurable in the sandbox
 
 ## Changed
 
 - Harmonize how cards look on the site (grey border and white background),
-- Move all the code demo site related to the demo site to its own application,
+- Move all the code related to the demo site to its own application,
 - Activating a filter that is a parent or child of a current active filter
   removes this active relative. This makes the experience of adding those
   relative filters more intuitive,
@@ -31,15 +32,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   customized (search, languages, plugins, general),
 - Change layout global background to darker grey,
 - Improve 'categories' page layout,
-- Every organization in a list is not displayed with an organization glimpse.
+- Every organization in a list is now displayed with an organization glimpse.
 
 ### Fixed
 
 - Fix links between objects managed via plugins (e.g. categories on a course)
   that allowed draft links to display objects on public pages.
-
-### Fixed
-
 - Show the highlighted organization on course glimpses in Search.
 - Show a placeholder image on course glimpses in Search when the
   cover for the course is missing.
@@ -194,7 +192,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.0.0-beta.5...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.0.0-beta.6...master
+[1.0.0-beta.6]: https://github.com/openfun/richie/compare/v1.0.0-beta.5...v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/openfun/richie/compare/v1.0.0-beta.4...v1.0.0-beta.5
 [1.0.0-beta.4]: https://github.com/openfun/richie/compare/v1.0.0-beta.3...v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/openfun/richie/compare/v1.0.0-beta.2...v1.0.0-beta.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.0.0-beta.5
+version = 1.0.0-beta.6
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -13,7 +13,7 @@ url = https://github.com/openfun/richie
 license = MIT
 keywords = Django, Django-CMS, Open edX
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Framework :: Django
     Framework :: Django :: 1.11
     Intended Audience :: Developers

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {


### PR DESCRIPTION
### Added

- Allow tagging persons with categories,
- A "Clear x active filters" button in the search filters pane lets the user remove all active filters with one click
- Add template and styling for persons list page,
- Add template and styling for categories list page,
- Add sub categories in category detail page.
- Show CTAs to Enroll on course glimpses in Search.
- Make the `RICHIE_ES_HOST` configurable in the sandbox

### Changed

- Harmonize how cards look on the site (grey border and white background),
- Move all the code related to the demo site to its own application,
- Activating a filter that is a parent or child of a current active filter removes this active relative. This makes the experience of adding those relative filters more intuitive,
- Simplify Richie settings and provide defaults for those unlikely to be customized (search, languages, plugins, general),
- Change layout global background to darker grey,
- Improve 'categories' page layout,
- Every organization in a list is now displayed with an organization glimpse.

### Fixed

- Fix links between objects managed via plugins (e.g. categories on a course) that allowed draft links to display objects on public pages.
- Show the highlighted organization on course glimpses in Search.
- Show a placeholder image on course glimpses in Search when the cover for the course is missing.
