### PR TITLE
✨(organizations) show related persons on the organization detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Show related persons on the organization detail page (a person is related to
+  an organization if it is part of the team of a course of this organization).
+
 ### Changed
 
 - Use checkboxes to enable/disable filters in search page.

--- a/src/richie/apps/courses/models/person.py
+++ b/src/richie/apps/courses/models/person.py
@@ -134,6 +134,7 @@ class PersonPluginModel(PagePluginMixin, CMSPlugin):
         Page,
         on_delete=models.CASCADE,
         limit_choices_to={"publisher_is_draft": True, "person__isnull": False},
+        related_name="person_plugins",
     )
 
     class Meta:

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -46,5 +46,20 @@
   {% endif %}
 {% endwith %}
 
+{% with persons=organization.get_persons %}
+  {% if persons %}
+  <div class="person-glimpse-list">
+    <h2 class="person-glimpse-list__title">{% trans "Related persons" %}</h2>
+    {% for person in persons %}
+      {% if person.extended_object.publisher_is_draft %}
+        {% include "courses/cms/fragment_person_glimpse.html" %}
+      {% elif person.check_publication %}
+        {% include "courses/cms/fragment_person_glimpse.html" %}
+      {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+{% endwith %}
+
 {% endwith %}
 {% endspaceless %}{% endblock content %}

--- a/tests/apps/courses/test_models_organization.py
+++ b/tests/apps/courses/test_models_organization.py
@@ -7,8 +7,12 @@ from django.test import TestCase
 from cms.api import add_plugin, create_page
 
 from richie.apps.core.helpers import create_i18n_page
-from richie.apps.courses.cms_plugins import OrganizationPlugin
-from richie.apps.courses.factories import CourseFactory, OrganizationFactory
+from richie.apps.courses.cms_plugins import OrganizationPlugin, PersonPlugin
+from richie.apps.courses.factories import (
+    CourseFactory,
+    OrganizationFactory,
+    PersonFactory,
+)
 from richie.apps.courses.models import Course, Organization
 
 
@@ -162,3 +166,85 @@ class OrganizationModelsTestCase(TestCase):
         self.assertEqual(Course.objects.count(), 4)
         self.assertEqual(organization.get_courses().count(), 1)
         self.assertEqual(organization.public_extension.get_courses().count(), 1)
+
+    def test_models_organization_get_persons(self):
+        """
+        It should be possible to retrieve the list of related persons on the organization instance.
+        The number of queries should be minimal.
+        """
+        organization = OrganizationFactory(should_publish=True)
+        persons = PersonFactory.create_batch(
+            2, page_title="my title", should_publish=True
+        )
+        CourseFactory(
+            fill_organizations=[organization],
+            fill_team=[persons[0]],
+            should_publish=True,
+        )
+        CourseFactory(
+            fill_organizations=[organization],
+            fill_team=[persons[1]],
+            should_publish=True,
+        )
+        retrieved_persons = organization.get_persons()
+
+        with self.assertNumQueries(2):
+            self.assertEqual(set(retrieved_persons), set(persons))
+
+        with self.assertNumQueries(0):
+            for person in retrieved_persons:
+                self.assertEqual(
+                    person.extended_object.prefetched_titles[0].title, "my title"
+                )
+
+    def test_models_organization_get_persons_draft_person_plugin(self):
+        """
+        If a person is related to an organization via a course but that the modification adding
+        the person to the course team is not published, the person should not be retrieved by
+        the `get_person` method on the organization.
+        """
+        organization = OrganizationFactory(should_publish=True)
+        person = PersonFactory(should_publish=True)
+        course = CourseFactory(fill_organizations=[organization], should_publish=True)
+
+        # Add a person to the course but don't publish the modification
+        placeholder = course.extended_object.placeholders.get(slot="course_team")
+        add_plugin(placeholder, PersonPlugin, "en", page=person.extended_object)
+
+        self.assertEqual(list(organization.get_persons()), [person])
+        self.assertEqual(list(organization.public_extension.get_persons()), [])
+
+        # Now publish the modification and check that the person is displayed
+        # on the public organization page
+        course.extended_object.publish("en")
+        self.assertEqual(
+            list(organization.public_extension.get_persons()), [person.public_extension]
+        )
+
+    def test_models_organization_get_persons_draft_organization_plugin(self):
+        """
+        If a person is related to an organization via a course but that the modification adding
+        the organization to the course is not published, the person should not be retrieved by
+        the `get_person` method on the organization.
+        """
+        organization = OrganizationFactory(should_publish=True)
+        person = PersonFactory(should_publish=True)
+        course = CourseFactory(fill_team=[person], should_publish=True)
+
+        # Add an organization to the course but don't publish the modification
+        placeholder = course.extended_object.placeholders.get(
+            slot="course_organizations"
+        )
+        add_plugin(
+            placeholder, OrganizationPlugin, "en", page=organization.extended_object
+        )
+
+        self.assertEqual(list(organization.get_persons()), [person])
+        self.assertEqual(list(organization.public_extension.get_persons()), [])
+
+        # Now publish the modification and check that the person is displayed
+        # on the public organization page
+        course.extended_object.publish("en")
+        self.assertEqual(
+            list(organization.public_extension.get_persons()), [person.public_extension]
+        )

--- a/tests/apps/courses/test_templates_blogpost_detail.py
+++ b/tests/apps/courses/test_templates_blogpost_detail.py
@@ -1,13 +1,13 @@
 """
 End-to-end tests for the blogpost detail view
 """
-from django.test import TestCase
+from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.factories import BlogPostFactory, CategoryFactory
 
 
-class BlogPostCMSTestCase(TestCase):
+class BlogPostCMSTestCase(CMSTestCase):
     """
     End-to-end test suite to validate the content and Ux of the blogpost detail view
     """

--- a/tests/apps/courses/test_templates_category_detail.py
+++ b/tests/apps/courses/test_templates_category_detail.py
@@ -1,13 +1,13 @@
 """
 End-to-end tests for the category detail view
 """
-from django.test import TestCase
+from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.factories import CategoryFactory, CourseFactory
 
 
-class CategoryCMSTestCase(TestCase):
+class CategoryCMSTestCase(CMSTestCase):
     """
     End-to-end test suite to validate the content and Ux of the category detail view
     """

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -1,16 +1,15 @@
 """
 End-to-end tests for the person detail view
 """
-from django.test import TestCase
-
 from cms.api import add_plugin
+from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.cms_plugins import CategoryPlugin
 from richie.apps.courses.factories import CategoryFactory, PersonFactory
 
 
-class PersonCMSTestCase(TestCase):
+class PersonCMSTestCase(CMSTestCase):
     """
     End-to-end test suite to validate the content and Ux of the person detail view
     """


### PR DESCRIPTION
## Purpose

Persons are indirectly related to an organization via the course teams in which they participate. We want to display these related persons on the organization detail page.

### Proposal

- [x] Add a utility method `get_persons` on the organization model to retrieve the related persons,
- [x] Add a `related persons` section on the organization detail page.
