### PR TITLE
Index persons themselves & on courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a persons index and viewset to enable text queries and autocomplete
+  requests on person names from the API.
 - Add a management command to create the required site structure,
 - Allow to dynamically set webpack publicPath. This is useful if a CDN is used
   to load statics. Define the settings `CDN_DOMAIN` and it will be used as base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add a persons index and viewset to enable text queries and autocomplete
   requests on person names from the API.
+- Index person names on courses to allow users to find courses when they
+  type a related person's name in full text search.
 - Add a management command to create the required site structure,
 - Allow to dynamically set webpack publicPath. This is useful if a CDN is used
   to load statics. Define the settings `CDN_DOMAIN` and it will be used as base

--- a/src/richie/apps/search/description.apib
+++ b/src/richie/apps/search/description.apib
@@ -7,15 +7,16 @@ FORMAT: 1A
 ## Course
 A single course as saved in our ElasticSearch index. Includes all fields useful for indexing it and displaying it in the client side. Foreign keys as richie knows them (eg. Categories & Organizations) are referenced by their IDs.
 
++ categories: ['L00040002', 'L-00040004'] (array[string], required) - IDs of the categories with which this course has been tagged
 + cover_image: `/about.png` (string) - URL to an image, a size of the thumbnail
 + end: `2018-02-28T06:00:00Z` (string, required) - ISO 8601 date, when this session of the course ends
 + enrollment_end: `2018-01-31T06:00:00Z` (string, required) - ISO 8601 date, when enrollment for the latest session of the course ends
 + enrollment_start: `2018-01-01T06:00:00Z` (string, required) - ISO 8601 date, when enrollment for the latest session of the course starts
 + id: 42 (number, required) - SQL database ID, reused in ElasticSearch
 + languages: ['fr', 'en'] (array[string], required) - ISO 639-1 code (2 letters) for the course's languages
-+ organizations: [17, 83] (array[number], required) - IDs of the organizations linked to this course
++ organizations: ['L00010007', 'L-00010009'] (array[string], required) - IDs of the organizations linked to this course
++ persons: [42, 44] (array[number], required) - IDs of the persons with whom this course has been associated
 + start: `2018-02-01T06:00:00Z` (string, required) - ISO 8601 date, when this session of the course starts
-+ categories: [42, 44] (array[number], required) - IDs of the categories this course has been tagged with
 + title: Python for Data Scientists (string, required) - Title for the course
 
 ## Organization

--- a/src/richie/apps/search/description.apib
+++ b/src/richie/apps/search/description.apib
@@ -21,17 +21,62 @@ A single course as saved in our ElasticSearch index. Includes all fields useful 
 ## Organization
 A single organization as saved in our ElasticSearch index. Includes only the fields necessary for indexing and displaying them on the consumer side.
 
-+ id: 42 (number, required) - SQL database ID, reused in ElasticSearch
++ id: L-00040002 (string, required) - MPTT path used as ElasticSearch index
 + logo: https://example.com/logo.png (string) - URL to and image containing the logo for the organization (smaller)
 + title: Université Paris 13 (string, required) - full text title of the organization; may be translated
 
 ## Category
-A single category as saved in our ElasticSearch index. Includes a small subset of the fields and data in the the SQL database model, in order to be as small and consumer-friendly as possible.
+A single category as saved in our ElasticSearch index. Includes a small subset of the fields and data actually contained in the CMS, in order to be as small and consumer-friendly as possible.
 
-+ id: 42 (number, required) - SQL database ID, reused in ElasticSearch
++ id: L-00040002 (string, required) - MPTT path used as ElasticSearch index
 + logo: https://example.com/image.png (string) - a logo for the category, only the most prominent ones have it
 + title: Computer Science (string, required)
 
+## Person
+A single person as saved in our ElasticSearch index. Includes a small subset of the fields and data actually contained in the CMS, in order to be as small and consumer-friendly as possible.
+
++ id: 42 (number, required) - SQL database ID, reused in ElasticSearch
++ portrait: https://example.com/image.png (string) - a logo for the category, only the most prominent ones have it
++ title: Master Miyagi (string, required)
+
+
+# Group Category
+Category-related resources for the richie search API.
+
+## GET /categories/{category_id}
+A single category object. Access through this API is read-only (and thus GET only) as we're interacting with ElasticSearch and not the underlying model.
+
+See the Category data structure for more information.
+
++ Request
+    + Headers
+
+            Accept: application/json
+            Accept-Language: fr-FR; fr; q=0.9, en-US; en; q=0.7, *; q=0.5
+
++ Response 200 (application/json)
+    + Attributes (Category)
+
+## GET /categories?limit&offset&name
+Collection of all categories indexed in ElasticSearch. Can be filtered and selected through search query parameters.
+
++ Request
+    + Parameters
+        + limit: 10 (number, optional) - return {limit} categories
+        + offset: 0 (number, optional) - skip the first {offset} results; used for pagination
+        + name: science (string, optional) - match on the name field
+    + Headers
+
+            Accept: application/json
+            Accept-Language: fr-FR; fr; q=0.9, en-US; en; q=0.7, *; q=0.5
+
++ Response 200 (application/json)
+    + Attributes
+        + meta
+            + count: 10 (number, required) - number of categories effectively returned
+            + offset: 0 (number, required) - number of categories skipped
+            + total_count: 89 (number, required) - total number of hits for the search parameters
+        + objects: array[Category]
 
 # Group Course
 Course-related resources for the richie search API.
