### PR TITLE
Show results count in course search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add organizations to a person via plugins on the person detail page,
 - Show related persons on the organization detail page,
 - On a person detail page, show courses to which s.he participated and
-  blogposts s.he authored.
+  blogposts s.he authored,
+- Show results count in the course search results list.
 
 ### Changed
 

--- a/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.spec.tsx
@@ -23,14 +23,36 @@ describe('components/CourseGlimpseList', () => {
         title: 'Course 45',
       },
     ] as Course[];
-    const { getByText } = render(
+    const { getAllByText, getByText } = render(
       <IntlProvider locale="en">
-        <CourseGlimpseList courses={courses} />
+        <CourseGlimpseList
+          courses={courses}
+          meta={{ limit: 20, offset: 0, total_count: 5 }}
+        />
       </IntlProvider>,
     );
 
+    expect(
+      getAllByText('Showing 5 courses matching your search').length,
+    ).toEqual(1);
     // Both courses' titles are shown
     getByText('Course 44');
     getByText('Course 45');
+  });
+
+  it('shows the count twice if there are more than 8 courses to show', () => {
+    const courses = [] as Course[];
+    const { getAllByText } = render(
+      <IntlProvider locale="en">
+        <CourseGlimpseList
+          courses={courses}
+          meta={{ limit: 20, offset: 0, total_count: 42 }}
+        />
+      </IntlProvider>,
+    );
+
+    expect(
+      getAllByText('Showing 42 courses matching your search').length,
+    ).toEqual(2);
   });
 });

--- a/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.tsx
@@ -1,18 +1,48 @@
 import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
+import { APIResponseListMeta } from '../../types/api';
 import { Course } from '../../types/Course';
 import { CourseGlimpse } from '../CourseGlimpse/CourseGlimpse';
 
+const messages = defineMessages({
+  courseCount: {
+    defaultMessage:
+      'Showing {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search',
+    description:
+      'Result count for course search. Appears right above search results',
+    id: 'components.CourseGlimpseList.courseCount',
+  },
+});
+
 interface CourseGlimpseListProps {
   courses: Course[];
+  meta: APIResponseListMeta;
 }
 
-export const CourseGlimpseList = ({ courses }: CourseGlimpseListProps) => {
+export const CourseGlimpseList = ({
+  courses,
+  meta,
+}: CourseGlimpseListProps) => {
   return (
     <div className="course-glimpse-list">
+      <div className="course-glimpse-list__count">
+        <FormattedMessage
+          {...messages.courseCount}
+          values={{ courseCount: meta.total_count }}
+        />
+      </div>
       {courses.map(
         course => course && <CourseGlimpse course={course} key={course.id} />,
       )}
+      {meta.total_count > 8 ? (
+        <div className="course-glimpse-list__count">
+          <FormattedMessage
+            {...messages.courseCount}
+            values={{ courseCount: meta.total_count }}
+          />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/frontend/js/components/Search/Search.tsx
+++ b/src/frontend/js/components/Search/Search.tsx
@@ -36,7 +36,10 @@ export const Search = () => {
             <SearchSuggestField
               filters={courseSearchResponse.content.filters}
             />
-            <CourseGlimpseList courses={courseSearchResponse.content.objects} />{' '}
+            <CourseGlimpseList
+              courses={courseSearchResponse.content.objects}
+              meta={courseSearchResponse.content.meta}
+            />{' '}
           </div>
         ) : (
           <SearchLoader />

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -5,7 +5,7 @@
 // Available object settings
 $richie-course-glimpse-list-maxwidth-constraint: true !default;
 $richie-course-glimpse-list-margin: 0 auto !default;
-$richie-course-glimpse-list-padding: 1rem 0 !default;
+$richie-course-glimpse-list-vertical-padding: 1rem !default;
 $richie-course-glimpse-list-title-margin: null !default;
 $richie-course-glimpse-list-title-padding: 0.5rem !default;
 
@@ -66,7 +66,8 @@ $richie-course-glimpse-foot-cta-background-hover: $firebrick6 !default;
   }
   display: flex;
   margin: $richie-course-glimpse-list-margin;
-  padding: $richie-course-glimpse-list-padding;
+  padding-top: $richie-course-glimpse-list-vertical-padding;
+  padding-bottom: $richie-course-glimpse-list-vertical-padding;
   flex-direction: row;
   flex-wrap: wrap;
 
@@ -74,6 +75,15 @@ $richie-course-glimpse-foot-cta-background-hover: $firebrick6 !default;
     @include sv-flex(1, 0, 100%);
     margin: $richie-course-glimpse-list-title-margin;
     padding: $richie-course-glimpse-list-title-padding;
+  }
+
+  &__count {
+    flex-basis: 100%; // Should not wrap with actual course glimpses
+    margin-left: $richie-course-glimpse-container-gutter;
+
+    &:first-child {
+      margin-top: -$richie-course-glimpse-list-vertical-padding; // Cancel out top padding
+    }
   }
 }
 


### PR DESCRIPTION
## Purpose

We want to show the number of results a given combination of a text query (or none) and search filters returns.

## Proposal

We can simply show it at the top of the search results, and repeat it at the bottom if the list is long enough to warrant it.

Closes #455 