### PR TITLE
Fix ci hub job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       - checkout
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-      # Activate docker-in-docker
+      # Activate docker-in-docker (with layers caching enabled)
       - setup_remote_docker:
           docker_layer_caching: true
       # Each image is tagged with the current git commit sha1 to avoid
@@ -99,7 +99,7 @@ jobs:
       - checkout
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-      # Activate docker-in-docker
+      # Activate docker-in-docker (with layers caching enabled)
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -369,9 +369,23 @@ jobs:
       - image: circleci/buildpack-deps:stretch
     working_directory: ~/fun
     steps:
-      # Activate docker-in-docker
+      # Checkout repository sources
+      - checkout
+      # Generate a version.json file describing app release
+      - <<: *generate-version-file
+      # Activate docker-in-docker (with layers caching enabled)
       - setup_remote_docker:
           docker_layer_caching: true
+      - run:
+          name: Build production image (using cached layers)
+          command: docker build -t richie:${CIRCLE_SHA1} .
+      - run:
+          name: Build alpine production image (using cached layers)
+          command: |
+            docker build \
+              -t richie:${CIRCLE_SHA1}-alpine \
+              -f docker/images/alpine/Dockerfile \
+              .
       - run:
           name: Check built images availability
           command: docker images "richie:${CIRCLE_SHA1}*"
@@ -703,6 +717,8 @@ workflows:
       # it has been tagged with a tag starting with the letter v
       - hub:
           requires:
+            - build-docker
+            - build-docker-alpine
             - test-front
             - test-back-mysql
             - test-back-postgresql

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -618,8 +618,7 @@ workflows:
             branches:
               ignore: master
             tags:
-              only: /.*/
-
+              only: /(?!^v).*/
       - lint-changelog:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,10 +561,8 @@ jobs:
             # Compile it!
             yarn node-sass --include-path node_modules main.scss main.css
 
-  # Publishing to npm requires that:
-  #   * you already registered to pypi.org
-  #   * you have define the NPM_TOKEN secret environment variables in CircleCI
-  #     UI (with your PyPI credentials)
+  # Publishing to npm requires that you have define the NPM_TOKEN secret
+  # environment variables in CircleCI UI (with your PyPI credentials)
   npm:
     docker:
       - image: circleci/node:10
@@ -572,9 +570,6 @@ jobs:
     steps:
       - checkout:
           path: ~/fun
-      - restore_cache:
-          keys:
-            - v5-front-dependencies-{{ checksum "yarn.lock" }}
       - run:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/fun/.npmrc


### PR DESCRIPTION
## Purpose

The build-docker* jobs are using CircleCI docker layers caching feature. At first, I thought that the images will also get restored in future jobs, but this is not the case; only layers are cached. 

## Proposal

In order to properly tag and publish build images, we need to rebuild them first (using cached layers). I expect that no new layer will be created and it should be blazing fast.

I've also made improvements to:

- [x] ignore the `check-changelog` job for release tags
- [x] remove the cache restoration step in the `npm` job (not required)
