### PR TITLE
🔖(chore) bump release to 1.0.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0-beta.8] - 2019-04-24
+
 ### Added
 
 - Link persons to a random set of organizations in the demo site,
@@ -227,7 +229,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.0.0-beta.7...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.0.0-beta.8...master
+[1.0.0-beta.8]: https://github.com/openfun/richie/compare/v1.0.0-beta.7...v1.0.0-beta.8
 [1.0.0-beta.7]: https://github.com/openfun/richie/compare/v1.0.0-beta.6...v1.0.0-beta.7
 [1.0.0-beta.6]: https://github.com/openfun/richie/compare/v1.0.0-beta.5...v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/openfun/richie/compare/v1.0.0-beta.4...v1.0.0-beta.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.0.0-beta.7
+version = 1.0.0-beta.8
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {


### PR DESCRIPTION
Added

- Link persons to a random set of organizations in the demo site,
- Add organizations to a person via plugins on the person detail page,
- Show related persons on the organization detail page,
- On a person detail page, show courses to which s.he participated and
  blogposts s.he authored,
- Show results count in the course search results list.

Changed

- Search as the user types in the course search field. This replaces
  autosuggest in course names with a full index search,
- Prevent search filters from jumping around by displaying facets with zero
  results as disabled and always reserving the space for the "Clear filters"
  button,
- Improve demo dataset by assigning each person to an organization,
- Use checkboxes to enable/disable filters in search page,
- Improve autosuggest tests to increase reliability.

Fixed

- Use proper HTML elements for accessibility of search filter groups.
