### PR TITLE
🐛(search) fix a display glitch in active parent filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a display glitch with parent filters when active
+
 ## [1.0.0-beta.6] - 2019-04-17
 
 ### Added

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
@@ -252,7 +252,7 @@ describe('<SearchFilterValueParent />', () => {
 
     // The button shows its active state
     const button = getByText('Human name').parentElement;
-    expect(button).toHaveClass('active');
+    expect(button!.parentElement).toHaveClass('active');
     expect(button).toHaveAttribute('aria-pressed', 'true');
   });
 

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
@@ -89,7 +89,11 @@ export const SearchFilterValueParent = injectIntl(
     const [isActive, toggle] = useFilterValue(filter, value);
     return (
       <div className="search-filter-value-parent">
-        <div className="search-filter-value-parent__self">
+        <div
+          className={`search-filter-value-parent__self ${
+            isActive ? 'active' : ''
+          }`}
+        >
           <button
             aria-label={intl.formatMessage(
               showChildren
@@ -104,9 +108,7 @@ export const SearchFilterValueParent = injectIntl(
             &gt;
           </button>
           <button
-            className={`search-filter-value-parent__self__btn ${
-              isActive ? 'active' : ''
-            }`}
+            className={`search-filter-value-parent__self__btn`}
             onClick={toggle}
             aria-pressed={isActive}
           >

--- a/src/frontend/scss/objects/_search-filter-value.scss
+++ b/src/frontend/scss/objects/_search-filter-value.scss
@@ -23,14 +23,6 @@ $richie-search-filter-value-active-divider-border: 1px solid $white !default;
     color: $richie-search-filter-value-fontcolor-hover;
   }
 
-  // Include both here for `<a>`s and `<button>`s
-  &.active {
-    z-index: 2; // Place active items above their siblings for proper border styling
-    font-weight: $richie-search-filter-value-active-fontweight;
-    color: $richie-search-filter-value-active-fontcolor;
-    border-top: $richie-search-filter-value-active-divider-border;
-  }
-
   &__name {
     flex-grow: 1;
     text-align: start;
@@ -56,11 +48,26 @@ $richie-search-filter-value-active-divider-border: 1px solid $white !default;
   }
 }
 
+// Most active styles are done on the filter button itself (which is the component itself for leaves
+// and an inner part for parents)
+.search-filter-value-leaf.active,
+.search-filter-value-parent__self.active
+  > .search-filter-value-parent__self__btn {
+  z-index: 2; // Place active items above their siblings for proper border styling
+  font-weight: $richie-search-filter-value-active-fontweight;
+  color: $richie-search-filter-value-active-fontcolor;
+}
+
+// Border styling needs to be done on an outer component for parents, incl. active styling
 .search-filter-value-leaf,
 .search-filter-value-parent__self {
   display: flex;
   border-top: $richie-search-filter-value-divider-border;
   padding: $richie-search-filter-value-padding;
+
+  &.active {
+    border-top: $richie-search-filter-value-active-divider-border;
+  }
 }
 
 .search-filter-value-parent {


### PR DESCRIPTION
## Purpose

Active parent filters in the search filters pane were displayed with 2 borders due to a mistake in the styles (as most styles are common between parent self filters & leaf filters).

## Proposal

We updated the CSS to fix this glitch and reorganized & added comments to the `.scss` file to make it more explicit where the two uses for these styles need to be handled with special care.
