### PR TITLE
♻️(persons) link persons to organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Show related persons on the organization detail page (a person is related to
-  an organization if s.he is in the team of a course of this organization),
+- Add organizations to a person via plugins on the person detail page,
+- Show related persons on the organization detail page,
 - On a person detail page, show courses to which s.he participated and
   blogposts s.he authored.
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -395,6 +395,10 @@ class Base(DRFMixin, Configuration):
             "plugins": ["CKEditorPlugin"],
             "limits": {"CKEditorPlugin": 1},
         },
+        "courses/cms/person_detail.html organizations": {
+            "name": _("Organizations"),
+            "plugins": ["OrganizationPlugin"],
+        },
         # Blog page detail
         "courses/cms/blogpost_detail.html author": {
             "name": _("Author"),

--- a/src/frontend/scss/objects/_organization_glimpses.scss
+++ b/src/frontend/scss/objects/_organization_glimpses.scss
@@ -1,7 +1,9 @@
 // Overridable & namespaced global variables
-$richie-org-glimpse-title-margin: 0 !default;
-$richie-org-glimpse-title-padding: 1rem !default;
-$richie-org-glimpse-title-textalign: center !default;
+$richie-org-glimpse-list-maxwidth-constraint: true !default;
+$richie-org-glimpse-list-margin: 0 auto !default;
+$richie-org-glimpse-list-padding: 1rem 0 !default;
+$richie-org-glimpse-list-title-margin: null !default;
+$richie-org-glimpse-list-title-padding: 0.5rem !default;
 
 $richie-org-glimpse-content-margin: 0 auto !default;
 $richie-org-glimpse-content-padding: 1rem 0 !default;
@@ -15,31 +17,35 @@ $richie-org-glimpse-item-border-radius: 0.25rem !default;
 
 $richie-org-glimpse-item-title-fontsize: 0.81rem !default;
 $richie-org-glimpse-item-title-fontcolor: $black !default;
-$richie-org-glimpse-item-title-textalign: center !default;
+$richie-org-glimpse-item-title-textalign: left !default;
 
 $richie-org-glimpse-item-empty-fontcolor: $gray40 !default;
-$richie-org-glimpse-item-empty-textalign: center !default;
+$richie-org-glimpse-item-empty-textalign: left !default;
 
 .organization-glimpse-list {
-  @include make-container();
-  @include make-container-max-widths();
-  padding-bottom: 1rem;
-  background: $richie-content-container-bg;
+  @if $richie-org-glimpse-list-maxwidth-constraint {
+    @include make-container-max-widths();
+  }
+  display: flex;
+  margin: $richie-org-glimpse-list-margin;
+  padding: $richie-org-glimpse-list-padding;
+  flex-direction: row;
+  flex-wrap: wrap;
 
   &__title {
-    margin: $richie-org-glimpse-title-margin;
-    padding: $richie-org-glimpse-title-padding;
-    text-align: $richie-org-glimpse-title-textalign;
+    @include sv-flex(1, 0, 100%);
+    margin: $richie-org-glimpse-list-title-margin;
+    padding: $richie-org-glimpse-list-title-padding;
   }
 
-  &__content {
-    &__item {
-      display: flex;
-      margin: $richie-org-glimpse-content-margin;
-      padding: $richie-org-glimpse-content-padding;
-      flex-direction: row;
-      flex-wrap: wrap;
-    }
+  // Special row when there is no entry
+  &__empty {
+    @include sv-flex(1, 0, auto);
+    font-style: italic;
+    padding: $richie-org-glimpse-list-title-padding;
+    color: $richie-org-glimpse-item-empty-fontcolor;
+    text-align: $richie-org-glimpse-item-empty-textalign;
+    background: transparent;
   }
 }
 
@@ -90,13 +96,5 @@ $richie-org-glimpse-item-empty-textalign: center !default;
     border: $richie-org-glimpse-item-border-hover;
     color: $richie-org-glimpse-item-title-fontcolor;
     cursor: pointer;
-  }
-
-  &--empty {
-    @include sv-flex(1, 0, 100%);
-    font-style: italic;
-    color: $richie-org-glimpse-item-empty-fontcolor;
-    text-align: $richie-org-glimpse-item-empty-textalign;
-    background: transparent;
   }
 }

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -761,3 +761,24 @@ class PersonFactory(PageExtensionDjangoModelFactory):
                 nb_paragraphs=1,
                 languages=self.extended_object.get_languages(),
             )