@@ -116,13 +161,14 @@ Collection of all organizations indexed in ElasticSearch. Can be filtered and se
             + total_count: 89 (number, required) - total number of hits for the search parameters
         + objects: array[Organization]
 
-# Group Category
-Category-related resources for the richie search API.
 
-## GET /categories/{category_id}
-A single category object. Access through this API is read-only (and thus GET only) as we're interacting with ElasticSearch and not the underlying model.
+# Group Persons
+Person-related resources for the richie search API.
 
-See the Category data structure for more information.
+## GET /persons/{person_id}
+A single person object. Access through this API is read-only (and thus GET only) as we're interacting with ElasticSearch and not the underlying model.
+
+See the Person data structure for more information.
 
 + Request
     + Headers
@@ -131,16 +177,16 @@ See the Category data structure for more information.
             Accept-Language: fr-FR; fr; q=0.9, en-US; en; q=0.7, *; q=0.5
 
 + Response 200 (application/json)
-    + Attributes (Category)
+    + Attributes (Person)
 
-## GET /categories?limit&offset&name
-Collection of all categories indexed in ElasticSearch. Can be filtered and selected through search query parameters.
+## GET /persons?limit&offset&name
+Collection of all persons indexed in ElasticSearch. Can be filtered and selected through search query parameters.
 
 + Request
     + Parameters
-        + limit: 10 (number, optional) - return {limit} categories
+        + limit: 10 (number, optional) - return {limit} persons
         + offset: 0 (number, optional) - skip the first {offset} results; used for pagination
-        + name: science (string, optional) - match on the name field
+        + query: science (string, optional) - match on the indexed text fields
     + Headers
 
             Accept: application/json
@@ -149,7 +195,7 @@ Collection of all categories indexed in ElasticSearch. Can be filtered and selec
 + Response 200 (application/json)
     + Attributes
         + meta
-            + count: 10 (number, required) - number of categories effectively returned
-            + offset: 0 (number, required) - number of categories skipped
+            + count: 10 (number, required) - number of persons effectively returned
+            + offset: 0 (number, required) - number of persons skipped
             + total_count: 89 (number, required) - total number of hits for the search parameters
-        + objects: array[Category]
+        + objects: array[Person]

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -315,11 +315,7 @@ class ItemSearchForm(SearchForm):
         # Build a query that matches on the name field if it was handed by the client
         full_text = self.cleaned_data.get("query")
         if full_text:
-            query = {
-                "query": {
-                    "match": {"title.fr": {"query": full_text, "analyzer": "french"}}
-                }
-            }
+            query = {"query": {"match": {"title.fr": {"query": full_text}}}}
         # Build a match_all query by default
         else:
             query = {"query": {"match_all": {}}}

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -221,6 +221,18 @@ class CourseSearchForm(SearchForm):
                                             "type": "cross_fields",
                                         }
                                     },
+                                    {
+                                        "multi_match": {
+                                            "boost": getattr(
+                                                settings,
+                                                "RICHIE_RELATED_CONTENT_BOOST",
+                                                RELATED_CONTENT_BOOST,
+                                            ),
+                                            "fields": ["persons_names.*"],
+                                            "query": full_text,
+                                            "type": "cross_fields",
+                                        }
+                                    },
                                 ]
                             }
                         }

