### PR TITLE
Live search when the user is typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Search as the user types in the course search field. This replaces
+  autosuggest in course names with a full index search.
 - Improve demo dataset by assigning each person to an organization,
 - Use checkboxes to enable/disable filters in search page,
 - Improve autosuggest tests to increase reliability.

--- a/src/frontend/js/types/searchSuggest.ts
+++ b/src/frontend/js/types/searchSuggest.ts
@@ -51,7 +51,10 @@ export interface DefaultSuggestion {
 /**
  * Any search suggestion, whether resource based or the default one.
  */
-export type SearchSuggestion = ResourceSuggestion | DefaultSuggestion;
+export type SearchSuggestion =
+  | OrganizationSuggestion
+  | CategorySuggestion
+  | DefaultSuggestion;
 
 /**
  * The base shape of a search suggestion section. Contains a bunch of suggestions and a title.
@@ -107,5 +110,6 @@ export interface DefaultSuggestionSection {
  * Any search suggestion section, whether resource based or the default one.
  */
 export type SearchSuggestionSection =
-  | ResourceSuggestionSection
+  | OrganizationSuggestionSection
+  | CategorySuggestionSection
   | DefaultSuggestionSection;

--- a/src/frontend/js/utils/searchSuggest/getSuggestionsSection.ts
+++ b/src/frontend/js/utils/searchSuggest/getSuggestionsSection.ts
@@ -3,7 +3,10 @@ import { stringify } from 'query-string';
 import { FormattedMessage } from 'react-intl';
 
 import { API_ENDPOINTS } from '../../settings';
-import { Resource } from '../../types/Resource';
+import { CategoryForSuggestion } from '../../types/Category';
+import { CourseForSuggestion } from '../../types/Course';
+import { modelName } from '../../types/models';
+import { OrganizationForSuggestion } from '../../types/Organization';
 import { ResourceSuggestionSection } from '../../types/searchSuggest';
 import { handle } from '../../utils/errors/handle';
 
@@ -47,7 +50,15 @@ export const getSuggestionsSection = async (
     );
   }
 
-  let data: Resource[];
+  let data: Array<
+    typeof sectionModel extends modelName.CATEGORIES
+      ? CategoryForSuggestion
+      : typeof sectionModel extends modelName.COURSES
+      ? CourseForSuggestion
+      : typeof sectionModel extends modelName.ORGANIZATIONS
+      ? OrganizationForSuggestion
+      : unknown
+  >;
   try {
     data = await response.json();
   } catch (error) {

--- a/src/frontend/js/utils/searchSuggest/suggestionsFromSection.ts
+++ b/src/frontend/js/utils/searchSuggest/suggestionsFromSection.ts
@@ -3,14 +3,13 @@ import {
   DefaultSuggestionSection,
   ResourceSuggestion,
   ResourceSuggestionSection,
-  SearchSuggestionSection,
 } from '../../types/searchSuggest';
 
 /**
  *  Type guard. Determines the kind of section to pick the correct suggestions extractor.
  */
 function isResourceSection(
-  section: SearchSuggestionSection,
+  section: ResourceSuggestionSection | DefaultSuggestionSection,
 ): section is ResourceSuggestionSection {
   return !!section.model;
 }
@@ -66,7 +65,9 @@ function suggestionsFromResourceSection(
  * @param section The search suggestion section we need to extract the suggestions from.
  * @returns An array containing the suggestions themselves.
  */
-export function suggestionsFromSection(section: SearchSuggestionSection) {
+export function suggestionsFromSection(
+  section: ResourceSuggestionSection | DefaultSuggestionSection,
+) {
   if (isResourceSection(section)) {
     return suggestionsFromResourceSection(section);
   }


### PR DESCRIPTION
## Purpose

Instead of offering autocomplete-based suggestions, we can offer users a more intuitive and faster experience by directly querying the search index itself with their query as they are typing.

## Proposal

This is what we're enabling here. We can simply rely on our existing change handler for the input, the only differences being checking for the change method to only run a search when it comes from the user (not when they eg. hover a suggestion), and debouncing these requests to avoid overloading the server.

Closes #483 (by making it irrelevant).