### PR TITLE
Link persons to organizations in demo site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Link persons to a random set of organizations in the demo site,
 - Add organizations to a person via plugins on the person detail page,
 - Show related persons on the organization detail page,
 - On a person detail page, show courses to which s.he participated and

--- a/src/frontend/scss/objects/_organization_glimpses.scss
+++ b/src/frontend/scss/objects/_organization_glimpses.scss
@@ -17,7 +17,7 @@ $richie-org-glimpse-item-border-radius: 0.25rem !default;
 
 $richie-org-glimpse-item-title-fontsize: 0.81rem !default;
 $richie-org-glimpse-item-title-fontcolor: $black !default;
-$richie-org-glimpse-item-title-textalign: left !default;
+$richie-org-glimpse-item-title-textalign: center !default;
 
 $richie-org-glimpse-item-empty-fontcolor: $gray40 !default;
 $richie-org-glimpse-item-empty-textalign: left !default;

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -8,6 +8,7 @@ NB_OBJECTS = {
     "course_organizations": 3,
     "course_persons": 6,
     "course_subjects": 2,
+    "person_organizations": 3,
     "person_subjects": 3,
     "organizations": 5,
     "licences": 5,


### PR DESCRIPTION
## Purpose

Now that we can link persons to a set of organizations, we should demonstrate it on the demo site.

## Proposal

Randomly assign organizations to each person.
I paid attention to keep course teams coherent ie the persons in a course team should be linked to one of the organizations that linked to the course.

Fixes https://github.com/openfun/richie/issues/456