### PR TITLE
🐛(search) fix course indexer when no related organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix serializer that was failing for a course indexed with no organization,
 - The language filter, which is not a drilldown filter, no longer behaves
-  like one. Ditto for any future similar filters.
+  like one. Ditto for any future similar filters,
 - All children are now shown when a parent filter value is "opened", instead
   of just the top 5 by facet count.
 

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -508,14 +508,17 @@ class CoursesIndexer:
         except KeyError:
             state["date_time"] = None
 
+        organizations_names = get_best_field_language(
+            source["organizations_names"], language
+        )
         return {
             "id": es_course["_id"],
             "absolute_url": get_best_field_language(source["absolute_url"], language),
             "categories": source["categories"],
             "cover_image": get_best_field_language(source["cover_image"], language),
-            "organization_highlighted": get_best_field_language(
-                source["organizations_names"], language
-            )[0],
+            "organization_highlighted": organizations_names[0]
+            if organizations_names
+            else None,
             "organizations": source["organizations"],
             "state": CourseState(**state),
             "title": get_best_field_language(source["title"], language),

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -352,3 +352,40 @@ class CoursesIndexersTestCase(TestCase):
                 ),
             },
         )
+
+    def test_indexers_courses_format_es_object_for_api_no_organization(self):
+        """
+        A course that has no organization and was indexed should not raise 500 errors (although
+        this should not happen if courses are correctly moderated).
+        """
+        es_course = {
+            "_id": 93,
+            "_source": {
+                "absolute_url": {"en": "campo-qui-format-do"},
+                "categories": [43, 86],
+                "cover_image": {"en": "image.jpg"},
+                "organizations": [],
+                "organizations_names": {},
+                "title": {"en": "Duis eu arcu erat"},
+            },
+            "fields": {
+                "state": [
+                    {"priority": 0, "date_time": "2019-03-17T21:25:52.179667+00:00"}
+                ]
+            },
+        }
+        self.assertEqual(
+            CoursesIndexer.format_es_object_for_api(es_course, "en"),
+            {
+                "id": 93,
+                "absolute_url": "campo-qui-format-do",
+                "categories": [43, 86],
+                "cover_image": "image.jpg",
+                "organization_highlighted": None,
+                "organizations": [],
+                "title": "Duis eu arcu erat",
+                "state": CourseState(
+                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, pytz.utc)
+                ),
+            },
+        )


### PR DESCRIPTION
## Purpose

This bug was identified in the Sentry dashboard of our https://richie.education demo site.

If a course with no organization is indexed in Elasticsearch (which should not happen if moderation is correctly done), the serializer breaks because it expects at least one organization to be declared
on the course. 

Even if this is not a desired situation, the code should not break if it happens.

# Proposal

I propose to set the highlighted organization to `null` in its serialized form if the course has no organization.

I added a test to surface the bug and secure the fix.
