### PR TITLE
Re-order placeholders on course page and force most of them to plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Change the order of placeholders on the course page following feedback from
+  our support team,
 - Simplify the Docker development stack to have a single `Dockerfile` and
   docker-compose configuration for testing either with MySQL or PostgreSQL
   database backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Restrict course content to plain text in standard sections,
 - Change the order of placeholders on the course page following feedback from
   our support team,
 - Simplify the Docker development stack to have a single `Dockerfile` and

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -304,15 +304,15 @@ class Base(DRFMixin, Configuration):
         },
         "courses/cms/course_detail.html course_description": {
             "name": _("About the course"),
-            "plugins": ["CKEditorPlugin"],
+            "plugins": ["PlainTextPlugin"],
         },
         "courses/cms/course_detail.html course_format": {
             "name": _("Format"),
-            "plugins": ["CKEditorPlugin"],
+            "plugins": ["PlainTextPlugin"],
         },
         "courses/cms/course_detail.html course_prerequisites": {
             "name": _("Prerequisites"),
-            "plugins": ["CKEditorPlugin"],
+            "plugins": ["PlainTextPlugin"],
         },
         "courses/cms/course_detail.html course_team": {
             "name": _("Team"),
@@ -346,7 +346,7 @@ class Base(DRFMixin, Configuration):
         },
         "courses/cms/course_detail.html course_assessment": {
             "name": _("Assessment and Certification"),
-            "plugins": ["CKEditorPlugin"],
+            "plugins": ["PlainTextPlugin"],
         },
         # Organization detail
         "courses/cms/organization_detail.html banner": {

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
@@ -44,9 +44,27 @@
 </div>
 {% endif %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_information" %}
-<div class="course-detail__content__row course-detail__content__information">
-  {% page_placeholder "course_information" page %}
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_assessment" %}
+<div class="course-detail__content__row course-detail__content__assessment">
+  <h2 class="course-detail__content__row__title">{% trans 'Assessment and certification' %}</h2>
+  {% page_placeholder "course_assessment" page or %}
+    <p class="course-detail__content__assessment__placeholder">
+      {% trans "How is progress evaluated and/or certified?" %}
+    </p>
+  {% endpage_placeholder %}
+</div>
+{% endif %}
+
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_organizations" %}
+<div class="course-detail__content__row course-detail__content__organizations">
+  <h2 class="course-detail__content__row__title course-detail__content__team__title">
+    {% trans 'Organizations' %}
+  </h2>
+  {% page_placeholder "course_organizations" page or %}
+    <p class="course-detail__content__organizations__placeholder">
+      {% trans "What are the organizations publishing this course?" %}
+    </p>
+  {% endpage_placeholder %}
 </div>
 {% endif %}
 
@@ -63,24 +81,9 @@
 </div>
 {% endif %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_organizations" %}
-<div class="course-detail__content__row course-detail__content__organizations">
-  {% page_placeholder "course_organizations" page or %}
-    <p class="course-detail__content__organizations__placeholder">
-      {% trans "What are the organizations publishing this course?" %}
-    </p>
-  {% endpage_placeholder %}
-</div>
-{% endif %}
-
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_assessment" %}
-<div class="course-detail__content__row course-detail__content__assessment">
-  <h2 class="course-detail__content__row__title">{% trans 'Assessment and certification' %}</h2>
-  {% page_placeholder "course_assessment" page or %}
-    <p class="course-detail__content__assessment__placeholder">
-      {% trans "How is progress evaluated and/or certified?" %}
-    </p>
-  {% endpage_placeholder %}
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_information" %}
+<div class="course-detail__content__row course-detail__content__information">
+  {% page_placeholder "course_information" page %}
 </div>
 {% endif %}
 


### PR DESCRIPTION
## Purpose

Our support team requested some cosmetic changes on the course page.

## Proposal

- [x] change the order of placeholders on the course page
- [x] restrict course content to plain text in standard sections