+
+    @factory.post_generation
+    # pylint: disable=unused-argument
+    def fill_organizations(self, create, extracted, **kwargs):
+        """
+        Add organizations plugin to person from a given list of organization instances.
+        """
+
+        if create and extracted:
+            for language in self.extended_object.get_languages():
+                placeholder = self.extended_object.placeholders.get(
+                    slot="organizations"
+                )
+
+                for organization in extracted:
+                    add_plugin(
+                        language=language,
+                        placeholder=placeholder,
+                        plugin_type="OrganizationPlugin",
+                        **{"page": organization.extended_object},
+                    )

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -121,25 +121,19 @@ class Organization(BasePageExtension):
 
     def get_persons(self, language=None):
         """
-        Return a query to get the persons related to this organization.
+        Return a query to get the persons related to this organization ie for which a plugin for
+        this organization is linked to the person page on the "organizations" placeholder.
         """
         is_draft = self.extended_object.publisher_is_draft
         organization = self if is_draft else self.draft_extension
         language = language or translation.get_language()
 
-        sel = "" if is_draft else "draft_extension__"
-        bfs_person = (
-            f"{sel:s}extended_object__person_plugins__cmsplugin_ptr__placeholder__page"
-        )
-        bfs_organization = (
-            "placeholders__cmsplugin__courses_organizationpluginmodel__page"
-        )
+        bfs = "extended_object__placeholders__cmsplugin__courses_organizationpluginmodel__page"
         filter_dict = {
             "extended_object__publisher_is_draft": is_draft,
-            f"{bfs_person:s}__course__isnull": False,
-            f"{bfs_person:s}__publisher_is_draft": is_draft,
-            f"{bfs_person:s}__placeholders__slot": "course_organizations",
-            f"{bfs_person:s}__{bfs_organization:s}": organization.extended_object,
+            "extended_object__placeholders__slot": "organizations",
+            "extended_object__placeholders__cmsplugin__language": language,
+            bfs: organization.extended_object,
         }
 
         person_model = apps.get_model(app_label="courses", model_name="person")

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
@@ -1,7 +1,7 @@
 {% load i18n cms_tags %}
 {% comment %}Obviously, the context template variable "organization" is required and must be an Organization page extension{% endcomment %}
 {% with organization_page=organization.extended_object %}
-<a class="organization-glimpse organization-glimpse--link{% if organization_page.publisher_is_draft is True %} organization-glimpse--draft{% endif %}" href="{{ organization_page.get_absolute_url }}" title="{{ organization_page.get_title }}" alt="{{ organization_page.get_title }} {% trans 'logo' %}">
+<a class="organization-glimpse organization-glimpse--link{% if organization_page.publisher_is_draft is True %} organization-glimpse--draft{% endif %}" href="{{ organization_page.get_absolute_url }}" title="{{ organization_page.get_title }}">
   <div class="organization-glimpse__logo">
     {% show_placeholder "logo" organization_page as logo %}
       {% if logo %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -39,6 +39,17 @@
     </div>
   </div>
 
+  {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"organizations" %}
+  <div class="organization-glimpse-list">
+    <h2 class="organization-glimpse-list__title">{% trans "Organizations" %}</h2>
+    {% placeholder "organizations" or %}
+      <p class="organization-glimpse-list__empty">
+        {% trans "No associated organizations" %}
+      </p>
+    {% endplaceholder %}
+  </div>
+  {% endif %}
+
   {% with courses=person.get_courses %}
     {% if courses %}
       <div class="course-glimpse-list">

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -134,15 +134,14 @@ class OrganizationCMSTestCase(CMSTestCase):
 
     def test_templates_organization_detail_related_persons(self):
         """
-        Persons related to an organization via a course team should appear on the organization
+        Persons related to an organization via a plugin should appear on the organization
         detail page.
         """
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
         organization = OrganizationFactory()
-        person = PersonFactory()
-        CourseFactory(fill_organizations=[organization], fill_team=[person])
+        person = PersonFactory(fill_organizations=[organization])
         page = organization.extended_object
 
         url = page.get_absolute_url()


### PR DESCRIPTION
## Purpose

Last week, we displayed the link between a person and an organization via their presence on a course. The problem is that a course is linked to several organizations and several persons and we are not able to differentiate which persons belong to which organization. 

## Proposal

- [x] Add a placeholder `organizations` on the person detail page,
- [x] Replace the utility method `get_persons` on the organization model to retrieve related persons from the new placeholder plugins,
- [x] Add tests and modify existing tests.
