### PR TITLE
Fix two issues related to incorrect handling of MPTT paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The language filter, which is not a drilldown filter, no longer behaves
   like one. Ditto for any future similar filters.
+- All children are now shown when a parent filter value is "opened", instead
+  of just the top 5 by facet count.
 
 ## [1.0.0-beta.8] - 2019-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The language filter, which is not a drilldown filter, no longer behaves
+  like one. Ditto for any future similar filters.
+
 ## [1.0.0-beta.8] - 2019-04-24
 
 ### Added

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
@@ -10,6 +10,7 @@ jest.mock('../../data/getResourceList/getResourceList', () => ({
 
 import { fetchList } from '../../data/getResourceList/getResourceList';
 import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
+import { modelName } from '../../types/models';
 import { jestMockOf } from '../../utils/types';
 import { SearchFilterValueParent } from './SearchFilterValueParent';
 
@@ -179,6 +180,13 @@ describe('<SearchFilterValueParent />', () => {
     getByLabelText((content, _) => content.includes('Modern Literature'));
 
     expect(mockFetchList).toHaveBeenCalledTimes(1);
+    expect(mockFetchList).toHaveBeenLastCalledWith(modelName.COURSES, {
+      limit: '999',
+      offset: '0',
+      scope: 'filters',
+      subjects: ['L-000400050004'],
+      subjects_include: '.-00040005.{4,}',
+    });
 
     fireEvent.click(getByLabelText('Hide child filters'));
 
@@ -195,13 +203,19 @@ describe('<SearchFilterValueParent />', () => {
     expect(
       queryByLabelText((content, _) => content.includes('Modern Literature')),
     ).toEqual(null);
-
     expect(mockFetchList).toHaveBeenCalledTimes(1);
 
     fireEvent.click(getByLabelText('Show child filters'));
 
     getByLabelText('Hide child filters');
     expect(mockFetchList).toHaveBeenCalledTimes(2);
+    expect(mockFetchList).toHaveBeenLastCalledWith(modelName.COURSES, {
+      limit: '999',
+      offset: '0',
+      scope: 'filters',
+      subjects: ['L-000400050004'],
+      subjects_include: '.-00040005.{4,}',
+    });
     expect(getByLabelText('Hide child filters')).toHaveAttribute(
       'aria-pressed',
       'true',

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
@@ -7,6 +7,7 @@ import { useFilterValue } from '../../data/useFilterValue/useFilterValue';
 import { requestStatus } from '../../types/api';
 import { FilterDefinition, FilterValue } from '../../types/filters';
 import { modelName } from '../../types/models';
+import { getMPTTChildrenPathMatcher } from '../../utils/mptt';
 import { useAsyncEffect } from '../../utils/useAsyncEffect';
 import { SearchFilterValueLeaf } from '../SearchFilterValueLeaf/SearchFilterValueLeaf';
 
@@ -51,7 +52,7 @@ export const SearchFilterValueParent = injectIntl(
     // path key convention.
     // If this parent filter has a key (path) `P-00040005`, all of its children will have with a matching
     // path such as `P-000400050001` or `L-000400050003`.
-    const childrenPathMatch = `.-${value.key.substr(2)}[0-9]+`;
+    const childrenPathMatch = getMPTTChildrenPathMatcher(value.key);
     const childrenPathMatchRegexp = new RegExp(childrenPathMatch);
     // Hide children by default, unless at least one of them is currently active
     const [showChildren, setShowChildren] = useState(

--- a/src/frontend/js/data/useCourseSearchParams/computeNewFilterValue.ts
+++ b/src/frontend/js/data/useCourseSearchParams/computeNewFilterValue.ts
@@ -1,12 +1,5 @@
+import { isMPTTChildOf, isMPTTParentOf } from '../../utils/mptt';
 import { Maybe } from '../../utils/types';
-
-// Use the pages' MPTT paths to determine if one is a parent of the other
-const isParentOf = (parentMPTTPath: string, childMPTTPath: string) =>
-  childMPTTPath.substr(2).startsWith(parentMPTTPath.substr(2));
-
-// Just reverse the arguments to make a utility `isChildOf` from `isParentOf`
-const isChildOf = (childMPTTPath: string, parentMPTTPath: string) =>
-  isParentOf(parentMPTTPath, childMPTTPath);
 
 // Compute a new value for a filter to apply to course search, reacting to a user interaction by
 // either adding a new filter or removing one
@@ -53,8 +46,8 @@ export const computeNewFilterValue = (
       FILTER_ADD: () =>
         existingValue === update.payload
           ? [existingValue]
-          : isParentOf(existingValue, update.payload) ||
-            isChildOf(existingValue, update.payload)
+          : isMPTTParentOf(existingValue, update.payload) ||
+            isMPTTChildOf(existingValue, update.payload)
           ? [update.payload]
           : [existingValue, update.payload],
       // REMOVE:
@@ -72,8 +65,8 @@ export const computeNewFilterValue = (
       ...existingValue.filter(
         value =>
           value !== update.payload &&
-          !isParentOf(value, update.payload) &&
-          !isChildOf(value, update.payload),
+          !isMPTTParentOf(value, update.payload) &&
+          !isMPTTChildOf(value, update.payload),
       ),
       update.payload,
     ],

--- a/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.spec.tsx
@@ -191,6 +191,45 @@ describe('data/useCourseSearchParams', () => {
       }
     });
 
+    it('adds to the existing list for non-MPTT-formatted filter value keys', () => {
+      mockWindow.location.search =
+        '?languages=en&languages=fr&offset=999&limit=0';
+      render(<TestComponent />);
+      {
+        const [courseSearchParams, dispatch] = getLatestHookValues();
+        expect(courseSearchParams).toEqual({
+          languages: ['en', 'fr'],
+          limit: '0',
+          offset: '999',
+        });
+
+        act(() =>
+          dispatch({
+            filter: {
+              is_drilldown: false,
+              name: 'languages',
+            },
+            payload: 'it',
+            type: 'FILTER_ADD',
+          }),
+        );
+      }
+      {
+        const [courseSearchParams] = getLatestHookValues();
+        expect(courseSearchParams).toEqual({
+          languages: ['en', 'fr', 'it'],
+          limit: '0',
+          offset: '999',
+        });
+        expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+        expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+          null,
+          '',
+          '?languages=en&languages=fr&languages=it&limit=0&offset=999',
+        );
+      }
+    });
+
     it('creates a list with the existing single value and the new value & updates history', () => {
       mockWindow.location.search =
         '?organizations=L-00010003&offset=999&limit=0';
@@ -226,6 +265,44 @@ describe('data/useCourseSearchParams', () => {
           null,
           '',
           '?limit=0&offset=999&organizations=L-00010003&organizations=L-00010017',
+        );
+      }
+    });
+
+    it('creates the new list for non-MPTT-formatted filter value keys', () => {
+      mockWindow.location.search = '?languages=de&offset=999&limit=0';
+      render(<TestComponent />);
+      {
+        const [courseSearchParams, dispatch] = getLatestHookValues();
+        expect(courseSearchParams).toEqual({
+          languages: 'de',
+          limit: '0',
+          offset: '999',
+        });
+
+        act(() =>
+          dispatch({
+            filter: {
+              is_drilldown: false,
+              name: 'languages',
+            },
+            payload: 'zh',
+            type: 'FILTER_ADD',
+          }),
+        );
+      }
+      {
+        const [courseSearchParams] = getLatestHookValues();
+        expect(courseSearchParams).toEqual({
+          languages: ['de', 'zh'],
+          limit: '0',
+          offset: '999',
+        });
+        expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+        expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+          null,
+          '',
+          '?languages=de&languages=zh&limit=0&offset=999',
         );
       }
     });

--- a/src/frontend/js/utils/mptt/index.spec.ts
+++ b/src/frontend/js/utils/mptt/index.spec.ts
@@ -1,0 +1,28 @@
+import { isMPTTParentOf } from '.';
+
+describe('utils/mptt', () => {
+  // NB: We're not testing isMPTTChildOf because it is logically the exact same function as `isMPTTParentOf`,
+  // with the arguments reversed, and is implemented this way.
+  describe('isMPTTParentOf()', () => {
+    it('returns false when any of the args is not an MPTT path', () => {
+      expect(isMPTTParentOf('en', 'fr')).toEqual(false);
+      expect(isMPTTParentOf('L-000300010004', 'fr')).toEqual(false);
+      expect(isMPTTParentOf('hello ther', 'P-000C00030009')).toEqual(false);
+      expect(isMPTTParentOf('L-000', 'P-000C00030009')).toEqual(false);
+    });
+
+    it('returns false when both args are MPTT paths but x is not a parent of y', () => {
+      expect(isMPTTParentOf('L-000300010004', 'P-000C00030009')).toEqual(false);
+      expect(isMPTTParentOf('P-0003', 'L-000C0003')).toEqual(false);
+      expect(isMPTTParentOf('P-00040001', 'L-00040002')).toEqual(false);
+      expect(isMPTTParentOf('L-000200040003', 'P-00020004')).toEqual(false); // y is a parent of x
+    });
+
+    it('returns true when both args are MPTT paths and x is a parent of y', () => {
+      expect(isMPTTParentOf('P-00020004', 'L-000200040003')).toEqual(true);
+      expect(isMPTTParentOf('P-00020004', 'L-000200040003000C0009')).toEqual(
+        true,
+      );
+    });
+  });
+});

--- a/src/frontend/js/utils/mptt/index.spec.ts
+++ b/src/frontend/js/utils/mptt/index.spec.ts
@@ -1,4 +1,4 @@
-import { isMPTTParentOf } from '.';
+import { getMPTTChildrenPathMatcher, isMPTTParentOf } from '.';
 
 describe('utils/mptt', () => {
   // NB: We're not testing isMPTTChildOf because it is logically the exact same function as `isMPTTParentOf`,
@@ -22,6 +22,23 @@ describe('utils/mptt', () => {
       expect(isMPTTParentOf('P-00020004', 'L-000200040003')).toEqual(true);
       expect(isMPTTParentOf('P-00020004', 'L-000200040003000C0009')).toEqual(
         true,
+      );
+    });
+  });
+
+  describe('getMPTTChildrenPathMatcher()', () => {
+    it('throws when the passed key is not an MPTT path', () => {
+      expect(() => getMPTTChildrenPathMatcher('en')).toThrow();
+      expect(() => getMPTTChildrenPathMatcher('L-000')).toThrow();
+    });
+
+    it('returns a regex-string that will match paths for children of the passed MPTT path entity', () => {
+      expect(getMPTTChildrenPathMatcher('P-0001')).toEqual('.-0001.{4,}');
+      expect(getMPTTChildrenPathMatcher('L-0001000C')).toEqual(
+        '.-0001000C.{4,}',
+      );
+      expect(getMPTTChildrenPathMatcher('P-000100090006000C')).toEqual(
+        '.-000100090006000C.{4,}',
       );
     });
   });

--- a/src/frontend/js/utils/mptt/index.ts
+++ b/src/frontend/js/utils/mptt/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Determine if a key looks close enough to an MPTT path that we can treat it like one.
+ * @param candidate The key to prop for MPTT-path-likeness.
+ */
+const isMPTTPath = (candidate: string) =>
+  candidate.length % 4 === 2 && !!candidate.match(/[P,L]-[0-9A-Z]{4,}/);
+
+/**
+ * Use entity MPTT paths to determine if one is a parent of the other. Will always return false if
+ * either the parent or child key is not an MPTT path.
+ * @param parentKey The potential parent entity key.
+ * @param childKey The potential child entity key.
+ */
+export const isMPTTParentOf = (parentKey: string, childKey: string) =>
+  isMPTTPath(parentKey) &&
+  isMPTTPath(childKey) &&
+  childKey.substr(2).startsWith(parentKey.substr(2));
+
+/**
+ * Use entity MPTT paths to determine if one is a parent of the other. Will always return false if
+ * either the parent or child key is not an MPTT path.
+ * @param parentKey The potential parent entity key.
+ * @param childKey The potential child entity key.
+ */
+export const isMPTTChildOf = (childKey: string, parentKey: string) =>
+  // Just reverse the arguments to make a utility `isChildOf` from `isParentOf`
+  isMPTTParentOf(parentKey, childKey);

--- a/src/frontend/js/utils/mptt/index.ts
+++ b/src/frontend/js/utils/mptt/index.ts
@@ -25,3 +25,18 @@ export const isMPTTParentOf = (parentKey: string, childKey: string) =>
 export const isMPTTChildOf = (childKey: string, parentKey: string) =>
   // Just reverse the arguments to make a utility `isChildOf` from `isParentOf`
   isMPTTParentOf(parentKey, childKey);
+
+/**
+ * Build a regex-string that will match the MPTT paths of all children of the entity with the passed key.
+ * Throws when the passed key is not an MPTT path as this would be a programmer error.
+ * @param parentMPTTPath The parent entity's key.
+ */
+export const getMPTTChildrenPathMatcher = (parentMPTTPath: string) => {
+  if (!isMPTTPath(parentMPTTPath)) {
+    throw new Error(
+      `${parentMPTTPath} is not an MPTT path, cannot build a children path matcher.`,
+    );
+  }
+
+  return `.-${parentMPTTPath.substr(2)}.{4,}`;
+};


### PR DESCRIPTION
## Purpose

We had two separate issues that ended up being related to incorrect handling of MPTT paths in the frontend:

- The `language` filter was behaving as a drilldown filter even though is was marked as `is_drilldown: false` in API responses.
- Parent filter values, when opened, would only show a maximum of 5 children filter values.

## Proposal

We made more fleshed out `utils` to handle MPTT paths, solving both issues.

- [x] write unit tests to reproduce both issues
- [x] build separately-tested `utils` to get information using MPTT paths
- [x] make sure call sites use the new tools, fixing both issues
