### PR TITLE
Show related pages on person detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Show related persons on the organization detail page (a person is related to
   an organization if s.he is in the team of a course of this organization),
-- On a person detail page, show courses to which s.he participated.
+- On a person detail page, show courses to which s.he participated and
+  blogposts s.he authored.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Show related persons on the organization detail page (a person is related to
-  an organization if it is part of the team of a course of this organization).
+  an organization if s.he is in the team of a course of this organization),
+- On a person detail page, show courses to which s.he participated.
 
 ### Changed
 

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -85,7 +85,7 @@ class Category(BasePageExtension):
         placeholder.
         """
         is_draft = self.extended_object.publisher_is_draft
-        blog_post = self if is_draft else self.draft_extension
+        category = self if is_draft else self.draft_extension
         language = language or translation.get_language()
 
         bfs = "extended_object__placeholders__cmsplugin__courses_categorypluginmodel__page"
@@ -93,7 +93,7 @@ class Category(BasePageExtension):
             "extended_object__publisher_is_draft": is_draft,
             "extended_object__placeholders__slot": "categories",
             "extended_object__placeholders__cmsplugin__language": language,
-            bfs: blog_post.extended_object,
+            bfs: category.extended_object,
         }
 
         blogpost_model = apps.get_model(app_label="courses", model_name="blogpost")

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -58,6 +58,25 @@
     {% endif %}
   {% endwith %}
 
+  {% with blogposts=person.get_blogposts %}
+    {% if blogposts %}
+      <div class="blogpost-glimpse-list">
+        <h2 class="blogpost-glimpse-list__title">{% trans "Blogposts" %}</h2>
+        {% for blogpost in blogposts %}
+          {% if blogpost.extended_object.publisher_is_draft %}
+            <a class="blogpost-glimpse blogpost-glimpse--link blogpost-glimpse--draft" href="{{ blogpost.extended_object.get_absolute_url }}">
+              {% include "courses/cms/fragment_blogpost_glimpse.html" %}
+            </a>
+          {% elif blogpost.check_publication %}
+            <a class="blogpost-glimpse blogpost-glimpse--link" href="{{ blogpost.extended_object.get_absolute_url }}">
+              {% include "courses/cms/fragment_blogpost_glimpse.html" %}
+            </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+
 </div>
 {% endwith %}
 {% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -1,8 +1,9 @@
 {% extends "richie/fullwidth.html" %} {% load cms_tags extra_tags i18n %} {% block content %}
+{% with header_level=2 person=current_page.person %}
 <div class="person-detail">
   <h1 class="person-detail__title">
-    {% render_model_block current_page.person %}
-      {{ instance.person_title.title }} {{ instance.first_name }} {{ instance.last_name }}
+    {% render_model_block person %}
+      {{ person.person_title.title }} {{ person.first_name }} {{ person.last_name }}
     {% endrender_model_block %}
   </h1>
 
@@ -19,27 +20,44 @@
   {% endif %}
 
   <div class="person-detail__card">
-    {% with header_level=2 %}
-      <div class="person-detail__card__media">
-        {% with width=216 height=120 %}
-          {% placeholder "portrait" or %}
-            <div class="person-detail__card__media__empty">{% trans "Portrait" %}</div>
-          {% endplaceholder %}
-        {% endwith %}
+    <div class="person-detail__card__media">
+      {% with width=216 height=120 %}
+        {% placeholder "portrait" or %}
+          <div class="person-detail__card__media__empty">{% trans "Portrait" %}</div>
+        {% endplaceholder %}
+      {% endwith %}
+    </div>
+
+    <div class="person-detail__card__content">
+      <div class="person-detail__card__content__wrapper">
+        {% placeholder "resume" or %}
+          <p class="person-detail__card__content__wrapper__empty">{% trans "Enter your bio here..." %}</p>
+        {% endplaceholder %}
+
+        {% placeholder "maincontent" %}
       </div>
-
-      <div class="person-detail__card__content">
-        <div class="person-detail__card__content__wrapper">
-          {% placeholder "resume" or %}
-            <p class="person-detail__card__content__wrapper__empty">{% trans "Enter your bio here..." %}</p>
-          {% endplaceholder %}
-
-          {% placeholder "maincontent" %}
-        </div>
-      </div>
-
-    {% endwith %}
+    </div>
   </div>
 
+  {% with courses=person.get_courses %}
+    {% if courses %}
+      <div class="course-glimpse-list">
+        <h2 class="course-glimpse-list__title">{% trans "Courses" %}</h2>
+        {% for course in courses %}
+          {% if course.extended_object.publisher_is_draft %}
+            <a class="course-glimpse course-glimpse--link course-glimpse--draft" href="{{ course.extended_object.get_absolute_url }}">
+              {% include "courses/cms/fragment_course_glimpse.html" %}
+            </a>
+          {% elif course.check_publication %}
+            <a class="course-glimpse course-glimpse--link" href="{{ course.extended_object.get_absolute_url }}">
+              {% include "courses/cms/fragment_course_glimpse.html" %}
+            </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+
 </div>
+{% endwith %}
 {% endblock content %}

--- a/src/richie/apps/intial/fun_universities.csv
+++ b/src/richie/apps/intial/fun_universities.csv
@@ -1,0 +1,1368 @@
+1	Conservatoire national des arts et métiers 	CNAM	universities/logo_le_cnamv3.png	universities/Le_Cnam_facade.jpg	cnam	0	1	<p>Le Conservatoire national des arts et métiers est un grand établissement d’enseignement supérieur dédié à la formation tout au long de la vie. Créé par la Convention en 1794 sur proposition de l’abbé Henri Grégoire « pour perfectionner l’industrie nationale », le Cnam est aujourd’hui un établissement public à caractère scientifique, culturel et professionnel, doté du statut de grand établissement.</p>
+\n
+\n<p>L’établissement public,&nbsp;ses 30 centres régionaux et 158 centres d’enseignement accueillent chaque année près de 100 000 élèves (salariés, demandeurs d’emploi, travailleurs indépendants), qui viennent au Cnam pour actualiser leurs connaissances, perfectionner leurs compétences, ou acquérir un diplôme, du niveau bac jusqu’aux diplômes de 3e cycle et d’ingénieur.</p>
+\n
+\n<p>Pour répondre aux attentes de ses publics, le Cnam se donne pour objectif de proposer 70% de son offre de formation au format numérique, permettant de déployer des modes d’apprentissage pluriels (présentiel, hybride, à distance) et d’assurer l’accessibilité de son offre à tous, partout et à tout moment.</p>
+\n
+\n<p>En complément de cet objectif le Cnam a inscrit dans son schéma directeur le développement de cours massifs, ouverts et en ligne (MOOC),&nbsp;pour un public essentiellement francophone, qui complète, sous une forme différente, son offre de formation diplômante en ligne. Les moocs du Cnam couvrent des domaines variés tels que le management et les RH, le dialogue social, la santé au travail, le droit du travail et celui de l’internet, l’informatique, les mathématiques, le bâtiment, la mode, la criminologie …</p>
+\n	level-3	900
+2	Ecole CentraleSupelec	CentraleParis	universities/logo_centralesupelec_170x110.png	universities/centraleparis_banner.jpg	CentraleParis	1	1	<p>Depuis sa cr&eacute;ation en 1829, CentraleSupelec poursuit la m&ecirc;me vocation : former les leaders de culture scientifique, des entrepreneurs et innovateurs capables de relever les grands d&eacute;fis de leur temps. Au fil des ans et des &eacute;poques, le monde n&rsquo;a cess&eacute; d&rsquo;&eacute;voluer et de se transformer, mais l&rsquo;&Eacute;cole a toujours su rester &agrave; la pointe de la formation, gr&acirc;ce, notamment, &agrave; une forte tradition d&rsquo;excellence alli&eacute;e &agrave; un esprit r&eacute;solument avant-gardiste.</p>
+\n
+\n<p>Cette &laquo; marque de fabrique &raquo; lui a permis d&rsquo;entrer dans le XXI&egrave;me si&egrave;cle en renfor&ccedil;ant sa position de leader, avec notamment un projet p&eacute;dagogique innovant destin&eacute; &agrave; former les ing&eacute;nieurs dont le monde a aujourd&rsquo;hui besoin : des g&eacute;n&eacute;ralistes de haut niveau scientifique et technique, de forte culture internationale, rompus au monde professionnel et aux grands enjeux &eacute;conomiques, environnementaux et sociaux de l&rsquo;&eacute;poque.</p>
+\n
+\n<p>CentraleSupelec participe activement &agrave; l&rsquo;&eacute;mergence du e-learning en France &agrave; travers une politique digitale d&rsquo;envergure : outils interactifs, environnement num&eacute;rique, nouveaux supports d&rsquo;enseignement. Le lancement de son Digital Institute en juin 2013 a &eacute;t&eacute; la premi&egrave;re pierre fondant son projet d&rsquo;&eacute;cole num&eacute;rique de r&eacute;f&eacute;rence internationale.</p>
+\n
+\n<p>En participant, aux c&ocirc;t&eacute;s d&rsquo;un r&eacute;seau mondial de prestigieuses universit&eacute;s, au d&eacute;veloppement de l&rsquo;offre de cours en libre acc&egrave;s pour tous, CentraleSupelec entend promouvoir le mod&egrave;le &eacute;ducatif fran&ccedil;ais et les innovations p&eacute;dagogiques qu&rsquo;elle d&eacute;veloppe.</p>
+\n	simple-partner	5
+3	Centre Virchow-Villermé	VirchowVillerme	universities/virchowvillerme_logo.png	universities/virchowvillerme_banner.jpg	VirchowVillerme	1	0	<p>Le Centre Virchow-Villerm&eacute; de Sant&eacute; Publique Paris-Berlin a &eacute;t&eacute; cr&eacute;&eacute; le 15 avril 2013 &agrave; l&rsquo;initiative des gouvernements fran&ccedil;ais et allemand dans le cadre du 50&egrave;me anniversaire du Trait&eacute; de l&rsquo;Elys&eacute;e. Il est confi&eacute; &agrave; Sorbonne Paris Cit&eacute; et la Charit&eacute;-Universit&auml;tsmedizin Berlin. L&rsquo;un de ses axes de d&eacute;veloppement est de rassembler des MOOCs d&eacute;di&eacute;s au secteur de la sant&eacute; publique et de la sant&eacute; globale. Il accueille des cours venant de diff&eacute;rents &eacute;tablissements. Les cours sont sous la responsabilit&eacute; des professeurs qui les d&eacute;livrent et n&rsquo;engagent pas les institutions qui les h&eacute;bergent.</p>
+\n
+\n<p style="font-style: italic">Das Centre Virchow-Villerm&eacute; for Public Health Paris-Berlin wurde am 15. April 2013 von Charit&eacute;-Universit&auml;tsmedizin und Sorbonne-Paris-Cit&eacute; auf Initiative der deutschen und der franz&ouml;sischen Regierung gegr&uuml;ndet. Die Gr&uuml;ndungsfeierlichkeiten fanden im Rahmen der Veranstaltungen zum 50. Jubil&auml;um des Elys&eacute;e-Vertrags statt.<br />
+\nDie Entwicklung einer MOOC-Plattform im Bereich Public Health und Global Health ist eine der Hauptaufgaben des Zentrums. Auf dieser Plattform werden Lehrangebote von unterschiedlichen universit&auml;ren Einrichtungen angeboten. Die inhaltliche Verantwortung verbleibt bei den Professoren, die diese Kurse durchf&uuml;hren und wird nicht auf die gastgebenden Institutionen &uuml;bertragen.</p>
+\n
+\n<p>The Centre Virchow-Villerm&eacute; for Public Health Paris-Berlin was launched on April 15, 2013 under the auspices of the French and German governments during the celebration of the 50th anniversary of the Elys&eacute;e Treaty. Sorbonne Paris Cit&eacute; and Charit&eacute;-Universit&auml;tsmedizin Berlin have been designated to develop this initiative. One of its major objectives is to gather MOOCs dedicated to the field of public health and global health. The Centre Virchow-Villerm&eacute; welcomes courses delivered by various institutions. All MOOCs presented here are under the responsibility of their authors, and do not imply opinions or statements from the corresponding institutions.</p>
+\n	level-2	600
+4	Ecole Polytechnique	Polytechnique	universities/Ecole_polytechnique_180x100.png	universities/polytechnique_banner.jpg	Polytechnique	0	1	<p>L’École polytechnique est un établissement d’enseignement supérieur et de recherche unique par son ambition et ses valeurs. Largement internationalisée (30% de ses étudiants, 20% de son corps d’enseignants-chercheurs), l’École polytechnique forme des femmes et des hommes responsables, capables de mener des activités complexes et innovantes, pour répondre aux défis de la société du XXIe siècle.</p>
+\n
+\n<p>Son modèle original pluridisciplinaire, basé sur les sciences et l’ingénierie, assure une forte intégration entre ses trois cycles de formation (ingénieur, master et doctorat) et son centre de recherche. Le centre de recherche rassemble 21 laboratoires, tous unités mixtes de recherche avec le CNRS, dans 8 disciplines scientifiques majeures : biologie, chimie, informatique, économie, mathématiques, mathématiques appliquées, mécanique et physique.</p>
+\n
+\n<p>Les MOOCs correspondent au rythme de vie des salariés qui souhaitent découvrir ou approfondir un thème ou une discipline. Véritable mouvement de fond dont l'École polytechnique se devait d’être un acteur, il est très motivant de pouvoir proposer les cours de l’École polytechnique à un public plus large et notamment francophone.</p>
+\n
+\n<p>Les MOOCs constituent un outil complémentaire au service de l’enseignement. L’avènement des MOOCs va accélérer l’introduction de méthodes pédagogiques innovantes au sein des établissements d’enseignement supérieur. Les outils développés autour des MOOCs sont considérés par l’École polytechnique comme des opportunités formidables d’améliorer l’enseignement.</p>
+\n	simple-partner	600
+5	IMT	MinesTelecom	universities/IMT_logo-pour-FUN_I1bSJma.png	universities/baniere_imt_EDX-02-02.jpg	IMT	0	1	<p>L'Institut Mines-Télécom est un établissement public dédié à l'enseignement supérieur et la recherche pour l'innovation dans les domaines de l'ingénierie et du numérique. À l’écoute du monde économique, l’IMT conjugue légitimité académique et proximité concrète avec les entreprises. Il se positionne sur les transformations numériques, industrielles, énergétiques et écologiques et forme les ingénieurs, managers et docteurs qui seront les acteurs de ces changements majeurs au XXIe siècle. Ses activités se déploient au sein des grandes écoles Mines et Télécom sous tutelle du ministre en charge de l’Industrie et des communications électroniques, d’une école filiale et de trois partenaires associés ou sous convention. Les écoles de l'IMT sont classées parmi les toutes premières grandes écoles en France.</p>
+\n	level-3	770
+6	Sciences Po.	SciencesPo	universities/sciencespo.a373fc2e097a_1_k4ifYVW.png	universities/sciencespo.21764b4b23e5.jpg	SciencesPo	0	1	<p>Sciences Po est une institution d’enseignement supérieur et de recherche en sciences humaines et sociales qui consacre 35% de son budget à la recherche.</p>
+\n
+\n<p>Fondée en 1871, elle forme depuis 140 ans les responsables de demain, dans le secteur privé comme dans la haute administration, la politique et la recherche.</p>
+\n
+\n<p>Sciences Po se caractérise par une internationalisation poussée : sur les 12 000 étudiants que compte l’établissement, 46% sont des étudiants internationaux et viennent de plus de 150 pays. Sciences Po investit dans la responsabilité sociale et fait de la diversité sociale et culturelle une composante structurante de son identité. 27 % des étudiants éligibles sont boursiers à Sciences Po. Ils étaient 6% en l’an 2000.</p>
+\n
+\n<p>Sciences Po contribue au débat public par sa recherche et par la variété des débats et conférences qui y sont organisés chaque année.</p>
+\n
+\n<p>Depuis une dizaine d’années, Sciences Po s’emploie à intégrer les outils numériques à ses enseignements (espaces de travail partagés, eCours, Moodle, Cartothèque en ligne, cartographie des controverses, projet Forccast etc.) et s’est donc naturellement intéressé au format proposé par les MOOCs et aux nouvelles possibilités offertes en matière d’innovation pédagogique.</p>
+\n	level-2	680
+7	Université Bordeaux 3 (ancien nom de Bordeaux Montaigne)	Bordeaux3	universities/bordeaux3.ba00217bb88d.png	universities/bordeaux3.06dbeb93eef7.jpg	Bordeaux3	1	0	<p>Situ&eacute;e au c&oelig;ur d&rsquo;un territoire connu internationalement pour son patrimoine et son art de vivre, l&rsquo;universit&eacute; Michel de Montaigne Bordeaux 3 se trouve sur l&rsquo;un des plus vastes campus d&rsquo;Europe. Fid&egrave;le &agrave; l&rsquo;esprit de Michel de Montaigne, elle entend contribuer &agrave; former des citoyens du monde.</p>
+\n
+\n<p>L&rsquo;universit&eacute; Michel de Montaigne Bordeaux 3 propose une offre de formation diversifi&eacute;e, donnant acc&egrave;s &agrave; des connaissances relevant des domaines des arts, lettres, langues, sciences humaines et sociales. Ces formations s&rsquo;adaptent sans cesse pour r&eacute;pondre &agrave; un d&eacute;fi socio-&eacute;conomique fort : la mise en synergie des savoirs acad&eacute;miques, des savoirs professionnels et des attentes du monde &eacute;conomique.</p>
+\n
+\n<p>L&#39;activit&eacute; scientifique dans des domaines d&#39;investigation essentiels pour la soci&eacute;t&eacute; contemporaine, contribue &agrave; enrichir les enseignements et &agrave; inscrire l&#39;universit&eacute; dans son temps.</p>
+\n
+\n<p>L&rsquo;universit&eacute; Michel de Montaigne Bordeaux 3 s&rsquo;est positionn&eacute;e de longue date sur le terrain de la formation &agrave; distance, proposant depuis de nombreuses ann&eacute;es de multiples dipl&ocirc;mes dans ce format. En partenariat avec l&rsquo;Universit&eacute; Num&eacute;rique d&rsquo;Aquitaine, elle investit &eacute;galement dans le domaine du num&eacute;rique et des plateformes d&rsquo;enseignements, co-organisant notamment le Moodle Mo&ouml;t 2013.</p>
+\n
+\n<p>La question des MOOC s&rsquo;est donc pos&eacute;e tout naturellement apr&egrave;s l&rsquo;explosion du ph&eacute;nom&egrave;ne dans le cours de l&rsquo;ann&eacute;e 2012 et il est clairement apparu que l&rsquo;universit&eacute; se devait d&rsquo;investir ce nouveau mode de diffusion des savoirs, s&rsquo;appuyant une nouvelle fois sur le soutien de l&rsquo;Universit&eacute; Num&eacute;rique d&rsquo;Aquitaine.</p>
+\n	level-2	600
+8	Université de Montpellier	umontpellier	universities/Logo-etablissement_vhkxFYa.png	universities/Photo-campus_rlrvHDS.png	umontpellier	0	1	<p>Née en janvier 2015 par la fusion des Universités Montpellier 1 et 2, l’Université de Montpellier bénéficie de l’excellence et de la complémentarité de ces deux établissements. Elle réunit aujourd’hui une vaste communauté de savoirs qui intègre les sciences, les techniques, la médecine, les sciences de l’environnement, les sciences de l’éducation, les sciences économiques, le droit ou encore les sciences politiques.<br />
+\nClassée dans les palmarès internationaux (Shanghaï, QS ranking), l’Université de Montpellier dispose d’une expertise internationalement reconnue dans un large éventail de domaines scientifiques.</p>
+\n
+\n<p><strong>CHIFFRES CLÉS</strong><br />
+\n17 composantes de formation : 9 Facultés, 6 Instituts, 2 Écoles<br />
+\n72 structures de recherche regroupées dans 9 départements scientifiques<br />
+\n41 000 étudiants dont 16 % d’étudiants étrangers<br />
+\nL’Université de Montpellier est la 6ème université française</p>
+\n
+\n<p>L’Université de Montpellier développe les usages du numérique au service de la formation depuis de nombreuses années. Elle s’est lancée dans l’expérience des MOOCs dans un esprit d’innovation pédagogique afin d’assurer une meilleure diffusion des savoirs et accompagner la construction des connaissances pour le plus grand nombre.<br />
+\nLe développement des ressources pédagogiques en ligne est un atout pour enrichir les enseignements en présence et favoriser la réussite des étudiants. Les MOOCs s'inscrivent dans un esprit d'ouverture internationale et d'attractivité des formations.</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	710
+9	Université Panthéon-Assas, Paris II	Paris2	universities/LOGO_PantheonAssas_sansFond_170x110p_MLiBlbk.png	universities/paris2.e025b3182afe.jpg	Paris2	0	1	<p>Héritière de l’ancienne Faculté de droit de Paris et première université juridique française, l’université Panthéon-Assas, forte du soutien de ses 270 professeurs et maîtres de conférences, 1790 intervenants extérieurs, garantit à ses 17000 étudiants la qualité de l’enseignement et de la recherche en droit, en synergie avec les sciences économiques, les sciences de gestion et les sciences de l’information-communication.</p>
+\n
+\n<p>En proposant 22 Licences et 100 Masters en formation initiale et continue ainsi qu’en apprentissage, en développant des coopérations internationales avec 165 universités dans 48 pays, en valorisant la diffusion de la production scientifique de ses 5 écoles doctorales et 23 centres de recherche et en participant à la construction d’un espace européen de la connaissance et du numérique, l’université Panthéon-Assas demeure plus que jamais attentive à remplir sa mission de service public.</p>
+\n
+\n<p>L’enseignement numérique représente un atout important par le potentiel d’innovation qu’il apporte aux pratiques pédagogiques, notamment grâce aux potentialités des MOOC. C’est pourquoi l’université Panthéon-Assas souhaite proposer des cursus et des certifications qui pourront être valorisés auprès d’un employeur ou à travers la formation tout au long de la vie. L’enjeu est d’importance pour l’université Panthéon-Assas, qui garantit la qualité des cours et des diplômes, et répond ainsi aux demandes nouvelles de formation et de diffusion des connaissances.</p>
+\n	level-2	710
+10	Université Paris Nanterre	Paris10	universities/pddkpodglldimppo.jpg	universities/paris10.f6605d9f5319.jpg	Paris10	0	1	<p>L'<a href="https://www.u-paris10.fr/" target="_new">université Paris Nanterre</a>&nbsp;a toujours été pionnière dans le domaine de l'enseignement à distance, tout d'abord sur des supports papiers, puis en audio, puis au travers de plate-forme d'enseignement en ligne et enfin via les cours scénarisés et enregistrés.</p>
+\n
+\n<p>Plus de 2000 étudiants suivent un cursus entièrement à distance dans cette université avec une offre de formation en master ou en préparation de concours. 17000 étudiants fréquentent régulièrement les plateformes d'enseignement en ligne et leurs espaces numériques préparés pour eux par environ 600 enseignants dans le cadre de cours présentiels avec accès à des vidéos. A cet égard, la mutation numérique est conçue comme un levier pour l'innovation pédagogique.</p>
+\n
+\n<p>Mais l'université Paris Nanterre ne peut pas se développer sans une collaboration avec d'autres universités. Elle est l'établissement porteur de l'université thématique AUNEGE et elle participe activement à l'université numérique régionale et à son projet de Cloud interuniversitaire.</p>
+\n
+\n<p>Des réflexions sont également menées pour faire de la CUE qu'elle forme notamment avec l'Université Paris 8 un centre de l'innovation pédagogique par le numérique, raison de son engagement dans le projet de MOOC, qui correspond tant à son savoir faire qu'à sa philosophie, soit celle d'une université ouverte sur son environnement, sur le monde et préoccupée de son rôle pour la société. En s'appuyant sur ses points forts que sont les SHS, point de départ de son engagement dans les MOOC, cette université s'appuie sur l'ensemble de ses ressources dont la BDIC. Avec celle-ci, l'Université dispose d'une des plus riches bibliothèques numériques de l'enseignement supérieur utilisée et valorisée en ligne. Par l'accès gratuit et massif aux connaissances pour des publics nouveaux, les MOOC participent ainsi de ses missions.</p>
+\n	level-1	600
+11	Groupe INSA	groupeinsa	universities/logoGroupeInsa_5.png	universities/groupeinsa.3d33fea5c0b6.jpg	groupeinsa	0	1	<p>Le groupe INSA - Lyon, Rennes, Rouen, Strasbourg, Toulouse et Centre Val de Loire - est le 1er groupe français d’écoles publiques d’ingénieur. 10 % des ingénieurs diplômés en France sortent des six INSA chaque année. Près de 100 % des diplômés sont embauchés en moins de trois mois.</p>
+\n
+\n<p>Expert dans son domaine de spécialisation, l'ingénieur INSA s'appuie sur de solides connaissances de base tant scientifiques que technologiques. Destiné à encadrer et à animer des groupes d'individus, il doit disposer d'un excellent bagage en sciences humaines et sociales.</p>
+\n
+\n<p>Le recrutement se fait majoritairement au niveau du baccalauréat (70%). D'autres possibilités d'intégrer les INSA existent au cours du cursus à partir d'autres établissements d'enseignement supérieur français ou étrangers.</p>
+\n
+\n<p>Le groupe INSA a la volonté d'augmenter l'efficience des processus de formation en prenant notamment en compte les besoins de publics diversifiés tels que les sportifs de haut niveau, les étudiants étrangers, les étudiants handicapés, les stagiaires de FC, mais aussi - et ils sont nombreux - tous les étudiants qui souhaitent apprendre autrement, à leur rythme, avec plus d'autonomie.</p>
+\n
+\n<p>Les TICE ne sont bien sûr qu'un des outils au service de cette vision. Leur usage est également l'occasion pour tous ces apprenants de développer de nouvelles compétences en relation avec leur travail futur.</p>
+\n	level-2	700
+12	Paris 11 (ancien nom de Université Paris Sud)	Paris11	universities/paris11.179729acb398.png	universities/paris11.ea38002e63b9.jpg	Paris11	1	0	<p>L&#39;Universit&eacute; Paris-Sud est l&#39;une des plus prestigieuses universit&eacute;s en Europe sur le plan de la recherche. Class&eacute;e parmi les premiers &eacute;tablissements d&#39;enseignement sup&eacute;rieur fran&ccedil;ais et 39e mondial au classement de Shanghai 2013, elle est un acteur majeur de la cr&eacute;ation de l&rsquo;Universit&eacute; Paris-Saclay qui devrait voir le jour en 2014. Pluridisciplinaire et &agrave; forte dominante scientifique et de sant&eacute;, l&#39;excellence de sa recherche est marqu&eacute;e par de nombreux prix internationaux, notamment dans le domaine des math&eacute;matiques (quatre m&eacute;dailles Fields entre 1994 et 2010) et de la physique (trois prix Nobel).</p>
+\n
+\n<p>L&rsquo;Universit&eacute; Paris-Sud est constitu&eacute;e de 5 Unit&eacute;s de Formation et de Recherche (UFR), de 3 Instituts Universitaires de Technologie (IUT) et d&rsquo;une &eacute;cole d&rsquo;ing&eacute;nieurs (Polytech Paris-Sud). Elle rassemble plus de 100 laboratoires reconnus internationalement.</p>
+\n
+\n<p>L&rsquo;Universit&eacute; Paris-Sud a d&eacute;velopp&eacute; ses services num&eacute;riques au sein du campus num&eacute;rique UNPIdF au sein du campus num&eacute;rique UNPIdF qui d&eacute;veloppe les infrastructures, les outils et services, la formation et l&#39;accompagnement des usagers. Ses services d&eacute;veloppent les infrastructures, les outils et services, et la formation et l&#39;accompagnement des usagers. L&rsquo;Universit&eacute; Paris-Sud participe &eacute;galement &agrave; deux campus num&eacute;riques th&eacute;matiques (UNT)&nbsp;: AUNEGE (&Eacute;conomie-Gestion) et UNISCIEL (Sciences). Au c&oelig;ur du sch&eacute;ma directeur num&eacute;rique, la collaboration entre le service de p&eacute;dagogie num&eacute;rique et la direction informatique a permis d&#39;&eacute;largir les publics vers ces nouvelles pratiques, et notamment &agrave; l&#39;international avec les MOOCs.</p>
+\n	level-2	600
+13	Université Paris 1 Panthéon-Sorbonne	Paris1	universities/logo_paris1-pantheon-sorbonne_180x100_1.png	universities/banniere_paris1-pantheon-sorbonne_980x200.jpg	Paris1	0	1	<p>Héritière de 800 ans d’histoire, l’université Paris 1 Panthéon-Sorbonne partage son prestige séculaire avec les plus anciennes universités au monde : Oxford et Bologne. L’établissement répond aujourd’hui aux attentes qu’il fait naître en offrant des formations de haut niveau à un vaste public. Près de 42000 étudiants (dont 3500 doctorants) sont ainsi formés dans le domaine des Humanités. 22000 d’entre eux sont diplômés chaque année.</p>
+\n
+\n<p>Structurée autour de 3 grands domaines disciplinaires que sont : les Sciences économiques et de gestion, mathématiques et informatiques appliquées, les Sciences juridiques et politique, les Sciences humaines et sociales et Arts, l’université Paris 1 Panthéon-Sorbonne compte 14 Unités de Formation et de Recherche, 37 laboratoires de recherche et 13 écoles doctorales dans lesquels sont répartis les 2000 chercheurs et enseignants-chercheurs.</p>
+\n
+\n<p>Ouverte au monde et partie prenante de nombreux échanges avec des universités étrangères de premier plan, l’université Paris 1 Panthéon-Sorbonne dispose d’une influence forte et grandissante. Elle compte&nbsp;350 partenaires dans 65 pays et accueille 8000 étudiants étrangers.</p>
+\n
+\n<p>Engagée dans une trajectoire numérique depuis de nombreuses années, l’université Paris 1 Panthéon-Sorbonne s’est tout naturellement mobilisée dans cette nouvelle forme de pédagogie que sont les MOOCs et qui répondent à des formats d’apprentissage novateurs et prisés par les étudiants comme les publics candidats à la formation tout au long de la vie.</p>
+\n
+\n<p>À l’ère du numérique, les MOOCs symbolisent l’avènement d’une nouvelle forme de pédagogie et apparaissent comme la consécration de la transformation de l’enseignement par le digital.</p>
+\n	level-2	630
+14	ENS Paris-Saclay	ENSCachan	universities/logo_180_100.png	universities/enscachan.921fde30c904.jpg	ENSCachan	0	1	<p>L’École normale supérieure de Cachan, école des métiers de la recherche et de l’enseignement supérieur, s’inscrit dans la tradition d’excellence des Écoles normales supérieures et offre une formation culturelle et scientifique de très haut niveau.<br />
+\nA la fois une école et un centre de recherche, l’ENS Cachan rassemble treize laboratoires de recherche reconnus au niveau national et international, en sciences fondamentales, en sciences humaines et sociales et en sciences pour l’ingénieur. Trois instituts fédératifs promeuvent les interactions entre ces laboratoires, les soutiennent dans les actions interdisciplinaires et font l’originalité et la force de l’ENS Cachan.<br />
+\nAinsi, la singularité de l’ENS Cachan est de rassembler des disciplines qu’aucun autre établissement d’enseignement supérieur ne rapproche de cette manière et à ce niveau. C’est dans cet environnement qu’élèves et étudiants de l’ENS Cachan reçoivent une formation disciplinaire renforcée «à la recherche et par la recherche», ouverte sur l’international et la pluridisciplinarité, qui les mène au master et au doctorat.<br />
+\nL’ENS Cachan est membre fondateur de l’Université Paris-Saclay, qui fédère les forces en formation et en recherche de 19 grandes écoles, universités et organismes de recherche en un ensemble scientifique de dimension internationale.</p>
+\n
+\n<p><br />
+\nThe main mission of École normale supérieure de Cachan is to train students for research and higher education, by providing them with a top-quality cultural and research education, in the tradition of excellence of Écoles normales supérieures.<br />
+\nBoth a training centre and a research centre, ENS Cachan gathers 13 internationally recognized laboratories, in basic sciences, in humanities and social sciences, and in engineering sciences. 3 federative institutes promote interactions between the laboratories, and give support to interdisciplinary actions, which contributes to ENS Cachan’s originality and strength.<br />
+\nBringing together disciplines, which no other institution congregates in such a way or at such a level, is a unique feature of ENS Cachan. In this environment, students receive a research- based and research-oriented training, reinforced in their own discipline, and at the same time, interdisciplinary and internationally open, leading them to Master’s degree and PhD.&nbsp;<br />
+\nENS Cachan is a founding member of Université Paris-Saclay, a world-class scientific university, acquiring strength from 19 grandes écoles, universities and research organizations."</p>
+\n	level-3	740
+15	UPMC	UPMC	universities/upmc.b2172efd19a0.png	universities/upmc.8c5fa9eee5e8.jpg	UPMC	1	0	<p>L’UPMC est l’héritière directe de la faculté des sciences de la Sorbonne. Elle est leader en France en sciences et en médecine et couvre un large éventail de disciplines (chimie, électronique, informatique, mathématiques, mécanique, physique, sciences de la terre et de l’environnement, sciences de la vie et médecine).</p>
+\n
+\n<p>Elle fait partie de Sorbonne Universités avec ses partenaires que sont le Muséum national d’histoire naturelle, l’université Paris-Sorbonne (Paris 4), l’Insead, l’UTC (Université de technologie de Compiègne), le CNRS, l’Inserm et l’IRD.</p>
+\n
+\n<p>Chiffres clés de l’UPMC:</p>
+\n
+\n<ul>
+\n\t<li>33 000 étudiants dont 6 900 étrangers</li>
+\n\t<li>10 500 personnels dont 8200 dans les unités de recherche</li>
+\n\t<li>100 laboratoires de recherche</li>
+\n\t<li>6 principaux centres hospitaliers universitaires (CHU)</li>
+\n\t<li>7 300 publications par an (environ 11% de la publication en France)</li>
+\n</ul>
+\n
+\n<p>Encouragée par son partenariat au sein de Sorbonne Universités, l’UPMC propose des parcours multidisciplinaires à ses étudiants et des cours d’approfondissement aux plus passionnés. Le numérique aide à offrir ces cours dans des emplois du temps contraints, sous des formats nouveaux, où l’innovation et l’inventivité des équipes pédagogiques jouent un grand rôle.</p>
+\n
+\n<p>Pour l’UPMC, les MOOCs sont d’abord envisagés comme un outil d’innovation pédagogique à l’usage de ses étudiants et de ceux de Sorbonne Universités. Un public plus large peut en profiter à travers la plateforme FUN.</p>
+\n
+\n<p>Ils sont dérivés très directement des formations proposées dans le cadre universitaire et montrent l’intérêt de l’enseignement constamment irrigué par la recherche que proposent les universités.</p>
+\n	simple-partner	0
+18	C2i	C2i	universities/c2i.png		c2i	0	0		level-2	620
+21	Unisciel	Unisciel	universities/unisciel_1.png		Unisciel	0	0		simple-partner	5
+24	ENS de Lyon	ENSDeLyon	universities/logo-ens-de-lyon-udl.jpg	universities/image-bandeau-ENSdeLyon.jpg	ens-de-lyon	0	1	<p>Membre fondateur de l’Université de Lyon, l’École normale supérieure de Lyon est une grande école universitaire pluridisciplinaire. Sa mission première est de former, par la recherche, à l'enseignement et à la recherche, le doctorat faisant partie intégrante de la formation. Elle abrite depuis 2011 l’Institut français de l’Éducation, opérateur de référence sur les questions d’éducation. Largement ouverte à l’international, l’ENS de Lyon produit, transmet et partage des connaissances fondamentales pour faire progresser la science et la société.</p>
+\n
+\n<p>En chiffres&nbsp;: 2200 étudiants et 600 enseignants-chercheurs de 67 nationalités différentes, 23 laboratoires de recherche, 11 LABEX, 12 départements d’enseignement.</p>
+\n
+\n<p>Avec les MOOCs, l’ENS de Lyon s’engage dans une démarche d’ouverture de ses enseignements vers le plus grand nombre. Elle s’appuie sur l’Ifé, expert de la formation par le numérique.<br />
+\nLa création de MOOCs est à la fois une opportunité d’innovation pédagogique pour les étudiants de l’ENS de Lyon et une contribution au partage de la connaissance vers l’ensemble du monde francophone.</p>
+\n	level-2	620
+27	FUN	FUN	universities/logo-FUN_complet_PI1AiG5.png		fun	0	0			15
+30	Grenoble INP	grenobleinp	universities/Grenoble_INP_1_1.png	universities/banniereGrenobleINP.jpg	grenoble-inp	1	0	<p>Grand Etablissement d'enseignement supérieur et de recherche, membre de l’Université de Grenoble Alpes et du réseau national Groupe INP, Grenoble INP propose des formations&nbsp; d'ingénieurs et de docteurs axées sur le double enjeu de l’excellence scientifique et de l’innovation technologique. Ses 6 écoles forment des ingénieurs responsables et citoyens qui relèveront les&nbsp; défis du XXIème siècle : énergie, société du numérique, micro et nanotechnologies, environnement, industrie - mondialisation et innovation. Ces défis structurent ses activités de recherche de haut niveau conduites avec le CNRS, Inria et les universités de Grenoble notamment, dans 36 laboratoires dont 10 internationaux.<br />
+\nActeur majeur de l’innovation, l’Institut entretient depuis toujours des rapports privilégiés avec les entreprises et nourrit la qualité de l’écosystème grenoblois reconnue mondialement.</p>
+\n
+\n<p>L’innovation pédagogique, les possibilités offertes par le numérique et la dimension internationale des savoirs et des apprentissages sont trois axes d’évolution que Grenoble INP a très tôt abordés dans leur globalité. Depuis 2007, l’établissement regroupe dans même service, http://perform.grenoble-inp.fr/, une équipe pluridisciplinaire de scientifiques, linguistes, conseillers pédagogiques et ingénieurs e.learning, qui accompagne les enseignants dans les mutations de leur métier. Les MOOCs ouvrent des pistes sur ces trois axes, que Grenoble INP a choisi d’explorer avec un projet original réunissant une équipe d’experts internationaux apportant chacun leur voix à un MOOC choral à la croisée de nos expertises et de nos engagements citoyens : le MOOC « Des rivières et des hommes ». Nous souhaitons développer ce modèle choral qui nous paraît prometteur.</p>
+\n	level-2	600
+33	Université Virtuelle Environnement et Développement durable (UVED) 	uved	universities/logoUVED_fond-clair_170x110.png	universities/unnamed_attachment_1.png	uved	0	1	<p>En s’inscrivant dans le mouvement mondial de l’accès aux ressources pédagogiques numériques universitaires, l’Université Virtuelle Environnement et Développement durable (UVED), une des huit Universités Numériques Thématiques françaises, favorise le libre accès au savoir, à l’éducation, à la diffusion des connaissances et à la formation de l’ensemble des acteurs du domaine de l’environnement et du développement durable.</p>
+\n
+\n<p>UVED apporte un complément pédagogique aux enseignements de la formation initiale et continue des établissements ; elle met librement à disposition des compléments de cours directement utilisables par les étudiants, offre aux enseignants des e-contenus pour leurs enseignements et apporte au grand public des informations fiables et des contenus pédagogiques labellisés.</p>
+\n
+\n<p>Au-delà de cette mission, et afin de mieux répondre aux besoins sociétaux en matière de formation continue et d’éducation tout au long de la vie, UVED a mis à profit sa vocation partenariale en s’engageant dans la production et la coordination de MOOCs pluri-établissements et pluridisciplinaires, réunissant pour chaque MOOC plusieurs experts scientifiques issus d’établissements différents.</p>
+\n
+\n<p>Les MOOCs produits et coordonnés par UVED se rapportent aux grands défis sociétaux en lien avec l’environnement et le développement durable.&nbsp;</p>
+\n	academic-partner	180
+36	Université de Strasbourg	Strasbourg	universities/Logo_Unistra_180x100.png	universities/illustration_etablissement_UNISTRA.jpg	universite-de-strasbourg	0	1	<div>
+\n<p>L'Université de Strasbourg, c'est près de cinq siècles d'histoire, des noms illustres, un patrimoine riche, une situation européenne. L'université c'est aussi plus de 43 000 étudiants accueillis chaque année dont 20% d'étudiants étrangers, 4600 enseignants chercheurs et personnels, 38 unités de formations et recherches, 79 unités de recherche. Des chiffres imposants qui font de l'Université un espace riche et multiple que ce soit dans l'offre de formation pluridisciplinaire et la recherche comme dans l'offre culturelle et patrimoniale. Une université comme cadre de vie.</p>
+\n
+\n<p>S'appuyant sur tous les domaines du savoir, elle entend mener une politique innovante en termes de formation initiale et continue, de recherche, d'insertion professionnelle de ses étudiants tout en jouant un rôle majeur au cœur de la cité et sur la scène internationale</p>
+\n
+\n<div>
+\n<p>Première université de France à s’être dotée d’un schéma Directeur Numérique, l’Université de Strasbourg a placé le numérique au cœur de son développement stratégique, et ce depuis la création de l’université fusionnée en 2009.</p>
+\n
+\n<p>Le développement des dispositifs et des usages du numérique qui en a résulté est la marque&nbsp; de cette politique ambitieuse et volontariste en soutien à la formation, à la recherche et plus globalement au bon fonctionnement de l’établissement.</p>
+\n
+\n<p>La diversité des services qui sont proposés est le fruit du travail soutenu des équipes de la Direction informatique et de la Direction des usages du numérique au service des enseignants-chercheurs, des personnels et des étudiants de l’Université de Strasbourg.&nbsp;</p>
+\n</div>
+\n</div>
+\n	level-1	300
+39	Université Paris-Sud	UPSUD	universities/paris11.179729acb398_2.png	universities/paris11.ea38002e63b9_1.jpg	UPSUD	0	1	<p>L'Université Paris-Sud est l'une des plus prestigieuses universités en Europe sur le plan de la recherche. Classée parmi les premiers établissements d'enseignement supérieur français et 39e mondial au classement de Shanghai 2013, elle est un acteur majeur de la création de l’<a href="https://www.universite-paris-saclay.fr/fr" target="_new">Université Paris-Saclay</a> qui a vu le jour en 2014. Pluridisciplinaire et à forte dominante scientifique et de santé, l'excellence de sa recherche est marquée par de nombreux prix internationaux, notamment dans le domaine des mathématiques (quatre médailles Fields entre 1994 et 2010) et de la physique (trois prix Nobel).</p>
+\n
+\n<p>L'Université Paris-Sud est constituée de 5 Unités de Formation et de Recherche (UFR), de 3 Instituts Universitaires de Technologie (IUT) et d'une école d'ingénieurs (Polytech Paris-Sud). Elle rassemble plus de 100 laboratoires reconnus internationalement.</p>
+\n
+\n<p>L'Université Paris-Sud a développé ses services numériques au sein du campus numérique UNPIdF qui développe les infrastructures, les outils et services, la formation et l'accompagnement des usagers. Ses services développent les infrastructures, les outils et services, et la formation et l'accompagnement des usagers. L'Université Paris-Sud participe également à deux campus numériques thématiques (UNT)&nbsp;: AUNEGE (Économie-Gestion) et UNISCIEL (Sciences). Au cœur du schéma directeur numérique, la collaboration entre le service de pédagogie numérique et la direction informatique a permis d'élargir les publics vers ces nouvelles pratiques, et notamment à l'international avec les MOOCs.</p>
+\n	level-2	660
+42	Inria	inria	universities/logo-inria-180x100.jpg	universities/bandeau_MoocInria.0124-121.jpg	inria	0	1	<p>Inria, créé en 1967 est un institut national de recherche dédié au numérique. Placé sous la double tutelle du Ministère de l'Enseignement supérieur et de la Recherche et de l'Industrie, il &nbsp;promeut &nbsp;« l'excellence scientifique au service du transfert technologique et de la société ».&nbsp;</p>
+\n
+\n<p>Inria emploie 2 700 collaborateurs qui relèvent les défis des sciences informatiques et mathématiques. Son modèle ouvert et agile lui permet d’explorer des voies originales avec ses partenaires industriels et académiques. Inria répond ainsi efficacement aux enjeux pluridisciplinaires et applicatifs de la transition numérique.&nbsp;</p>
+\n
+\n<p>En 2013, l’institut a participé au déploiement et lancement de la plate forme de MOOCs France Université Numérique.<br />
+\nInria s’est doté d’un Mooc Lab qui produit des MOOCs.&nbsp;</p>
+\n
+\n<p>Ces cours sont financés en partie par le projet IDEFI uTOP-Inria (Université de Technologie Ouverte Pluripartenaire) « Valorisation de la recherche par la formation » auquel participe le Mooc Lab. &nbsp;&nbsp;</p>
+\n
+\n<p>A travers les Moocs, Inria vise :</p>
+\n
+\n<ul>
+\n\t<li>la diffusion et la valorisation des recherches de l’institut ;</li>
+\n\t<li>le transfert vers la société et les industriels de méthodes et technologies issues des recherches menées au sein de l’institut ;</li>
+\n\t<li>le développement et l’expérimentation d’outils numériques pour l’apprentissage.</li>
+\n</ul>
+\n	level-2	760
+43	Ecole Nationale Supérieure d’Arts et Métiers	ensam	universities/AM-ParisTech-logo.jpeg	universities/Angers-2013-cour_ecole__etudiants_-_0613_M.jpg_1.jpeg	arts-et-metiers-paristech	0	1	<p>L’Ecole Nationale Supérieure d’Arts et Métiers (ENSAM), dénommée Arts et Métiers ParisTech, est une Grande Ecole d’Ingénieurs publique. Elle a formé plus de 85000 ingénieurs depuis sa création en 1780 par le Duc de La Rochefoucauld Liancourt.</p>
+\n
+\n<p>Arts et Métiers ParisTech est un grand établissement technologique proposant des formations initiales du Bac au Bac +8 et a pour mission principale la formation d’ingénieurs aux disciplines du génie mécanique, du génie énergétique et du génie industriel : conception-réalisation, procédés-industrialisation, tenue en service-usages.</p>
+\n
+\n<p>Etablissement unique coordonné par une Direction Générale, Arts et Métiers ParisTech comprend 8 Campus et 3 instituts répartis sur l’ensemble du territoire français. Ces sites lui confèrent une proximité exceptionnelle avec le milieu industriel en régions.&nbsp;</p>
+\n
+\n<div>
+\n<p>La stratégie d’Arts et Métiers ParisTech en matière de numérique est d’intégrer les TICE comme service d’appui à la formation et comme moyen pour faire évoluer les pratiques pédagogiques et favoriser ainsi la réussite des élèves.</p>
+\n
+\n<div>
+\n<p>L’engagement d’Arts et Métiers dans la création de MOOC vient des initiatives de ses équipes pédagogiques souhaitant innover en intégrant pleinement le numérique dans leur manière d’enseigner. Elles souhaitent à travers les MOOC rendre leurs enseignements accessibles à un large public, et favoriser le développement de communautés rassemblant le monde de l’enseignement, de la recherche, de l’industrie et un public curieux de découvrir des nouvelles pratiques d’enseignement.</p>
+\n</div>
+\n</div>
+\n	level-2	660
+46	Normandie Université	unormandie	universities/logo_unormandie_170.png	universities/illustration_normandie_université.jpg	normandie-universite	0	1	<p>Sur le territoire normand, <a href="http://www.normandie-univ.fr/les-membres-et-associes-273.kjsp?RH=1350994264629&amp;RF=1350994281142" target="_blank">Normandie Université</a>, regroupant les universités de Caen Normandie, Le Havre Normandie, de Rouen Normandie, l’Ensa Normandie, l'ENSICAEN, l'INSA Rouen Normandie et 9 associés, organise la coordination territoriale des établissements d’enseignement supérieur et organismes de recherche en matière d’offre de formation et de stratégie de recherche et de transfert, sous la forme du regroupement territorial normand.</p>
+\n
+\n<p>Normandie Université regroupe des établissements d’enseignement supérieur et de recherche liés par la volonté commune de proposer une offre de formation et de recherche au meilleur niveau, de veiller au développement de l’innovation sous toutes ses formes.</p>
+\n
+\n<p>Parmi les grandes ambitions affichées par Normandie Université, on peut citer une plus grande attractivité nationale et internationale, une politique scientifique de qualité et de grande ampleur au niveau territorial, une offre de formation cohérente et complémentaire et un dispositif commun de valorisation. A cela s’ajoute une démarche collective de mutualisation et d'optimisation des services (numérique, documentation, etc.).</p>
+\n
+\n<p>Défini par le schéma directeur numérique normand, la stratégie numérique des établissements normands a pour but, entre autres, de contribuer à l’économie de la connaissance, d’améliorer l’accès à l’enseignement supérieur et de favoriser la réussite de l’étudiant.</p>
+\n
+\n<p>C’est dans cette logique que Normandie Université offre aujourd’hui des cours sous forme de MOOC.</p>
+\n	level-2	650
+49	Animafac-Cnous	animafac-cnous	universities/logo_Animafac-Cnous_2016_HCNXApo.png		animafac-cnous	0	0		academic-partner	155
+52	Université de Bordeaux	ubordeaux	universities/LOGO-UBX-170X110.png	universities/UBx-980X200.jpg	universite-de-bordeaux	0	1	<p>Créée le 3 septembre 2013, l'université de Bordeaux est le fruit de la fusion des universités Bordeaux 1, Bordeaux Segalen et Montesquieu Bordeaux 4.&nbsp;</p>
+\n
+\n<p><br />
+\nAvec 3200 enseignants et chercheurs, plus de 56 000 étudiants dont 6 200 étudiants internationaux et plus de 700 diplômes, l’université de Bordeaux est un des premiers pôles universitaires français et la 3ème université française (hors région parisienne) par son nombre d’étudiants. La formation et la recherche, fondamentalement liées, sont organisées autour de 4 collèges de formation (sciences et technologies, sciences de la santé, droit - science politique - économie-gestion, sciences de l'Homme), d’un collège regroupant 2 000 doctorants dans 8 écoles doctorales, d’un IUT, d’une École supérieure du professorat et de l’éducation, d’un Institut des sciences de la vigne et du vin, de 3 départements de recherche (sciences et technologies, sciences du vivant et de la santé, sciences humaines et sociales) et de 15 fédérations de recherche. L’université de Bordeaux propose plus de 50 formations internationales et 23 doubles diplômes et est l’un des 10 campus d’excellence français reconnus par un jury international.&nbsp;</p>
+\n
+\n<p><br />
+\nL’Université de Bordeaux a pour objectif prioritaire la transformation pédagogique de son offre de formation. Lieu de diffusion des savoirs et de développement de compétences, elle choisit de diversifier ses dispositifs pédagogiques au service de l’apprentissage de tous les étudiants, notamment avec les MOOC.</p>
+\n
+\n<p>&nbsp;</p>
+\n
+\n<p>Les MOOC impliquent des équipes d’enseignants-chercheurs et une Mission d’Appui à la Pédagogie et à l’Innovation (MAPI) dans la conception de ce nouveau modèle de formation à distance, et permettent à un public plus large d’accéder à de nouveaux domaines de connaissances.</p>
+\n	level-2	650
+55	Essec	essec	universities/Logo_Essec.jpg	universities/ESSEC_Bannière_2.jpg	essec	0	0	<div style="margin: 0cm 0cm 0.0001pt; text-align: justify;">
+\n<p>Institution acad&eacute;mique d&rsquo;excellence cr&eacute;&eacute;e en 1907, ESSEC BUSINESS SCHOOL s&rsquo;est, tout au long de son histoire, illustr&eacute;e par son esprit pionnier, partag&eacute; par la communaut&eacute; de ses 46 000 dipl&ocirc;m&eacute;s.</p>
+\n
+\n<p>Aujourd&rsquo;hui, l&rsquo;ESSEC propose &agrave; Cergy-Pontoise, Paris-La D&eacute;fense et Singapour une large gamme de programmes, en formation initiale et continue, irrigu&eacute;s par une recherche de pointe.</p>
+\n
+\n<p>Marqu&eacute;e par une profonde tradition humaniste, l&rsquo;ESSEC a fait du lien entre vie &eacute;conomique et soci&eacute;t&eacute; un enjeu fondamental de la formation de managers responsables. Par l&agrave;-m&ecirc;me, l&rsquo;ESSEC affirme la n&eacute;cessit&eacute; de mettre l&rsquo;innovation, le savoir et la cr&eacute;ation de valeur au service de l&rsquo;int&eacute;r&ecirc;t g&eacute;n&eacute;ral.&quot;</p>
+\n</div>
+\n
+\n<div style="margin: 0cm 0cm 0.0001pt; text-align: justify;">
+\n<p>Nous sommes dans un monde en pleine mutation, &eacute;conomique, sociale, culturelle&nbsp;: nos &eacute;tudiants doivent d&eacute;velopper leur sens de l&rsquo;adaptation, surtout leur cr&eacute;ativit&eacute;, et la place du num&eacute;rique est un sujet majeur.</p>
+\n
+\n<p><span style="line-height: 1.6;">L&rsquo;&eacute;tudiant adapt&eacute; aux besoins &eacute;conomiques de demain est quelqu&rsquo;un qui tient les deux bouts de la cha&icirc;ne entre d&rsquo;une part, une tr&egrave;s forte comp&eacute;tence sur le plan des humanit&eacute;s modernes &ndash; les humanit&eacute;s classiques plus les humanit&eacute;s num&eacute;riques &ndash; et d&rsquo;autre part, un professionnalisme incluant la comp&eacute;tence num&eacute;rique. Sans oublier la technicit&eacute; r&eacute;elle que donne l&rsquo;exp&eacute;rience ESSEC telle que nous sommes en train de la revitaliser gr&acirc;ce au plan strat&eacute;gique.</span></p>
+\n
+\n<div>&nbsp;</div>
+\n</div>
+\n
+\n<div style="margin: 0cm 0cm 0.0001pt; text-align: justify;"><o:p></o:p></div>
+\n	level-1	300
+58	Paris Sciences Lettres	psl	universities/LOGO_PSL_typoCERA_INDIGO_RVB_180x100.png	universities/baniere-PSL-2.jpg	paris-sciences-lettres	0	1	<p>PSL est l’Université de recherche qu’ont créée, en se rassemblant, 21 établissements prestigieux unis par la volonté créer une nouvelle entité institutionnelle comparable aux plus grandes universités mondiales. D’une exceptionnelle diversité, ces institutions partagent une culture commune&nbsp;: l’excellence scientifique, le haut potentiel de leurs étudiants. Leur ambition est simple : susciter des convergences disciplinaires, dynamiser l’innovation et la créativité, attirer et former les meilleurs talents, faire de la recherche un véritable moteur de croissance. Lauréate des « Initiatives d’excellence », PSL dispose de tous les atouts pour relever ce défi : 107 laboratoires de recherche, 12 labEx, 8 equipEx, 2 500 chercheurs, 14 000 étudiants (70% en master et doctorat).</p>
+\n
+\n<p>&nbsp;</p>
+\n
+\n<div>
+\n<p>Le numérique se situe au cœur du projet de PSL. La diffusion de MOOC est l’un des aspects d’un ample schéma directeur numérique comprenant notamment le lancement d’un portail X-NET et d’un portail des savoirs, la création d’une plateforme d’e-learning et d’un learning center, la diffusion et la production de contenus pédagogiques innovants, la mise en place d’ENT, la mutualisation d’infrastructures haute performance (cluster de calcul, stockage et archivage), ainsi que plusieurs projets Big data. L’enjeu est triple&nbsp;: promouvoir la visibilité et l’attractivité de PSL à l’international, développer la valorisation et l’innovation sur l’ensemble de ses domaines, fédérer la communauté PSL.&nbsp;</p>
+\n</div>
+\n	level-3	900
+60	Université Nice Sophia Antipolis	unice	universities/logo-UNS.png	universities/Bandeau.jpg	unice	1	0	<div>
+\n<p>L’université Nice Sophia Antipolis (UNS) est une université pluridisciplinaire. Créée en 1965, elle est implantée sur l'ensemble du département des Alpes Maritimes à Nice, Cannes, Menton, Grasse et se compose de 12 campus principaux, de 300&nbsp;000&nbsp;m² de locaux, de 9 facultés, de 2 instituts et de 2 écoles. De surcroît, engagée dans l’innovation, elle est aussi un acteur incontournable de la technopole de Sophia Antipolis. Elle accueille chaque année plus de 25&nbsp;000&nbsp;étudiants et près de 20% d'étrangers, répartis sur plusieurs campus et unités de formation et de recherche (UFR). Elle compte près de 2&nbsp;700&nbsp;personnels&nbsp;: plus de 1&nbsp;600&nbsp;enseignants, enseignants-chercheurs et moniteurs et près de 1&nbsp;100&nbsp;personnels administratifs (personnels de bibliothèque, ingénieurs, administratifs, techniques, ouvriers, de service ou de santé). Environ 200 thèses y sont soutenues chaque année.</p>
+\n
+\n<p>Sur le plan de l’innovation pédagogique, l’université de Nice Sophia Antipolis a très tôt pris toute la mesure des enjeux. Le Service universitaire des Pédagogies Innovantes est en charge de la promotion, l’accompagnement et l’accélération des projets pédagogiques s’adossant aux outils numériques.</p>
+\n
+\n<p>Depuis plusieurs années, l’Université de Nice propose à ses étudiants des formations mixtes et à distance à la fois dans le cadre de la formation initiale et continue. En 2014, l’engagement dans la conception des MOOCs vient des initiatives des enseignants de l’UNS et a pour objectif l’ouverture vers l’international et l’appropriation des nouvelles pratiques de l’enseignement supérieur.</p>
+\n</div>
+\n	level-2	600
+63	Université Bordeaux Montaigne	bordeauxmontaigne	universities/ubordeauxmontaigne.png	universities/ubordeauxmontaignepano.jpg	bordeauxmontaigne	0	1	<p>Située au cœur d'un territoire connu internationalement pour son patrimoine et son art de vivre, l'université Bordeaux Montaigne se trouve sur l'un des plus vastes campus d'Europe. Fidèle à l'esprit de Michel de Montaigne, elle entend contribuer à former des citoyens du monde.</p>
+\n
+\n<p>L'université Bordeaux Montaigne propose une offre de formation diversifiée, donnant accès à des connaissances relevant des domaines des arts, lettres, langues, sciences humaines et sociales. Ces formations s'adaptent sans cesse pour répondre à un défi socio-économique fort : la mise en synergie des savoirs académiques, des savoirs professionnels et des attentes du monde économique. A ce titre, l'activité scientifique dans des domaines d'investigation essentiels pour la société contemporaine contribue à enrichir les enseignements et à inscrire l'université dans son temps.</p>
+\n
+\n<p>L'université Bordeaux Montaigne s'est positionnée de longue date sur le terrain de la formation à distance, proposant depuis de nombreuses années de multiples diplômes dans ce format, depuis le DU de Coréen jusqu'au Master 2 d'anglais, en passant par des licences de lettres, d'histoire ou d'espagnol. En partenariat avec l'Université Numérique d'Aquitaine, elle s'est aussi donné pour objectif d'explore les multiples hybridations possibles entre pédagogie et numérique – entre la présence et la distance – dans le but de continuer à améliorer la réussite de ses étudiants.</p>
+\n	level-2	640
+66	Université Stendhal-Grenoble 3	ugrenoble3	universities/logo-stendhal.png	universities/visuel-Mooc.jpg	ugrenoble3	1	0	<p>Cr&eacute;&eacute;e en 1970, l&#39;universit&eacute; Stendhal propose et d&eacute;veloppe des activit&eacute;s de formation et de recherche en langues et cultures &eacute;trang&egrave;res, lettres et arts du spectacle, sciences du langage et FLE, communication et journalisme.<br />
+\nAvec pr&egrave;s de 6 000 &eacute;tudiants en licence, master, doctorat et dipl&ocirc;me d&rsquo;universit&eacute; (dont 22% d&rsquo;&eacute;trangers) et presque autant d&rsquo;inscrits &agrave; des cours de langues, l&rsquo;universit&eacute; Stendhal affirme son caract&egrave;re r&eacute;solument international. Elle se classe d&rsquo;ailleurs en haut du palmar&egrave;s des universit&eacute;s fran&ccedil;aises les plus performantes en mati&egrave;re de mobilit&eacute; internationale.<br />
+\nL&#39;universit&eacute; Stendhal est aussi connue pour son dynamisme au service de la francophonie, notamment gr&acirc;ce au Centre universitaire d&rsquo;&eacute;tudes fran&ccedil;aises (CUEF) de Grenoble et aux missions d&rsquo;expertise men&eacute;es dans le domaine de la formation de formateurs.</p>
+\n
+\n<p>L&rsquo;universit&eacute; Stendhal Grenoble 3 est particuli&egrave;rement en pointe sur la question de la p&eacute;dagogie universitaire num&eacute;rique appliqu&eacute;e &agrave; l&rsquo;apprentissage des langues (axe 3 du laboratoire Lidilem, IDEFI Innovalangues, Masters FLE et DILIPEM - didactique des langues et ing&eacute;nierie p&eacute;dagogique multim&eacute;dia, Service Commun LANSAD). C&rsquo;est pourquoi elle n&rsquo;a pas h&eacute;sit&eacute; &agrave; r&eacute;pondre favorablement &agrave; la proposition de l&rsquo;ENS Cachan de r&eacute;aliser un prolongement en didactique des langues du MOOC &laquo; Enseigner et former avec le num&eacute;rique &raquo; (EFAN). Elle &eacute;tudie actuellement la possibilit&eacute; de r&eacute;aliser d&rsquo;autres MOOC li&eacute;s &agrave; l&rsquo;apprentissage du FLE ou d&rsquo;autres langues.</p>
+\n	level-2	600
+69	ISAE-SUPAERO	isaesupaero	universities/logo-isae-supaero.png	universities/Bandeau_établissement_ISAE.jpg	isae-supaero	0	1	<p>Pôle mondial de formation et de recherche&nbsp;dans les domaines aéronautiques, spatial et systèmes connexes, <a href="https://www.isae-supaero.fr">l’ISAE-SUPAERO</a> offre une gamme complète et unique de formations de haut niveau scientifique : formation ingénieur ISAE-SUPAERO, masters, mastères spécialisés,&nbsp;doctorats&nbsp;et formation continue.</p>
+\n
+\n<p>L’Institut développe une politique de recherche active pour assurer un lien fort entre formation et recherche, constituer un centre international d’accueil et de formation et promouvoir l’innovation dans tous les domaines de l’aéronautique.&nbsp;</p>
+\n
+\n<p>Au niveau international, l’Institut coopère avec les meilleures universités européennes et nord-américaines par des échanges d’étudiants et de professeurs, des programmes communs de formation et de recherche et la présence active dans de nombreux réseaux.</p>
+\n
+\n<div>
+\n<p>Le numérique révolutionne la façon de travailler, de collaborer, de communiquer ; il devait nécessairement transformer en profondeur la manière d’enseigner.&nbsp;&nbsp;</p>
+\n
+\n<p><a href="https://www.isae-supaero.fr">L’ISAE-SUPAERO</a> accorde une place importante à l’innovation pédagogique au niveau de l’ensemble des formations proposées. Dans ce contexte, le numérique constituent une opportunité permettant de diversifier les méthodes d’apprentissage et de former les étudiants à un usage professionnel de ces outils.&nbsp;</p>
+\n
+\n<p>L’essor des MOOCs au sein de l'établissement redessine peu à peu l’accès à la connaissance aéronautique et spatiale, pour qu'au-delà de nos propres étudiants, les salariés, les futurs étudiants et tous les passionnés puissent bénéficier du savoir-faire et de l'expertise de l'ISAE-SUPAERO.</p>
+\n
+\n<p>&nbsp;</p>
+\n</div>
+\n
+\n<div>&nbsp;</div>
+\n	level-2	600
+72	Université de Nantes	univnantes	universities/logo-un.png	universities/photo-illustration-un_copie.png	universite-de-nantes	0	1	<div>
+\n<p>Pôle majeur d'enseignement supérieur et de recherche du Grand Ouest, l'Université de Nantes est l'une des grandes universités pluridisciplinaires françaises et un acteur incontournable du développement de la métropole. Force d’innovation, l’Université de Nantes inscrit depuis plusieurs années sa recherche dans une dynamique d’excellence à travers l’activité de ses 63 laboratoires couvrant tous les domaines de la connaissance (Lettres, langues, sciences humaines et sociales, Sciences de la vie - santé, Sciences – technologies).</p>
+\n
+\n<p>L’Université de Nantes se place également comme un producteur et diffuseur du savoir et de la connaissance scientifique sur son territoire avec pour ambition de créer le débat, faire connaître les sciences et d’apporter un éclairage sur les grands enjeux de notre société. L’Université de Nantes s’implique régulièrement dans l’organisation d’évènements scientifiques grand public au sein de l’établissement mais aussi dans la cité. L’université participe également activement au partage des connaissances à travers la diffusion de conférences et d’émissions de vulgarisation scientifique qu’elle diffuse notamment sur <a href="http://webtv.univ-nantes.fr/">sa WebTV</a>.</p>
+\n
+\n<p>Le soutien offert par France Université Numérique au développement des MOOCs (Massive Open Online Courses) a permis à l’Université de Nantes d'ouvrir ses premières formations de ce type.<br />
+\nLa politique MOOC de l'Université de Nantes est motivée par la volonté de proposer des MOOCs à forte valeur de différenciation et de valorisation pour l'établissement et repose également sur l'intégration d'un volet recherche qui permettra de questionner le développement et l'usage des MOOCs ainsi que leurs apports dans la pédagogie.</p>
+\n</div>
+\n	level-2	670
+75	Université de Genève	unige	universities/logo-unige.png	universities/UNIGE-Banner1-980x200.jpg	unige	0	1	<p>Fondée en 1559, l'<a href="http://www.unige.ch/" target="_new&quot;">Université de Genève</a>&nbsp;est aujourd'hui la deuxième plus grande Haute école de Suisse. Fleuron de la cité de Calvin, l'institution jouit d'un rayonnement international privilégié et cultive son ouverture au monde. L'UNIGE se distingue par son patrimoine intellectuel, un enseignement de qualité couvrant l'essentiel des domaines des sciences, des arts et des lettres ainsi que par une recherche de pointe.</p>
+\n
+\n<p>Seule haute école généraliste de Suisse romande, l’Université de Genève s'appuie sur sa polyvalence pour assurer une formation supérieure de qualité et garantir l'interdisciplinarité de la recherche. Soucieuse de participer au décloisonnement des savoirs et de suivre les évolutions de la société, elle oeuvre aussi activement en faveur de l’égalité des chances, afin de garantir un accès large aux études et de bonnes conditions de formation.</p>
+\n
+\n<p>L’Université de Genève poursuit plusieurs objectifs à travers les MOOCs. Ils permettent d’une part d’améliorer sa visibilité internationale sur des thématiques choisies, de renforcer ses équipes autour d’enseignements communs, de consolider ses liens avec la Genève Internationale, et de renforcer la place de l’UNIGE dans l’espace universitaire francophone. Les MOOCs permettent également de tester et de mesurer l’effet de certains dispositifs pédagogiques contribuant ainsi à améliorer l’enseignement. À travers les MOOCs, l&nbsp;‘UNIGE permet la diffusion de nouveaux savoirs et de renforcer la participation citoyenne dans la recherche. Pour finir, les MOOCs permettent de consolider les partenariats stratégiques et de faciliter la mise en place d’enseignements partagés.</p>
+\n	academic-partner	150
+78	AGROCAMPUS OUEST	agrocampusouest	universities/Logo-AGROCAMPUS-OUEST.png	universities/agrocampusouest.jpg	agrocampusouest	0	1	<p>Grande école publique, <a href="http://www.agrocampus-ouest.fr/">AGROCAMPUS OUEST</a> constitue un ensemble unique en France par la palette des thématiques couvertes et des expertises rassemblées dans les domaines de l'agronomie, de l'alimentation, de l'environnement, de l'horticulture et du paysage - de l'alimentation au cadre de vie.</p>
+\n
+\n<p>Établissement public à caractère scientifique, culturel et professionnel sous tutelle du ministère de l'Agriculture et du ministère de l'Enseignement supérieur et de la Recherche, AGROCAMPUS OUEST :</p>
+\n
+\n<p>- met les compétences de ses 140 enseignants-chercheurs au service de 2 000 étudiants inscrits dans 4 cursus d'ingénieurs et autres formations allant de la licence au doctorat (120 doctorants, co-accréditation dans 6 écoles doctorales).</p>
+\n
+\n<p>- mène des recherches académiques et finalisées axées sur un développement durable de l'agriculture, de l'alimentation et des territoires, en partenariat étroit avec les organismes nationaux et internationaux de recherche, au 1er rang desquels l'INRA, et des activités de transfert et de développement en lien avec 3 pôles de compétitivité (Mer Bretagne, Végépolys, Valorial).</p>
+\n
+\n<p>suivant 5 axes thématiques</p>
+\n
+\n<ul>
+\n\t<li>Végétal, animal, systèmes</li>
+\n\t<li>Enjeux environnementaux - ressources, territoire et ville</li>
+\n\t<li>Halieutique, mer et littoral</li>
+\n\t<li>Alimentation</li>
+\n\t<li>Paysages</li>
+\n</ul>
+\n
+\n<p>AGROCAMPUS OUEST en chiffres</p>
+\n
+\n<ul>
+\n\t<li>2000 étudiants</li>
+\n\t<li>2 centres de formation et de recherche</li>
+\n\t<li>6 départements d'enseignement et de recherche</li>
+\n\t<li>14 unités de recherche labellisés</li>
+\n\t<li>6 écoles doctorales</li>
+\n\t<li>70 partenaires académiques dans une quarantaine de pays</li>
+\n\t<li>13000 alumni</li>
+\n</ul>
+\n
+\n<p>AGROCAMPUS OUEST est membre de l'Institut agronomique, vétérinaire et forestier de France - Agreenium et de la COMUE Université Bretagne Loire – UBL et dans ces cadres collaboratifs, actif depuis 10 ans dans l'enseignement en ligne.</p>
+\n
+\n<img src="/media/2017/07/06/agreenium180x100.png" width="" height="">
+\n	level-2	640
+81	Université Jean Moulin Lyon 3	lyon3	universities/UDL-Lyon3_WEB.jpg	universities/JeanMoulin1.jpg	universite-jean-moulin-lyon-3	0	1	<p>L’Université Jean Moulin Lyon 3, spécialisée en sciences humaines et sociales, accueille plus de 27000 étudiants sur trois campus :&nbsp;la Manufacture des Tabacs,&nbsp;le quai Claude Bernard/ rue Chevreul, au cœur de la vie lyonnaise et le Campus de Bourg-en-Bresse.</p>
+\n
+\n<p>Elle propose des formations de la Licence au Doctorat en : droit, science politique, francophonie, management, économie, gestion, philosophie, langues, lettres, histoire, aménagement, géographie, information et communication au sein de six facultés et instituts (Droit, Langues, Lettres et Civilisations, Philosophie, IAE et IUT).</p>
+\n
+\n<p>Dans le cadre de son objectif d’ouverture et d’égalité des chances, l’Université Jean Moulin Lyon 3 mène une politique déterminée d’accompagnement de ses étudiants dans leur parcours pédagogique et d’insertion professionnelle. Elle développe des actions de coopération pédagogique et scientifique à l’international et accueille près de 4 400 étudiants étrangers chaque année.</p>
+\n
+\n<p>www.univ-lyon3.fr</p>
+\n	level-2	660
+84	Université Pierre Mendès France (Grenoble 2)	upmf	universities/logo_UPMF_170x110px.png	universities/UPMF_01.jpg	universite-pierre-mendes-france-grenoble	1	0	<p style="line-height: 20.7999992370605px;">L&#39;Universit&eacute; Pierre-Mend&egrave;s-France est l&#39;Universit&eacute; des sciences sociales&nbsp;<span style="line-height: 1.6;">et humaines de Grenoble. Elle propose plus de 200 dipl&ocirc;mes aux 17 200&nbsp;</span><span style="line-height: 1.6;">&eacute;tudiants qu&#39;elle accueille.&nbsp;</span><span style="line-height: 1.6;">L&rsquo;UPMF se situe dans un environnement scientifique exceptionnel, aux&nbsp;</span><span style="line-height: 1.6;">c&ocirc;t&eacute;s des autres &eacute;tablissements d&rsquo;enseignement sup&eacute;rieur du sillon alpin&nbsp;</span><span style="line-height: 1.6;">qui forment ensemble la COMUE &laquo; Universit&eacute; Grenoble-Alpes &raquo;.&nbsp;</span><span style="line-height: 1.6;">Les sciences sociales et humaines apportent des r&eacute;ponses aux grandes&nbsp;</span><span style="line-height: 1.6;">questions de soci&eacute;t&eacute;. Elles contribuent &eacute;galement aux avanc&eacute;es&nbsp;</span><span style="line-height: 1.6;">technologiques en les accompagnant voire en les suscitant par ses&nbsp;</span><span style="line-height: 1.6;">approches pluridisciplinaires croisant des disciplines telles que&nbsp;</span><span style="line-height: 1.6;">l&rsquo;&eacute;conomie, le droit, la philosophie ou la psychologie. L&#39;objectif de&nbsp;</span><span style="line-height: 1.6;">l&#39;UPMF est de renforcer ces champs de recherche et &agrave; pr&eacute;parer ses&nbsp;</span><span style="line-height: 1.6;">&eacute;tudiants pour r&eacute;pondre aux d&eacute;fis de demain.</span></p>
+\n
+\n<p style="line-height: 20.7999992370605px;">&nbsp;</p>
+\n
+\n<div style="line-height: 20.7999992370605px;">
+\n<p>L&rsquo;Universit&eacute; Pierre-Mend&egrave;s-France a une longue exp&eacute;rience dans les&nbsp;<span style="line-height: 1.6;">pratiques p&eacute;dagogiques num&eacute;riques, en particulier pour l&rsquo;enseignement &agrave;&nbsp;</span><span style="line-height: 1.6;">distance (1400 &eacute;tudiants par an inscrits dans ce r&eacute;gime). Les MOOCS&nbsp;</span><span style="line-height: 1.6;">constituent une prolongation naturelle de ces modes d&rsquo;enseignement.&nbsp;</span><span style="line-height: 1.6;">L&rsquo;&eacute;tablissement met en place un accompagnement des &eacute;quipes enseignantes&nbsp;</span><span style="line-height: 1.6;">pour la r&eacute;alisation de leurs projets de MOOCS en lien avec leurs besoins&nbsp;</span><span style="line-height: 1.6;">p&eacute;dagogiques. Les MOOCS de l&rsquo;UPMF ont une triple vocation : donner le&nbsp;</span><span style="line-height: 1.6;">go&ucirc;t des sciences sociales et humaines &agrave; l&rsquo;&eacute;tudiant avant l&rsquo;entr&eacute;e &agrave;&nbsp;</span><span style="line-height: 1.6;">l&rsquo;Universit&eacute; ; compl&eacute;ter la formation de l&#39;&eacute;tudiant apr&egrave;s l&rsquo;obtention de&nbsp;</span><span style="line-height: 1.6;">son dipl&ocirc;me (processus de &laquo; formation tout au long de la vie &raquo;) ;&nbsp;</span><span style="line-height: 1.6;">renforcer les nouvelles pratiques d&rsquo;apprentissage pendant la formation.</span></p>
+\n</div>
+\n	level-2	600
+87	Université Lille 1	lille1	universities/UL-WEB-2014.jpg	universities/ULille-portail_FUN-MOOC-980x200px-V1-2x-100.jpg	lille1	0	0	<p>&nbsp;</p>
+\n
+\n<p>L’Université de Lille est née en janvier 2018 de la fusion des trois universités lilloises. À une demi-heure de Bruxelles, 1h de Paris, 1h20 de Londres, 2h d’Amsterdam, elle occupe une position stratégique au cœur de l’Europe du nord, et collabore avec de grandes universités internationales particulièrement dynamiques. Dotée d’importants équipements de pointe, elle est lauréate avec ses partenaires d’un vaste plan national de financement d’excellence («&nbsp;I-SITE+&nbsp;»), dont l’un des axes est de diffuser largement les meilleures initiatives pédagogiques.</p>
+\n
+\n<p>L’Université de Lille en chiffres&nbsp;: 67000 étudiants dont 7300 étudiants internationaux, 24 composantes, 66 laboratoires de recherche, 6300 personnels.</p>
+\n
+\n<p>Le développement des MOOC s’inscrit dans la volonté de l’Université de Lille de promouvoir l’enseignement&nbsp;au plus grand nombre grâce aux dispositifs numériques et d’améliorer sa visibilité tant nationale qu’internationale.</p>
+\n
+\n<p>Avec son accessibilité facilitée et sa gratuité, le MOOC permet réellement d’organiser une formation tout au long de la vie très ouverte. Le recours aux MOOC est aussi l’occasion d’utiliser toutes les potentialités du numérique quant aux méthodes pédagogiques permettant de favoriser la réussite de l’apprenant mais aussi sa participation à une certaine co-construction de la connaissance. Par d’ailleurs les MOOC sont un objet de recherche au sein de l’Université de Lille.</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	660
+90	Université Libre de Bruxelles (ULB)	ulb	universities/logo-ulb_epXmC0R.png	universities/ULB_baniere_980x200.jpg	universite-libre-de-bruxelles	0	1	<p>Créée en 1834, l’Université libre de Bruxelles (ULB) avec ses 13 facultés, écoles et instituts spécialisés couvre aujourd’hui toutes les disciplines en associant très étroitement enseignement et recherche. Elle propose 386 programmes d’enseignement et a reçu de nombreux prix prestigieux : cinq Prix Nobel (Jules Bordet, Albert Claude, Ilya Prigogine, Henri-Marie La Fontaine et le récent Prix Nobel de Physique attribué en 2013 à Françoise Englert), une Médaille Fields, trois Prix Wolf.&nbsp;</p>
+\n
+\n<p>Université francophone dans un environnement multiculturel – 32 % des étudiants et des académiques et scientifiques proviennent de 130 pays à travers le monde – l’ULB est une université internationale à l’image de la ville de Bruxelles.</p>
+\n
+\n<p>Forte de nombreuses expériences techno-pédagogiques et scientifiques en matière d’e-learning et de production audiovisuelle pédagogique, l’ULB vise, dans le courant 2015, la mise en ligne progressive de plusieurs MOOCs dans les domaines des sciences humaines et sociales, des sciences exactes et naturelles, ainsi que des sciences du vivant et de la santé.</p>
+\n
+\n<p>La production de ces MOOCS s’aligne sur sa politique d’émancipation sociale et d’ouverture des savoirs à tous. Elle s’inscrit également dans sa volonté de soutenir ses enseignements et la pédagogie universitaire par le biais d’outils technologiques adéquats et innovants ainsi que d’une recherche-action sur les pratiques de ses enseignants et apprenants.&nbsp;</p>
+\n	academic-partner	170
+93	AgroParisTech	AgroParisTech	universities/logagroparistech_RVB_180x100.png	universities/Banniere_Grignon_ciel_Ph-Joyet.jpg	AgroParisTech	0	1	<p>Considéré comme établissement supérieur leader dans les sciences du vivant, <a href="http://www.agroparistech.fr" target="_new">AgroParisTech</a> conduit deux missions fondamentales :</p>
+\n
+\n<ul>
+\n\t<li>la formation d'ingénieurs au coeur d'un dispositif étendu à d'autres cursus académiques et professionnalisant&nbsp;;</li>
+\n\t<li>la production et la diffusion de connaissances (recherche et développement) en partenariat avec les grands organismes de recherche et les principaux centres techniques professionnels.</li>
+\n</ul>
+\n
+\n<p>Les grands domaines de compétences de l'établissement sont :</p>
+\n
+\n<ul>
+\n\t<li>la transformation agro-industrielle,</li>
+\n\t<li>l'environnement,</li>
+\n\t<li>les biotechnologies,</li>
+\n\t<li>la distribution,</li>
+\n\t<li>l'ensemble des activités liées à la production, au mangement et à la commercialisation.</li>
+\n\t<li>les ressources agricoles et forestières.</li>
+\n</ul>
+\n
+\n<p>L'alimentation des hommes et les préoccupations nutritionnelles, la santé, la prévention des risques sanitaires, la protection de l'environnement, la gestion durable des ressources naturelles et la valorisation des territoires sont au coeur de la mission d'AgroParisTech.</p>
+\n
+\n<p>AgroParisTech s'applique à répondre à trois enjeux majeurs de l'usage des technologies numériques :</p>
+\n
+\n<ul>
+\n\t<li>participer à la diffusion des savoirs auprès de tous les publics pour contribuer à l'alimentation des grands débats de société ;</li>
+\n\t<li>élargir le nombre de personnes accédant à ses formations diplômantes, tant en formation initiale qu'en formation professionnelle ;</li>
+\n\t<li>favoriser l'innovation pédagogique par l'usage raisonné des nouvelles technologies de l'information et de la communication pour l'enseignement dans l'ensemble de ses cursus.</li>
+\n</ul>
+\n
+\n<p>Les objectifs de moyen terme sont de :</p>
+\n
+\n<ul>
+\n\t<li>proposer un ensemble de ressources libres au grand public, sous forme de ressources documentaires multimédia &nbsp;ainsi que de parcours pédagogiques ;</li>
+\n\t<li>construire des cursus diplômants correspondant à un enseignement entièrement à distance.</li>
+\n</ul>
+\n	level-2	640
+96	FERRANDI Paris - l'école française de gastronomie	ferrandiparis	universities/Ferrandi_170x110_grand.png	universities/bandeau_ferrandi.png	ferrandi-paris	0	1	<p>FERRANDI Paris est une école de la Chambre de Commerce et d’Industrie,&nbsp;qui est aujourd’hui considérée comme l’un des acteurs majeurs de la formation gastronomique en France.</p>
+\n
+\n<p>Créée en 1920, l’institution propose à tous ses apprenants, du CAP au Bac+5, une même philosophie : celle du travail et de l’exigence comme passages obligés vers l’excellence.</p>
+\n
+\n<p>Maîtrise du geste, pratique en situation réelle, acquisition d’une posture managériale et d’entrepreneur, incitation à la créativité : FERRANDI Paris propose un accès à une expertise technique unique qui appuie son projet pédagogique sur un corps professoral d’exception (professionnels issus des maisons les plus prestigieuses et lauréats des plus grands concours culinaires&nbsp;: Meilleurs Ouvriers de France, Prix Prosper Montagné…).</p>
+\n
+\n<p>Aujourd’hui engagée dans une valorisation de la «&nbsp;French Touch&nbsp;», FERRANDI Paris propose à tous les curieux et passionnés, amateurs ou professionnels, des formations leurs permettant de développer leur créativité culinaire.</p>
+\n
+\n<p><strong><a href="http://www.ferrandi-paris.fr/" target="_blank">www.ferrandi-paris.fr</a></strong></p>
+\n	level-2	640
+99	Université de Perpignan	UPVD	universities/logo-upvd_180_96_b.png	universities/photo-campus-UPVD-980x199-2.jpg	UPVD	0	1	<p>L'<a href="http://www.univ-perp.fr/" target="_new">université de Perpignan Via Domitia</a> est un campus à taille humaine, dynamique, de proximité et pluridisciplinaire, tourné vers la Catalogne Sud et l'international.</p>
+\n
+\n<p>L'UPVD, c'est aussi une université engagée. Engagée en premier lieu dans une véritable transformation numérique, afin d'offrir à ses étudiants ce qui existe de meilleur dans le domaine : un service et un bâtiment dédiés aux usages du numérique, Platinium+.<br />
+\nCette plateforme d’innovation pour une université numérisée a ainsi vu le jour et continue à se développer sur le campus. Engagée également dans une démarche de transition écologique et énergétique et de développement durable, avec des chantiers-écoles, des plans d'action sur les déchets, l'énergie, le bâti. Mais aussi dans la pédagogie innovante. Dans le cadre de son projet d’établissement 2014-2020, l’UPVD met en œuvre un programme pionnier de Pédagogie Innovante à destination de la communauté universitaire. Ce programme novateur vise à dynamiser et valoriser notre réflexion et nos pratiques d’enseignants, et à replacer l’ensei­gnement au cœur de notre métier.</p>
+\n
+\n<p>Avec l’appui de ce nouveau service Pl@tinium+ , dédié à l’accompagnement des usages du numérique,&nbsp; l’Université participe activement, par l’intermédiaire de son président en charge du numérique, à l’activité des groupes de la filière numérique. De plus, avec le certificat c2i pour tous, en licence et master, l’Université de Perpignan est très volontaire dans l’installation du numérique auprès de ses étudiants. L'UPVD cherche à se démarquer toujours plus dans le domaine du numérique en organisant par exemple, à son initiative, le regroupement de la filière numérique pour&nbsp; participer à la concertation nationale « ambition numérique » proposée par le gouvernement.</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-1	300
+102	Université de Cergy Pontoise	u-cergy	universities/Logo-UCP-170-110.jpg	universities/fond-980-199.jpg	u-cergy	0	1	<p>En 24 ans, l'<a href="http://www.u-cergy.fr/fr/index.html" target="_new">université de Cergy-Pontoise</a> (UCP) s'est imposée comme un acteur majeur de l'enseignement supérieur et de la recherche tant à l'échelle nationale que régionale. En s'appuyant sur un pôle économique attractif et dynamique, l'université a noué des relations solides avec le réseau d'entreprises locales et des partenariats avec les collectivités territoriales.</p>
+\n
+\n<p>L'université de Cergy-Pontoise est composée de 5 unités de formation et de recherche: Droit, Economie et gestion, Langues et études internationales, Lettres et sciences humaines, Sciences et techniques ; de 3 instituts : institut d'éducation, institut universitaire de technologie (IUT) et institut d'études politiques (Sciences Po Saint-Germain-en-Laye) ; ainsi que d'une école supérieure du professorat et de l'éducation (ÉSPÉ). Un institut d'études avancées (IEA) a également été créé à pour stimuler les collaborations scientifiques entre les chercheurs de l'UCP et la communauté scientifique internationale dans les grands domaines.</p>
+\n
+\n<p>Avec 23 laboratoires, deux Laboratoires d'excellence (LabEx) et l'IEA, l'université de Cergy-Pontoise compte parmi les centres de recherche les plus actifs en France, et est reconnue internationalement. L'université est entrée dans le très sélectif classement de Shanghai par ses activités en mathématiques.</p>
+\n
+\n<p>Le SEFIAP, service de la pédagogie numérique, accompagne et forme la communauté universitaire aux différentes usages du numérique : enseignement à distance, présentiel enrichi, certification C2I niveau 1 et 2 et pour la production audiovisuelle et multimédia à des fins pédagogiques.</p>
+\n	level-1	300
+105	Université de Montpellier 2 (ancien nom)	Montpellier2	universities/Logo-etablissement_vA2n9Cy.png		universite-de-montpellier	1	0		level-2	600
+108	Université Paris Diderot	parisdiderot	universities/LogoParisDiderot_170x110px.png	universities/FUN-MOOC_Paris_Diderot.jpg	parisdiderot	0	1	<p>Ouverte sur la ville et sur le monde, Paris Diderot est une université pluridisciplinaire qui forme ses étudiant.e.s par la recherche. Carrefour des savoirs, en prise avec les grands débats qui animent la société contemporaine, elle est un creuset qui stimule les échanges et les innovations. Formation initiale ou tout au long de la vie, formations courtes ou longues, technologiques ou théoriques, chacun.e y trouvera les atouts pour réussir et s’épanouir.<br />
+\nElle accueille chaque année un peu plus de 29 000 étudiant.e.s répartis en trois grands domaines : santé / sciences / arts, lettres, langues, sciences humaines et sociales. &nbsp;Elle compte 87 équipes de recherche. Son site principal est situé dans le 13e arrondissement à proximité de la Bibliothèque François Mitterrand. Elle est membre fondateur de la Communauté d’universités et d’établissements Sorbonne Paris Cité.</p>
+\n
+\n<p>L’université du XXIe siècle sera numérique et Paris Diderot s’inscrit pleinement dans cette dynamique. Le monde est devenu un « village numérique global », la transmission des savoirs est au cœur de nos activités et les MOOCs sont un formidable outil de partage. Université pluridisciplinaire qui possède des enseignants chercheurs de grand talent, Paris Diderot souhaite dépasser les frontières physiques de son campus pour diffuser l’excellence de ses enseignements et de sa recherche à un public large et passionné.</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	660
+113	Agreenium	Agreenium	universities/Agreenium_logo_180x100.png	universities/banniere_agreenium.png	Agreenium	0	1	<p><a href="https://www.agreenium.fr/" target="_blank">Agreenium, l'Institut agronomique, vétérinaire et forestier de France</a>, est un établissement public de coopération rassemblant 14 établissements d’enseignement supérieur et 4 institutions de recherche.</p>
+\n
+\n<p>Placé sous la tutelle des ministères chargés de l’agriculture et de l’enseignement supérieur, Agreenium développe le lien entre la formation-recherche-innovation-développement en agrobiosciences, et favorise des coopérations entre ses membres autour de 3 axes : international, formation et numérique.</p>
+\n
+\n<p>L'Institut a lancé en 2017, Agreen U, l'université numérique en agrobiosciences, afin de promouvoir l'offre française et d'améliorer sa visibilité. Agreen U constitue une véritable vitrine pour les MOOC produits par les membres d'Agreenium.</p>
+\n	level-2	720
+116	Ecole des hautes études en santé publique	EHESP	universities/ehesp-logo.png	universities/ehesp-banniere.png	EHESP	0	1	<p><a href="http://www.ehesp.fr/" target="_blank">L'Ecole des hautes études en santé publique</a>&nbsp;(EHESP) est l'école de référence française pour les cadres de la santé et du secteur social.&nbsp;</p>
+\n
+\n<p>Plateforme pour l’enseignement et la recherche en santé publique au niveau international, l’EHESP propose une offre complète de formation tout au long de la vie, des filières de formation de cadres supérieurs de la fonction publique, des spécialités de diplôme national de master, des diplômes de mastères spécialisés. L’École anime en outre un réseau doctoral national en santé publique.</p>
+\n
+\n<p>L’EHESP est structurée en quatre départements (méthodes quantitatives en santé publique / santé, environnement et travail / Institut du management/ sciences humaines et sociales) comprenant des unités de recherche labellisées. En partenariat avec des centres de recherche, l’École s’attache à construire un projet interdisciplinaire.</p>
+\n
+\n<p>L’École développe une stratégie dynamique d'innovation et d'adaptation aux nouvelles méthodes de transmission des connaissances. L'établissement favorise ainsi le développement des apprentissages par de nouvelles modalités pédagogiques, en accompagnant les acteurs pédagogiques et en développant notamment les usages du numérique. Ce MOOC permet ainsi à l’EHESP de mettre à nouveau son savoir-faire et son réseau d’experts au service d’une nouvelle formation à distance en santé publique, renforçant ainsi sa position d’école numérique.&nbsp;</p>
+\n
+\n<p>L’EHESP accueille 10 000 élèves, étudiants ou stagiaires en formation continue provenant d’une cinquantaine de nationalités différentes et fait appel à 1 300 conférenciers par an.&nbsp;</p>
+\n	level-2	600
+118	Aix-Marseille Université	amu	universities/logo-amu-170x110.png	universities/Aix-Marseille-BANDEAU.jpg	amu	0	1	<p>Aix-Marseille Université a été créée le 1er janvier 2012, se substituant à l’université de Provence, de la Méditerranée et Paul-Cézanne. C’est aujourd’hui une des plus jeunes universités de France et la deuxième plus grande de par le nombre de ses étudiants, de ses personnels et par son budget.&nbsp;<br />
+\nAix-Marseille Université compte près de 72000 étudiants, 7680 personnels, enseignants-chercheurs, enseignants, ingénieurs, techniciens et administratifs, 12 écoles doctorales et près de 3800 doctorants. L’université est composée de 130 structures de recherche en lien avec les plus grands organismes &nbsp;de recherche (CNRS, INSERM, IRD, INRA, CEA).&nbsp;<br />
+\nAix-Marseille Université est une université pluridisciplinaire et interdisciplinaire qui propose cinq grands secteurs, structurés en 19 composantes, réparties sur 5 grands campus.</p>
+\n
+\n<p>Aix-Marseille Université souhaite profiter des initiatives FUN afin de promouvoir au niveau national certaines de ses formations et de ses unités de recherches labélisées dans le cadre des Académies d’Excellence.<br />
+\nCes projets s’inscrivent dans une démarche plus large visant à dynamiser l’utilisation des outils numériques au sein de l’université.</p>
+\n
+\n<p>&nbsp;</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-1	610
+120	Université de Bretagne Occidentale	UBO	universities/Nouveau_logo_UBO-Hor-Noir_vecto_Dzrt79V.png	universities/UBO-technopole-980x200.png	UBO	0	1	<p>L'<a href="http://www.univ-brest.fr" target="_new">université de Bretagne Occidentale</a> (UBO) s'est créée en 1971 à Brest, son site principal, avant d'ouvrir des sites secondaires à Quimper et Morlaix. Université pluridisciplinaire, l'UBO accueille plus de 18 000 étudiants et environ 7 000 stagiaires en formation continue chaque année. Elle offre un large choix de formations dans tous les domaines&nbsp;: arts, lettres et langues&nbsp;; sciences humaines et sociales&nbsp;; droit, économie, gestion&nbsp;; staps&nbsp;; sciences de la mer et du littoral&nbsp;; sciences, technologies, santé. Cette offre de formation est soutenue par une recherche dynamique (37 laboratoires, 700 chercheurs et enseignants-chercheurs), menée en collaboration avec les grands organismes (IFREMER, CNRS, INSERM, IRD) organisée en 4 axes&nbsp;: Sciences de la Mer, Santé-Agro-Matière, Maths-STIC, Sciences de l'Homme et de la Société.</p>
+\n
+\n<p><br />
+\nL'UBO est membre de l'Université Européenne de Bretagne (UEB).&nbsp;La politique de l'UBO intègre le numérique au cœur de ses enjeux stratégiques. Le développement progressif des installations de <a href="https://numerique.ueb.eu" style="line-height: 1.6;" target="_new">l'UEB c@mpus</a>, 1er campus numérique régional en Europe, apporte à l'UBO et à sa communauté, l'opportunité de disposer d'outils particulièrement innovants pour communiquer, enseigner et collaborer à l'échelle régionale mais aussi au-delà du territoire national.</p>
+\n
+\n<p>C'est dans ce contexte qu'une réflexion sur la pédagogie a été engagée début 2014 à l'échelle de l'établissement : <a href="http://www.univ-brest.fr/assises_pedagogie" style="line-height: 1.6;" target="_new">les Assises de la pédagogie de l'UBO</a>. Les usages du numérique pour la pédagogie font naturellement partie de cette réflexion.</p>
+\n	level-2	600
+123	Université d'Artois	univartois	universities/UNIV_ARTOIS_LOGO_RVB200x200.png	universities/banniere.jpg	universite-dartois	0	1	<p>Multipolaire, l’<a href="http://www.univ-artois.fr/" target="_blank">Université d'Artois</a> est implantée sur différents sites du territoire du Nord-Pas de Calais : Arras, Béthune, Douai, Lens et Liévin. Elle accueille plus de 10 000 étudiants et&nbsp;comprend 8 UFR, 2 IUT et 17 centres de recherche.<br />
+\nDepuis sa création en 1992, l’Université d’Artois s’impose comme un acteur de promotion sociale et bénéficie d’un environnement convivial et stimulant propice aux études et à la culture.&nbsp;C’est une université moderne et dynamique qui répond à l'évolution du système éducatif en proposant une pédagogie innovante alliant savoir et professionnalisation.<br />
+\nPluridisciplinaire, elle propose un large choix de formations allant de bac + 2 à bac + 8 dans les domaines suivants : Droit, Economie, Gestion, Langues, Lettres, Arts, Sciences humaines et sociales, Sciences, Technologies, Sport.</p>
+\n
+\n<p>L'Université d'Artois par son service universitaire de pédagogie SUPArtois soutient et encourage les pédagogies actives et l’innovation pédagogique. Elle soutient également via sa cellule TICE l'utilisation du numérique dans les formations à la fois comme complément des formations en présentiel et pour développer et moderniser les formations à distance. En créant un premier MOOC sur des spécialités de recherche fortement ancrées dans l'université, elle cherche à faire partager les connaissances acquises dans ses laboratoires de recherche et promouvoir les innovations pédagogiques qu'elle porte.</p>
+\n
+\n<p>Ce MOOC complètement original et résolument nouveau est conçu par les plus grands spécialistes de la fantasy, un sujet qui s'inscrit dans une spécialité de l'université d'Artois, les études sur la littérature de jeunesse. Il vous permettra de découvrir un nouveau domaine,<br />
+\nd’apprendre avec plaisir, d’aborder de nouveaux concepts, de collaborer, de construire ensemble des apprentissages...<br />
+\nBon voyage !</p>
+\n	level-2	600
+126	L'observatoire de la Côte d'Azur	oca	universities/logo-OCA.png		oca	0	0		level-2	605
+129	Université de Jendouba	ujendouba	universities/UJ_nouveau2.png	universities/banniereujb3.png	ujendouba	0	1	<p>L'<a href="http://www.uj.rnu.tn/" target="_blank">Université de Jendouba</a>(Tunisie) a été créée par le décret numéro 1662-2003 du 4 août 2003 concrétisant la politique de l'Etat de décentraliser la connaissance et la technologie et de promouvoir le rôle de l'université dans les régions.</p>
+\n
+\n<p><br />
+\nGrande, bien que jeune, l'Université de Jendouba est une véritable pépinière avec ses treize institutions d'enseignement supérieur, rayonnant sur l’international. Trente six filières au total, dont la moitié est déjà insérée dans le cadre du système LMD sont offertes parmi les curricula de formations proposés. Ainsi, de l'économie-gestion aux sciences juridiques et humaines, en passant par l'informatique, les nouvelles technologies, l'ingénierie rurale, les études agro-pastorales et les métiers artistiques, des milliers de perspectives prometteuses se profilent à l'horizon.</p>
+\n	academic-partner	160
+132	Université Toulouse - Jean Jaurès	UT2J	universities/LOGO_texte_noir.png	universities/bandeau-ministere.png	UT2J	1	0	<p>Etablissement public d’enseignement supérieur et de recherche, l’Université Toulouse – Jean Jaurès, anciennement Université de Toulouse II – Le Mirail, est une université, où se croisent les sciences humaines et sociales et &nbsp;les arts, lettres et langues. Y sont également enseignées : les mathématiques, l’informatique, l’économie et la gestion..</p>
+\n
+\n<p>Héritière de la faculté des lettres, elle s’enracine dans une tradition de plusieurs siècles et s’inscrit dans une longue tradition d’humanisme et d’ouverture disciplinaire.</p>
+\n
+\n<p>Au XXe siècle, l'Université des Lettres atteint son plein développement : elle quitte le centre ville en 1968 pour s'installer définitivement en 1971 dans le nouveau quartier du Mirail.</p>
+\n
+\n<p>Depuis, ses effectifs ont presque doublé : de 14 000 étudiants en 1984, elle est passé aujourd'hui à plus de 27 000 en 2015.</p>
+\n
+\n<p>Elle est la seule de France à être entièrement reconstruite à l’horizon 2016, avec près de 100 000 m2 de bâtiments et plus de 350 millions d’euros investis.</p>
+\n
+\n<p>Original et ambitieux, le projet offrira un tout nouveau confort de travail d’étude et de vie à l’ensemble de la communauté universitaire.&nbsp;</p>
+\n
+\n<p>Forte de son rayonnement régional, national et international (elle est présente dans toute la Région Midi-Pyrénées mais également à Madrid, Kuala Lumpur et Hanoï), l’université prend, en 2014, un nouvel élan en changeant de nom. Elle devient l’Université Toulouse – Jean Jaurès, en hommage au grand intellectuel et homme politique français.&nbsp;</p>
+\n
+\n<p>La Recherche à l’université est reconnue pour sa très grande qualité avec &nbsp;28 unités de recherche, dont 8 liées au CNRS. 83 % de ses laboratoires ont été classés A et A+ par l’AERES.</p>
+\n
+\n<p>L’utilisation du numérique pour la pédagogie à l'UT2J fait d'ores et déjà partie de notre histoire. Des ressources pédagogiques sont régulièrement produites pour deux UNT : l’UOH (Université Ouverte des Humanités) et l’UVED (Université Virtuelle de l’Environnement et du Développement durable). Un DU consacré à l’autisme, entièrement en FOAD, vient de démarrer. Des dispositifs d'incitation à l'utilisation du numérique pour l'amélioration de la pédagogie sont également proposés.</p>
+\n
+\n<p>L’UT2J s’inscrit dans le mouvement de développement des MOOC, en s'attachant au respect de ses valeurs : la réussite des étudiants (MOOC de découverte des études en psychologie) et le développement durable (MOOC Ecotourisme).</p>
+\n
+\n<p>Ollivier Haemmerlé&nbsp;<br />
+\nVice-président délégué Système d'information et usages du numérique</p>
+\n
+\n<p>L'UT2J est également partenaire de l'Université de Jendouba pour le MOOC «&nbsp;L'écotourisme : Imaginons-le ensemble&nbsp;».&nbsp;</p>
+\n	level-2	605
+135	Université de Sousse	usousse	universities/LogoUS_170x110.png	universities/Batiment_US.jpg	usousse	0	1	<p>Créée en 1986, l’Université de Monastir a pris sa nouvelle appellation pour devenir en 1991 l’Université du Centre, puis pour devenir en 2004 l’<a href="http://www.uc.rnu.tn" target="_blank">Université de Sousse</a>.<br />
+\nElle dispense un éventail de formations académiques et professionnalisées dans les domaines des sciences fondamentales, juridiques, économiques et de gestion, techniques, agronomiques, médicales, paramédicales, des arts et métiers, des lettres et des sciences humaines.<br />
+\nL’Université de Sousse compte 17 établissements d’enseignement supérieur, avec 1950 enseignants et 32765 étudiants.</p>
+\n
+\n<p>La production de cours numérisés et la pratique de l’enseignement à distance a débuté depuis 2003 et, actuellement, l’Université de Sousse compte environ 30 cours en ligne et espaces de formation à distance.<br />
+\nL’initiative de lancement de ce MOOC vient comme une suite naturelle de ces multiples initiatives d’innovation et d’utilisation du e-learning, et grâce à l’expertise acquise par les enseignants de l’université.</p>
+\n	academic-partner	150
+136	Observatoire de Paris	OBSPM	universities/logo-obspm.png	universities/banniere-obspm.png	OBSPM	0	1	<p>L’<a href="http://www.obspm.fr" target="_new&quot;">Observatoire de Paris</a> est un Grand établissement relevant du Ministère de l'Enseignement supérieur et de la Recherche. Fondé en 1667, il est le plus grand pôle national de recherche en astronomie. Ses missions principales&nbsp; sont la recherche en contribuant au progrès de la connaissance de l’Univers, l'enseignement (formation initiale et continue) et la diffusion des connaissances auprès du grand public. Il travaille en collaboration avec le CNRS et de grandes universités scientifiques de la région parisienne.</p>
+\n
+\n<p>Dans le cadre du campus virtuel « Astrophysique Sur Mesure », l’Observatoire de Paris propose déjà des formations à distance diplômantes en astronomie, astrophysique et techniques associées. C'est dans cette logique qu'il offre aujourd'hui son premier MOOC en astrophysique.</p>
+\n
+\n<p>Depuis plus de dix ans, l’Unité de Formation et d’Enseignement (UFE) de l'Observatoire de Paris utilise les outils numériques pour proposer des enseignements créés au plus proche de sa recherche. Ces enseignements, de niveau licence et master, complètent une offre de formation en présentiel et offrent à des personnes aux profils variés des formations scientifiques rigoureuses aux concepts et théories de l’astronomie et de l’astrophysique. Les Formations Ouvertes A Distance (FOAD) de l’UFE remportent un vif succès. Nous proposons de compléter ces formations par des MOOCs, plus courts que les FOAD. Ce projet relève de la volonté de l’Observatoire de mettre à disposition sous forme numérique au plus grand nombre des ressources rigoureuses et accessibles sous des formes variées.</p>
+\n	level-2	650
+139	École de l'air	EcoleAir	universities/LOGO_ECOLE_DE_LAIR_carré_new.png		EcoleAir	0	0		academic-partner	165
+142	Ecole Nationale Supérieure de Sécurité Sociale	en3s	universities/logo_en3s_pour_MOOC.png		en3s	0	0		academic-partner	155
+145	Institut de Physique du Globe de Paris	IPGP	universities/USPCIPGP-1.png	universities/IPGP_nuit.jpg	IPGP	0	1	<p>L'<a href="http://www.ipgp.fr" target="_new">Institut de Physique du Globe de Paris</a> (IPGP) est un Grand Établissement d'Enseignement Supérieur et de Recherche spécialisé dans le domaine des Sciences de la Terre, de l'Environnement et la Planétologie. Associé au CNRS et membre de Sorbonne Paris Cité, Il rassemble dans 15 équipes de recherche, environ 150 chercheurs, 170 personnels techniques et administratifs, et plus de 150 doctorants.<br />
+\nL'IPGP mène des recherches au meilleur niveau mondial, nourries de nombreuses collaborations nationales et internationales. Il gère les observatoires volcanologiques des outremers, l'observatoire magnétique national, le réseau mondial de sismologie Géoscope, et l'observatoire de l'érosion aux Antilles. Il propose, avec l'université Paris Diderot, un cursus complet d'enseignements de Sciences de la Terre en Licence, Master et Doctorat.</p>
+\n
+\n<p>Les Sciences de la Terre jouent un rôle central dans le monde moderne marqué par l'entrée dans «&nbsp;l'Anthropocène&nbsp;», nouvelle ère géologique définie par l'impact majeur de l'Homme sur la planète. Les enjeux de connaissance, de préservation de l'environnement et de développement durable, d'adaptation aux changements des milieux, la protection des populations face aux catastrophes naturelles, préoccupent fortement le grand public et singulièrement les jeunes citoyens.<br />
+\nEn s'engageant dans la conception de MOOCs, l'Institut de physique du globe de Paris souhaite offrir au plus grand nombre un meilleur accès aux connaissances et compétences nécessaires pour mieux appréhender ces enjeux.</p>
+\n	level-2	600
+148	Alliance française Paris Ile-de-France	AFPIF	universities/logo_AFPIF_170x110.png		AFPIF	0	0		academic-partner	170
+151	CANOPÉ	Canope	universities/Logo_reseauCanope_170x110.jpg		Canope	0	0		simple-partner	15
+154	GOBELINS, l'école de l'image	gobelins	universities/logo_gobelins_ccir_transparent_198x110v3_Vku4As1.png	universities/baniere_goblins.png	gobelins	0	1	<p>Au cœur des industries créatives, GOBELINS s’est imposée depuis plus de 50 ans comme l’école de référence dans les métiers de la création visuelle, de la conception de l’image à sa production.&nbsp;</p>
+\n
+\n<p>Établissement de la Chambre de commerce et d’industrie de Région Paris Ile-de-France, GOBELINS forme chaque année plus de 850 élèves. Du Bac pro au Bac+6, six filières permettent d’acquérir des compétences recherchées par les entreprises&nbsp;: cinéma d’animation, design graphique/motion design, photographie, design interactif, communication imprimée et plurimédia, et jeu vidéo.</p>
+\n
+\n<p>Et plus de 1900 adultes choisissent également chaque année de se professionnaliser ou de se reconvertir en se formant à GOBELINS, en bénéficiant d’une offre diversifiée et sans cesse renouvelée.</p>
+\n	level-2	640
+157	Université Paul Sabatier - Toulouse III	UPS	universities/logo_ut3-170x110.png	universities/ut3-ps-02_199.png	UPS	1	0	<p>H&eacute;riti&egrave;re directe de l&rsquo;ancienne Universit&eacute; de Toulouse fond&eacute;e en 1229, l&rsquo;universit&eacute; Toulouse III &ndash; Paul Sabatier est n&eacute;e officiellement en 1969 de la fusion des Facult&eacute;s de m&eacute;decine, de pharmacie et des sciences.<br />
+\nElle se situe aujourd&rsquo;hui parmi les premi&egrave;res universit&eacute;s fran&ccedil;aises, &nbsp;gr&acirc;ce &agrave; son rayonnement scientifique &nbsp;et &agrave; la diversit&eacute; &nbsp;des &nbsp;laboratoires et des formations qu&rsquo;elle propose en sciences, sant&eacute;, sport, technologie et ing&eacute;nierie.</p>
+\n
+\n<p>L&rsquo;universit&eacute; Toulouse III &ndash; Paul Sabatier en chiffres :</p>
+\n
+\n<ul>
+\n\t<li>30 887 &eacute;tudiants</li>
+\n\t<li>16 mentions de licence</li>
+\n\t<li>54 licences professionnelles</li>
+\n\t<li>14 sp&eacute;cialit&eacute;s de DUT</li>
+\n\t<li>23 mentions de masters d&eacute;clin&eacute;s en 91 sp&eacute;cialit&eacute;s (hors master enseignement)</li>
+\n\t<li>91% des dipl&ocirc;m&eacute;s sur le march&eacute; du travail sont en emploi 30 mois apr&egrave;s l&rsquo;obtention d&rsquo;un master. Ce chiffre place l&rsquo;&eacute;tablissement parmi les premi&egrave;res universit&eacute;s fran&ccedil;aises pour l&rsquo;insertion professionnelle, &agrave; ce niveau d&rsquo;&eacute;tude.</li>
+\n</ul>
+\n
+\n<p><span style="line-height: 1.6;">Attirer plus d&rsquo;&eacute;tudiants vers les sciences fondamentales, r&eacute;&eacute;quilibrer les fili&egrave;res, acc&eacute;der aux savoirs les plus actuels, permettre &agrave; chacun de suivre un parcours de r&eacute;ussite &nbsp;adapt&eacute; &agrave; ses talents &nbsp;et &agrave; ses projets, telle est l&rsquo;ambition de l&rsquo;universit&eacute; Toulouse III &ndash; Paul Sabatier.</span></p>
+\n
+\n<p>La nouvelle offre de formation inclut une r&eacute;flexion sur la transmission des savoirs, afin de placer les &eacute;tudiants au c&oelig;ur du projet p&eacute;dagogique de l&rsquo;enseignement sup&eacute;rieur. Dans cet esprit, l&rsquo;universit&eacute; a donn&eacute; la priorit&eacute; &agrave; l&rsquo;innovation p&eacute;dagogique et a d&eacute;velopp&eacute; les usages du num&eacute;riques au service de la formation depuis de nombreuses ann&eacute;es. Elle se lance &agrave; pr&eacute;sent dans la dynamique des MOOCs.</p>
+\n
+\n<p><br />
+\n&Agrave; l&rsquo;Universit&eacute; Toulouse III - Paul Sabatier, la recherche &nbsp;s&rsquo;articule autour &nbsp;de quatre p&ocirc;les : sciences de la mati&egrave;re ; sciences du vivant ; univers, plan&egrave;tes, espace, &nbsp;environnement ; math&eacute;matiques et sciences &nbsp;et technologies &nbsp;de l&rsquo;information et de l&rsquo;ing&eacute;nierie. Au-del&agrave; de ces th&eacute;matiques principales, la communication, l&rsquo;information, la gestion et la didactique des langues font aussi partie de la recherche &agrave; l&rsquo;Universit&eacute;.</p>
+\n	level-2	605
+160	Université Paris-Saclay	ParisSaclay	universities/logo-paris-saclay-170x110.png	universities/Banniere_UP-Saclay.png	ParisSaclay	0	1	<p>L’Université Paris-Saclay a été conçue pour développer à un niveau inédit en France le continuum des connaissances depuis les sciences fondamentales jusqu’aux sciences appliquées, mettant l’accent sur l’interdisciplinarité et l’ouverture sur le monde. Son objectif est de faire avancer la connaissance sur les grands enjeux de société grâce à une recherche au plus haut niveau international. L’Université Paris-Saclay offre ainsi aux étudiants un cadre et un contenu de formation tournés vers l’avenir. Les interactions permanentes entre laboratoires et acteurs socio-économiques permettent de transformer des résultats d’une recherche de pointe en innovations.</p>
+\n
+\n<p>Les dix-neuf institutions fondatrices apportent à l’Université Paris-Saclay les forces qui font leur réputation : lien étroit entre formation et recherche, laboratoires et grands instruments de recherche aux standards internationaux, réputation internationale des formations d’ingénieurs et de managers, cursus diversifiés de haut niveau.</p>
+\n
+\n<p>Pour soutenir l’offre de formations communes portées par l’Université Paris-Saclay, et donner les moyens aux partenaires d’enrichir leur propre offre de formation, l’Université Paris-Saclay a conçu le programme « former avec le numérique » qui s’inscrit dans la dynamique de création du Learning center de l’Université.</p>
+\n
+\n<p>Ce programme, doté par l’IDEX Paris-Saclay en appui des moyens mis par les partenaires, accompagne la création de MOOC et celle de SPOC* pour les étudiants de l’Université, ainsi que pour des usages de formation continue vers le monde socio-économique avec lequel les contacts sont déjà forts.</p>
+\n	level-3	910
+163	Université de Bourgogne	ubourgogne	universities/logo_uB_orange_filet_-_166c-170x109.png	universities/uB_bannière.jpg	ubourgogne	0	1	<p>L’<a href="http://www.u-bourgogne.fr/" target="_blank">université de Bourgogne</a> (uB) est une grande université pluridisciplinaire qui propose plus de 400 formations à 27 100 étudiants à Dijon, dans cinq villes de Bourgogne et partout dans le monde en formation à distance.</p>
+\n
+\n<p>Les 6 secteurs pluridisciplinaires de recherche, « Aliment et Environnement », « Santé (Health) et Ingénierie moléculaire », « Photonique et matériaux avancés », « Apprentissage et santé (Care) », « Patrimoines et Territoires » et « Vigne et Vin » définissent l’identité scientifique de la Bourgogne.</p>
+\n
+\n<p>Les origines de l’uB remontent à 1722 avec la création à Dijon d’une Faculté de Droit. C’est aujourd’hui un établissement public national à caractère scientifique, culturel et professionnel, labellisé « Campus innovant » et engagé dans la COMUE Bourgogne Franche-Comté pour créer un ensemble universitaire de référence au sein de l’espace européen.</p>
+\n
+\n<p>L’initiative MOOCs à l’uB s’inscrit dans le cadre de sa politique de développement de la pédagogie numérique, pilotée par le service AIDE-numérique du Pôle des Systèmes d’Information et des Usages du Numérique. Cette stratégie s’articule autour de la création et la diffusion de ressources pédagogiques numériques, l’accompagnement aux usages et le développement de dispositifs (formations hybrides, à distance et MOOCs).&nbsp;</p>
+\n
+\n<p>Les MOOCs représentent une opportunité stratégique pour accroitre la visibilité internationale de l’établissement sur ses domaines de spécialité en matière de recherche, ouvrir l’enseignement supérieur à un public ‘non-traditionnel’ et impulser l’innovation pédagogique.</p>
+\n	level-2	650
+165	Ecole Nationale Supérieure de Céramique Industrielle	ensci	universities/ensci_170x110.png	universities/BANNIERE_FUN_ENSCILIMOGES_980x200.png	ensci	0	0	<p>L’<a href="http://www.ensci.fr/" target="_blank">ENSCI</a> est un établissement public d’enseignement supérieur. Créée en 1893, l’école a pour mission de former des ingénieurs dont les compétences spécifiques relèvent de la mise en forme des matériaux minéraux non métalliques en intégrant l’approche complète de la poudre aux produits finis aussi associée à l’ingénierie des procédés. L’enseignement s’organise autour de 5 grands thèmes : la formation humaine et sociale à l’entreprise, la formation générale scientifique, les sciences et matériaux, les sciences appliquées aux procédés et les langues vivantes. Certifiée ISO 9001, l’ENSCI entretient un partenariat étroit avec le monde économique et industriel, et possède un tissu relationnel fort avec des laboratoires et des établissements universitaires du monde entier.</p>
+\n
+\n<p><br />
+\nPour l’Ecole Nationale Supérieure de Céramique Industrielle, le numérique est aujourd’hui un outil pédagogique essentiel pour permettre à tous, particulier ou industriel, l’accès au monde des matériaux céramiques. Plus particulièrement, l’établissement souhaite développer des cours en ligne non seulement pour diversifier ses supports mais surtout pour faciliter, aussi bien en France qu’à l’international, le suivi de ses enseignements et de ses formations sur des sujets peu abordés portant sur de multiples domaines tels que les matériaux minéraux, l’ingénierie des procédés ou les produits à propriétés d’usage.</p>
+\n	academic-partner	155
+167	Université Paris Descartes	parisdescartes	universities/Logo-descartes-uspc.png	universities/ParisDescartes_7_1-1.jpg	parisdescartes	0	1	<p>L’Université Paris Descartes, située dans le coeur historique du Quartier Latin, est la deuxième plus grande université de Paris et la quatrième plus grande université française par le nombre d’étudiants. Près de 2000 enseignants y forment près de 40 000 étudiants au sein de 9 Unités de Formation et de Recherche (UFR) et de son Institut Universitaire de Technologie (IUT). Université des sciences de l’Homme et de la santé, l’Université Paris Descartes est la seule université parisienne à proposer l’ensemble des formations de santé - médecine, pharmacie, odontologie et maïeutique - mais également la psychologie, les sciences sociales et de l’éducation, le droit, l’économie-gestion, les mathématiques, l’informatique, la biologie, la physique et la chimie dans le cadre du LMD européen.</p>
+\n
+\n<p>L’Université Paris Descartes est résolument engagée dans une politique ambitieuse de généralisation des usages pédagogiques numériques ; en recrutant huit ingénieurs pédagogiques titulaires pour accompagner les enseignants au sein d’un service TICE moteur pour toute la communauté nationale des TICE.&nbsp;</p>
+\n
+\n<p>Les MOOCs participent à la montée en compétences des ingénieurs pédagogiques et des ingénieurs multimédias. Ces compétences sont réinvesties dans les dispositifs de formations initiales et continues pour créer avec les enseignants des contenus multimédias riches.<br />
+\nParis Descartes a participé à la conception et à la réussite des premiers MOOCs de FUN par sa collaboration avec le centre Virchow-Villermé.</p>
+\n	level-2	650
+168	Université de Lorraine	lorraine	universities/LOGO_UL_170x110.jpg	universities/Image_Universite_de_Lorraine.jpg	lorraine	0	1	<p>L’<a href="http://www.univ-lorraine.fr/" target="_blank">Université de Lorraine</a> est née le 1er janvier 2012 de la fusion de 4 établissements. Forte de 55000 étudiants et 6700 personnels dont 3700 enseignants chercheurs, l’Université de Lorraine est actrice du développement économique et social du territoire.</p>
+\n
+\n<p>Elle offre une couverture complète des domaines de la connaissance : sciences, santé, technologies, sciences de l'ingénieur, sciences humaines et sociales, droit, économie, gestion, arts, lettres et langues. Les étudiants peuvent adapter leur parcours grâce à des passerelles toujours plus nombreuses entre composantes et entre disciplines.</p>
+\n
+\n<p>L’Université de Lorraine promeut la mutualisation des savoirs pour accélérer l’innovation dans une société en mutation. Elle relève les défis du monde professionnel et apporte du dynamisme dans des environnements en mouvement.</p>
+\n
+\n<p>&nbsp;</p>
+\n
+\n<p>L’Université de Lorraine souhaite ouvrir au plus grand nombre l’accès aux savoirs et se positionne en tant qu’acteur dans une démarche de formation initiale et de Formation Tout au Long de la Vie.</p>
+\n
+\n<p>Par ailleurs, nous avons engagé, avec la communauté enseignante et étudiante, une politique de transformation des pratiques pédagogiques s’appuyant notamment sur l’usage du numérique. La production de MOOCs sur la plateforme FUN s’inscrit naturellement dans le prolongement de cette démarche.</p>
+\n	level-1	610
+170	MINES ParisTech	ENSMP	universities/logominesparis_170x110.png	universities/bannière.jpg	ENSMP	0	1	<p>L'Ecole supérieure des Mines de Paris ou MINES-ParisTech forme depuis sa création des ingénieurs de très haut niveau.&nbsp;<br />
+\nFondée en 1783, à l’époque où l’exploitation des mines était l’industrie de haute technologie par excellence, les compétences de l’École ont suivi le développement de l’industrie. &nbsp;MINES-ParisTech étudie, développe et enseigne aujourd’hui l’ensemble des techniques utiles aux ingénieurs, y compris les sciences économiques et sociales.<br />
+\nPremière école d'ingénieurs en France par son volume de recherche contractuelle, MINES ParisTech dispense une importante activité de recherche orientée vers l’industrie, dans des domaines aussi variés que l'énergie, les matériaux ou les mathématiques appliquées. L’école d'ingénieurs développe également la création de chaires d’enseignement et de recherche sur des thèmes émergents.<br />
+\nMINES ParisTech entretient de multiples partenariats et rayonne au cœur de réseaux réputés. L'Ecole est, notamment, membre de la ComUE Paris Sciences et Lettres (PSL) et de l'Institut Mines-Télécom (IMT). Grâce à tous ces partenariats, l’École mobilise des compétences dans le monde entier et met au service de ses étudiants des programmes originaux et de grande qualité.</p>
+\n
+\n<p>L'engagement de l’Ecole supérieure des Mines de Paris dans le développement d'une offre de MOOCs, s'inscrit pleinement dans les objectifs de sa politique d'innovation pédagogique et de transformation numérique des enseignements.&nbsp;<br />
+\nLes MOOCs constituent, pour MINES-ParisTech, un moyen &nbsp;de développer des communautés apprenantes, de faciliter la formation des ingénieurs tout au long de la vie, &nbsp;et de faire correspondre les enseignements dispensés à l'évolution des attentes des publics, en termes de dispositif d'apprentissage.</p>
+\n	level-2	660
+171	IFOCA	IFOCA	universities/logo_ifoca.png		IFOCA	0	0		academic-partner	165
+172	Université de Lyon	universite-lyon	universities/UDL_logo_couleur-01_180x110.png	universities/bandeau_fun_UdL.jpg	universite-lyon	0	1	<p><strong>Université de Lyon : Construire l’université de demain&nbsp;</strong></p>
+\n
+\n<div>L’Université de Lyon est un site académique d’excellence à vocation mondiale. Labellisée IDEX en 2017, elle se situe au cœur de la Région Auvergne-Rhône-Alpes, sur le bassin Lyon Saint-Étienne.</div>
+\n
+\n<div>&nbsp;</div>
+\n
+\n<div>Structurée autour de 12 établissements membres et d’établissements associés, l’Université de Lyon porte trois ambitions majeures :</div>
+\n
+\n<ul>
+\n\t<li>Concevoir une grande université attractive, responsable, bénéficiant d’une réputation d’excellence et d’innovation, et dotée d’un fort rayonnement international ;</li>
+\n\t<li>Proposer une offre de formation et des axes de recherche d’excellence, en adéquation avec les attentes et les mutations de la société ;</li>
+\n\t<li>Développer et valoriser la dynamique du site Lyon Saint-Étienne, en lien avec tous les acteurs du territoire : citoyens, associations, entreprises, collectivités locales (métropoles de Lyon et Saint-Étienne, Région Auvergne-Rhône-Alpes, autres collectivités territoriales).</li>
+\n</ul>
+\n
+\n<p><em>Crédits photo :&nbsp;Desvigne Conseil, collectif IRIS, Jean François Marin, Eric Le Roux service communication UCBL</em></p>
+\n	level-2	750
+173	Wikimédia France	WMFr	universities/Facebook_profil_WikiMOOC_2018.jpg		WMFr	0	0		academic-partner	155
+175	Université de Franche-Comté	univ-fcomte	universities/logo-ufc_170x110.png	universities/banniere980_200.jpg	univ-fcomte	0	1	<p>Créée en 1423, l’<a href="http://www.univ-fcomte.fr/" target="_blank">Université de Franche-Comté</a> (UFC) compte aujourd’hui plus de 22 500 étudiants répartis dans cinq villes du territoire à Besançon, Belfort, Montbéliard, Lons-le-Saunier et Vesoul.<br />
+\nPluridisciplinaire, elle propose tous les niveaux de diplômes européens et les enseignements sont étroitement adossés à ses activités de recherche. Ses 1 352 enseignants et enseignants-chercheurs sont répartis dans 27 équipes de recherche internationalement reconnues (environnement et santé, homme et société, sciences pour l'ingénieur et sciences fondamentales).<br />
+\nOuverte à l’international, l’UFC accueille plus de 2500 étudiants internationaux de 132 nationalités.&nbsp;</p>
+\n
+\n<p>En transformant son service TICE en <a href="http://sun-ip.univ-fcomte.fr/" target="_blank">SUN-IP (Service universitaire du numérique et de l’innovation pédagogique)</a>, l’UFC a résolument tourné la page de la technologie, considérée comme une opportunité, pour mettre toute son énergie au service de la pédagogie : le cœur même de notre mission première. Ce sont donc les enseignants qui remontent leurs besoins ou leurs expériences pour que les chercheurs puissent les évaluer. Avec la technologie au service de la pédagogie par exemple dans les MOOCs, la collaboration au service de l'apprendre en face à face ou en ligne, avec la recherche pour évaluer et étayer nos pratiques, c'est l'innovation qui est le moteur de la pédagogie à l'UFC !</p>
+\n	level-2	600
+177	ENAC	enac	universities/logo_enac-bleu_900x500.png	universities/campus_ENAC3_ydgt5kP.jpg	enac	0	1	<p>Première école aéronautique européenne, l’<a href="http://www.enac.fr/" target="_blank">Ecole Nationale de l’Aviation Civile</a> est l’unique exemple d’une seule école proposant un ensemble aussi large et aussi complet de formations et d’activités destinées au domaine aéronautique, et en particulier au secteur du transport aérien.<br />
+\nL’ENAC rassemble 2.000 élèves répartis dans 30 programmes de formation initiale en France et à l’international, et 7.500 stagiaires participant chaque année à plus de 500 sessions de stage de formation continue, dans les domaines de l’ingénierie aéronautique, de la navigation aérienne et du pilotage. Elle s’appuie pour cela sur des laboratoires de recherche de niveau mondial, et sur des moyens pédagogiques exceptionnels répartis sur 10 sites.<br />
+\nQue ce soit dans le cadre de la formation initiale ou continue, l’ENAC s’est engagée en profondeur dans une stratégie d’incorporation des technologies éducatives dans ses pratiques pédagogiques. La production de MOOCs s’inscrit naturellement dans cette dynamique, ainsi que dans une démarche de dissémination de notre passion auprès d’un public toujours plus large.</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	600
+179	Centre national de la fonction publique territoriale (CNFPT)	CNFPT	universities/Logo_CNFPT_transparent.png	universities/Bandeau_CNFPT_original.jpg	CNFPT	0	1	<p>Le <a href="http://www.cnfpt.fr/" target="_blank">Centre national de la fonction publique territoriale (CNFPT)</a> est un établissement public paritaire déconcentré. Il est chargé de construire et délivrer les formations obligatoires à destination des agents des collectivités territoriales : les formations d’intégration, les formations de professionnalisation, les formations réglementées, adaptées aux exigences et contraintes de certains métiers.</p>
+\n
+\n<p>Le CNFPT conçoit et dispense également des formations qui, non obligatoires pour l’agent, lui permettent d’être acteur de sa promotion : les formations de perfectionnement, les formations diplômantes ou certifiantes, les préparations aux concours et examens professionnels de la fonction publique territoriale.</p>
+\n
+\n<p>Par ailleurs, le CNFPT organise plusieurs concours de la fonction publique territoriale : administrateur territorial, conservateur du patrimoine, conservateur des bibliothèques, ingénieur en chef. Il propose également un accompagnement à la validation des acquis de l’expérience (VAE) et organise la reconnaissance de l’équivalence des diplômes (RED).</p>
+\n	level-3	900
+182	Institut Catholique de Paris	ICP	universities/NEW-LOGO_ICP.png		ICP	0	0		academic-partner	155
+184	ENSTA Paristech	ENSTA	universities/logo_ENSTA_RVB_modif_100_180_.png	universities/bandeau_FUN_ENSTAParisTech.jpg	ENSTA	0	1	<p style="line-height: 20.8px;"><br />
+\nGrande &Eacute;cole d&rsquo;ing&eacute;nieurs sous tutelle du minist&egrave;re de la d&eacute;fense, l&rsquo;ENSTA ParisTech est un &eacute;tablissement public administratif d&rsquo;enseignement sup&eacute;rieur et de recherche qui dispense des formations dipl&ocirc;mantes (cycle ing&eacute;nieur en 3 ans, master, doctorat, Mast&egrave;re Sp&eacute;cialis&eacute;) et qui d&eacute;veloppe une recherche appliqu&eacute;e de haut niveau en lien avec des partenaires industriels. Elle est particuli&egrave;rement reconnue par les entreprises pour son expertise dans les domaines des transports, de l&rsquo;&eacute;nergie et de l&rsquo;ing&eacute;nierie des syst&egrave;mes industriels complexes.&nbsp;</p>
+\n
+\n<p style="line-height: 20.8px;">Elle est accessible sur concours ou sur titre, pour des &eacute;tudiants fran&ccedil;ais ou internationaux (21 accords de double-dipl&ocirc;me, recrutements ParisTech, accords d&rsquo;&eacute;changes&hellip;).</p>
+\n
+\n<p style="line-height: 20.8px;">Elle est l&rsquo;un des membres fondateurs de l&rsquo;Universit&eacute; Paris-Saclay.</p>
+\n	level-2	615
+186	Institut Pasteur	pasteur	universities/logo_seul_noir_-_Copie_JU8ynXh.png	universities/ip_42050_Fronton_Trav.png	pasteur	0	1	<p>Fondation privée reconnue d’utilité publique, créée en 1887 par Louis Pasteur, l’Institut Pasteur est aujourd’hui un centre de recherche biomédicale de renommée internationale, au cœur d’un réseau regroupant 33 instituts présents sur les cinq continents. Pour mener sa mission dédiée à la prévention et à la lutte contre les maladies, en France et dans le monde, l’Institut Pasteur développe ses activités dans quatre domaines : recherche scientifique et médicale, santé publique et veille sanitaire, enseignement, valorisation économique et transfert technologique. Les priorités scientifiques incluent notamment la microbiologie et les maladies infectieuses mais aussi l’immunologie, les neurosciences, la biologie du développement, la génétique et le cancer. L’Institut Pasteur a placé les MOOCs comme une priorité du développement de son enseignement.</p>
+\n	simple-partner	639
+188	Université Fédérale Toulouse Midi-Pyrénées	univ-toulouse	universities/Logo-UTFTMP_horizontale_O_180x99.png	universities/presentationMOOC-UFTMP.jpg	univ-toulouse	0	1	<p>L'Université Fédérale Toulouse Midi-Pyrénées est une structure fédérative, labellisée parmi les 8 pôles d'excellence pour l’enseignement supérieur français, qui regroupe les principaux établissements d'enseignement supérieur et de recherche de la région : 5 universités, 18 écoles d’ingénieurs ou écoles spécialisées et 5 organismes de recherche. L’objectif de l’Université Fédérale est d’inscrire le site universitaire de Toulouse et de Midi-Pyrénées au meilleur niveau international grâce au rayonnement de sa recherche de haut niveau, à la diversité et la qualité de son offre de formation et au cadre de vie privilégié pour les étudiants.</p>
+\n
+\n<p>L’Université Fédérale a mis en place un schéma directeur du numérique visant à déployer une stratégie numérique partagée entre tous les établissements. La pédagogie et la formation par le numérique sont au cœur de ce schéma. Innovation pédagogique, formation des enseignants, déploiement d’outils numériques de formation, collaboration des services pédagogiques permettent ainsi la mise en place de nouvelles pratiques pédagogiques et de nouvelles formations notamment à travers les différents MOOC proposés par les établissements de l’Université Fédérale</p>
+\n	level-2	730
+192	Université Paris-Seine	parisseine	universities/logo_paris_seine_180x100.png	universities/FABLAB_ciel_bleu_FUN_980x200.jpg	parisseine	0	1	<p>L’Université Paris-Seine est un établissement public à caractère scientifique, culturel et&nbsp;professionnel constitué sous la forme d’une communauté d’universités et établissements (ComUE).</p>
+\n
+\n<p>Rassemblant des institutions d’enseignement supérieur et de recherche sous statut, ministère et gouvernance divers, elle ambitionne d’inscrire ses membres au cœur des questions sociétales qui traversent le monde contemporain et de porter un nouveau modèle académique dédié à l’innovation, à l’esprit d’entreprise et à la créativité.&nbsp;</p>
+\n
+\n<p>Forte de cette triple ambition innovante, entrepreneuriale et créative, la ComUE Université Paris Seine crée un campus international d'une ère nouvelle qui permet à sa communauté de vivre au sein d'une cité intellectuelle où se croisent et interagissent des acteurs académiques et économiques riches de leur diversité et constitue l'indispensable instrument de rééquilibrage du territoire francilien aux côtés des grands pôles universitaires que sont notamment les campus de Condorcet, Paris-est et Paris-Saclay, rivalisant avec les campus mondiaux et mobilisant le Grand Ouest de la région parisienne.</p>
+\n
+\n<p>L'université de Perpignan, l'université de Lille 1, Science et technologies, et l'université de Cergy, membre de l'Université Paris-Seine, vous proposent 4 MOOC dans une collection&nbsp;<strong>«&nbsp;<em>Compétences numériques et C2i</em>&nbsp;».</strong></p>
+\n
+\n<p>&nbsp;</p>
+\n	level-1	300
+195	ComUE d’Aquitaine	cuea	universities/image001.png	universities/bandeau_UCA_sophiatech980x200_srG4HiF.jpg	cuea	0	1	<p>La ComUE d’Aquitaine est un établissement public à caractère scientifique, culturel et professionnel. Forte de ses six membres (Université Bordeaux Montaigne, Université de Bordeaux, Université de Pau et des Pays de l’Adour, Sciences Po Bordeaux, Bordeaux INP et Bordeaux Sciences Agro), la ComUE d’Aquitaine est chargée de :</p>
+\n
+\n<ul>
+\n\t<li>Coordonner l’offre de formation et la stratégie de recherche et de transfert de ses membres à l’échelle de la région Aquitaine;&nbsp;</li>
+\n\t<li>Piloter la stratégie numérique à l’échelle de la région Aquitaine;&nbsp;</li>
+\n\t<li>Organiser la coordination territoriale des établissements d’enseignement supérieur membres et partenaires à l’échelle de la région Aquitaine;&nbsp;</li>
+\n\t<li>Elaborer avec le réseau des œuvres universitaires et scolaires un projet d’amélioration de la qualité de la vie étudiante et de promotion sociale sur le territoire, en associant l’ensemble des établissements partenaires.&nbsp;</li>
+\n\t<li>Porter le volet commun du contrat pluriannuel conclu avec le ministre chargé de l’enseignement supérieur sur la base du projet partagé.</li>
+\n</ul>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	670
+198	Université Sorbonne Paris Cité	USPC	universities/LogoUSPC_180x100.png	universities/Recherche_montaGabirelle-3.jpg	USPC	0	1	<p>L’Université Sorbonne Paris Cité rassemble 8 établissements d’enseignement supérieur et 5 organismes de recherche. Elle mène des activités de recherche et de formation dans toutes les grandes disciplines scientifiques. C'est le premier regroupement français pour la santé et les sciences du vivant, les aires culturelles, les langues et civilisations.</p>
+\n
+\n<p>L’université figure dans les premiers rangs mondiaux, dans de nombreuses disciplines des sciences humaines et sociales, en mathématiques et en sciences de la terre et de l’univers.</p>
+\n
+\n<p>Les nouvelles formes pédagogiques, mélangeant les enseignements numériques et classiques, sont au cœur du projet pédagogique de USPC qui soutient et développe une offre innovante de formations des établissements membres, misant notamment sur l’internationalisation et l’interdisciplinarité.</p>
+\n
+\n<p>Depuis 2012, l’Université Sorbonne Paris Cité soutient l’innovation pédagogique, à travers :</p>
+\n
+\n<p>la création de son Service d’Accompagnement des enseignants aux pédagogies innovantes (SAPIENS), lequel a développé une expertise en matière de production de Moocs. C’est aussi ce Service qui porte la relation avec le GIP Fun-Mooc pour l’ensemble des universités et établissements membres de USPC.</p>
+\n
+\n<p>l’élargissement de Ilumens (Département de simulation en santé issu de l’Université Paris Descartes) à l’ensemble des Facultés de médecine des universités membres de USPC.</p>
+\n
+\n<p>le projet de Mooc Factory du Centre en santé publique franco-allemand, Virchow-Villermé, pleinement intégré à cette dynamique ;</p>
+\n
+\n<p>le Centre de Recherches Interdisciplinaires (CRI) qui développe des Moocs, Spocs… entre autres formes d’innovations pédagogiques.</p>
+\n
+\n<p>L’évolution des pratiques d’enseignement et d’apprentissage est au cœur de la stratégie de USPC.</p>
+\n
+\n<p><em>Image d'illustration&nbsp;copyright : Pascal Monteil</em></p>
+\n	level-2	770
+201	Communauté Université Grenoble Alpes	grenoblealpes	universities/logo_COMUE_Grenoble_180x100.png	universities/campus_bu-001.jpg	grenoblealpes	0	1	<p>Née le 31 décembre 2014, la Communauté Université Grenoble Alpes regroupe&nbsp;quatre institutions membres (l’Université GrenobleAlpes, Grenoble INP, le&nbsp;CNRS et l’INRIA) et à ce jour quatre institutions associées (l’Université&nbsp;Savoie Mont-Blanc, Sciences Po Grenoble, l’ENSAG et le CEA).</p>
+\n
+\n<p>Elle porte le projet “Université Grenoble Alpes : Université de&nbsp;l’innovation”, (lauréat IDEX 2016), qui ambitionne de créer une université de&nbsp;recherche et d’innovation pluridisciplinaire, visible internationalement, et&nbsp;en lien étroit avec son territoire.</p>
+\n
+\n<p>Pionnière dans le numérique, elle est engagée depuis plusieurs années dans&nbsp;l’innovation pédagogique et la transdisciplinarité de sa recherche et de ses&nbsp;formations avec ses 62 000 étudiants, ses 3&nbsp;700 doctorants et ses 7 000&nbsp;enseignants et/ou chercheurs.</p>
+\n
+\n<p>C’est ainsi tout naturellement au travers de sa participation au dispositif&nbsp;France Université Numérique que la Communauté Université Grenoble Alpes veut&nbsp;contribuer, parmi ses consœurs, à la diffusion et à la valorisation de ses&nbsp;résultats et connaissances au service de tous les apprenants et de nos&nbsp;sociétés. Ses ambitions et compétences dans le domaine du numérique sont&nbsp;importantes et FUN est l’un des vecteurs qu’elle a choisi pour déployer sa&nbsp;stratégie numérique.</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	710
+204	Université de Caen	unicaen	universities/UNICAEN-logo-NOIR-horizontal.png	universities/banniere-unicaen.png	unicaen	0	1	<p>Fondée en 1432, l'université de Caen Basse-Normandie accueille plus de 25 000 étudiants sur ses 5 antennes, dont un peu plus de 10% d’étudiants étrangers&nbsp;; elle est classée sixième pour la mobilité de ses étudiants sur des programmes internationaux.<br />
+\nMembre fondateur de la ComUE Normandie Université, notre établissement pluridisciplinaire propose des formations de la Licence au Doctorat dans 4 domaines&nbsp;: Arts-Lettres-Langues, Droit-Économie-Gestion, Sciences humaines et sociales, Sciences-Technologies-Santé, reposant sur 43 unités de recherche majoritairement associées aux grands organismes de recherche et à 9 pôles de compétitivité.<br />
+\nLes activités de valorisation et de transfert de technologies sont partie intégrante de la culture de l’établissement grâce à l’incubateur d’entreprises technologiques Normandie-Incubation dont il est membre fondateur.</p>
+\n
+\n<p>L'université de Caen Basse-Normandie est dotée d’un environnement numérique de travail matériel et virtuel et est engagée depuis longtemps dans la formation à distance. Le Centre d’Enseignement Multimédia Universitaire (CEMU) joue un rôle central tant dans la production de ressources pédagogiques numériques que la diffusion des pratiques pédagogiques innovantes auprès des enseignants-chercheurs. La publication de MOOC est une déclinaison naturelle d’un savoir faire de l’établissement.<br />
+\nNormandie Université a déjà produit un MOOC diffusé sur FUN en reposant sur les compétences du CEMU.</p>
+\n	level-2	600
+207	AgroSup Dijon	agrosupdijon	universities/logo_AgroSup_simple_180x110_pour_FUN.png	universities/Photo_Ecole_AgroSup_Dijon_980x200pixels.png	agrosup-dijon	0	1	<p>Riche d'une expérience de 50 ans, AgroSup Dijon, institut national supérieur des sciences agronomiques, de l'alimentation et de l'environnement est l'un des 6 grands établissements français dédiés à ces domaines [sous double tutelle du ministère en charge de l'agriculture et de l'alimentation et du ministère en charge de l'enseignement supérieur et de la recherche]&nbsp;<br />
+\nLes missions confiées à AgroSup Dijon en font un établissement doté de compétences riches et atypiques. Ces missions sont :</p>
+\n
+\n<p>•&nbsp;&nbsp; &nbsp;la formation d'ingénieurs,<br />
+\n•&nbsp;&nbsp; &nbsp;la recherche, le transfert et la valorisation,<br />
+\n•&nbsp;&nbsp; &nbsp;la formation des agents de l'État,<br />
+\n•&nbsp;&nbsp; &nbsp;l'appui au système éducatif dans le cadre de l'institut Eduter.</p>
+\n
+\n<p><br />
+\nAgroSup Dijon contribue au rayonnement des agrobiosciences à l’international, en participant à la construction d’une offre de formation numérique au sein de l’Institut Agronomique Vétérinaire et Forestier de France.</p>
+\n
+\n<p>AgroSup Dijon &nbsp;est membre de l’Institut Agronomique Vétérinaire et Forestier de France&nbsp;</p>
+\n
+\n<p>&nbsp;</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	600
+212	Cirad	cirad	universities/agreenium180x100_HmYBD43.png		cirad	1	0		level-2	600
+215	Université de Rennes 1	univrennes1	universities/Logo-UR1-FUN_ZYuUExc.png	universities/UR1-FUN.jpg	univrennes1	0	1	<p><a href="http://www.univ-rennes1.fr/" target="_blank">Rennes 1</a> est une université transdisciplinaire à dominante scientifique : santé (médecine, pharmacie, odontologie, maïeutique), sciences humaines et sociales (droit, économie, gestion, philosophie) ; sciences et technologies (biologie, informatique, électronique et télécommunications, mathématiques, sciences de la Terre, chimie, physique, mécanique). Elle compte 27 700 étudiants et 3 700 personnels répartis sur 11 sites en Bretagne, dont 3 campus à Rennes et 3 stations expérimentales.</p>
+\n
+\n<p><br />
+\nLe numérique constitue le facteur clé d'un enseignement innovant en phase avec la société. Rennes 1, à travers son service d'appui à l'enseignement, le SUPTICE, et son engagement spécifique dans le projet régional Université des TICE, s’attache à développer la e-pédagogie (plate-forme, classes virtuelles, téléprésence, tableau blanc interactif, ressources multi formats et tutorat en ligne). Elle pilote également le campus numérique ENVAM, offre unique de formation francophone à distance de niveau master dans le domaine de l'environnement et de l'aménagement du territoire.</p>
+\n
+\n<p><a href="http://www.univ-rennes1.fr/" target="_blank">L’Université de Rennes 1</a> est membre de l’Université Bretagne Loire (UBL).</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	600
+218	Institut National Polytechnique de Toulouse	INPT	universities/INP_logo_Quadri_170x110.png	universities/INP_Toulouse2_bannière.jpg	institut-national-polytechnique-de-toulouse	0	1	<p>Université originale dans le paysage de l'enseignement supérieur et de la recherche, membre de l’Université Fédérale de Toulouse et du réseau national Groupe INP, <a href="http://www.inp-toulouse.fr/" target="_blank">Toulouse INP</a>&nbsp;regroupe 6&nbsp;Grandes Ecoles d’ingénieurs et accueille près de 6 600 étudiants. Agronomie, Chimie, Électronique, Hydraulique, Informatique, Télécommunications, Mécanique, Météorologie... sont autant de domaines dans lesquels Toulouse INP dispense des formations d’excellence reconnues au niveau &nbsp;national et international.</p>
+\n
+\n<p><br />
+\nLa puissance de sa recherche permet à l’établissement d’entretenir et de développer de nombreuses collaborations avec les entreprises et les acteurs économiques.<br />
+\nToulouse INP s'appuie sur les nombreux champs de compétences de son réseau d'écoles et de laboratoires pour proposer des formations transversales.</p>
+\n
+\n<p>La stratégie de Toulouse INP en matière de numérique est d’intégrer l’innovation pédagogique et les TICE dans ses &nbsp;pratiques pour répondre aux nouveaux enjeux de la Formation et construire ainsi la réussite de ses élèves. A l’entrée du XXIème siècle, les MOOCs apparaissent comme un lien entre formation initiale et formation continue vers la Formation Tout au Long de la Vie et s’inscrivent donc dans la continuité de la politique de l’établissement.</p>
+\n
+\n<p><br />
+\nEvolution ou révolution, le MOOC est un outil nouveau et incontournable pour répondre à un large public, curieux de découvrir les dernières connaissances issues de la recherche technologique. C’est aussi une nouvelle possibilité de visibilité à l’international susceptible de favoriser l’attractivité de l’établissement.</p>
+\n	level-2	640
+223	Institut Supérieur International du Parfum, de la Cosmétique et de l'Aromatique alimentaire	isipca	universities/ISIPCA-logo-180x100-FUN-MOOC-v2016-06-15.png	universities/ISIPCA-banner-980x200-FUN-MOOC-v2016-06-15.png	isipca	0	1	<p>Créée par Jean-Jacques GUERLAIN en 1970, l'ISIPCA est l'école de référence en parfumerie, cosmétique et aromatique.&nbsp;Elle dispense des formations en alternance de BAC +1 à BAC + 5 qui s'appuient sur un plateau technique de 14 laboratoires et sur des équipements de dernière génération.&nbsp;</p>
+\n
+\n<p>8 diplômes de niveau master sont délivrés dont 4 masters anglophones. Ces formations sont mises en oeuvre en partenariat avec des universités ou des industriels de la parfumerie.&nbsp;</p>
+\n
+\n<p>Forte d'un réseau de 3 500 élèves à travers le monde et de 600 étudiants, l'ISIPCA est l'école internationale de référence dans les domaines de la parfumerie, de la cosmétique et des arômes.</p>
+\n
+\n<p>Lien vers le site internet :&nbsp;<br />
+\n<a href="https://www.isipca.fr/" target="_blank">https://www.isipca.fr/</a></p>
+\n	level-2	600
+225	ComUE Lille Nord de France	cuelnf	universities/logo-CUE-Quadri180x100.png	universities/bandeau_mooc.jpg	cuelnf	0	1	<p>La <a href="http://www.cue-lillenorddefrance.fr/" target="_blank">ComUE Lille Nord de France</a> est une structure de coopération et de coordination qui organise la politique de l’enseignement supérieur et de la recherche en région. Elle constitue un ensemble capable de renforcer la visibilité et l’attractivité des grands acteurs régionaux de l’enseignement supérieur et de la recherche au niveau national et international. Elle porte des missions à forte valeur ajoutée et dispose de compétences de formation à travers son École Supérieure du Professorat et de l’Éducation (ÉSPÉ Lille Nord de France) et ses formations doctorales transdisciplinaires.</p>
+\n
+\n<p>La ComUE Lille Nord de France est un Établissement Public à caractère Scientifique, Culturel et Professionnel (EPCSP). Les statuts de la ComUE Lille Nord de France ont été approuvés par le décret n° 2105-1064 du 26 août 2015.</p>
+\n
+\n<p>La ComUE Lille Nord de France regroupe onze établissements : les six universités de la région, l’École Centrale de Lille, L’École des Mines de Douai, &nbsp;La Fédération Universitaire Polytechnique de Lille, ainsi que deux organismes de recherche : le Centre National de la Recherche Scientifique (CNRS) et l’Institut National de la Recherche en Informatique et en Automatique (INRIA). La COMUE assure la coordination de l’ensemble des politiques conduites.&nbsp;</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	700
+228	Institut National des Langues et Civilisations Orientales	Inalco	universities/logo-inalco.png	universities/bandeau-inalco.png	Inalco	0	1	<p>Créé le 10 germinal an III (1795), aujourd'hui membre fondateur de Sorbonne Paris Cité (USPC), l'<a href="http://www.inalco.fr/" target="_new">Inalco</a> (Institut national des langues et civilisations orientales ) est un Grand établissement public à caractère scientifique, culturel et professionnel.<br />
+\nHaut lieu de la recherche croisant aires culturelles et disciplines, l'Inalco a pour vocation d'enseigner les langues et civilisations du monde, en formation initiale et continue ainsi que dans des filières professionnelles de haut niveau. Un tiers des ambassadeurs de France y a été formé.<br />
+\nEurope Centrale et Orientale, Asie, Océanie, Afrique, populations amérindiennes&nbsp;: une centaine de langues du monde sont enseignées aujourd'hui avec leurs civilisations dans cet établissement dont l'international est la raison d'être.</p>
+\n
+\n<p>Le numérique est pour l'Inalco un axe stratégique de sa politique contractuelle, il est inscrit au cœur du projet d'établissement.<br />
+\nL'Institut se veut un acteur résolu des innovations pédagogiques en cours, il s'ouvre largement à l'utilisation des nouvelles technologies déployées au service de l'enseignement, monte et développe des formations à distance ou hybrides (hébreu, inuktitut, swahili).<br />
+\nL'Inalco a vu dans les MOOCs un moyen de repousser les frontières d'espace et de temps pour faire profiter de ses formations au plus grand nombre. Ainsi, le «&nbsp;Kit de survie en langues orientales&nbsp;» décline des formations en arabe, berbère, birman, chinois, mazatec, mongol, persan, tchèque et turc.</p>
+\n	level-2	650
+231	Université Polytechnique des Hauts de France	UVHC	universities/uvhc_logo.png	universities/bandeauUVHC.jpg	universite-de-valenciennes-et-du-hainaut-cambresis	0	1	<p>L'<a href="http://www.univ-valenciennes.fr/" target="_blank">Université de Valenciennes et du Hainaut-Cambrésis</a> est un établissement pluridisciplinaire hors santé qui accueille près de 11 000 étudiants sur des campus à taille humaine à Valenciennes, Cambrai, Maubeuge et Arenberg.</p>
+\n
+\n<p>&nbsp;</p>
+\n
+\n<p>Elle donne la possibilité de se former à un métier en proposant plus de 180 parcours de formations professionnalisants du bac 2 + au bac 8 et elle accueille des publics en formation initiale, en formation continue et parmi les toutes premières en nombre d’étudiants suivant un cursus par alternance.</p>
+\n
+\n<p>Elle est reconnue comme l'un des principaux acteurs de la recherche au niveau régional dans le domaine du transport et de la mobilité durables.</p>
+\n
+\n<p>3 axes stratégiques viennent en complément de cet axe de recherche majeur :</p>
+\n
+\n<ul>
+\n\t<li>Images et Créations Numériques,</li>
+\n\t<li>Ingénierie de la santé et du handicap,</li>
+\n\t<li>Sécurité et maîtrise des risques.</li>
+\n</ul>
+\n
+\n<p>L’Université de Valenciennes et du Hainaut-Cambrésis est membre de la <a href="https://www.fun-mooc.fr/universities/cuelnf/" target="_blank">ComUE Lille Nord de France.</a></p>
+\n	level-2	600
+234	Ecole Centrale Lyon	eclyon	universities/UDL_lofgo_UU8gp3k.png		eclyon	0	1	<p>L’École Centrale de Lyon a pour mission de former des ingénieurs généralistes et des docteurs disciplinaires ouverts sur le monde.</p>
+\n
+\n<p>À la rigueur d’un socle de compétences scientifiques et techniques, elle allie une approche des sciences humaines et sociales qui permet aux Centraliens de Lyon d’appréhender rapidement les fonctions managériales et/ou internationales qui seront les leurs.</p>
+\n
+\n<p>Dans un monde en perpétuel changement, l’École Centrale de Lyon – par les partenariats qu’elle a noués et renouvelle sans cesse- fait en sorte que la formation des ingénieurs-centraliens soit sans cesse alignée avec les attentes des entreprises pour qu’ils puissent répondre aux défis scientifiques et sociétaux de demain.</p>
+\n
+\n<p>L’Ecole Centrale de Lyon est membre fondateur de l’Université de Lyon et du groupe des Ecoles Centrales.</p>
+\n	level-2	600
+237	CoR	CoR	universities/CoR-EN.PNG		CoR	0	0			15
+240	HESAM Université	hesam	universities/HESAM_bandeau.jpg	universities/FunMOOCV2.png	hesam	0	1	<p>HESAM Université est une communauté de la connaissance, dont la stratégie de recherche, de formation et d’innovation interdisciplinaire se concentre sur les questions de transformation de nos sociétés. HESAM Université allie et conjugue l’excellence de ses membres en&nbsp;ingénierie, architecture, design, management, création, patrimoine, sciences de la vie et de l’environnement, pour produire, diffuser et mobiliser les connaissances et les compétences nécessaires pour penser le futur.&nbsp;</p>
+\n
+\n<p>Conformément à nos politiques de recherche et de formation, HESAM s’engage dans la production de ressources numériques (MOOC, MOOG, SPOC) à forte valeur ajoutée, de référence mondiale, à destination de la francophonie mais aussi plus largement, accessibles à tous les publics de la formation initiale à la formation tout au long de la vie. Reposant sur l’interdisciplinarité et les pédagogies innovantes, nos productions e-learning reflètent la diversité et l’excellence des enseignements dispensés dans nos établissements.</p>
+\n
+\n	level-3	920
+243	Université de Mons	UMONS	universities/_UMONS_rouge_quadri_180x110.png	universities/banniere_umons_2016.png	UMONS	0	0	<p>L’Université de Mons (UMONS) est une université francophone implantée en Belgique, dans la province de Hainaut, à proximité de la frontière franco-belge et de Bruxelles.</p>
+\n
+\n<p>Les bâtiments de l’UMONS sont répartis au sein du centre historique de la ville, qui constitue le véritable campus de l’université.</p>
+\n
+\n<p>L’UMONS est née en 2009 de la fusion entre l’Université de Mons-Hainaut et de la Faculté Polytechnique de Mons, sa plus ancienne Faculté créée en 1837. Elle est l’héritière des acquis des facultés qui la composent.</p>
+\n
+\n<p>Au travers d’une centaine de formations qui, toutes, veillent à ce que l’étudiant demeure toujours au cœur des préoccupations, l’UMONS délivre les grades de Bachelier (Licence), Master et Docteur dans des domaines aussi divers que : le Droit, la Psychologie, les Sciences sociales, le Biomédical, l’Économie, l’Electricité, la Gestion, les Matériaux, la Mécanique, l’Urbanisme, l’Informatique, l’Architecture, l’Interprétation, la Linguistique, la Physique, la Logopédie, les Mathématiques, la Chimie, la Pharmacie, la Traduction, l’Education, la Biologie, la Géologie, la Médecine…</p>
+\n
+\n<p>Sa politique en matière de développement de formations à distance sous divers formats s’inscrit dans la mouvance générale des institutions universitaires pour répondre à la diversité des profils en formation supérieure. La présence de l’UMONS sur la toile, notamment à travers la création de Moocs qui témoignent de l’expertise scientifique et pédagogique de ses enseignants-chercheurs, illustre sa volonté de contribuer à la formation continue pour le plus grand nombre.</p>
+\n	academic-partner	150
+246	Université de Versailles Saint-Quentin-en-Yvelines (UVSQ)	UVSQ	universities/Logo_UVSQ_transp_180x100px72.png	universities/panorama_UVSQ_sept16_EG_980x200px72.jpg	universite-de-versailles-saint-quentin-en-yvelines-uvsq	0	1	<p>Créée en 1991 et fortement soutenue par les collectivités territoriales, l'UVSQ participe à l'aménagement et au développement économique, social et culturel du territoire des Yvelines avec une implantation au cœur de cinq agglomérations (Versailles, Saint-Quentin-en-Yvelines, Mantes en Yvelines, Rambouillet et Vélizy).</p>
+\n
+\n<p>L'UVSQ, répond aux attentes et aux besoins de formation de publics différenciés : jeunes en formation initiale, salariés ou demandeurs d'emploi en reprise d'études dans le cadre d'une formation initiale ou continue, entreprises privées et publiques.</p>
+\n
+\n<p>Sa pluridisciplinarité : sciences exactes, sciences sociales, sciences humaines, sciences juridiques et politiques, ingénierie et technologie, médecine, la diversité et la complémentarité de ses enseignements, la multiplicité de ses méthodes et pratiques pédagogiques et l'éventail de ses cursus de bac+2 à bac+8 lui permettent de former des généralistes mais également des techniciens, des ingénieurs, des chercheurs et des cadres supérieurs spécialisés.</p>
+\n
+\n<p>Le potentiel de sa recherche novatrice et internationale, sa stratégie de valorisation liée au transfert technologique tout comme sa politique de professionnalisation et d'internationalisation des formations confèrent à cette université son caractère d'excellence.</p>
+\n
+\n<p>Pour atteindre ses objectifs, l'UVSQ s'est dotée de structures d'interface avec les milieux socio-économiques et a mis en place des services ou des actions centrés sur la vie de l'étudiant. Elle a intégré dans tous ses processus les technologies nouvelles d'information, de communication et d'enseignement.</p>
+\n
+\n<p>Résolument engagée dans l'université Paris-Saclay dont elle est l'un des membres fondateurs, l'UVSQ entend relever le double défi de la compétition économique et technologique et de l'accélération des évolutions scientifiques au niveau mondial.</p>
+\n	level-2	600
+249	Université Bretagne Loire	u-bretagneloire	universities/logo_UBL_RVBnoir.png	universities/bandeauUBL.png	universite-bretagne-loire	0	1	<p>L’<a href="http://u-bretagneloire.fr/" target="_blank">Université Bretagne Loire</a>&nbsp;fédère 7 universités, 15 grandes écoles et 5 organismes de recherche de Bretagne et Pays de la Loire.</p>
+\n
+\n<p>Cette communauté d’universités et établissements (ComUE) a pour objectif de développer le potentiel scientifique et académique de ce territoire au niveau national et international.</p>
+\n
+\n<p>Acteur majeur de l'innovation, l'Université Bretagne Loire coordonne des actions au niveau de la stratégie de recherche et de l'offre de formation. Elle anime notamment 10 départements de recherches et 11 écoles doctorales.</p>
+\n
+\n<p>Elle favorise la logique interdisciplinaire et la coopération en s'appuyant sur le numérique comme instrument majeur au service de son ambition.</p>
+\n
+\n<p>Elle met à disposition de ses membres des outils et services mutualisés dont par exemple : un c@mpus numérique ; une cartographie des compétences scientifiques et techniques du territoire, un pôle d'ingénierie de projets européens ; un pôle étudiant pour l'innovation, le transfert et entrepreneuriat.</p>
+\n	level-2	690
+252	Montpellier SupAgro	supagro	universities/logo_supagro_180x100.png	universities/banniere_supagro.jpg	montpellier-supagro	0	1	<p><a href="https://www.montpellier-supagro.fr/">Montpellier SupAgro</a>, Institut national d’études supérieures agronomiques de Montpellier, forme des cadres pour l’agriculture, l’alimentation, et la gestion durable des ressources naturelles et des territoires. Ses missions dans ces domaines sont de :</p>
+\n
+\n<ul>
+\n\t<li>Dispenser des formations d’ingénieur ;</li>
+\n\t<li>Exercer des activités de formation initiale et continue, de recherche, de diffusion de connaissances, d’expertise et d’appui à l’innovation et à la création d’entreprise ;</li>
+\n\t<li>Exercer des missions d’appui à l’enseignement technique agricole ;</li>
+\n\t<li>Concourir à la coopération scientifique, technique et pédagogique internationale, en particulier avec les pays des zones méditerranéennes et tropicales.</li>
+\n</ul>
+\n
+\n<p>Installé dans un environnement de scientifique et de recherche exceptionnel, 1er rang mondial en agronomie, Montpellier SupAgro bénéficie de réseaux de professionnels et de partenaires à la pointe de la recherche et de l’innovation.</p>
+\n
+\n<p>Montpellier SupAgro est engagé vers l’évolution du numérique et reconnu pour ses prises d’initiatives dans le domaine de l’innovation pédagogique. Accompagné par le service « Ressources pédagogiques et numériques », les équipes enseignantes développent les usages du numérique au service de la formation.</p>
+\n
+\n<p>Montpellier SupAgro travaille avec la plateforme de FUN pour la diffusion de MOOCs. Les objectifs sont de proposer et de co-construire un ensemble de ressources libres et de parcours de formation pour le grand public.</p>
+\n
+\n<p>Ces cours en ligne ouverts à tous favorisent le développement de communautés actives. Ils participent au partage de connaissances avec les enseignants-chercheurs et les étudiants en formations initiales et tout au long de la vie.</p>
+\n
+\n<p>Retrouvez Montpellier SupAgro à travers nos MOOCs sur l’agroécologie, la taxonomie des arthropodes, la vigne et le vin.</p>
+\n
+\n<p>Montpellier SupAgro est membre de&nbsp;<a href="http://www.languedoc-roussillon-universites.fr/presentation/la-comue">COMUE Languedoc-Roussillon Universités</a>.</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	650
+255	La conférence des ITII	itii	universities/ITII_LOGO_FILETS_Q-01.jpg		la-conference-des-itii	0	0		academic-partner	0
+258	Ecole Supérieure d'Ingénieurs Léonard de Vinci	devinci	universities/logo_pulv.png	universities/cover_pulv.jpg	devinci	0	1	<p>Le Pôle Léonard de Vinci est composé de trois établissements d’enseignement supérieur délivrant des diplômes reconnus qui couvrent des champs disciplinaires complémentaires, notamment dans le secteur du numérique :</p>
+\n
+\n<ul>
+\n\t<li>une école de commerce, l’EMLV (Ecole de Management Léonard de Vinci),</li>
+\n\t<li>une école d’ingénieurs, l’ESILV (Ecole Supérieure d’Ingénieurs Léonard de Vinci),</li>
+\n\t<li>une école du digital, l’IIM (Institut de l’Internet et du Multimédia).</li>
+\n</ul>
+\n
+\n<p>Créées en 1995, les écoles sont rassemblées au Pôle Universitaire Léonard de Vinci à Paris – La Défense. L’hybridation est le résultat de la transversalité qui existe entre les écoles : cours &amp; projets en commun, développement progressif et intensif des soft skills, incubateur, FabLab, vie associative, activités sportives, double-diplômes… Ingénieurs, managers, designers et développeurs apprennent à vivre et à travailler ensemble au-delà des frontières de leur propre cursus.</p>
+\n	academic-partner	150
+261	Fondation Maison des      Sciences de l'Homme	fmsh	universities/Logo_FMSH	universities/Bannière.jpg	fondation-maison-des-sciences-de-lhomme	0	1	<p><em><strong>Un lieu de référence et d’innovation pour penser à un niveau global les grandes questions du monde contemporain</strong></em></p>
+\n
+\n<p>Créée par Fernand Braudel en 1963 à Paris, et reconnue d’utilité publique, la Fondation Maison des sciences de l’homme (FMSH) est un carrefour international pour les sciences humaines et sociales. Ouverte aux grandes questions du monde contemporain dans toute leur densité historique, ainsi qu’aux théories, outils et méthodes pour les appréhender, la Fondation met en synergie réseaux scientifiques nationaux et internationaux, acteurs publics et privés.</p>
+\n
+\n<p>La Fondation remplit plusieurs missions : accueil de programmes de recherche, hébergement de réseaux et d'infrastructures de recherche ; elle contribue à l'internationalisation de la recherche par la mobilité et l'accueil de chercheurs, elle participe à la valorisation de la recherche et à sa diffusion. Elle est membre fondateur du Campus Condorcet.</p>
+\n
+\n<p>La Fondation Maison des sciences de l’homme est membre de la COMUE Université Sorbonne Paris Cité (USPC).</p>
+\n
+\n<p>&nbsp;</p>
+\n	simple-partner	100
+264	Université de Liège	ulg	universities/logo-ULg_OJtOWgE.png	universities/ULiège_collage.jpg	universite-de-liege	0	1	<p>Pluraliste, l’Université de Liège (ULiège) est la seule université publique complète en Belgique francophone. Fondée en 1817 au cœur de la Cité Ardente, elle fête en 2017 son bicentenaire et comporte aujourd’hui 11 Facultés.</p>
+\n
+\n<p>Par ordre de création : Philosophie et Lettres, Droit - Science politique &amp; criminologie, Sciences, Médecine, Sciences appliquées, Médecine vétérinaire, Psychologie et Sciences de l’éducation, Gembloux Agro-Bio Tech, Architecture, Sciences sociales et et HEC Liège, école de gestion de l’Université de Liège.. Elle offre des formations de premier, deuxième et troisième cycles (38 bacheliers,191 masters2, 65 masters complémentaires) dans tous les domaines du savoir (en 2017 : 38 bacheliers, 201 masters, 65 masters de spécialisation et 29 collèges de doctorat), ainsi que des centaines de formations tout au long de la vie.</p>
+\n
+\n<p>Avec ses 23 500 étudiants, dont 23% d’étudiants étrangers, 1400 enseignants, plus de 3000 assistants et chercheurs et ses 80 000 diplômés, l’ULiège s’équilibre entre l’enseignement, la&nbsp;recherche et les activités au service de la société.<br />
+\n&nbsp;</p>
+\n	academic-partner	160
+267	Université de Carthage	ucarthage	universities/logo_carthage.jpg		universite-de-carthage	0	0		academic-partner	0
+270	Université Bourgogne Franche-Comté 	UBFC	universities/logo_UBFC_grand_complet.jpg	universities/Image_page_de_garde_Funmooc_Ubfc.png	universite-bourgogne-franche-comte	0	1	<p>Université Bourgogne Franche-Comté (UBFC) est une Communauté d’universités et établissements (COMUE). Elle fédère sept établissements fondateurs : deux universités pluridisciplinaires, l’Université de Bourgogne et l’Université de Franche-Comté, une Université de Technologie, l’UTBM, trois Ecoles d’ingénieurs, l’ENSMM, AgroSup Dijon, et l’ENSAM, ainsi que l’Ecole Supérieure de Commerce de Dijon (Burgundy School of Business). Les établissements membres d’UBFC représentent ainsi 58&nbsp;000 étudiants et sont présents sur 13 sites de la Région Bourgogne Franche-Comté.</p>
+\n
+\n<p>En coordonnant les offres de formation des établissements membres et les stratégies scientifiques des laboratoires, UBFC entend développer le rayonnement et l’attractivité du site, les partenariats avec le monde socio-économique, et ainsi dynamiser le territoire.</p>
+\n
+\n<p>UBFC porte la coordination du grand projet fédérateur et structurant I-SITE BFC, dont le partenariat, outre ses établissements fondateurs, comprend également des organismes de recherche et des établissements de santé, soit 15 partenaires en tout. L’ambition est de créer un environnement international stimulant et attractif, devenir une référence internationale dans trois domaines de recherche intense et développer les approches pluridisciplinaires et les connexions avec les enjeux du monde économique.</p>
+\n
+\n<p>Outils pédagogiques innovants, les MOOC’s permettent d’atteindre un large public, en favorisant l’accès à l’enseignement supérieur, à la demande de connaissances nouvelles, ainsi qu’au besoin des entreprises dans le cadre de la formation tout au long de la vie. UBFC et ses établissements membres s’engagent ainsi résolument dans la production de MOOC’s et de SPOC’s à forte valeur ajoutée et d’audience internationale.</p>
+\n	level-2	600
+273	Ecole du Val de Grace	EVDG	universities/logo-FUN_complet.png		ecole-du-val-de-grace	1	1			0
+276	Université Lille	universiteLilleDroitSante	universities/UL2-linkelin2_180x100.png.180x100_q85.png		universiteLilleDroitSante	0	0	<div>
+\n<p><strong>La formation à l'Université de Lille, Droit et santé</strong>. L'Université offre à chaque étudiant une formation diversifiée, adossée à une recherche largement reconnue, à une politique ambitieuse d'ouverture à l'international et élaborée pour permettre l'accessibilité de tous à un projet et à une insertion professionnelle.</p>
+\n
+\n<p><strong>La recherche à l'Université de Lille, Droit et santé</strong>. Compte tenu de ses champs de compétences, seule ou en lien avec ses partenaires, l'Université de Lille, Droit et Santé, à travers sa stratégie de recherche veut contribuer à l'ambition de répondre aux quatre défis sociétaux identifiés par l'Union Européenne: santé, changement démographique et bien être; sociétés innovantes, intégrantes et adoptives; sécurité alimentaire et bio économie; garantie de la liberté et de la sécurité de l'Europe de ses citoyens et de ses résidents.</p>
+\n
+\n<div>
+\n<p><strong>L'université de Lille, Droit et Santé a engagé une politique volontariste dans le domaine du Numérique.</strong></p>
+\n
+\n<p>Nous sommes parmi les premiers a avoir proposé, de manière obligatoire en licence, une formation certifiante à la Culture Numérique au travers du C2i niveau 1. En 2020, 90% des métiers nécessiteront une solide Culture Numérique, nos étudiants intègrent d'ores et déjà ce paradigme.</p>
+\n
+\n<p>Un accompagnement a été mis en place pour tous les enseignants désireux de mettre en œuvre des usages et des outils numériques.</p>
+\n
+\n<p>Un financement important a été débloqué pour le développement de projets pédagogiques innovants et/ou numériques, en mettant l'accent sur le pilotage, l'évaluation des objectifs et la transférabilité disciplinaire et interdisciplinaire des projets.</p>
+\n
+\n<p>La création de MOOC est un volet de cette politique numérique, qui se veut exhaustive pour permettre l'éclosion de tous lesusages possibles du numérique dans les apprentissages.</p>
+\n
+\n<p>L’Université de Lille Droit et Santé est membre de la ComUE Lille Nord de France.</p>
+\n
+\n<ul>
+\n\t<li><a href="https://www.univ-lille2.fr" target="_blank">www.univ-lille2.fr</a></li>
+\n\t<li><a href="https://www.facebook.com/universitelille2droitetsante" target="_blank">https://www.facebook.com/universitelille2droitetsante</a></li>
+\n\t<li><a href="https://twitter.com/univ_lille2" target="_blank">https://twitter.com/univ_lille2</a></li>
+\n</ul>
+\n
+\n<p>&nbsp;</p>
+\n</div>
+\n</div>
+\n	level-2	600
+279	Université de la Polynésie Française	UPF	universities/logo-upf-2014-193x110.png		universite-de-la-polynesie-francaise	0	0	<p>Créée en 1987, l'UPF propose une offre de formation diversifiée pluridisciplinaire au sein de 3 départements de formation, d'un service de formation continue, d'une école supérieure du professorat et de l'éducation (ESPE), d'un Institut Confucius et du CNAM. L'UPF, ce sont 3500 étudiants, 40 doctorants, 100 enseignants permanents, 250 vacataires ou missionnaires et 70 personnels administratifs.<br />
+\nAvec 5 laboratoires, 2 structures fédératives et une école doctorale, l'UPF contribue au développement scientifique, technologique et culturel de la Polynésie française. Elle est un pôle d'excellence dans l'étude et la mise en valeur du patrimoine polynésien et des cultures et civilisations océaniennes. Forte de cette identité et de cet ancrage, elle a tissé des liens privilégiés avec les universités du Pacifique en matière de recherche et aussi de mobilité internationale et d'accueil des étudiants.</p>
+\n
+\n<p>L'UPF s’investit dans les TICE et entend renforcer la pédagogie liée au numérique dans ses formations. Les objectifs de ses investissements sont nombreux : s'affranchir des distances, améliorer les pratiques pédagogiques, favoriser la réussite des étudiants et accroitre son rayonnement dans le Pacifique.<br />
+\nUn Pôle TICE a été créé en septembre 2014. Plusieurs projets voient le jour et se concrétisent, comme la création de formations hybrides, l’amélioration de la plateforme pédagogique en ligne, l’acquisition de matériel tactile interactif et d’un système de captation vidéo pour diffuser les cours en ligne… L'intérêt pour le numérique est croissant parmi les enseignants comme au niveau du territoire.<br />
+\nLa création de MOOC entre pleinement dans cette dynamique.</p>
+\n		0
+280	Direction des Ressources Humaines de l'Armée de Terre 	drhatform	universities/Logo_DRHAT.png		direction-des-ressources-humaines-de-larmee-de-terre	0	0		academic-partner	150
+283	Institut supérieur de l'électronique et du numérique (ISEN)	isentoulon	universities/yncrea_toulon_v2.png		institut-superieur-de-lelectronique-et-du-numerique	0	0			0
+286	L'ADEME	ADEME	universities/Logo-ADEME-mooc.png	universities/msg1.jpg	ademe	0	1	<p><a href="http://www.ademe.fr" target="_blank">L'ADEME</a> (Agence de l’Environnement et de la Maîtrise de l’Energie) participe à la mise en œuvre des politiques publiques dans les domaines de l'environnement, de l'énergie et du développement durable. Afin de leur permettre de progresser dans leur démarche environnementale, l'Agence met à disposition des entreprises, des collectivités locales, des pouvoirs publics et du grand public, ses capacités d'expertise et de conseil. Elle aide en outre au financement de projets, de la recherche à la mise en œuvre et ce, dans ses domaines d'intervention.</p>
+\n
+\n<p>L’ADEME est à l’initiative, avec le Plan Bâtiment Durable et plusieurs organisations de la filière bâtiment, d’une plateforme thématique&nbsp;: <a href="https://www.mooc-batiment-durable.fr/" target="_blank">MOOC Bâtiment Durable</a>, déployée par FUN.</p>
+\n
+\n<p>Les objectifs de la plateforme sont les suivants :</p>
+\n
+\n<ul>
+\n\t<li>la montée en compétence des professionnels de la filière bâtiment et immobilier sur les thématiques de la transition énergétique et du bâtiment durable en général (construction et rénovation),</li>
+\n\t<li>la diffusion, auprès du grand public, d’une connaissance des enjeux liés au bâtiment durable, en particulier la rénovation énergétique des logements.</li>
+\n</ul>
+\n
+\n<p>Vous pouvez accéder aux cours de la plateforme ici : <a href="https://www.mooc-batiment-durable.fr/" target="_blank">MOOC Bâtiment Durable</a>.</p>
+\n
+\n<p>Par ailleurs, l’ADEME développe, seule ou en partenariat, des MOOC sur d’autres thématiques telles que l’efficacité énergétique dans l’industrie, l’écoconception, etc.</p>
+\n
+\n<p>Elle contribue enfin à des MOOC portés par d’autres établissements, par exemple certains MOOC de l’UVED ou d’AgroParisTech</p>
+\n	level-2	700
+289	ENSAE ParisTech	ensae	universities/Logo-ENSAE-100517_EuV4sM8.png	universities/ensae2.png	ensae	0	1	<p><a href="http://www.ensae.fr/ensae/fr/">L'ENSAE</a> ParisTech est la seule grande école d’ingénieur spécialisée en économie, statistique, finance et actuariat. L’école et le centre de recherche qui lui est associé, le CREST (Centre de recherche en économie et statistique) forment un pôle d’enseignement supérieur et de recherche de premier plan qui fait partie du GENES (Groupe des écoles nationales d’économie et statistique). L’école est par ailleurs membre du réseau ParisTech.<br />
+\nL’ENSAE ParisTech est ainsi membre fondateur de la fondation de coopération scientifique (FCS) du Campus Paris-Saclay. L’école et le centre de recherche devraient déménager dans un nouveau bâtiment à construire sur le plateau de Saclay à l’horizon de 2016. &nbsp;; au sein de la future « Université Paris-Saclay », l’ENSAE ParisTech a vocation à jouer, au côté de ses partenaires, un rôle pivot dans la structuration du domaine « économie, statistique et sciences sociales ».</p>
+\n
+\n<p>Pour l’ENSAE ParisTech les enjeux d’une offre MOOC sont les suivants :&nbsp;<br />
+\n- Tester et comprendre la technologie, l’impact, la certification, le modèle économique<br />
+\n- Promouvoir nos cursus<br />
+\n- Appuyer nos objectifs de politique publique : transfert de connaissance (y compris vers d’autres pays francophones), vitrine éducative (au-delà de nos cursus, promouvoir l’enseignement supérieur)</p>
+\n
+\n<p>Pour tester et comprendre nous menons actuellement un premier test, sur le cours de « Modèles de durée », essentiel dans notre cursus. Ce cours est d’une part proposé en MOOC « hybride » à nos élèves, c’est-à-dire que le cours magistral est remplacé par le MOOC et complété par des séances de travaux dirigés. Il sera d’autre part proposé seul sur la plateforme FUN à la fin du semestre, après le bilan fait avec les étudiants et lorsque quelques compléments seront apportés (sous-titres anglais, matériel pédagogique, quizz).<br />
+\nPour l’avenir nous envisageons de tester la certification (par exemple en proposant aux étudiants qui le souhaitent de passer un examen contre rémunération, examen dont la forme serait à définir).&nbsp;</p>
+\n
+\n<p>D’autres cours devraient suivre ce premier essai, les pistes envisagées étant&nbsp;<br />
+\n- Une mise à niveau des candidats aux Mastères Spécialisés<br />
+\n- Des Certificats de formation continue partiellement en MOOC<br />
+\n- D’autres cours du cursus ingénieur en MOOC</p>
+\n		600
+292	Université Paris 13	paris13	universities/Logo_Univ_Paris_13.png	universities/exterieur_forum980x200px.jpg	universite-paris-13	0	1	<p>L'Université Paris 13 est l'une des treize universités qui ont succédé à la Sorbonne après 1968. Elle compte aujourd'hui près de 23 000 étudiants dont 5000 étudiants étrangers venant de 121 pays, en formation initiale ou continue répartis sur cinq campus. Pluridisciplinaire, elle est composée de 9 composantes. L’université Paris 13 est un pôle majeur d'enseignement qui délivre aujourd’hui plus de 200 diplômes (DUT, Licences professionnelles, Diplômes d’Ingénieurs, Licence, Master, Doctorat…).<br />
+\nLa recherche s’exerce dans trois grands domaines : littérature, sciences humaines et sociales, sciences du vivant (médecine, santé et biologie) et sciences exactes (mathématiques, physique, chimie, informatique).<br />
+\nL’enseignement et la recherche en mathématiques, physique, chimie et informatique sont regroupés au sein de l’Institut Galilée. Quatre IUT forment également aux carrières scientifiques et l’école Sup Galilée délivre le diplôme d’Ingénieur.<br />
+\nDepuis 2010, l’université Paris13 est membre de la communauté d ‘établissements Sorbonne Paris Cité SPC.</p>
+\n
+\n<p>Le format des MOOCs a pour objectif de transmettre des savoirs à un public bien plus large que celui constitué traditionnellement par nos étudiants en formation initiale ou continue. En effet, la démocratisation massive du savoir grâce au numérique accroît l’accessibilité des ressources pédagogiques depuis un ordinateur, une tablette ou encore un smartphone, gratuitement et à tout moment.</p>
+\n
+\n<p>Les MOOCs de l’Université Paris 13 s’appuient sur des pédagogies numériques innovantes pour vous faire (re)découvrir et apprécier de nombreuses disciplines dans les domaines littéraires, scientifiques ou juridiques.</p>
+\n	level-2	400
+295	Université d'Evry-Val-d'Essonne	univ-evry	universities/logosaclayUEVE.png		universite-devry-val-dessonne	0	0	<p>L'université d'Évry-Val-d'Essonne est une des quatre universités nouvelles créées en 1991 dans le cadre du développement de l'enseignement supérieur dans la région Ile-de-France et de la déconcentration des universités parisiennes.</p>
+\n
+\n<p>Située dans une agglomération en expansion, l'université, dès sa création, s'est constituée en université pluridisciplinaire et s'est tournée vers des enseignements professionnalisants pour répondre aux besoins de son environnement économique et social.</p>
+\n
+\n<p>Avec plus de 160 formations proposées - dont plus de la moitié à caractère professionnel, l'université d'Evry offre dans le cadre de ses filières des formations dans les disciplines scientifiques et technologiques, juridiques, économiques et de gestion, et sciences humaines et sociales.</p>
+\n
+\n<p>Reconnue comme un établissement dynamique de proximité, favorisant une intégration rapide dans la vie active, &nbsp;l'université d'Evry compte environ 10 000 étudiants et répond aux attentes de publics très divers, inscrits tant en formation initiale que continue (22% des diplômes).</p>
+\n
+\n<p>Depuis la rentrée 2015, l’Université d’Evry est l’un des campus d’excellence de l’université Paris-Saclay. 70% des Masters et la totalité des Ecoles Doctorales de l’Université d’Evry sont intégrés à l’université Paris-Saclay.</p>
+\n
+\n<p>L’Université représente également un pôle important de recherche développant au sein de 18 laboratoires, 3 programmes de recherche et de trois écoles doctorales, de grands programmes de recherche, notamment autour de la génomique, post génomique et de l'environnement en lien étroit avec le Génopole.</p>
+\n	level-3	500
+298	École Pratique des Hautes Études	EPHE	universities/logo-EPHE-180x100.png	universities/Bannière-EPHE.jpg	ephe	0	1	<p>L’École Pratique des Hautes Études (EPHE) est un grand établissement d’enseignement supérieur où l’on pratique la recherche dans trois sections&nbsp;: Sciences de la vie et de la terre, Sciences historiques et philologiques et Sciences religieuses. Son enseignement est dispensé à partir du niveau master. Elle accueille également des auditeurs libres.</p>
+\n
+\n<p>Établissement « hors-murs », l’EPHE est hébergée à la Sorbonne et dans différents centres de recherche à Paris, sur tout le territoire métropolitain et en Polynésie française.</p>
+\n
+\n<p>Au niveau international, l’EPHE entretient&nbsp;un réseau avec les organismes de recherche pour ses chercheurs et doctorants, ainsi que des partenariats pour ses étudiants avec plus de 100 grandes institutions (Italie, Suisse, Chine, Russie, Canada, Liban…). Près de la moitié des étudiants de l’EPHE sont étrangers et l’École invite de nombreux chercheurs étrangers chaque année.</p>
+\n
+\n<p>L’EPHE est membre de l’Université de recherche Paris Sciences et Lettres – PSL</p>
+\n
+\n<p><strong><a href="http://www.ephe.fr" target="_blank">http://www.ephe.fr</a></strong></p>
+\n	level-3	605
+301	Université d'Ottawa	uottawa	universities/logo-ottawa.png	universities/banniere.png	universite-dottawa	0	0	<p>L’<a href="http://www.uottawa.ca/fr" target="_new">Université d’Ottawa</a>, l’une des plus anciennes institutions universitaires canadiennes fondée en 1848, est la plus grande université bilingue (français-anglais) du monde. Située au cœur de la capitale du Canada, elle profite d'un accès direct aux plus grandes institutions de recherche du pays. Ses avancées en sciences sociales, en santé et en sciences font d’elle un endroit sans pareil où apprendre et exceller.<br />
+\nElle accueille aujourd'hui quelque 43 000 étudiants. Elle s'est engagée à développer le plus large éventail possible de programmes d'enseignement et de recherche en français et en anglais. Elle s'est également fixée pour mandat de promouvoir la coopération internationale et joue un rôle déterminant dans la promotion des femmes dans toutes les sphères de la vie universitaire.</p>
+\n
+\n<p>Engagée dans un virage numérique en matière de cyber apprentissage depuis trois ans, l’Université d’Ottawa désire augmenter son offre de cours hybrides et entièrement en ligne.<br />
+\nLa conception et la mise en œuvre d’un premier MOOC lui permettront d’en apprendre plus sur ce type de cours et son impact sur les étudiants. L’Université d’Ottawa désire offrir son premier MOOC sur une plateforme de renom et faire valoir ses compétences et son engagement envers la francophonie.<br />
+\nForte de son ouverture à&nbsp;l’international, elle cherche à défier les conventions dans la sphère pédagogique en évoluant au rythme des tendances technologiques afin d’enrichir l’expérience universitaire mondiale.</p>
+\n	academic-partner	150
+304	Université Côte d'Azur	UCA	universities/logo_uca_180x110_v2.png	universities/bandeau_UCA_980x200_tiO0zfJ.jpg	comueuca	0	1	<p>L'Université Côte d'Azur est une Communauté d'Universités et d'Etablissements, créée par décret du 27 février 2015, ce qui en fait un Etablissement Public à caractère Scientifique, Culturel et Professionnel.&nbsp;Il rassemble les principaux acteurs de l'enseignement supérieur et de la recherche sur la Côte d'Azur. L'Université Côte d'Azur vise à développer le modèle du XXIe siècle pour les universités françaises, basé sur de nouvelles &nbsp;interactions entre disciplines, une nouvelle forme de coordination entre recherche, enseignement et innovation et de solides partenariats avec le secteur privé et les collectivités locales. En janvier 2016, l'Université Côte d'Azur a remporté un prestigieux prix «IDEX» du gouvernement français pour son projet UCA-JEDI.</p>
+\n
+\n<p>Université Côte d’Azur regroupe l’ensemble des établissements suivants : l'Université Nice Sophia Antipolis, le CNRS, l'INRIA, l'Observatoire de la Côte d'Azur, le CHU de Nice, Skema Business School, EDHEC Business School, le Centre National de Création Musicale, l'Ecole Nationale Supérieure d'Art Villa Arson, The Subtainable Design School, le Conservatoire de Nice, l'Ecole de Danse de Cannes Rosella Hightower et l'Ecole Supérieure de Réalisation Audiovisuelle.&nbsp;</p>
+\n
+\n<p>L'Université Côte d'Azur compte plus de 30.000 étudiants (diplômes nationaux, diplômes universitaires, B.Sc., MBA, etc.) dont : 1700 doctorants, 8.000 étudiants en master, 16.000 étudiants de premier cycle, dont 20% d'étudiants étrangers, 740 doctorats internationaux, 94 chercheurs de renommée mondiale invités et 493 des partenariats de recherche.</p>
+\n	level-1	300
+307	Université Ouaga II	Ouaga2	universities/logo_170-110_ouaga2.png	universities/bannière_ouaga2.jpg	universite-ouaga-ii	0	0	<p>L’université de Ouagadougou (UO) enregistre depuis l’an 2000 une arrivée massive de nouveaux bacheliers. L’accroissement rapide des effectifs a conduit à l’insuffisance et l’inadaptation des infrastructures d’accueil. Pour faire face à ce problème des effectifs devenus pléthoriques, le gouvernement burkinabé a décidé par décret le 12 décembre 2007 de la création de l’université Ouaga II qui sera basée à Gonsé, localité située dans la commune de Saaba.</p>
+\n
+\n<p>Cette université regroupe depuis l’année universitaire 2007-2008, les unités de formation et de recherche (UFR) en Sciences Juridiques et Politiques (SJP) et en Sciences Économiques et de Gestion (SEG). Ces unités étaient précédemment rattachées à l’université de Ouagadougou.</p>
+\n
+\n<p>L’Université Ouaga II est un établissement public de l’Etat à caractère scientifique, culturel et technique (EPSCT). Elle a pour mission fondamentale, l’élaboration et la transmission de la connaissance pour la formation des hommes et des femmes, afin de répondre aux besoins de la nation.</p>
+\n
+\n<p>Pour ce faire, elle poursuit les objectifs suivants :</p>
+\n
+\n<p>•&nbsp;&nbsp; &nbsp;la formation des cadres dans divers domaines notamment en Droit et en Économie ;<br />
+\n•&nbsp;&nbsp; &nbsp;la recherche scientifique et la vulgarisation des travaux de recherche ;<br />
+\n•&nbsp;&nbsp; &nbsp;l’élévation des niveaux technique, scientifique et culturel des travailleurs ;<br />
+\n•&nbsp;&nbsp; &nbsp;la contribution au développement économique, social et culturel du pays ;<br />
+\n•&nbsp;&nbsp; &nbsp;la collation des titres et diplômes ;<br />
+\n•&nbsp;&nbsp; &nbsp;la valorisation des compétences dans les secteurs d’activités à son actif ;<br />
+\n•&nbsp;&nbsp; &nbsp;la coopération en matière de formation et de recherche ;&nbsp;<br />
+\n•&nbsp;&nbsp; &nbsp;la promotion des échanges inter universitaires.</p>
+\n
+\n<p>Si l’UO II veut être une solution du système éducatif, elle doit contribuer significativement à accroître l’accès à l’enseignement supérieur dans un contexte de forte pression démographique et de forte demande d’éducation, qui tire son origine des réformes du sous secteur de l’éducation de base. A cet effet, il est important de développer le numérique éducatif et en particulier l’ingénierie pédagogico-technique. A l’ère des technologies de l’information et de la communication et de son utilisation comme vecteur de l’accroissement de l’accès à l’éducation à un coût abordable, pour un grand nombre, le développement de l’ingénierie pédagogico-technique s’impose comme une solution complémentaire aux autres actions pour accroître l’accès à l’enseignement supérieur. Une mise en œuvre conséquente de cette ingénierie pédagico-technique et du numérique éducatif en général permettra de réduire la pression sur l’infrastructure physique.</p>
+\n
+\n<p>UOII &nbsp;à travers son premier MOOC « Négociation sociétale et développement local » sur FUN &nbsp;identifie quatre principales catégories de participants aux MOOCS &nbsp;de façon général.&nbsp;</p>
+\n
+\n<p>&nbsp;Deux catégories « d’apprenants distingués »&nbsp;</p>
+\n
+\n<p>1. Les étudiants inscrits dans les universités ou les grandes écoles pour qui le MOOC est alors en usage local et diffusé en « renforcement » à l’enseignement présentiel.&nbsp;<br />
+\n2. Des professionnels &nbsp;en perfectionnement, public de formation continue, poursuivant un projet professionnel précis. En recherche d’une certification.&nbsp;<br />
+\n&nbsp; Deux catégories « d’apprenants buissonniers » :&nbsp;<br />
+\n3. Des étudiants inscrits dans des cursus universitaires classiques dans d’autres établissements en recherche individuelle &nbsp;d’un soutien universitaire, de documents, de cours ou de méthodes.&nbsp;<br />
+\n4. Un public qui relève de l’autodidaxie, amateurs, curieux, individus soucieux de « culture individuelle ». Public qui est sans doute celui qui décroche le plus.</p>
+\n		0
+310	Université Paris-Est	UPE	universities/logo_UPE_vignette.png	universities/banniere_UPE_980x200.png	universite-paris-est	0	0	<p>Créée le 21 mars 2007, Université Paris-Est (UPE) fédère au sein d’une Communauté d’universités et établissements vingt-deux institutions caractérisées par la diversité de leurs missions et de leurs rattachements ministériels : 2 universités, 2 grandes écoles, 3 écoles d’ingénieurs, 3 écoles d’architecture, 3 établissements de recherche, 7 agences opérationnelles et d’expertise, et 2 centres hospitaliers. Orientée vers les secteurs économiques publics et privés, elle associe étroitement recherche et enseignements généraux, technologiques et professionnels, concourant à la structuration d’une université pluridisciplinaire de pointe, répondant aux exigences de visibilité mondiale et de lien fort entre recherche, formation tout au long de la vie, expertise et transfert.</p>
+\n
+\n<p>Université Paris-Est (UPE) was created on March 21st, 2007 as a higher education and research federal organisation and groups together a community of 22 institutions with highly diverse missions under the supervision of different government ministries: 2 universities, 2 grandes écoles, 3 engineering schools, 3 schools of architecture, 3 research and development institutes, 7 operating agencies and technical centres, and 2 hospital centres. It builds close links between research and general, technical and professional learning, underpinning a multidisciplinary, cutting-edge university that can compete on the international stage with strong links between research, life-long training, expertise and knowledge transfer. It works with both public and private sectors.</p>
+\n	level-1	0
+313	Université Paris-Dauphine 	dauphine	universities/Dauphine_180x100.png	universities/illustration_dauphine_980x200.png	dauphine	0	1	<p>L'Université Paris-Dauphine est l'institution d'enseignement supérieur de référence en France et en Europe dans les sciences des organisations et de la décision. Depuis sa création, en 1968, Paris-Dauphine occupe une position originale dans l'enseignement supérieur français en s'appuyant sur :</p>
+\n
+\n<ul>
+\n\t<li>&nbsp;la qualité et la sélectivité de ses formations en Licence, Master et Doctorat,&nbsp;</li>
+\n\t<li>des jeunes diplômés qui trouvent leur premier emploi dans les deux mois qui suivent l'obtention de leur diplôme,&nbsp;</li>
+\n\t<li>l'excellence des travaux de recherche menés dans ses six laboratoires (CR2D - Droit, DRM - Gestion, Lamsade - Informatique, Ceremade - Mathématiques appliquées, LEDa - Economie, IRISSO - Sciences sociales),&nbsp;</li>
+\n\t<li>son puissant réseau de 80 000 alumni présents sur les cinq continents, dont certains ont créé ou dirigent des entreprises de renom (The Kooples, NeverEatAlone, Unilever EMEA...).</li>
+\n</ul>
+\n
+\n<p>Ce modèle est aujourd'hui reconnu aux niveaux national (en étant membre de la Conférence des Grandes Ecoles) et international (seule université française accréditée Equis - parmi les 50 meilleures universités mondiales en mathématiques). Pour asseoir sa notoriété internationale, Paris-Dauphine s'est engagée dans l'implantation de campus à l'étranger (Casablanca, Londres, Madrid, Mannheim, Shanghai, Tunis), en fondant l'alliance Sigma (Copenhagen Business School - Danemark, Fundaçao Getulio Vargas - Brésil, Singapore Management University - Singapour, St. Gallen University - Suisse, Esade Barcelone - Espagne, Wien Wirtschaft Universität - Autriche, Hitotsubashi University - Japon, Renmin University - Chine), et en rejoignant 27 établissements parisiens prestigieux (dont l'Ecole Normale Supérieure, Mines ParisTech, les écoles d'arts, l'Ecole des Hautes Etudes en Sciences Sociales) au sein de Paris Sciences &amp; Lettres Research University (19 000 étudiants, 4 600 enseignants-chercheurs, 178 laboratoires de recherche), classée récemment 38ème université mondiale selon Times Higher Education.</p>
+\n
+\n<p>Paris-Dauphine a, depuis plusieurs années, initié une transformation profonde de sa pédagogie, pour toujours mieux répondre aux attentes de ses étudiants et les préparer le plus efficacement possible à leur insertion professionnelle. Ils bénéficient ainsi de classes inversées, de sessions de développement personnel, d'un portail de services numériques intégrant des cours en ligne, l'accès à la plus importante base documentaire en économie et gestion de France... Paris-Dauphine a également investi, début 2015, dans un équipement d'enregistrement de dernière génération pour produire des Moocs et des Spocs. Fin 2016, la nouvelle gouvernance de l'université a décidé d'aller encore plus loin en nommant un délégué à la transformation pédagogique afin de créer, entre autres, un Center for Teaching Excellence et un TeachLab. Enfin, dès janvier 2019, Paris-Dauphine va transformer son campus principal de la Porte Dauphine pour concevoir un bâtiment adapté à cette transformation pédagogique.</p>
+\n
+\n<p>Plus d'information :&nbsp;<a href="http://www.dauphine.fr/" target="_blank">http://www.dauphine.fr</a></p>
+\n	level-3	645
+316	AUF_OIF	AUF_OIF	universities/logo-FUN_complet_1_fxL0Grv.png		auf_oif	0	0		academic-partner	0
+319	INSPQ	INSPQ	universities/logo_inspq_180x100px_VQS2SsL.png		inspq	0	0		academic-partner	150
+322	Le Ministère de l'Enseignement  Supérieur, de la Recherche et de l'Innovation	enseignementsup	universities/ministere.jpg	universities/MESRI_funmooc_980x200_01123.jpg	enseignementsup	0	1	<p>Le <a href="http://www.enseignementsup-recherche.gouv.fr/pid24528/ministere.html">Ministère de l'Enseignement Supérieur, de la Recherche et de&nbsp;l'Innovation</a> a inscrit la pédagogie au coeur de son projet stratégique.</p>
+\n
+\n<p>Il&nbsp;s'agit d'adapter les processus pédagogiques à la diversité des publics&nbsp;universitaires en exploitant pleinement le potentiel du numérique, de&nbsp;diversifier les méthodes pédagogiques, de favoriser la flexibilité des&nbsp;parcours&nbsp;et le développement d'espaces d'apprentissage innovants, formels ou&nbsp;informels.&nbsp;</p>
+\n
+\n<p><br />
+\nAprès avoir soutenu le développement&nbsp;du GIP FUN&nbsp;MOOC, le Ministère souhaite orienter son action vers le&nbsp;développement de MOOC à destination des enseignants-chercheurs, enseignants et personnels pour favoriser leur développement professionnel.</p>
+\n	level-1	10
+325	Education & Numérique	education-et-numerique	universities/EN.png		education-et-numerique	0	0		simple-partner	0
+326	Université de La Réunion	univ-reunion	universities/logo_univ_reunion_180x110_v2.png	universities/PHOTO-COUV-FUN.png	universite-de-la-reunion	0	1	<p>L’<a href="http://www.univ-reunion.fr/">Université de La Réunion</a> est le seul établissement français d’enseignement supérieur et de recherche implanté dans l'Indiaocéanie, dans l’une des neuf régions ultrapériphériques que comporte l’Europe. Cette situation géopolitique particulière lui confère le statut stratégique d’unique université européenne de la zone.</p>
+\n
+\n<p>Pluridisciplinaire, elle propose une large gamme de formations d’excellence aux 14 000 étudiants qu’elle accueille chaque année : des diplômes en Licence, Master et Doctorat (LMD) en formation initiale ou continue, des formations professionnalisantes ainsi que des diplômes d’ingénieur.</p>
+\n
+\n<p>Ces diplômes LMD (Licence, Master et Doctorat) conformes aux standards européens sont déployés au sein de quatre grands domaines&nbsp;:</p>
+\n
+\n<ul>
+\n\t<li>Arts, lettres et langues,</li>
+\n\t<li>Droit, économie, gestion,</li>
+\n\t<li>Sciences humaines et sociales,</li>
+\n\t<li>Sciences, technologies, santé.</li>
+\n</ul>
+\n
+\n<p>Depuis de nombreuses années, l'Université de La Réunion développe les usages du numérique au service de la formation et de la valorisation scientifique. Depuis &nbsp;2018, l'établissement fixe parmi ses objectifs stratégiques de développer une offre de formation en ligne, dans le cadre d'une université numérique avec l'ambition de développer ces nouvelles modalités d’accès au savoir et au développement des compétences, notamment par le biais des MOOC.</p>
+\n	academic-partner	130
+327	Université de Limoges	unilim	universities/logo_universitelimoges_L71odfY.png	universities/Photo_V2.jpg	universite-de-limoges	0	1	<p>Au cœur de l’Europe, l’Université de Limoges est un important pôle d’enseignement supérieur pluridisciplinaire, dans un environnement des plus propices à l’épanouissement scientifique. Ouverte, elle est un lieu foisonnant d’interactions, avec une population étudiante multiple, des structures d’accueil efficaces, des équipes proches, des formations fondées sur des recherches de très haut niveau et pour des débouchés bien identifiés. Son excellence scientifique, avec des laboratoires de pointe et des partenariats de grande envergure, contribue à inventer le monde de demain.</p>
+\n
+\n<p>L'Université de Limoges fait figure de pionnière dans le domaine du numérique grâce notamment à un campus virtuel d'enseignement des TIC, créé en 1998.<br />
+\nPour l’Université de Limoges, le numérique est un outil pédagogique essentiel pour permettre à tous, en formation initiale ou continue, l’accès aux connaissances de ses différentes formations. &nbsp;L’Université de Limoges développe ainsi des cours en ligne pour faciliter, aussi bien en France qu’à l’international, le suivi de ses enseignements et de ses formations de haut niveau.&nbsp;</p>
+\n
+\n<p>Pour nous retrouver en ligne :</p>
+\n
+\n<p>&nbsp;</p>
+\n
+\n<ul>
+\n\t<li>Site internet de l'Université de Limoges : <a href="https://www.unilim.fr/">https://www.unilim.fr/</a></li>
+\n\t<li>Facebook : <a href="https://www.facebook.com/unilim">https://www.facebook.com/unilim</a></li>
+\n\t<li>Twitter: <a href="https://twitter.com/unilim">https://twitter.com/unilim</a></li>
+\n\t<li>Youtube : <a href="https://www.youtube.com/user/CANALSUPwebTV">https://www.youtube.com/user/CANALSUPwebTV</a></li>
+\n</ul>
+\n
+\n<p>&nbsp;</p>
+\n	academic-partner	150
+330	LFB BIOMEDICAMENTS	groupe-lfb	universities/logo-FUN_complet_zGQHMsK.png		lfb-biomedicaments	0	0			0
+332	Université François-Rabelais de Tours	univ-tours	universities/logo-FUN_complet_SuEtZXy.png		universite-francois-rabelais-de-tours	0	0			0
+334	VetAgro Sup	vetagrosup	universities/logo-vetagro_sup-PT.png	universities/banniere_vetagro_sup.jpg	vetagro-sup	0	1	<div>
+\n<p><strong>Institut d'enseignement supérieur et de recherche en alimentation, santé animale, sciences agronomiques et de l'environnement</strong>, <a href="http://www.vetagro-sup.fr/">VetAgro&nbsp;Sup</a> forme des vétérinaires, des ingénieurs agronomes et des inspecteurs de santé publique vétérinaire. L’établissement vise la Santé Globale en plaçant aux premiers rangs de ses objectifs la production de connaissances et l'appui aux acteurs économiques dans les domaines de l'alimentation, santé animale, des sciences agronomiques et de l’environnement.</p>
+\n</div>
+\n
+\n<p>Ce grand établissement a été la première structure française créée pour former à la fois des ingénieurs agronomes et des docteurs vétérinaires&nbsp;; il réunit <strong>1200 étudiants</strong> et <strong>120 enseignants-chercheurs.</strong></p>
+\n
+\n<p>L'implantation de l'établissement au cœur de la région Auvergne-Rhône-Alpes lui permet d'être un acteur majeur de l'enseignement et la recherche avec ses partenaires au sein de l'Université de Lyon et de l'Université de Clermont.</p>
+\n
+\n<p>Depuis de nombreuses années, les nouvelles approches pédagogiques font partie intégrante des enseignements&nbsp;et c’est donc naturellement que VetAgro Sup a souhaité réaliser des MOOCs dans ses domaines de compétence.</p>
+\n
+\n<p>VetAgro Sup est membre de l'Institut agronomique, vétérinaire et forestier de France – Agreenium.</p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	600
+337	Direction générale des étrangers en France	dgef-interieur	universities/logo-minint_BUC8Hqs.jpg	universities/banniere_minist.jpg	direction-generale-des-etrangers-en-france	0	1	<p>La direction générale des étrangers en France (DGEF) du ministère de l’intérieur agit dans de nombreux domaines qui couvrent l’intégralité du parcours des étrangers en France, de l’entrée sur le territoire à l’acquisition de la nationalité. Elle est notamment compétente pour traiter de l'accueil et de l’accompagnement des étrangers.</p>
+\n
+\n<p>A ce titre, la direction de l’accueil, de l’accompagnement des étrangers et de la nationalité (DAAEN) définit et met en œuvre la politique d’intégration des étrangers accédant pour la première fois au séjour en France et souhaitant s’y installer durablement. Elle dispense également, dès le pays d’origine, une information pratique sur la vie en France.</p>
+\n
+\n<p>La connaissance de la langue du pays d’accueil constituant un vecteur essentiel d’intégration dans la société, la DAAEN met à disposition des outils favorisant l’apprentissage de la langue française et de la vie citoyenne en France.</p>
+\n
+\n<p>Notre site internet :&nbsp;<a href="https://www.immigration.interieur.gouv.fr/Accueil-et-accompagnement">https://www.immigration.interieur.gouv.fr/Accueil-et-accompagnement</a></p>
+\n
+\n<p>&nbsp;</p>
+\n	academic-partner	150
+341	XuetangX	xuetangx	universities/fun-02.png	universities/fun-01.png	xuetangx	0	1	<p>Founded by Tsinghua University in October 2013, XuetangX is the world’s first Chinese MOOC platform and serves as the research and application platform for the Ministry of Education (MOE) Research Center for Online Education. XuetangX has been awarded as one of the national first batch of demonstration base projects for innovation and entrepreneurship. Besides, XuetangX also works with the International Center for Engineering Education (ICEE) under the auspices of UNESCO and supports its online portion. By the end of June 2018, with a total of 25 million enrollments and more than 1,500 online courses from 13 disciplined fields, XuetangX has accumulated over 12 million registered users, covering 209 countries and regions.</p>
+\n
+\n<p>All MOOC on this page are &nbsp;provided under <a href="https://www.fun-mooc.fr/news/echange-de-mooc-retour-sur-un-partenariat-entre-fu/" target="_blank"> a cooperative agreement between FUN-MOOC and XuetangX.</a></p>
+\n	academic-partner	100
+346	Bordeaux Sciences Agro	bordeaux-sciences-agro	universities/LOGO_BSA_180x110.png	universities/bordeauxsciencesagro-980x222.png	bordeaux-sciences-agro	0	1	<p><a href="https://www.agro-bordeaux.fr/">Bordeaux Sciences Agro</a> est un&nbsp;établissement public d’enseignement supérieur et de recherche&nbsp;agronomique sous tutelle du Ministère de l’Agriculture et&nbsp; l’Alimentation.&nbsp;Créé en 1962, il forme chaque année 600 étudiants qui&nbsp;suivent le cursus&nbsp;Ingénieur Agronome par la voie de la formation&nbsp;initiale sous statut&nbsp;étudiant&nbsp;ou&nbsp;apprenti ou l’un des six Masters&nbsp;co-accrédités avec les universités bordelaises et les partenaires&nbsp;nationaux ou encore&nbsp;le Mastère spécialisé labellisé CGE Manager de&nbsp;domaines viticoles.</p>
+\n
+\n<p><strong>L’enseignement supérieur agronomique, vétérinaire et de paysage</strong>, rassemble en France 20 établissements qui assurent la&nbsp;formation de 17 000 étudiants. Dans ces établissements sont proposées&nbsp;des formations au service du développement durable, de l’agronomie, de&nbsp;l’alimentation, de l’environnement, du paysage, de la médecine&nbsp;vétérinaire et de l’aménagement du territoire.&nbsp;Par son ancrage local et&nbsp;ses partenariats nationaux et internationaux, Bordeaux Sciences Agro&nbsp;participe au rayonnement du site universitaire&nbsp;bordelais en étant l’un&nbsp;des 7&nbsp;membres fondateurs de l’IDEX «&nbsp;Université de Bordeaux&nbsp;» et&nbsp;contribue aux activités des&nbsp;clusters et pôles de compétitivité&nbsp;régionaux.</p>
+\n
+\n<p><a href="https://www.agro-bordeaux.fr/">Bordeaux Sciences Agro </a>est membre d’Agreenium, réseau dédié à&nbsp;l’enseignement supérieur agronomique, vétérinaire et de paysage, qui&nbsp;rassemble en France les principaux acteurs de la recherche et de la&nbsp;<br />
+\nformation supérieure agronomique et vétérinaire en France.</p>
+\n
+\n<img src="/media/2018/02/21/bandeau-logos-bsa.png" width="" height="">	level-2	600
+351	GIP FTLV-IP Orléans - Tours	GIPFTLVIP	universities/gip180x100.png	universities/bandeaugip.png	GIPFTLVIP	0	1	<p>Créé en 2002, le GIP Formation Tout au Long de la Vie - Insertion professionnelle de l’académie d’Orléans-Tours-(GIP FTLV-IP) a pour objet, dans le cadre des orientations définies par le Recteur, le développement d’une coopération concertée au niveau de l’académie dans les domaines de la formation continue des adultes, de la formation et de l’insertion professionnelle.</p>
+\n
+\n<p>Pour ce faire il exerce, notamment, des fonctions supports pour le compte du réseau des Greta et de ses membres ainsi que des activités et prestations spécifiques.</p>
+\n
+\n<p>Le GIP FTLV-IP un outil régional au service de tous les acteurs et professionnels de la formation.</p>
+\n
+\n<p>Le Pôle Formation et Ingénierie de Formation (FORIF) du GIP mobilise savoirs, compétences et moyens pour construire avec et réaliser pour ses clients des solutions de conseil et de professionnalisation dans une logique de services intégrant :</p>
+\n
+\n<ul>
+\n\t<li>ingénierie de formation et conception pédagogique,</li>
+\n\t<li>mise en œuvre et animation des prestations,</li>
+\n\t<li>évaluation des effets de la formation,</li>
+\n\t<li>ingénierie administrative et financière.</li>
+\n</ul>
+\n	academic-partner	150
+356	Le Mans Université	univlemans	universities/logo_LEMANS_UNIVERSITE.png	universities/banniereLeMansUniv_980x200_dernier_test.jpeg	le-mans-universite	0	1	<p>Le Mans Université, c’est : <strong>11 000 étudiants</strong>, <strong>2 campus</strong>, Le Mans et Laval, <strong>3 facultés</strong>,<strong> 2 IUT</strong> et <strong>1 école d’ingénieurs</strong>, <strong>15 laboratoires de recherche</strong> dont <strong>6 associés au CNRS</strong>.&nbsp;</p>
+\n
+\n<p>Le Mans Université s’inscrit dans une démarche visant la professionnalisation et l’épanouissement de chacun, tout au long de la vie : étudiants en formation initiale, en reprise d’étude, en formation professionnelle, à l’étranger.</p>
+\n
+\n<p>L’Université met tout en oeuvre pour permettre l’accès à l’enseignement supérieur aux étudiants et aux professionnels grâce à une offre de formation pluridisciplinaire, une pédagogie innovante et un accompagnement individualisé. Nos enseignements s’appuient sur une activité de recherche de qualité menée dans des laboratoires de renommée internationale avec des thématiques de recherche variées.</p>
+\n
+\n<p><br />
+\nLe Mans Université est membre de la ComUE <a href="https://www.fun-mooc.fr/universities/universite-bretagne-loire/">Université Bretagne Loire</a>
+\n<img src="/media/2018/02/26/logo_ubl_rvbnoirpng180x100_q85.png"alt="Logo ComUE UBL"/>.</p>
+\n	level-2	600
+361	ESPCI Paris 	ESPCI	universities/logo_espci_MZQk898.png	universities/FRONTON_ESPCI_V2_3.png	ecole-superieure-de-physique-et-de-chimie-industrielles	0	0	<div>L’<a href="https://www.espci.fr/fr/">Ecole Supérieure de Physique et Chimie Industrielles</a> (ESPCI Paris) est une école d’ingénieurs de la ville de Paris. C’est un endroit unique, au cœur de la Montagne Sainte-Geneviève dans le 5e arrondissement, où se conjuguent enseignement, recherche et innovation. L’école se démarque par sa formation scientifique de haut niveau, interdisciplinaire, fortement adossée à une recherche d’excellence, alliant science fondamentale et ouverture vers les applications et l’innovation. Elle forme chaque année 90 élèves-ingénieurs, recrutés parmi les meilleurs. Elle dispense une formation originale en physique, chimie et biologie, basée sur la recherche et les travaux pratiques. Elle est reconnue dans le monde entier pour l’excellence de sa Recherche fondamentale et appliquée, génératrice d’innovations pour l’industrie.</div>
+\n
+\n<div>&nbsp;</div>
+\n
+\n<div>Fondée en 1882, L’ESPCI Paris compte 6 Prix Nobel depuis sa création et est meilleure école d’ingénieurs françaises au classement de Shanghai. L’ESPCI Paris est membre fondateur de Paris Sciences et Lettres.</div>
+\n
+\n<div>&nbsp;</div>
+\n
+\n<div>L'ESPCI Paris développe une offre de MOOCs ciblés sur des thèmes emblématiques de l’école et sur la manière originale dont ces thèmes sont abordés</div>
+\n
+\n<div>en enseignement et en recherche. L’école souhaite rendre accessible son modèle d’enseignement par l’expérimentation à un très large public.</div>
+\n
+\n<div>&nbsp;</div>
+\n
+\n<div>L’ESPCI Paris est membre de Paris Sciences et Lettres.</div>
+\n	level-3	0
+363	COMUE Université Paris Lumières	parislumiere	universities/logo_UPL_RVB_283x148pix_E7bYaW9.jpg		comue-universite-paris-lumieres	0	0		level-2	600
+368	Cetim	cetim	universities/Logo_Cetim.png		cetim	0	0		simple-partner	0
+373	Université du Québec à Montréal	uqam	universities/logo-FUN_complet_IzdD8t4.jpg		universite-du-quebec-montreal	0	0		academic-partner	150
+378	Université Paris Lumières	upl	universities/logo_UPL_RVB_283x148pix.jpg	universities/bandeau_FUN_-_MOOC_-_DEF.jpg	universite-paris-lumieres	0	1	<p>La ComUE Université Paris Lumières (UPL) a été fondée en 2014 par les 2 universités Paris 8 et Paris Nanterre, ainsi que par le CNRS. Elle associe par décret deux écoles (ENS Louis Lumières et INSHEA) et intègre comme composante le Collège International de Philosophie (CIPh). L’UPL couvre en formation et recherche l’ensemble des disciplines de sciences humaines et sociales, et intègre également des disciplines du domaine des sciences et technologies.</p>
+\n
+\n<p>Aujourd’hui, onze institutions culturelles et patrimoniales franciliennes de premier plan s’y sont associées pour mener des projets de recherche ou de formation.</p>
+\n
+\n<p>Diffuser largement des savoirs, favoriser l’accès à la culture du plus grand nombre est au cœur des ambitions de l’UPL et de ses partenaires. S’appuyant sur l’expérience pionnière de l’université Paris Nanterre dans la diffusion de MOOCs, sur une tradition ancrée de l’enseignement à distance pour ses deux universités, et sur les ressources numériques produites au sein de ses laboratoires, l’UPL a fait des MOOCs relevant de la culture et de la société un axe important de sa stratégie numérique. Elle y développe des partenariats originaux avec des institutions culturelles en vue de renforcer les apprentissages avec les ressources et évènements qu’elles proposent.</p>
+\n
+\n<p>Voici le site internet de la ComUE Université Paris Lumières : &nbsp;<a href="http://www.u-plum.fr/">http://www.u-plum.fr/</a></p>
+\n
+\n<p>&nbsp;</p>
+\n	level-2	610
+381	Centre national de la recherche scientifique	cnrs	universities/lo_CNRS.png		cnrs	0	0		academic-partner	150
+386	Université de Rouen	unirouen	universities/Logo-URN-quadri_v2_5SmhdA9.png		universite-de-rouen	0	0		level-2	0
+391	Université de Lille 	lille	universities/UL-WEB-2014_qaJbrMo.jpg	universities/ULille-portail_FUN-MOOC-980x200px-V1-2x-100_xa4cZgW.jpg	lille	0	1	<p>L’Université de Lille est née en janvier 2018 de la fusion des trois universités lilloises. À une demi-heure de Bruxelles, 1h de Paris, 1h20 de Londres, 2h d’Amsterdam, elle occupe une position stratégique au cœur de l’Europe du nord, et collabore avec de grandes universités internationales particulièrement dynamiques. Dotée d’importants équipements de pointe, elle est lauréate avec ses partenaires d’un vaste plan national de financement d’excellence («&nbsp;I-SITE+&nbsp;»), dont l’un des axes est de diffuser largement les meilleures initiatives pédagogiques.</p>
+\n
+\n<p>L’Université de Lille en chiffres&nbsp;: 67000 étudiants dont 7300 étudiants internationaux, 24 composantes, 66 laboratoires de recherche, 6300 personnels.</p>
+\n
+\n<p>Le développement des MOOC s’inscrit dans la volonté de l’Université de Lille de promouvoir l’enseignement&nbsp;au plus grand nombre grâce aux dispositifs numériques et d’améliorer sa visibilité tant nationale qu’internationale.</p>
+\n
+\n<p>Avec son accessibilité facilitée et sa gratuité, le MOOC permet réellement d’organiser une formation tout au long de la vie très ouverte. Le recours aux MOOC est aussi l’occasion d’utiliser toutes les potentialités du numérique quant aux méthodes pédagogiques permettant de favoriser la réussite de l’apprenant mais aussi sa participation à une certaine co-construction de la connaissance. Par d’ailleurs les MOOC sont un objet de recherche au sein de l’Université de Lille.</p>
+\n
+\n<div>&nbsp;</div>
+\n	level-2	660
+396	CNIL	CNIL	universities/logo_complet_2_TWlpasS.jpg		CNIL	0	0		simple-partner	0
+401	La Fabrique\t\t\t	lafabrique-ecole	universities/logo_la_fabrique.png	universities/bandeau-lafabrique.jpg	la-fabrique	0	1	<p style="margin-left:0cm; margin-right:0cm">La Fabrique, l’École des métiers de la mode et de la décoration de la CCI Paris Ile-de-France, créée en 2013, conjugue trois programmes de formation, l'Ecole supérieur des industries du vêtement [ESIV], les Ateliers Grégoire et des Ateliers d'étalage. Ces trois programmes ont, depuis des décennies, fait leur preuve au service des jeunes, des salariés et des entreprises.</p>
+\n
+\n<p style="margin-left:0cm; margin-right:0cm">Forte de près de 1&nbsp;000 apprenants en formation initiale et formation continue, La Fabrique propose quatre domaines de formation : management de la mode, maroquinerie, merchandising et décoration d'intérieur. Cité du savoir-faire, La Fabrique est entièrement dédiée aux métiers techniques de la création.</p>
+\n
+\n<p style="margin-left:0cm; margin-right:0cm"><a href="https://www.lafabrique-ecole.fr/" target="_blank">https://www.lafabrique-ecole.fr/</a></p>
+\n	level-2	600
+406	Ecole Nationale Supérieure d’Architecture de Montpellier 	montpellierarchi	universities/Logo_ENSAM_attestation_v61YhCa.png	universities/Bandeau_FUN.png	ecole-nationale-superieure-darchitecture-de-montpellier	0	1	<p>L’Ecole Nationale Supérieure d’Architecture de Montpellier fait partie du réseau des 20 écoles d’État dont la mission principale est de former chaque année 1100 étudiants en formation initiale et continue aux métiers liés à l’architecture. Membre de la Conférence des grandes écoles, son positionnement est singulier, avec notamment une antenne à l’Ile de La Réunion, spécialisée dans l’architecture en milieu tropical.</p>
+\n
+\n<p>Dispensant un enseignement de qualité prenant en compte les besoins de la société, l’école bénéficie d’un cadre de travail exceptionnel avec notamment un atelier maquettes-expérimentations, un laboratoire de fabrication numérique, une médiathèque, des laboratoires informatiques et vidéo, une maison d’édition, les Editions de l’Espérou ainsi qu’une résidence d’artiste.</p>
+\n	level-2	300
+411	Institut National de la Consommation	INC	universities/00_LOGOTYPE_INC_ROUGE-sansmarge_-_Copie_xsb81aa.jpg	universities/banniere-INC-FUN.png	INC	0	1	<p><strong>Un établissement public de référence pour tous les sujets liés à la consommation</strong></p>
+\n
+\n<p>L’Institut national de la consommation (INC) est un établissement public national à caractère industriel et commercial (EPIC), centre d’expertise et d’information au service des consommateurs et de leurs associations.</p>
+\n
+\n<p>Il est le producteur de l’émission <em><a href="https://www.inc-conso.fr/recherche?displayModeParam=grids&amp;keyword=&amp;im_vid_4%5B%5D=312" target="_blank">ConsoMag</a></em> diffusée sur les chaînes de France Télévisions, l’éditeur du site de service public <a href="http://www.inc-conso.fr/" target="_blank">inc-conso.fr</a> et du magazine <em><a href="https://www.60millions-mag.com/" target="_blank">60 Millions de consommateurs</a></em>. Il édite également le site sur la consommation responsable et le développement durable <a href="http://www.jeconsommeresponsable.fr/" target="_blank">jeconsommeresponsable.fr</a>.</p>
+\n
+\n<p>Ses missions&nbsp;:</p>
+\n
+\n<ul>
+\n\t<li>décrypter les nouvelles réglementations,</li>
+\n\t<li>tester des produits et des services,</li>
+\n\t<li>informer et protéger les consommateurs,</li>
+\n\t<li>accompagner les associations de consommateurs.</li>
+\n</ul>
+\n
+\n<p>A l’occasion de ses <a href="https://www.inc-conso.fr/content/demain-un-consommateur-augmente-ou-diminue-conference-15-mars-2018-0" target="_blank">50 ans célébrés en 2018</a>, l’INC s’est tourné vers le futur et a mené une démarche critique et prospective sur la consommation. Ces travaux ont abouti et à la publication du livre blanc "<a href="https://www.inc-conso.fr/content/livre-blanc-demain-un-consommateur-augmente-ou-diminue" target="_blank">Demain&nbsp;: un consommateur augmenté ou diminué&nbsp;? Penser le consommateur du futur à l’ère de la société numérique</a>".</p>
+\n	simple-partner	0
+416	Université La Sagesse du Liban	LaSagesse	universities/logo_univ_sagesse_180x100.png		universite-la-sagesse-du-liban	0	0		simple-partner	0
+417	CPGE économiques et commerciales 	cpge-economiques	universities/3logos_AWyGD0w.png	universities/00-bandeau-v2.png	cpge-economiques	0	1	<p>L'APHEC, ESCP Europe et SKEMA s’associent pour produire un MOOC d’orientation afin d’informer sur les classes préparatoires économiques et commerciales (anciennement " Prépa HEC ") et les grandes écoles de commerce. Ce MOOC s'inscrit dans le cadre de la coopération entre l'APHEC et la CGE (au sein de laquelle la Directrice générale de SKEMA préside le Chapitre des Écoles de management et le Directeur général de ESCP Europe préside la Commission Formation).</p>
+\n
+\n<p><strong>APHEC</strong></p>
+\n
+\n<p>L’APHEC est&nbsp; l’Association des Professeurs des classes préparatoires&nbsp;Économiques et&nbsp;Commerciales. Elle réunit quelque 1400 professeurs adhérents répartis dans environ 170 établissements publics et privés sous contrat. L’APHEC entretient un dialogue privilégié avec les grandes écoles de management et l’ensemble des acteurs institutionnels sur toutes les thématiques qui concernent la filière économique et commerciale des classes préparatoires au Master en management. L’APHEC est membre de la Conférence des Grandes Écoles et du Comité de Concertation et de Suivi des classes préparatoires au ministère de l’enseignement supérieur.</p>
+\n
+\n<p><strong>ESCP EUROPE</strong></p>
+\n
+\n<p>ESCP Europe est la première école de commerce au monde (fondée en 1819 à Paris) et la seule pan-européenne. Elle délivre un portefeuille complet de programmes : du Bac+3 au Bac+8 (BSc, MiM, MS/MSc, MBA, PhD) et en Formation Continue. ESCP Europe c'est aussi :</p>
+\n
+\n<p style="margin-left:48.0pt">·&nbsp;+ de 5000 étudiants répartis sur 6 campus urbains: Berlin, Londres, Madrid, Paris, Turin et Varsovie</p>
+\n
+\n<p style="margin-left:48.0pt">·&nbsp;140 professeurs-chercheurs représentant plus de 20 nationalités, sur nos 6 campus.</p>
+\n
+\n<p style="margin-left:48.0pt">·&nbsp;130 partenariats académiques en Europe et dans le monde</p>
+\n
+\n<p style="margin-left:48.0pt">·&nbsp;une Triple Accréditation AACSB-EQUIS-AMBA</p>
+\n
+\n<p style="margin-left:48.0pt">&nbsp;une reconnaissance nationale comme établissement d'enseignement supérieur dans nos 5 pays fondateurs</p>
+\n
+\n<p><strong>SKEMA :</strong></p>
+\n
+\n<p>SKEMA Business School est un établissement d’enseignement supérieur et de recherche privé sous statut d’association Loi 1901 sans but lucratif. SKEMA est née en 2009 de la fusion entre l'Ecole Supérieure de Commerce de Lille et le CERAM Business School de Sophia Antipolis. Ces deux écoles fondatrices ont respectivement été fondées en 1892 pour l’une et 1963 pour l’autre.</p>
+\n
+\n<p>SKEMA est une communauté dédiée à l’apprentissage, à la création et à la transmission des connaissances et des pratiques de management. Depuis sa création, SKEMA a relevé le défi d’être <strong>une école globale grâce à sa structure multi-campus </strong>et offre un large portefeuille de programmes francophones et anglophones en formation initiale et en formation continue, aux niveaux Licence, Master et Doctorat.</p>
+\n
+\n<p>→&nbsp;Plus de 8 000 étudiants (40% d’étudiants internationaux)</p>
+\n
+\n<p>→&nbsp;40 000 alumni dans 134 pays dans le monde</p>
+\n
+\n<p>→ 160 professeurs permanents</p>
+\n
+\n<p>→ Plus de 100 partenariats avec des universités internationales (76% accréditées)</p>
+\n
+\n<p>→&nbsp;6 campus : 3 sites en France, 1 campus à Suzhou (China), 1 campus à Raleigh (USA), 1 campus à Belo Horizonte (Brazil)</p>
+\n
+\n<p>→ Plus de 65 associations étudiantes.</p>
+\n
+\n<p>&nbsp;</p>
+\n	academic-partner	0
+420	Université de Lille (réparation)	Ulille	universities/logo-FUN_complet_1HEKgSj.jpg		universite-de-lille-reparation	0	0			0
+423	Ecole Charles Dullin	ecolecharlesdullin	universities/Logo.png		ecole-charles-dullin	0	0		academic-partner	0
+426	UNESCO	UNESCO	universities/unesco_logo_IJEISnr.png		unesco	0	0		simple-partner	0
+429	K-MOOC	K-MOOC	universities/logo_top.png		k-mooc	0	0		academic-partner	0
+433	Institut des hautes études de défense nationale	ihedn	universities/Logo_PLATEFORME_FUN_170x110_zqWk3yb.png		ihedn	0	0		academic-partner	150
+434	Oniris	Oniris	universities/Oniris_logo_sansSign_0vOOy3M.png	universities/2015_08_Parc_EcoleVeto31.jpg	oniris	0	0	<p><a href="https://www.oniris-nantes.fr"><strong>Oniris</strong></a>&nbsp;est un établissement d'enseignement supérieur et de recherche du Ministère de l'agriculture et de l'alimentation. Il dispose d’une palette thématique très large incluant la santé animale et la santé publique, les domaines clinique, biomédical, les sciences de l’alimentation et le génie des procédés.</p>
+\n
+\n<p><strong>Oniris</strong>&nbsp;forme environ 1100 élèves, en proposant les formations correspondant aux métiers de vétérinaire (diplôme de docteur vétérinaire), aux métiers d'ingénieur (diplôme d’ingénieur) comportant deux approfondissements : (i) en « agroalimentaire/alimentation », (ii) en « bioproductions ».</p>
+\n
+\n<p>Grâce à son accréditation à délivrer le doctorat et à son offre de masters, Oniris possède un dispositif très attractif de formation-recherche, en articulation avec différents organismes de recherche.</p>
+\n
+\n<p>L’Ecole s'insère dans l'espace de collaboration formé par l'Université Bretagne Loire (UBL).&nbsp;</p>
+\n	level-2	600
+437	Université Bretagne Sud	ubs	universities/logo_dmEOAL5.png	universities/UBSbanniere2.jpg	ubs	0	1	<p>L’Université Bretagne Sud a été créée en 1995 et compte trois campus : Lorient, Vannes et Pontivy. Professionnalisante, ouverte sur la cité comme à l’international, elle s’appuie sur les compétences de ses 900 personnels dont 500 enseignants et enseignants-chercheurs pour former chaque année près de 10 000 étudiants.</p>
+\n
+\n<p>Les formations de l’Université Bretagne Sud s’organisent autour de 5 grands domaines de formation : Lettres et Langues, Sciences Humaines et Sociales, Droit, Économie et Gestion, Sciences, Technologies et Santé (hors médecine), Enseignement, Éducation et Formation.</p>
+\n
+\n<p>L'Université veut maintenir l'équilibre entre ses missions d'enseignement et de recherche.Une expertise scientifique qui s’appuie sur ses 14 laboratoires.</p>
+\n
+\n<p>L’UBS a identifié 4 domaines d’excellence qu'elle entend développer en enseignement et en recherche pour satisfaire les exigences de demain, tant sur la scène nationale qu'internationale&nbsp;: «&nbsp;Mer et Littoral&nbsp;», «&nbsp;Cyber&nbsp;», «&nbsp;Matériaux&nbsp;» et «&nbsp;Data Sciences&nbsp;».</p>
+\n	level-2	600
+440	Fédération Française des Secouristes et Formateurs Policiers	ffsfp	universities/logo_ETS.png		ffsfp	0	1	<p>La Fédération Française des Secouristes et Formateurs Policiers (FFSFP) crée en 2001, est une association de professionnel concourant à la sécurité intérieure&nbsp;regroupant : médecins, policiers, enseignants, douaniers, pompiers, militaires,…</p>
+\n
+\n<p>Elle est agréée par le ministère de l’intérieur pour l’enseignement du secourisme.&nbsp;</p>
+\n
+\n<p>A ce titre nous dispensons différentes actions de formation&nbsp;:</p>
+\n
+\n<ul>
+\n\t<li>Secourisme grand public&nbsp;</li>
+\n\t<li>Secourisme en équipe&nbsp;</li>
+\n\t<li>Secourisme en entreprise (SST)</li>
+\n\t<li>Formateurs&nbsp;(initiale et continue)</li>
+\n\t<li>Concepteurs de formation</li>
+\n</ul>
+\n
+\n<p>Notre objectif est de développer la formation aux premiers secours au plus grand nombre.</p>
+\n	simple-partner	150
+447	Ecole des Ingénieurs de la Ville de Paris 	EIVP	universities/logo_EIVP_couleurs.png	universities/Facade_EIVP.JPG	ecole-des-ingenieurs-de-la-ville-de-paris	0	1	<p>Créée en <strong>1959, l'EIVP</strong> (<strong>Ecole des Ingénieurs de la Ville de Paris</strong>) est une régie autonome de la ville de Paris.</p>
+\n
+\n<p>En plus de son activité principale d’enseignement, elle met en place une recherche appliquée, autour de la ville durable et des enjeux techniques et environnementaux liés à l'aménagement urbain et à l'utilisation des techniques urbaines.</p>
+\n
+\n<p>La recherche à l'EIVP tente de répondre aux besoins des praticiens qui font la ville d'aujourd'hui et de demain. Pour cela, l'Ecole a décidé d'orienter sa recherche autour de quatre axes qui s’articulent autour du génie urbain refondé : "<strong>Résilience urbaine et son ingénierie</strong>", "<strong>Energie en ville et climat urbain</strong>", "Aménagement urbain opérationnel et espaces publics" et "<strong>Systèmes urbains numériques</strong>".</p>
+\n	academic-partner	150
+452	Université de Namur	unamur	universities/logo.png		unamur	0	0		academic-partner	150
+457	Université Toulouse 1 Capitole	Ut1	universities/logo_ut1_180_100.png	universities/image_fond_page_presentation_FUN.png	Ut1	0	1	<p>Université Toulouse 1 Capitole, excellence et attractivité&nbsp;: les ambitions d’une université pour ses étudiants et ses enseignants-chercheurs</p>
+\n
+\n<p>&nbsp;</p>
+\n
+\n<p>Avec 3 facultés, 2 écoles, 1 institut universitaire technologique, 12 unités de recherche, l’Université Toulouse Capitole est présente dans les domaines du droit, de l’économie et de la gestion. Elle trouve ses racines dans la création à Toulouse en 1229 de l’Université de Toulouse.</p>
+\n
+\n<p>Elle est reconnue au niveau internationale pour son <a href="http://www.ut-capitole.fr/recherche/equipes-et-structures/toulouse-school-of-economics-research-tse-r--562118.kjsp?RH=1319193100055" target="_blank">excellence scientifique</a> en sciences économiques, couronnée en 2014 par le Prix Nobel décerné à Jean Tirole. Les instances européennes ont aussi reconnu son rayonnement scientifique dans le domaine juridique en lui accordant pour la deuxième fois consécutive le label Centre d’excellence Jean Monnet. Avec 21&nbsp;000 étudiants inscrits chaque année, elle les prépare en <a href="http://www.ut-capitole.fr/formations" target="_blank">formation initiale</a> à 62 diplômes nationaux et 41 diplômes d’université et préparations. Parmi ces diplômes 6 sont enseignés en anglais et 20 sont des doubles diplômes avec les universités européennes les plus prestigieuses. Innovante dans le domaine pédagogique, elle a été dans les premières universités à proposer des parcours dans ses domaines en <a href="http://www.ut-capitole.fr/formations/se-former-autrement/formation-ouverte-et-a-distance/" target="_blank">formation ouverte et à distance</a> ou <a href="http://www.ut-capitole.fr/formations/se-former-autrement/formation-continue/diplomes-en-alternance-apprentissage-ou-professionnalisation-fcv2a-605144.kjsp?RH=1319186991830" target="_blank">en alternance</a>. Très impliquée dans la <a href="http://www.ut-capitole.fr/formations/se-former-autrement/formation-continue/diplomes-en-alternance-apprentissage-ou-professionnalisation-fcv2a-605144.kjsp?RH=1319186991830" target="_blank">formation continue</a>, elle œuvre activement pour la <a href="http://www.ut-capitole.fr/formations/se-former-autrement/validation-des-acquis/" target="_blank">validation des acquis de l’expérience</a>.&nbsp;</p>
+\n	level-2	730
+462	Institut français	institutfrancais	universities/logo_institut_fr.png		institut-francais	0	0		academic-partner	0
+471	Les Cols Verts	LesColsVerts	universities/Logo_LesColsVerts.png		les-cols-verts	0	0		academic-partner	150
+476	Centre Pompidou	centrepompidou	universities/Logo-Centre-Pompidou.jpg		centre-pompidou	0	0		level-2	600
+481	Université Paris-Est Créteil	UPEC	universities/UPEC-logo_284_120_IccqBJn.png	universities/banniere_UPEC_campus.jpg	universite-paris-est-creteil	0	1	<p>Avec 7 facultés, 4 instituts, 3 écoles, un observatoire et 32 laboratoires de recherche, l’Université Paris-Est Créteil est présente dans tous les domaines de la connaissance depuis 1970, et forme chaque année plus de 36 000 étudiant·e·s et actifs de tous les âges.</p>
+\n
+\n<p>Acteur majeur de la diffusion de la culture académique, scientifique et technologique, l’établissement dispense plus de <a href="http://www.u-pec.fr/formation/formation-234404.kjsp?RH=1261131077805&amp;RF=1176930618854">600 parcours de formations</a> dans toutes les disciplines, du DUT au doctorat. L'UPEC offre ainsi un accompagnement personnalisé de toutes les réussites, grâce à des parcours de formation initiale, des <a href="http://www.u-pec.fr/vous-etes/adulte-en-reprise-d-etudes/vae/la-vae-a-l-upec-6132.kjsp?RH=1261131077805">validations d’acquis</a> et la <a href="http://www.u-pec.fr/vous-etes/adulte-en-reprise-d-etudes/formation-continue/la-formation-continue-a-l-upec-340634.kjsp?RH=1261131077805">formation continue</a>, ou encore par le biais de l’<a href="http://www.u-pec.fr/vous-etes/entreprises-et-partenaires/alternance/l-alternance-a-l-upec-363175.kjsp?RH=1261131077805">apprentissage</a> et des actions en faveur de l’entrepreneuriat.</p>
+\n
+\n<p>&nbsp;Université Paris-Est Créteil (UPEC) est membre de la&nbsp;<em>Comue</em> Université Paris-Est.</p>
+\n
+\n<p style="text-align:center;"><img src="/media/universities/LOGO_COMUE_UPE.jpg" width="284" height="120"></p>	level-1	300
+490	Université de Senghor	usenghor	universities/index.png		universite-de-senghor	0	0			0
+493	Syntec-Ingénierie	SyntecIngenierie	universities/logo-FUN_complet_Ixk5aC4.png		syntec-ingenierie	0	0		simple-partner	0

--- a/tests/apps/courses/test_models_person.py
+++ b/tests/apps/courses/test_models_person.py
@@ -4,9 +4,12 @@ Unit tests for the Person model
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from cms.api import create_page
+from cms.api import add_plugin, create_page
 
-from richie.apps.courses.factories import PersonFactory
+from richie.apps.core.helpers import create_i18n_page
+from richie.apps.courses.cms_plugins import PersonPlugin
+from richie.apps.courses.factories import CourseFactory, PersonFactory
+from richie.apps.courses.models import Course
 
 
 class PersonModelsTestCase(TestCase):
@@ -74,3 +77,87 @@ class PersonModelsTestCase(TestCase):
         with self.assertNumQueries(1):
             self.assertEqual(person1.get_full_name(), "Madam Louise Dupont")
             self.assertEqual(person2.get_full_name(), "Jacques Martin")
+
+    def test_models_person_get_courses(self):
+        """
+        It should be possible to retrieve the list of related courses on the person instance.
+        The number of queries should be minimal.
+        """
+        person = PersonFactory(should_publish=True)
+        courses = CourseFactory.create_batch(
+            3, page_title="my title", fill_team=[person], should_publish=True
+        )
+        retrieved_courses = person.get_courses()
+
+        with self.assertNumQueries(2):
+            self.assertEqual(set(retrieved_courses), set(courses))
+
+        with self.assertNumQueries(0):
+            for course in retrieved_courses:
+                self.assertEqual(
+                    course.extended_object.prefetched_titles[0].title, "my title"
+                )
+
+    def test_models_person_get_courses_public_person_page(self):
+        """
+        When a person is added on a draft course, the course should not be visible on
+        the public person page until the course is published.
+        """
+        person = PersonFactory(should_publish=True)
+        person_page = person.extended_object
+        course = CourseFactory(page_title="my title", should_publish=True)
+        course_page = course.extended_object
+
+        # Add a person to the course but don't publish the modification
+        placeholder = course_page.placeholders.get(slot="course_team")
+        add_plugin(placeholder, PersonPlugin, "en", page=person_page)
+
+        self.assertEqual(list(person.get_courses()), [course])
+        self.assertEqual(list(person.public_extension.get_courses()), [])
+
+        # Now publish the modification and check that the course is displayed
+        # on the public person page
+        course.extended_object.publish("en")
+        self.assertEqual(
+            list(person.public_extension.get_courses()), [course.public_extension]
+        )
+
+    def test_models_person_get_courses_several_languages(self):
+        """
+        The courses should not be duplicated if they exist in several languages.
+        """
+        person = PersonFactory(should_publish=True)
+        CourseFactory(
+            page_title={"en": "my title", "fr": "mon titre"},
+            fill_team=[person],
+            should_publish=True,
+        )
+        self.assertEqual(Course.objects.count(), 2)
+        self.assertEqual(person.get_courses().count(), 1)
+
+    def test_models_person_get_courses_snapshots(self):
+        """
+        Snapshot courses should be excluded from the list of courses returned.
+        The new filter query we added to exclude snapshots should not create duplicates.
+        Indeed, we had to add a "distinct" clause to the query so this test enforces it.
+        """
+        # We create a root page because it was responsible for duplicate results when the
+        # distinct clause is not applied.
+        # This is because of the clause "extended_object__node__parent__cms_pages__..."
+        # which is there to exclude snapshots but also acts on the main course page and
+        # checks its parent (so the root page) and the duplicate comes from the fact that
+        # the parent has a draft and a public page... so "cms_pages" has a cardinality of 2
+        root_page = create_i18n_page(published=True)
+
+        person = PersonFactory(should_publish=True)
+        course = CourseFactory(
+            page_parent=root_page, fill_team=[person], should_publish=True
+        )
+        CourseFactory(
+            page_parent=course.extended_object, fill_team=[person], should_publish=True
+        )
+
+        self.assertEqual(Course.objects.count(), 4)
+        self.assertEqual(person.get_courses().count(), 1)
+        self.assertEqual(person.public_extension.get_courses().count(), 1)
+

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -7,6 +7,7 @@ from cms.test_utils.testcases import CMSTestCase
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.cms_plugins import CategoryPlugin
 from richie.apps.courses.factories import (
+    BlogPostFactory,
     CategoryFactory,
     CourseFactory,
     PersonFactory,
@@ -167,3 +168,24 @@ class PersonCMSTestCase(CMSTestCase):
             html=True,
         )
 
+    def test_templates_person_detail_related_blog_posts(self):
+        """
+        The blog posts written by a person should appear on this person's detail page.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        person = PersonFactory()
+        blog_post = BlogPostFactory(fill_author=[person])
+
+        url = person.extended_object.get_absolute_url()
+        response = self.client.get(url)
+
+        # The blog post should be present on the page
+        self.assertContains(
+            response,
+            '<p class="blogpost-glimpse__content__title">{:s}</p>'.format(
+                blog_post.extended_object.get_title()
+            ),
+            html=True,
+        )

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -6,7 +6,11 @@ from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.cms_plugins import CategoryPlugin
-from richie.apps.courses.factories import CategoryFactory, PersonFactory
+from richie.apps.courses.factories import (
+    CategoryFactory,
+    CourseFactory,
+    PersonFactory,
+)
 
 
 class PersonCMSTestCase(CMSTestCase):
@@ -140,3 +144,26 @@ class PersonCMSTestCase(CMSTestCase):
         )
         # The modified draft version of the published category should not be visible
         self.assertNotContains(response, "modified title")
+
+    def test_templates_person_detail_related_courses(self):
+        """
+        The courses to which a person has participated should appear on this person's detail page.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        person = PersonFactory()
+        course = CourseFactory(fill_team=[person])
+
+        url = person.extended_object.get_absolute_url()
+        response = self.client.get(url)
+
+        # The course should be present on the page
+        self.assertContains(
+            response,
+            '<p class="course-glimpse__content__title">{:s}</p>'.format(
+                course.extended_object.get_title()
+            ),
+            html=True,
+        )
+


### PR DESCRIPTION
## Purpose

We want to show more information on the person detail page : blog posts s.he authored, courses to which s.he participated...

## Proposal

- [x] Add a utility method `get_courses` on the person model to retrieve the related courses,
- [x] Add a `Courses` section on the person detail page,
- [x] Add a utility method `get_blogposts` on the person model to retrieve the related blogposts,
- [x] Add a `Blog posts` section on the person detail page.