--- a/src/richie/apps/search/indexers/__init__.py
+++ b/src/richie/apps/search/indexers/__init__.py
@@ -8,9 +8,10 @@ ES_INDICES = IndicesList(
         settings,
         "ES_INDICES",
         {
+            "categories": "richie.apps.search.indexers.categories.CategoriesIndexer",
             "courses": "richie.apps.search.indexers.courses.CoursesIndexer",
             "organizations": "richie.apps.search.indexers.organizations.OrganizationsIndexer",
-            "categories": "richie.apps.search.indexers.categories.CategoriesIndexer",
+            "persons": "richie.apps.search.indexers.persons.PersonsIndexer",
         },
     )
 )

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -31,15 +31,14 @@ class CategoriesIndexer:
         "dynamic_templates": MULTILINGUAL_TEXT,
         "properties": {
             # Searchable
+            # description & title are handled by `MULTILINGUAL_TEXT`
             **{
                 "complete.{:s}".format(lang): {"type": "completion"}
                 for lang, _ in settings.LANGUAGES
             },
-            "description": {"type": "object"},
             "is_meta": {"type": "boolean"},
             "nb_children": {"type": "integer"},
             "path": {"type": "keyword"},
-            "title": {"type": "object"},
             # Not searchable
             "absolute_url": {"type": "object", "enabled": False},
             "logo": {"type": "object", "enabled": False},

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -49,13 +49,12 @@ class CoursesIndexer:
             "categories": {"type": "keyword"},
             "organizations": {"type": "keyword"},
             # Searchable
+            # description, title are handled my `MULTILINGUAL_TEXT`
             **{
                 "complete.{:s}".format(lang): {"type": "completion"}
                 for lang, _ in settings.LANGUAGES
             },
-            "description": {"type": "object"},
             "is_new": {"type": "boolean"},
-            "title": {"type": "object"},
             # Not searchable
             "absolute_url": {"type": "object", "enabled": False},
             "cover_image": {"type": "object", "enabled": False},

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -31,12 +31,11 @@ class OrganizationsIndexer:
         "dynamic_templates": MULTILINGUAL_TEXT,
         "properties": {
             # Searchable
+            # description & title are handled by `MULTILINGUAL_TEXT`
             **{
                 "complete.{:s}".format(lang): {"type": "completion"}
                 for lang, _ in settings.LANGUAGES
             },
-            "description": {"type": "object"},
-            "title": {"type": "object"},
             # Not searchable
             "absolute_url": {"type": "object", "enabled": False},
             "logo": {"type": "object", "enabled": False},

--- a/src/richie/apps/search/indexers/persons.py
+++ b/src/richie/apps/search/indexers/persons.py
@@ -1,0 +1,142 @@
+"""
+ElasticSearch person document management utilities
+"""
+from collections import defaultdict
+
+from django.conf import settings
+
+from cms.models import Title
+from djangocms_picture.models import Picture
+
+from richie.plugins.simple_text_ckeditor.models import SimpleText
+
+from ...courses.models import Person
+from .. import defaults
+from ..forms import ItemSearchForm
+from ..text_indexing import MULTILINGUAL_TEXT
+from ..utils.i18n import get_best_field_language
+from ..utils.indexers import slice_string_for_completion
+
+
+class PersonsIndexer:
+    """
+    Makes available the parameters the indexer requires as well as a function to shape
+    objects into what we want to index in ElasticSearch
+    """
+
+    document_type = "person"
+    index_name = "richie_persons"
+    form = ItemSearchForm
+    mapping = {
+        "dynamic_templates": MULTILINGUAL_TEXT,
+        "properties": {
+            # Searchable
+            **{
+                "complete.{:s}".format(lang): {"type": "completion"}
+                for lang, _ in settings.LANGUAGES
+            },
+            **{
+                "{key}.{lang}": {"type": "text", "analyzer": "simple"}
+                for lang, _ in settings.LANGUAGES
+                for key in ["bio", "title"]
+            },
+            # Not searchable
+            "absolute_url": {"type": "object", "enabled": False},
+            "portrait": {"type": "object", "enabled": False},
+        },
+    }
+    scripts = {}
+    display_fields = ["absolute_url", "portrait", "title.*"]
+
+    @classmethod
+    def get_es_document_for_person(cls, person, index=None, action="index"):
+        """Build an Elasticsearch document from the person instance."""
+        index = index or cls.index_name
+
+        # Get published titles
+        titles = {
+            t.language: t.title
+            for t in Title.objects.filter(page=person.extended_object, published=True)
+        }
+
+        # Get portrait images
+        portrait_images = {}
+        for portrait_image in Picture.objects.filter(
+            cmsplugin_ptr__placeholder__page=person.extended_object,
+            cmsplugin_ptr__placeholder__slot="portrait",
+        ):
+            # Force the image format before computing it
+            portrait_image.use_no_cropping = False
+            portrait_image.width = defaults.ORGANIZATIONS_LOGO_IMAGE_WIDTH
+            portrait_image.height = defaults.ORGANIZATIONS_LOGO_IMAGE_HEIGHT
+            portrait_images[
+                portrait_image.cmsplugin_ptr.language
+            ] = portrait_image.img_src
+
+        # Get bio texts
+        bio = defaultdict(list)
+        for simple_text in SimpleText.objects.filter(
+            cmsplugin_ptr__placeholder__page=person.extended_object,
+            cmsplugin_ptr__placeholder__slot="bio",
+        ):
+            bio[simple_text.cmsplugin_ptr.language].append(simple_text.body)
+
+        return {
+            "_id": str(person.extended_object_id),
+            "_index": index,
+            "_op_type": action,
+            "_type": cls.document_type,
+            "absolute_url": {
+                language: person.extended_object.get_absolute_url(language)
+                for language in titles.keys()
+            },
+            "bio": {l: " ".join(st) for l, st in bio.items()},
+            "complete": {
+                language: slice_string_for_completion(title)
+                for language, title in titles.items()
+            },
+            "portrait": portrait_images,
+            "title": titles,
+        }
+
+    @classmethod
+    def get_es_documents(cls, index=None, action="index"):
+        """
+        Loop on all the persons in database and format them for the ElasticSearch index
+        """
+        index = index or cls.index_name
+
+        for person in Person.objects.filter(
+            extended_object__publisher_is_draft=False,
+            extended_object__title_set__published=True,
+        ).distinct():
+            yield cls.get_es_document_for_person(person, index=index, action=action)
+
+    @staticmethod
+    def format_es_object_for_api(es_person, best_language):
+        """
+        Format an person stored in ES into a consistent and easy-to-consume record for
+        API consumers
+        """
+        return {
+            "id": es_person["_id"],
+            "portrait": get_best_field_language(
+                es_person["_source"]["portrait"], best_language
+            ),
+            "title": get_best_field_language(
+                es_person["_source"]["title"], best_language
+            ),
+        }
+
+    @staticmethod
+    def format_es_document_for_autocomplete(es_document, language=None):
+        """
+        Format a document stored in ES into an easy-to-consume record for autocomplete consumers.
+        This method differs from the regular one as objects retrieved from query VS complete
+        queries can be formatted differently; and consumers of autocomplete do not need
+        full objects.
+        """
+        return {
+            "id": es_document["_id"],
+            "title": get_best_field_language(es_document["_source"]["title"], language),
+        }

--- a/src/richie/apps/search/urls.py
+++ b/src/richie/apps/search/urls.py
@@ -6,14 +6,16 @@ from rest_framework import routers
 from .viewsets.categories import CategoriesViewSet
 from .viewsets.courses import CoursesViewSet
 from .viewsets.organizations import OrganizationsViewSet
+from .viewsets.persons import PersonsViewSet
 
 # Instantiate a router
 ROUTER = routers.SimpleRouter()
 
 # Define our app's routes with the router
+ROUTER.register(r"categories", CategoriesViewSet, "categories")
 ROUTER.register(r"courses", CoursesViewSet, "courses")
 ROUTER.register(r"organizations", OrganizationsViewSet, "organizations")
-ROUTER.register(r"categories", CategoriesViewSet, "categories")
+ROUTER.register(r"persons", PersonsViewSet, "persons")
 
 # Use the standard name for our urlpatterns so urls.py can import it effortlessly
 urlpatterns = ROUTER.urls

--- a/src/richie/apps/search/viewsets/persons.py
+++ b/src/richie/apps/search/viewsets/persons.py
@@ -1,0 +1,94 @@
+"""
+API endpoints to access organizations through ElasticSearch
+"""
+from django.conf import settings
+from django.utils.translation import get_language_from_request
+
+from elasticsearch.exceptions import NotFoundError
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from .. import ES_CLIENT
+from ..defaults import ES_PAGE_SIZE
+from ..indexers import ES_INDICES
+from ..utils.viewsets import AutocompleteMixin, ViewSetMetadata
+
+
+class PersonsViewSet(AutocompleteMixin, ViewSet):
+    """
+    A simple viewset with GET endpoints to fetch persons
+    See API Blueprint for details on consumer use.
+    """
+
+    _meta = ViewSetMetadata(indexer=ES_INDICES.persons)
+
+    # pylint: disable=no-self-use,unused-argument
+    def list(self, request, version):
+        """
+        Person search endpoint: pass query params to ElasticSearch so it filters
+        persons and returns a list of matching items
+        """
+        # Instantiate the form to allow validation/cleaning
+        params_form = self._meta.indexer.form(data=request.query_params)
+
+        # Return a 400 with error information if the query params are not valid
+        if not params_form.is_valid():
+            return Response(status=400, data={"errors": params_form.errors})
+
+        limit, offset, query = params_form.build_es_query()
+
+        # pylint: disable=unexpected-keyword-arg
+        search_query_response = ES_CLIENT.search(
+            _source=getattr(self._meta.indexer, "display_fields", "*"),
+            index=self._meta.indexer.index_name,
+            doc_type=self._meta.indexer.document_type,
+            body=query,
+            # Directly pass meta-params through as arguments to the ES client
+            from_=offset,
+            size=limit or getattr(settings, "RICHIE_ES_PAGE_SIZE", ES_PAGE_SIZE),
+        )
+
+        # Format the response in a consumer-friendly way
+        # NB: if there are 0 hits the query response is formatted the exact same way, only the
+        # .hits.hits array is empty.
+        response_object = {
+            "meta": {
+                "count": len(search_query_response["hits"]["hits"]),
+                "offset": offset,
+                "total_count": search_query_response["hits"]["total"],
+            },
+            "objects": [
+                self._meta.indexer.format_es_object_for_api(
+                    person,
+                    # Get the best language to return multilingual fields
+                    get_language_from_request(request),
+                )
+                for person in search_query_response["hits"]["hits"]
+            ],
+        }
+        return Response(response_object)
+
+    # pylint: disable=no-self-use,invalid-name,unused-argument
+    def retrieve(self, request, pk, version):
+        """
+        Return a single person by ID
+        """
+        # Wrap the ES get in a try/catch so we control the exception we emit — it would
+        # raise and end up in a 500 error otherwise
+        try:
+            query_response = ES_CLIENT.get(
+                index=self._meta.indexer.index_name,
+                doc_type=self._meta.indexer.document_type,
+                id=pk,
+            )
+        except NotFoundError:
+            return Response(status=404)
+
+        # Format a clean person object as a response
+        return Response(
+            self._meta.indexer.format_es_object_for_api(
+                query_response,
+                # Get the best language we can return multilingual fields in
+                get_language_from_request(request),
+            )
+        )

--- a/tests/apps/search/test_autocomplete_persons.py
+++ b/tests/apps/search/test_autocomplete_persons.py
@@ -1,0 +1,99 @@
+"""
+Tests for person autocomplete
+"""
+import json
+from unittest import mock
+
+from django.test import TestCase
+
+from elasticsearch.client import IndicesClient
+from elasticsearch.helpers import bulk
+
+from richie.apps.search import ES_CLIENT
+from richie.apps.search.indexers.persons import PersonsIndexer
+from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
+from richie.apps.search.utils.indexers import slice_string_for_completion
+
+PERSONS_INDEX = "test_persons"
+
+
+@mock.patch.object(  # Plug the test index we're filling on the indexer itself
+    PersonsIndexer,
+    "index_name",
+    new_callable=mock.PropertyMock,
+    return_value=PERSONS_INDEX,
+)
+class AutocompletePersonsTestCase(TestCase):
+    """
+    Test person autocomplete queries in a real-world situation with ElasticSearch.
+    """
+
+    def execute_query(self, querystring=""):
+        """
+        Not a test.
+        Prepare the ElasticSearch index and execute the query in it.
+        """
+
+        persons = [
+            {
+                "complete": {"en": slice_string_for_completion("Éponine Thénardier")},
+                "id": "25",
+                "title": {"en": "Éponine Thénardier"},
+            },
+            {
+                "complete": {
+                    "en": slice_string_for_completion("Monseigneur Bienvenu Myriel")
+                },
+                "id": "34",
+                "title": {"en": "Monseigneur Bienvenu Myriel"},
+            },
+            {
+                "complete": {"en": slice_string_for_completion("Fantine")},
+                "id": "52",
+                "title": {"en": "Fantine"},
+            },
+        ]
+
+        indices_client = IndicesClient(client=ES_CLIENT)
+        # Delete any existing indexes so we get a clean slate
+        indices_client.delete(index="_all")
+        # Create an index we'll use to test the ES features
+        indices_client.create(index=PERSONS_INDEX)
+        # Use the default persons mapping from the Indexer
+        indices_client.put_mapping(
+            body=PersonsIndexer.mapping, doc_type="person", index=PERSONS_INDEX
+        )
+        # The index needs to be closed before we set an analyzer
+        indices_client.close(index=PERSONS_INDEX)
+        indices_client.put_settings(body=ANALYSIS_SETTINGS, index=PERSONS_INDEX)
+        indices_client.open(index=PERSONS_INDEX)
+        # Actually insert our persons in the index
+        actions = [
+            {
+                "_id": person["id"],
+                "_index": PERSONS_INDEX,
+                "_op_type": "create",
+                "_type": "person",
+                "absolute_url": {"en": "url"},
+                "logo": {"en": "/some/img.png"},
+                **person,
+            }
+            for person in persons
+        ]
+        bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
+        indices_client.refresh()
+
+        response = self.client.get(f"/api/v1.0/persons/autocomplete/?{querystring:s}")
+        self.assertEqual(response.status_code, 200)
+
+        return persons, json.loads(response.content)
+
+    def test_autocomplete_text(self, *_):
+        """
+        Make sure autocomplete is operational and returns the expected persons.
+        """
+        all_persons, response = self.execute_query(querystring="query=Bien")
+        self.assertEqual([all_persons[1]["id"]], [person["id"] for person in response])
+
+        all_persons, response = self.execute_query(querystring="query=épo")
+        self.assertEqual([all_persons[0]["id"]], [person["id"] for person in response])

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -210,6 +210,14 @@ class CourseSearchFormTestCase(TestCase):
                                             "type": "cross_fields",
                                         }
                                     },
