### PR TITLE
🚸(search) prevent search filters from jumping around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Search as the user types in the course search field. This replaces
-  autosuggest in course names with a full index search.
+  autosuggest in course names with a full index search,
+- Prevent search filters from jumping around by displaying facets with zero
+  results as disabled,
 - Improve demo dataset by assigning each person to an organization,
 - Use checkboxes to enable/disable filters in search page,
 - Improve autosuggest tests to increase reliability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Search as the user types in the course search field. This replaces
   autosuggest in course names with a full index search,
 - Prevent search filters from jumping around by displaying facets with zero
-  results as disabled,
+  results as disabled and always reserving the space for the "Clear filters"
+  button,
 - Improve demo dataset by assigning each person to an organization,
 - Use checkboxes to enable/disable filters in search page,
 - Improve autosuggest tests to increase reliability.

--- a/src/frontend/js/components/SearchFilterValueLeaf/SearchFilterValueLeaf.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/SearchFilterValueLeaf.spec.tsx
@@ -74,6 +74,40 @@ describe('components/SearchFilterValueLeaf', () => {
     expect(checkbox.parentElement).toHaveClass('active'); // label that contains checkbox
   });
 
+  it('disables the value when its count is 0', () => {
+    const { getByLabelText } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[{ limit: '999', offset: '0' }, jest.fn()]}
+        >
+          <SearchFilterValueLeaf
+            filter={{
+              base_path: null,
+              human_name: 'Filter name',
+              name: 'filter_name',
+              values: [],
+            }}
+            value={{
+              count: 0,
+              human_name: 'Human name',
+              key: '42',
+            }}
+          />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    // The filter shows its active state
+    const checkbox = getByLabelText((content, _) =>
+      content.includes('Human name'),
+    );
+    expect(checkbox).not.toHaveAttribute('checked');
+    expect(checkbox).toHaveAttribute('disabled');
+    expect(checkbox.parentElement).toHaveClass(
+      'search-filter-value-leaf--disabled',
+    );
+  });
+
   it('dispatches a FILTER_ADD action on filter click if it was not active', () => {
     const dispatchCourseSearchParamsUpdate = jest.fn();
     const { getByLabelText } = render(

--- a/src/frontend/js/components/SearchFilterValueLeaf/SearchFilterValueLeaf.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/SearchFilterValueLeaf.tsx
@@ -15,10 +15,15 @@ export const SearchFilterValueLeaf = ({
   const [isActive, toggle] = useFilterValue(filter, value);
 
   return (
-    <label className={`search-filter-value-leaf ${isActive ? 'active' : ''}`}>
+    <label
+      className={`search-filter-value-leaf ${isActive ? 'active' : ''} ${
+        value.count === 0 ? 'search-filter-value-leaf--disabled' : ''
+      }`}
+    >
       <input
         checked={isActive}
         className="search-filter-value-leaf__checkbox"
+        disabled={value.count === 0}
         onChange={toggle}
         type="checkbox"
       />

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
@@ -244,6 +244,39 @@ describe('<SearchFilterValueParent />', () => {
     expect(checkbox!.parentElement!.parentElement).not.toHaveClass('active'); // parent self filter
   });
 
+  it('disables the parent value when its count is 0', () => {
+    const { getByLabelText } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[{ limit: '999', offset: '0' }, jest.fn()]}
+        >
+          <SearchFilterValueParent
+            filter={{
+              base_path: '0009',
+              human_name: 'Filter name',
+              name: 'filter_name',
+              values: [],
+            }}
+            value={{
+              count: 0,
+              human_name: 'Human name',
+              key: 'P-00040005',
+            }}
+          />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    // The filter shows its active state
+    const checkbox = getByLabelText((content, _) =>
+      content.includes('Human name'),
+    );
+    expect(checkbox).not.toHaveAttribute('checked');
+    expect(checkbox).toHaveAttribute('disabled');
+    expect(checkbox.parentElement).toHaveClass(
+      'search-filter-value-parent__self__label--disabled',
+    );
+  });
   it('shows the parent filter value itself as active when it is in the search params', () => {
     const { getByLabelText } = render(
       <IntlProvider locale="en">

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
@@ -93,10 +93,17 @@ export const SearchFilterValueParent = injectIntl(
             isActive ? 'active' : ''
           }`}
         >
-          <label className={`search-filter-value-parent__self__label`}>
+          <label
+            className={`search-filter-value-parent__self__label ${
+              value.count === 0
+                ? 'search-filter-value-parent__self__label--disabled'
+                : ''
+            }`}
+          >
             <input
               checked={isActive}
               className="search-filter-value-parent__self__label__checkbox"
+              disabled={value.count === 0}
               onChange={toggle}
               type="checkbox"
             />

--- a/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.spec.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.spec.tsx
@@ -17,7 +17,7 @@ describe('components/SearchFiltersPane', () => {
   afterEach(cleanup);
 
   it('renders all our search filter groups', () => {
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <IntlProvider locale="en">
         <CourseSearchParamsContext.Provider
           value={[{ limit: '999', offset: '0' }, jest.fn()]}
@@ -46,7 +46,9 @@ describe('components/SearchFiltersPane', () => {
     getByText('Filter courses');
     getByText('Received filter title: Categories');
     getByText('Received filter title: Organizations');
-    expect(queryByText('Clear 0 active filters')).toEqual(null);
+    expect(getByText('Clear 0 active filters').parentElement).toHaveClass(
+      'search-filters-pane__clear--hidden',
+    );
   });
 
   it('still renders with its title when it is not passed anything', () => {
@@ -98,6 +100,10 @@ describe('components/SearchFiltersPane', () => {
     );
 
     const clearButton = getByText('Clear 2 active filters');
+    expect(getByText('Clear 2 active filters').parentElement).not.toHaveClass(
+      'search-filters-pane__clear--hidden',
+    );
+
     fireEvent.click(clearButton);
     expect(mockDispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
       type: 'FILTER_RESET',

--- a/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.tsx
@@ -53,20 +53,20 @@ export const SearchFiltersPane = ({ filters }: SearchFiltersPaneProps) => {
       <h2 className="search-filters-pane__title">
         <FormattedMessage {...messages.filter} />
       </h2>
-      {activeFilterCount ? (
-        <a
-          className="search-filters-pane__clear"
-          tabIndex={0}
-          onClick={() =>
-            dispatchCourseSearchParamsUpdate({ type: 'FILTER_RESET' })
-          }
-        >
-          <FormattedMessage
-            {...messages.clearFilters}
-            values={{ activeFilterCount }}
-          />
-        </a>
-      ) : null}
+      <a
+        className={`search-filters-pane__clear ${
+          !activeFilterCount ? 'search-filters-pane__clear--hidden' : ''
+        }`}
+        tabIndex={0}
+        onClick={() =>
+          dispatchCourseSearchParamsUpdate({ type: 'FILTER_RESET' })
+        }
+      >
+        <FormattedMessage
+          {...messages.clearFilters}
+          values={{ activeFilterCount }}
+        />
+      </a>
       {filterList &&
         filterList.map(filter => (
           <SearchFilterGroup filter={filter} key={filter.name} />

--- a/src/frontend/js/components/SearchFiltersPane/_SearchFiltersPane.scss
+++ b/src/frontend/js/components/SearchFiltersPane/_SearchFiltersPane.scss
@@ -35,5 +35,9 @@ $richie-search-filters-pane-clear-padding: 0rem 0.5rem 0 !default;
     &:active {
       color: $richie-search-filters-pane-clear-color;
     }
+
+    &--hidden {
+      visibility: hidden;
+    }
   }
 }

--- a/src/frontend/scss/objects/_search-filter-value.scss
+++ b/src/frontend/scss/objects/_search-filter-value.scss
@@ -23,6 +23,13 @@ $richie-search-filter-value-active-divider-border: 1px solid $white !default;
     color: $richie-search-filter-value-fontcolor-hover;
   }
 
+  &--disabled,
+  &--disabled:hover,
+  &--disabled:focus {
+    color: rgba(255, 255, 255, 0.6);
+    cursor: not-allowed;
+  }
+
   &__checkbox {
     align-self: start;
     margin-right: 0.5rem;

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -51,10 +51,11 @@ FILTERS_CONFIGURATION = [
     (
         "richie.apps.search.filter_definitions.StaticChoicesFilterDefinition",
         {
-            "name": "new",
-            "human_name": _("New courses"),
-            "position": 0,
             "fragment_map": {"new": [{"term": {"is_new": True}}]},
+            "human_name": _("New courses"),
+            "min_doc_count": 0,
+            "name": "new",
+            "position": 0,
             "values": {"new": _("First session")},
         },
     ),
@@ -66,17 +67,21 @@ FILTERS_CONFIGURATION = [
                 (
                     "richie.apps.search.filter_definitions.AvailabilityFilterDefinition",
                     {
-                        "name": "availability",
                         "human_name": _("Availability"),
-                        "position": 1,
                         "is_drilldown": True,
+                        "min_doc_count": 0,
+                        "name": "availability",
+                        "position": 1,
                     },
                 ),
                 (
                     "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
                     {
-                        "name": "languages",
                         "human_name": _("Languages"),
+                        # There are too many available languages to show them all, all the time.
+                        # Eg. 200 languages, 190+ of which will have 0 matching courses.
+                        "min_doc_count": 1,
+                        "name": "languages",
                         "position": 5,
                         "sorting": "count",
                     },
@@ -87,8 +92,9 @@ FILTERS_CONFIGURATION = [
     (
         "richie.apps.search.filter_definitions.IndexableFilterDefinition",
         {
-            "name": "subjects",
             "human_name": _("Subjects"),
+            "min_doc_count": 0,
+            "name": "subjects",
             "position": 2,
             "reverse_id": "subjects",
             "term": "categories",
@@ -97,8 +103,9 @@ FILTERS_CONFIGURATION = [
     (
         "richie.apps.search.filter_definitions.IndexableFilterDefinition",
         {
-            "name": "levels",
             "human_name": _("Levels"),
+            "min_doc_count": 0,
+            "name": "levels",
             "position": 3,
             "reverse_id": "levels",
             "term": "categories",
@@ -107,8 +114,9 @@ FILTERS_CONFIGURATION = [
     (
         "richie.apps.search.filter_definitions.IndexableFilterDefinition",
         {
-            "name": "organizations",
             "human_name": _("Organizations"),
+            "min_doc_count": 0,
+            "name": "organizations",
             "position": 4,
             "reverse_id": "organizations",
         },

--- a/src/richie/apps/search/filter_definitions/base.py
+++ b/src/richie/apps/search/filter_definitions/base.py
@@ -208,7 +208,7 @@ class BaseChoicesFilterDefinition(BaseFilterDefinition):
             key.split("@")[1]: facet["doc_count"]
             for key, facet in facets.items()
             if "{:s}@".format(self.name) in key  # 6 times faster than startswith
-            and facet["doc_count"] > self.min_doc_count
+            and facet["doc_count"] >= self.min_doc_count
         }
 
         # Sort facets as requested

--- a/src/richie/apps/search/filter_definitions/mixins.py
+++ b/src/richie/apps/search/filter_definitions/mixins.py
@@ -53,7 +53,13 @@ class TermsAggsMixin:
             self.name: {
                 # Rely on the built-in "terms" aggregation to get everything we need
                 "aggregations": {
-                    self.name: {"terms": {"field": self.term, "include": include}}
+                    self.name: {
+                        "terms": {
+                            "field": self.term,
+                            "include": include,
+                            "min_doc_count": self.min_doc_count,
+                        }
+                    }
                 },
                 # Use all the query fragments from the queries *but* the one(s) that
                 # filter on the current filter, as it is handled by ElasticSearch for us

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -674,6 +674,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 {"count": 2, "human_name": "#P-00010001", "key": "P-00010001"},
                 {"count": 1, "human_name": "#P-00010002", "key": "P-00010002"},
                 {"count": 1, "human_name": "#P-00010003", "key": "P-00010003"},
+                {"count": 0, "human_name": "#P-00010004", "key": "P-00010004"},
             ],
         )
         self.assertEqual(
@@ -681,6 +682,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             [
                 {"count": 1, "human_name": "#L-00020001", "key": "L-00020001"},
                 {"count": 1, "human_name": "#L-00020003", "key": "L-00020003"},
+                {"count": 0, "human_name": "#L-00020002", "key": "L-00020002"},
             ],
         )
         self.assertEqual(
@@ -689,6 +691,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 {"count": 2, "human_name": "#P-00030001", "key": "P-00030001"},
                 {"count": 1, "human_name": "#P-00030003", "key": "P-00030003"},
                 {"count": 1, "human_name": "#P-00030004", "key": "P-00030004"},
+                {"count": 0, "human_name": "#P-00030002", "key": "P-00030002"},
             ],
         )
 
@@ -785,6 +788,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 {"count": 1, "human_name": "Open for enrollment", "key": "open"},
                 {"count": 1, "human_name": "Coming soon", "key": "coming_soon"},
                 {"count": 2, "human_name": "On-going", "key": "ongoing"},
+                {"count": 0, "human_name": "Archived", "key": "archived"},
             ],
         )
         # A, D and F course runs are in French
@@ -803,6 +807,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             [
                 {"count": 2, "human_name": "#L-00020001", "key": "L-00020001"},
                 {"count": 1, "human_name": "#L-00020002", "key": "L-00020002"},
+                {"count": 0, "human_name": "#L-00020003", "key": "L-00020003"},
             ],
         )
         self.assertEqual(
@@ -893,6 +898,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 {"count": 2, "human_name": "#P-00010002", "key": "P-00010002"},
                 {"count": 1, "human_name": "#P-00010001", "key": "P-00010001"},
                 {"count": 1, "human_name": "#P-00010004", "key": "P-00010004"},
+                {"count": 0, "human_name": "#P-00010003", "key": "P-00010003"},
             ],
         )
         self.assertEqual(
@@ -900,6 +906,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             [
                 {"count": 1, "human_name": "#L-00020001", "key": "L-00020001"},
                 {"count": 1, "human_name": "#L-00020002", "key": "L-00020002"},
+                {"count": 0, "human_name": "#L-00020003", "key": "L-00020003"},
             ],
         )
         self.assertEqual(
@@ -908,6 +915,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 {"count": 2, "human_name": "#P-00030004", "key": "P-00030004"},
                 {"count": 1, "human_name": "#P-00030001", "key": "P-00030001"},
                 {"count": 1, "human_name": "#P-00030002", "key": "P-00030002"},
+                {"count": 0, "human_name": "#P-00030003", "key": "P-00030003"},
             ],
         )
 


### PR DESCRIPTION
## Purpose

The number of facets displayed varies each time a new filter or query is applied because we only display facets that have some results. 

## Proposal

In order to prevent this annoying effect, we can display all facets and disable those that have zero results.

- [x] Make minimum document count configurable on term facets and don't exclude facets with zero results,
- [x] Stop excluding facets with zero results from choice facets (they are configurable as well...),
- [x] Display facets with zero results as disabled,
- [x] Reserve vertical space for the "Disable all active filters" link, even when it is hidden.

Fixes https://github.com/openfun/richie/issues/663
