### PR TITLE
🔧(project) improve Makefile readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Simplify the Docker development stack to have a single `Dockerfile` and
   docker-compose configuration for testing either with MySQL or PostgreSQL
   database backend
+- Standardize the project's `Makefile` to make it more easily maintainable by
+  our peers
 
 ### Removed
 


### PR DESCRIPTION
## Purpose

While developing Riche, the project's `Makefile` became quite big and messy. It was time to invest some efforts to make it more readable / homogeneous.

## Proposal

We've updated the project's `Makefile` with the following statements in mind:

1. Every variable should be defined in the _ad hoc_ **VARIABLES** section with a relevant subsection
2. Every new rule should be defined in the _ad hoc_ **RULES** section with a relevant subsection depending on the targeted service
3. Rules should be sorted alphabetically within their section
4. When a rule has multiple dependencies, you should:
   - duplicate the rule name to add the help string (if required)
   - write one dependency per line to increase readability and diffs
5. `.PHONY` rule statement should be written after the corresponding rule

I am open to other rules to apply to make this `Makefile` more easily readable/maintainable.