+                                    {
+                                        "multi_match": {
+                                            "boost": 0.05,
+                                            "fields": ["persons_names.*"],
+                                            "query": "some phrase " "terms",
+                                            "type": "cross_fields",
+                                        }
+                                    },
                                 ]
                             }
                         }

--- a/tests/apps/search/test_forms_search_items.py
+++ b/tests/apps/search/test_forms_search_items.py
@@ -113,20 +113,7 @@ class ItemSearchFormTestCase(TestCase):
         self.assertTrue(form.is_valid())
         self.assertEqual(
             form.build_es_query(),
-            (
-                20,
-                2,
-                {
-                    "query": {
-                        "match": {
-                            "title.fr": {
-                                "query": "some phrase terms",
-                                "analyzer": "simple",
-                            }
-                        }
-                    }
-                },
-            ),
+            (20, 2, {"query": {"match": {"title.fr": {"query": "some phrase terms"}}}}),
         )
 
     def test_forms_items_build_es_query_search_all(self, *_):

--- a/tests/apps/search/test_forms_search_items.py
+++ b/tests/apps/search/test_forms_search_items.py
@@ -121,7 +121,7 @@ class ItemSearchFormTestCase(TestCase):
                         "match": {
                             "title.fr": {
                                 "query": "some phrase terms",
-                                "analyzer": "french",
+                                "analyzer": "simple",
                             }
                         }
                     }

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -187,6 +187,12 @@ class IndexManagerTestCase(TestCase):
                 "actions": [
                     {
                         "add": {
+                            "index": "richie_categories_created_index",
+                            "alias": "richie_categories",
+                        }
+                    },
+                    {
+                        "add": {
                             "index": "richie_courses_created_index",
                             "alias": "richie_courses",
                         }
@@ -199,7 +205,19 @@ class IndexManagerTestCase(TestCase):
                     },
                     {
                         "add": {
-                            "index": "richie_categories_created_index",
+                            "index": "richie_persons_created_index",
+                            "alias": "richie_persons",
+                        }
+                    },
+                    {
+                        "remove": {
+                            "index": "richie_categories_forgotten",
+                            "alias": "richie_categories",
+                        }
+                    },
+                    {
+                        "remove": {
+                            "index": "richie_categories_previous",
                             "alias": "richie_categories",
                         }
                     },
@@ -229,14 +247,14 @@ class IndexManagerTestCase(TestCase):
                     },
                     {
                         "remove": {
-                            "index": "richie_categories_forgotten",
-                            "alias": "richie_categories",
+                            "index": "richie_persons_forgotten",
+                            "alias": "richie_persons",
                         }
                     },
                     {
                         "remove": {
-                            "index": "richie_categories_previous",
-                            "alias": "richie_categories",
+                            "index": "richie_persons_previous",
+                            "alias": "richie_persons",
                         }
                     },
                 ]
