### PR TITLE
🐛(courses) return error for invalid slugs on page creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fail and return a meaningful error when an invalid slug is submitted in
+  page creation wizards,
 - Fix serializer that was failing for a course indexed with no organization,
 - The language filter, which is not a drilldown filter, no longer behaves
   like one. Ditto for any future similar filters,

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -2,6 +2,7 @@
 CMS Wizard to add a course page
 """
 from django import forms
+from django.core import validators
 from django.core.exceptions import PermissionDenied
 from django.template.defaultfilters import slugify
 from django.utils.functional import cached_property
@@ -96,6 +97,7 @@ class BaseWizardForm(forms.Form):
         max_length=200,  # Should be less than 255, the "max_length" of a Page's "path" field
         required=False,
         widget=SlugWidget(),
+        validators=[validators.validate_slug],
         label=_("Page slug"),
         help_text=_("Slug of the page in current language"),
     )

--- a/tests/apps/courses/test_cms_wizards_blogpost.py
+++ b/tests/apps/courses/test_cms_wizards_blogpost.py
@@ -176,6 +176,26 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
 
+    def test_cms_wizards_blogpost_submit_form_invalid_slug(self):
+        """Trying to submit a slug that is not valid should raise a 400 exception."""
+        # A parent page should pre-exist
+        create_page(
+            "News",
+            "richie/single_column.html",
+            "en",
+            reverse_id=BlogPost.ROOT_REVERSE_ID,
+        )
+
+        # Submit an invalid slug
+        data = {"title": "my title", "slug": "invalid slug"}
+
+        form = BlogPostWizardForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["slug"][0],
+            "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.",
+        )
+
     def test_cms_wizards_blogpost_submit_form_slug_duplicate(self):
         """
         Trying to create a blog post with a slug that would lead to a duplicate path should

--- a/tests/apps/courses/test_cms_wizards_category.py
+++ b/tests/apps/courses/test_cms_wizards_category.py
@@ -216,6 +216,27 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
 
+    def test_cms_wizards_category_submit_form_invalid_slug(self):
+        """Trying to submit a slug that is not valid should raise a 400 exception."""
+        # A parent page should pre-exist
+        parent_page = create_page(
+            "Categories",
+            "richie/single_column.html",
+            "en",
+            reverse_id=Category.ROOT_REVERSE_ID,
+        )
+
+        # Submit an invalid slug
+        data = {"title": "my title", "slug": "invalid slug"}
+
+        form = CategoryWizardForm(data=data)
+        form.page = parent_page
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["slug"][0],
+            "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.",
+        )
+
     def test_cms_wizards_category_submit_form_slug_duplicate(self):
         """
         Trying to create a category with a slug that would lead to a duplicate path should

--- a/tests/apps/courses/test_cms_wizards_course.py
+++ b/tests/apps/courses/test_cms_wizards_course.py
@@ -236,6 +236,26 @@ class CourseCMSWizardTestCase(CMSTestCase):
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
 
+    def test_cms_wizards_course_submit_form_invalid_slug(self):
+        """Trying to submit a slug that is not valid should raise a 400 exception."""
+        # A parent page should pre-exist
+        create_page(
+            "Courses",
+            "richie/single_column.html",
+            "en",
+            reverse_id=Course.ROOT_REVERSE_ID,
+        )
+
+        # Submit an invalid slug
+        data = {"title": "my title", "slug": "invalid slug"}
+
+        form = CourseWizardForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["slug"][0],
+            "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.",
+        )
+
     def test_cms_wizards_course_submit_form_slug_duplicate(self):
         """
         Trying to create a course with a slug that would lead to a duplicate path should

--- a/tests/apps/courses/test_cms_wizards_course_run.py
+++ b/tests/apps/courses/test_cms_wizards_course_run.py
@@ -246,6 +246,25 @@ class CourseRunCMSWizardTestCase(CMSTestCase):
         # Snapshot was not request and should not have been triggered
         self.assertFalse(mock_snapshot.called)
 
+    def test_cms_wizards_course_run_submit_form_invalid_slug(self, mock_snapshot):
+        """Trying to submit a slug that is not valid should raise a 400 exception."""
+        # A course should pre-exist
+        course = CourseFactory()
+
+        # Submit an invalid slug
+        data = {"title": "my title", "slug": "invalid slug"}
+
+        form = CourseRunWizardForm(data=data)
+        form.page = course.extended_object
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["slug"][0],
+            "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.",
+        )
+
+        # Snapshot was not request and should not have been triggered
+        self.assertFalse(mock_snapshot.called)
+
     def test_cms_wizards_course_run_submit_form_slug_duplicate(self, mock_snapshot):
         """
         Trying to create a course_run with a slug that would lead to a duplicate path should

--- a/tests/apps/courses/test_cms_wizards_organization.py
+++ b/tests/apps/courses/test_cms_wizards_organization.py
@@ -168,6 +168,26 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
 
+    def test_cms_wizards_organization_submit_form_invalid_slug(self):
+        """Trying to submit a slug that is not valid should raise a 400 exception."""
+        # A parent page should pre-exist
+        create_page(
+            "Organizations",
+            "richie/single_column.html",
+            "en",
+            reverse_id=Organization.ROOT_REVERSE_ID,
+        )
+
+        # Submit an invalid slug
+        data = {"title": "my title", "slug": "invalid slug"}
+
+        form = OrganizationWizardForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["slug"][0],
+            "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.",
+        )
+
     def test_cms_wizards_organization_submit_form_slug_duplicate(self):
         """
         Trying to create an organization with a slug that would lead to a duplicate path should

--- a/tests/apps/courses/test_cms_wizards_person.py
+++ b/tests/apps/courses/test_cms_wizards_person.py
@@ -213,6 +213,26 @@ class PersonCMSWizardTestCase(CMSTestCase):
             ["Ensure this value has at most 200 characters (it has 201)."],
         )
 
+    def test_cms_wizards_person_submit_form_invalid_slug(self):
+        """Trying to submit a slug that is not valid should raise a 400 exception."""
+        # A parent page should pre-exist
+        create_page(
+            "Persons",
+            "richie/single_column.html",
+            "en",
+            reverse_id=Person.ROOT_REVERSE_ID,
+        )
+
+        # Submit an invalid slug
+        data = {"title": "my title", "slug": "invalid slug"}
+
+        form = PersonWizardForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["slug"][0],
+            "Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens.",
+        )
+
     def test_cms_wizards_person_submit_form_slug_duplicate(self):
         """
         Trying to create a person with a slug that would lead to a duplicate path should


### PR DESCRIPTION
## Purpose

The form field used for the slug, on the page creation wizards, was missing a validator. The form was accepting invalid slugs and the code later crashed with a 500 error.

## Proposal

I added a validator to the slug form field and wrote tests to secure this feature on all the page creation wizards that are depending on this code.