@@ -269,6 +287,12 @@ class IndexManagerTestCase(TestCase):
                 "actions": [
                     {
                         "add": {
+                            "index": "richie_categories_created_index",
+                            "alias": "richie_categories",
+                        }
+                    },
+                    {
+                        "add": {
                             "index": "richie_courses_created_index",
                             "alias": "richie_courses",
                         }
@@ -281,8 +305,8 @@ class IndexManagerTestCase(TestCase):
                     },
                     {
                         "add": {
-                            "index": "richie_categories_created_index",
-                            "alias": "richie_categories",
+                            "index": "richie_persons_created_index",
+                            "alias": "richie_persons",
                         }
                     },
                 ]

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -15,6 +15,7 @@ from richie.apps.courses.factories import (
     CourseFactory,
     CourseRunFactory,
     OrganizationFactory,
+    PersonFactory,
 )
 from richie.apps.courses.models import CourseState
 from richie.apps.search.indexers.categories import CategoriesIndexer
@@ -134,18 +135,32 @@ class CoursesIndexersTestCase(TestCase):
             },
             should_publish=True,
         )
+
+        person1 = PersonFactory(
+            page_title={"en": "Eugène Delacroix", "fr": "Eugène Delacroix"},
+            should_publish=True,
+        )
+        person2 = PersonFactory(
+            page_title={"en": "Comte de Saint-Germain", "fr": "Earl of Saint-Germain"},
+            should_publish=True,
+        )
+        person_draft = PersonFactory(
+            page_title={"en": "Jules de Polignac", "fr": "Jules de Polignac"}
+        )
+
         course = CourseFactory(
-            page_title={
-                "en": "an english course title",
-                "fr": "un titre cours français",
-            },
+            fill_categories=published_categories + [draft_category],
+            fill_cover=True,
             fill_organizations=[
                 main_organization,
                 other_draft_organization,
                 other_published_organization,
             ],
-            fill_categories=published_categories + [draft_category],
-            fill_cover=True,
+            fill_team=[person1, person_draft, person2],
+            page_title={
+                "en": "an english course title",
+                "fr": "un titre cours français",
+            },
             should_publish=True,
         )
         CourseRunFactory.create_batch(
@@ -219,6 +234,14 @@ class CoursesIndexersTestCase(TestCase):
                     "titre organisation principale français",
                     "titre autre organisation français",
                 ],
+            },
+            "persons": [
+                str(person1.public_extension.extended_object_id),
+                str(person2.public_extension.extended_object_id),
+            ],
+            "persons_names": {
+                "en": ["Eugène Delacroix", "Comte de Saint-Germain"],
+                "fr": ["Eugène Delacroix", "Earl of Saint-Germain"],
             },
             "title": {"fr": "un titre cours français", "en": "an english course title"},
         }

--- a/tests/apps/search/test_indexers_persons.py
+++ b/tests/apps/search/test_indexers_persons.py
@@ -1,0 +1,120 @@
+"""
+Tests for the person indexer
+"""
+from unittest import mock
+
+from django.test import TestCase
+
+from cms.api import add_plugin
+from djangocms_picture.models import Picture
+
+from richie.apps.courses.factories import PersonFactory
+from richie.apps.search.indexers.persons import PersonsIndexer
+
+
+class PersonsIndexersTestCase(TestCase):
+    """
+    Test the get_es_documents() function on the person indexer, as well as our mapping,
+    and especially dynamic mapping shape in ES
+    """
+
+    @mock.patch.object(
+        Picture, "img_src", new_callable=mock.PropertyMock, return_value="123.jpg"
+    )
+    def test_indexers_persons_get_es_documents(self, _mock_picture):
+        """
+        Happy path: person data is fetched from the models properly formatted
+        """
+        person1 = PersonFactory(
+            fill_portrait=True,
+            page_title={"en": "my first person", "fr": "ma première personne"},
+            should_publish=True,
+        )
+        person2 = PersonFactory(
+            page_title={"en": "my second person", "fr": "ma deuxième personne"},
+            should_publish=True,
+        )
+
+        # Add a description in several languages to the first person
+        placeholder = person1.public_extension.extended_object.placeholders.get(
+            slot="bio"
+        )
+        plugin_params = {"placeholder": placeholder, "plugin_type": "CKEditorPlugin"}
+        add_plugin(body="english bio line 1.", language="en", **plugin_params)
+        add_plugin(body="english bio line 2.", language="en", **plugin_params)
+        add_plugin(body="texte français ligne 1.", language="fr", **plugin_params)
+        add_plugin(body="texte français ligne 2.", language="fr", **plugin_params)
+
+        # The results were properly formatted and passed to the consumer
+        self.assertEqual(
+            sorted(
+                list(
+                    PersonsIndexer.get_es_documents(
+                        index="some_index", action="some_action"
+                    )
+                ),
+                key=lambda p: p["_id"],
+            ),
+            [
+                {
+                    "_id": str(person1.public_extension.extended_object.id),
+                    "_index": "some_index",
+                    "_op_type": "some_action",
+                    "_type": "person",
+                    "absolute_url": {
+                        "en": "/en/my-first-person/",
+                        "fr": "/fr/ma-premiere-personne/",
+                    },
+                    "bio": {
+                        "en": "english bio line 1. english bio line 2.",
+                        "fr": "texte français ligne 1. texte français ligne 2.",
+                    },
+                    "complete": {
+                        "en": ["my first person", "first person", "person"],
+                        "fr": ["ma première personne", "première personne", "personne"],
+                    },
+                    "portrait": {"en": "123.jpg", "fr": "123.jpg"},
+                    "title": {"en": "my first person", "fr": "ma première personne"},
+                },
+                {
+                    "_id": str(person2.public_extension.extended_object.id),
+                    "_index": "some_index",
+                    "_op_type": "some_action",
+                    "_type": "person",
+                    "absolute_url": {
+                        "en": "/en/my-second-person/",
+                        "fr": "/fr/ma-deuxieme-personne/",
+                    },
+                    "bio": {},
+                    "complete": {
+                        "en": ["my second person", "second person", "person"],
+                        "fr": ["ma deuxième personne", "deuxième personne", "personne"],
+                    },
+                    "portrait": {},
+                    "title": {"en": "my second person", "fr": "ma deuxième personne"},
+                },
+            ],
+        )
+
+    def test_indexers_persons_format_es_object_for_api(self):
+        """
+        Make sure format_es_object_for_api returns a properly formatted person
+        """
+        es_person = {
+            "_id": 217,
+            "_source": {
+                "portrait": {"en": "/my_portrait.png", "fr": "/mon_portrait.png"},
+                "title": {
+                    "en": "University of Paris XIII",
+                    "fr": "Université Paris 13",
+                },
+            },
+        }
+        self.assertEqual(
+            PersonsIndexer.format_es_object_for_api(es_person, "en"),
+            {
+                "id": 217,
+                "portrait": "/my_portrait.png",
+                "title": "University of Paris XIII",
+            },
+        )

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -32,6 +32,8 @@ COURSES = [
         "is_new": True,
         "organizations": ["P-00030001", "P-00030004", "L-000300010001"],
         "organizations_names": {"en": ["Org 31", "Org 34", "Org 311"]},
+        "persons": [2],
+        "persons_names": {"en": ["Mikhaïl Boulgakov"]},
         "title": {"en": "Artificial intelligence for mushroom picking"},
     },
     {
@@ -48,6 +50,8 @@ COURSES = [
         "is_new": True,
         "organizations": ["P-00030001", "P-00030003", "L-000300010002"],
         "organizations_names": {"en": ["Org 31", "Org 33", "Org 312"]},
+        "persons": [],
+        "persons_names": {},
         "title": {"en": "Click-farms: managing the autumn harvest"},
     },
     {
@@ -64,6 +68,8 @@ COURSES = [
         "is_new": False,
         "organizations": ["P-00030002", "P-00030003", "L-000300020001"],
         "organizations_names": {"en": ["Org 32", "Org 33", "Org 321"]},
+        "persons": [],
+        "persons_names": {},
         "title": {"en": "Building a data lake out of mountain springs"},
     },
     {
@@ -79,6 +85,8 @@ COURSES = [
         "is_new": False,
         "organizations": ["P-00030002", "P-00030004", "L-000300020002"],
         "organizations_names": {"en": ["Org 32", "Org 34", "Org 322"]},
+        "persons": [2],
+        "persons_names": {"en": ["Mikhaïl Boulgakov"]},
         "title": {"en": "Kung-fu moves for cloud infrastructure security"},
     },
 ]
@@ -1072,6 +1080,19 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         self.assertEqual(content["filters"]["subjects"]["values"], [])
         self.assertEqual(content["filters"]["levels"]["values"], [])
         self.assertEqual(content["filters"]["organizations"]["values"], [])
+
+    def test_query_courses_by_related_person(self, *_):
+        """
+        Full-text search appropriately returns the list of courses that match a given
+        related person name even through a text query.
+        """
+        courses_definition, content = self.execute_query("query=boulgakov")
+        # Keep only the courses that are linked to persons whose name contains "boulgakov"
+        courses_definition = filter(lambda c: c[0] in [0, 3], courses_definition)
+        self.assertEqual(
+            list([int(c["id"]) for c in content["objects"]]),
+            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+        )
 
     def test_query_courses_text_language_analyzer(self, *_):
         """

--- a/tests/apps/search/test_viewsets_persons.py
+++ b/tests/apps/search/test_viewsets_persons.py
@@ -1,0 +1,144 @@
+"""
+Tests for the person viewset
+"""
+from unittest import mock
+
+from django.test import TestCase
+
+from elasticsearch.exceptions import NotFoundError
+from rest_framework.test import APIRequestFactory
+
+from richie.apps.search import ES_CLIENT
+from richie.apps.search.viewsets.persons import PersonsViewSet
+
+
+class PersonsViewSetTestCase(TestCase):
+    """
+    Test the API endpoints for persons (list and details)
+    """
+
+    def test_viewsets_persons_retrieve(self):
+        """
+        Happy path: the client requests an existing person, gets it back
+        """
+        factory = APIRequestFactory()
+        request = factory.get("/api/v1.0/persons/42")
+
+        with mock.patch.object(
+            ES_CLIENT,
+            "get",
+            return_value={
+                "_id": 42,
+                "_source": {
+                    "portrait": {"fr": "/portrait.png"},
+                    "title": {"fr": "Edmond Dantès"},
+                },
+            },
+        ):
+            # Note: we need to use a separate argument for the ID as that is what the ViewSet uses
+            response = PersonsViewSet.as_view({"get": "retrieve"})(
+                request, 42, version="1.0"
+            )
+
+        # The client received a proper response with the relevant person
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {"id": 42, "portrait": "/portrait.png", "title": "Edmond Dantès"},
+        )
+
+    def test_viewsets_persons_retrieve_unknown(self):
+        """
+        Error case: the client is asking for an person that does not exist
+        """
+        factory = APIRequestFactory()
+        request = factory.get("/api/v1.0/persons/43")
+
+        # Act like the ES client would when we attempt to get a non-existent document
+        with mock.patch.object(ES_CLIENT, "get", side_effect=NotFoundError):
+            response = PersonsViewSet.as_view({"get": "retrieve"})(
+                request, 43, version="1.0"
+            )
+
+        # The client received a standard NotFound response
+        self.assertEqual(response.status_code, 404)
+
+    @mock.patch(
+        "richie.apps.search.forms.ItemSearchForm.build_es_query",
+        lambda x: (2, 0, {"query": "something"}),
+    )
+    @mock.patch.object(ES_CLIENT, "search")
+    def test_viewsets_persons_search(self, mock_search):
+        """
+        Happy path: the consumer is filtering the persons by title
+        """
+        factory = APIRequestFactory()
+        request = factory.get("/api/v1.0/persons?query=Michel&limit=2")
+
+        mock_search.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_id": 21,
+                        "_source": {
+                            "portrait": {"fr": "/portrait_21.png"},
+                            "title": {"fr": "Michel de Montaigne"},
+                        },
+                    },
+                    {
+                        "_id": 61,
+                        "_source": {
+                            "portrait": {"fr": "/portrait_61.png"},
+                            "title": {"fr": "Michel Polnareff"},
+                        },
+                    },
+                ],
+                "total": 32,
+            }
+        }
+
+        response = PersonsViewSet.as_view({"get": "list"})(request, version="1.0")
+
+        # The client received a properly formatted response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "meta": {"count": 2, "offset": 0, "total_count": 32},
+                "objects": [
+                    {
+                        "id": 21,
+                        "portrait": "/portrait_21.png",
+                        "title": "Michel de Montaigne",
+                    },
+                    {
+                        "id": 61,
+                        "portrait": "/portrait_61.png",
+                        "title": "Michel Polnareff",
+                    },
+                ],
+            },
+        )
+        # The ES connector was called with a query that matches the client's request
+        mock_search.assert_called_with(
+            _source=["absolute_url", "portrait", "title.*"],
+            body={"query": "something"},
+            doc_type="person",
+            from_=0,
+            index="richie_persons",
+            size=2,
+        )
+
+    def test_viewsets_persons_search_with_invalid_params(self):
+        """
+        Error case: the client used an incorrectly formatted request
+        """
+        factory = APIRequestFactory()
+        # The request contains incorrect params: limit should be a positive integer
+        request = factory.get("/api/v1.0/persons?title=&limit=-2")
+
+        response = PersonsViewSet.as_view({"get": "list"})(request, version="1.0")
+
+        # The client received a BadRequest response with the relevant data
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue("limit" in response.data["errors"])


### PR DESCRIPTION
## Purpose

We want users to be able to find courses by persons (in the UI) and to find persons themselves through the API (for now).

## Proposal

- [x] Create a persons index that opens up the possibility to make a person search, and that makes available persons autocompletion right now.
- [x] Index related persons on courses to users can find courses by related persons through full text search.

Handles boxes 1 and 3 from #664 
