### PR TITLE
Add command to initialize site structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a management command to create the required site structure,
 - Allow to dynamically set webpack publicPath. This is useful if a CDN is used
   to load statics. Define the settings `CDN_DOMAIN` and it will be used as base
   domain to fetch js chunks.

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -390,8 +390,8 @@ class Base(DRFMixin, Configuration):
             "plugins": ["PicturePlugin"],
             "limits": {"PicturePlugin": 1},
         },
-        "courses/cms/person_detail.html resume": {
-            "name": _("Resume"),
+        "courses/cms/person_detail.html bio": {
+            "name": _("Bio"),
             "plugins": ["CKEditorPlugin"],
             "limits": {"CKEditorPlugin": 1},
         },

--- a/src/frontend/scss/objects/_person_glimpses.scss
+++ b/src/frontend/scss/objects/_person_glimpses.scss
@@ -106,7 +106,7 @@ $richie-person-glimpse-caption-background: $gray80 !default;
     }
   }
 
-  &__content__wrapper__resume {
+  &__content__wrapper__bio {
     @include m-o-media_empty($width: 100%, $height: 13vh, $absolute: false);
   }
 

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -21,9 +21,9 @@ from cms.models import Page
 from cms.wizards.wizard_base import Wizard
 from cms.wizards.wizard_pool import wizard_pool
 
+from . import defaults
 from .helpers import snapshot_course
 from .models import (
-    ROOT_REVERSE_IDS,
     BlogPost,
     Category,
     Course,
@@ -40,9 +40,9 @@ class ExcludeRootReverseIDMixin:
     def user_has_add_permission(self, user, page):
         """Check that the page or any of its ancestors is not a special Richie page."""
         if (
-            page.reverse_id in ROOT_REVERSE_IDS
+            page.reverse_id in defaults.ROOT_REVERSE_IDS
             or page.get_ancestor_pages()
-            .filter(reverse_id__in=ROOT_REVERSE_IDS)
+            .filter(reverse_id__in=defaults.ROOT_REVERSE_IDS)
             .exists()
         ):
             return False
@@ -148,7 +148,7 @@ class BaseWizardForm(forms.Form):
         """
         try:
             return Page.objects.get(
-                reverse_id=self.model.ROOT_REVERSE_ID, publisher_is_draft=True
+                reverse_id=self.model.PAGE["reverse_id"], publisher_is_draft=True
             )
         except Page.DoesNotExist:
             raise forms.ValidationError(
@@ -156,7 +156,7 @@ class BaseWizardForm(forms.Form):
                     "slug": [
                         _(
                             "You must first create a parent page and set its `reverse_id` to "
-                            "`{reverse}`.".format(reverse=self.model.ROOT_REVERSE_ID)
+                            "`{reverse}`.".format(reverse=self.model.PAGE["reverse_id"])
                         )
                     ]
                 }
@@ -171,7 +171,7 @@ class BaseWizardForm(forms.Form):
             slug=self.cleaned_data["slug"],
             language=get_language(),
             parent=self.parent_page,
-            template=self.model.TEMPLATE_DETAIL,
+            template=self.model.PAGE["template"],
             published=False,  # The creation wizard should not publish the page
         )
 

--- a/src/richie/apps/courses/defaults.py
+++ b/src/richie/apps/courses/defaults.py
@@ -6,3 +6,53 @@ from django.conf import settings
 PAGE_EXTENSION_TOOLBAR_ITEM_POSITION = getattr(
     settings, "RICHIE_PAGE_EXTENSION_TOOLBAR_ITEM_POSITION", 4
 )
+
+# For each type of page we define:
+#   - the `reverse_id` of the page under which pages should be created via the wizard,
+#   - the template to be used when creating a new page of this type,
+BLOGPOSTS_PAGE = {
+    "reverse_id": "blogposts",
+    "template": "courses/cms/blogpost_detail.html",
+}
+CATEGORIES_PAGE = {
+    "reverse_id": "categories",
+    "template": "courses/cms/category_detail.html",
+}
+COURSERUNS_PAGE = {"template": "courses/cms/course_run_detail.html"}
+COURSES_PAGE = {"reverse_id": "courses", "template": "courses/cms/course_detail.html"}
+ORGANIZATIONS_PAGE = {
+    "reverse_id": "organizations",
+    "template": "courses/cms/organization_detail.html",
+}
+PERSONS_PAGE = {"reverse_id": "persons", "template": "courses/cms/person_detail.html"}
+
+PAGES_INFO = {
+    BLOGPOSTS_PAGE["reverse_id"]: {
+        "title": "News",
+        "in_navigation": True,
+        "template": "courses/cms/blogpost_list.html",
+    },
+    CATEGORIES_PAGE["reverse_id"]: {
+        "title": "Categories",
+        "in_navigation": True,
+        "template": "courses/cms/category_list.html",
+    },
+    COURSES_PAGE["reverse_id"]: {
+        "title": "Courses",
+        "in_navigation": True,
+        "template": "search/search.html",
+    },
+    ORGANIZATIONS_PAGE["reverse_id"]: {
+        "title": "Organizations",
+        "in_navigation": True,
+        "template": "courses/cms/organization_list.html",
+    },
+    PERSONS_PAGE["reverse_id"]: {
+        "title": "Persons",
+        "in_navigation": True,
+        "template": "courses/cms/person_list.html",
+    },
+}
+PAGES_INFO.update(getattr(settings, "PAGES_INFO", {}))
+
+ROOT_REVERSE_IDS = PAGES_INFO.keys()

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -139,7 +139,7 @@ class OrganizationFactory(BLDPageExtensionDjangoModelFactory):
         ]
 
     # fields concerning the related page
-    page_template = Organization.TEMPLATE_DETAIL
+    page_template = Organization.PAGE["template"]
 
     @factory.lazy_attribute_sequence
     def code(self, sequence):
@@ -188,7 +188,7 @@ class CourseFactory(PageExtensionDjangoModelFactory):
         ]
 
     # fields concerning the related page
-    page_template = Course.TEMPLATE_DETAIL
+    page_template = Course.PAGE["template"]
 
     @factory.post_generation
     # pylint: disable=unused-argument
@@ -364,7 +364,7 @@ class CourseRunFactory(PageExtensionDjangoModelFactory):
         ]
 
     # fields concerning the related page
-    page_template = CourseRun.TEMPLATE_DETAIL
+    page_template = CourseRun.PAGE["template"]
     page_title = factory.Sequence("session {:d}".format)
 
     resource_link = factory.Faker("uri")
@@ -480,7 +480,7 @@ class CategoryFactory(BLDPageExtensionDjangoModelFactory):
         ]
 
     # fields concerning the related page
-    page_template = Category.TEMPLATE_DETAIL
+    page_template = Category.PAGE["template"]
 
     @factory.post_generation
     # pylint: disable=unused-argument
@@ -541,7 +541,7 @@ class BlogPostFactory(PageExtensionDjangoModelFactory):
         ]
 
     # fields concerning the related page
-    page_template = BlogPost.TEMPLATE_DETAIL
+    page_template = BlogPost.PAGE["template"]
 
     @factory.post_generation
     # pylint: disable=unused-argument
@@ -686,7 +686,7 @@ class PersonFactory(PageExtensionDjangoModelFactory):
         ]
 
     # fields concerning the related page
-    page_template = Person.TEMPLATE_DETAIL
+    page_template = Person.PAGE["template"]
 
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -750,14 +750,14 @@ class PersonFactory(PageExtensionDjangoModelFactory):
 
     @factory.post_generation
     # pylint: disable=unused-argument
-    def fill_resume(self, create, extracted, **kwargs):
+    def fill_bio(self, create, extracted, **kwargs):
         """
-        Add a text plugin for resume with a long random text
+        Add a text plugin for bio with a long random text
         """
         if create and extracted:
             create_text_plugin(
                 self.extended_object,
-                "resume",
+                "bio",
                 nb_paragraphs=1,
                 languages=self.extended_object.get_languages(),
             )

--- a/src/richie/apps/courses/management/commands/richie_init.py
+++ b/src/richie/apps/courses/management/commands/richie_init.py
@@ -1,0 +1,22 @@
+"""Create_demo_site management command."""
+import logging
+
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand
+
+from richie.apps.core.helpers import recursive_page_creation
+
+from ...defaults import PAGES_INFO
+
+logger = logging.getLogger("richie.commands.core.richie_init")
+
+
+class Command(BaseCommand):
+    """Create the minimum site structure required by Richie."""
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        """Call the `richie_init` function."""
+        site = Site.objects.get(id=1)
+        recursive_page_creation(site, PAGES_INFO)

--- a/src/richie/apps/courses/models/__init__.py
+++ b/src/richie/apps/courses/models/__init__.py
@@ -7,8 +7,3 @@ from .category import *
 from .course import *
 from .organization import *
 from .person import *
-
-ROOT_REVERSE_IDS = [
-    model.ROOT_REVERSE_ID
-    for model in [BlogPost, Category, Course, Organization, Person]
-]

--- a/src/richie/apps/courses/models/blog.py
+++ b/src/richie/apps/courses/models/blog.py
@@ -9,6 +9,7 @@ from cms.extensions.extension_pool import extension_pool
 from cms.models.pluginmodel import CMSPlugin
 
 from ...core.models import BasePageExtension, PagePluginMixin
+from ..defaults import BLOGPOSTS_PAGE
 
 
 class BlogPost(BasePageExtension):
@@ -16,8 +17,7 @@ class BlogPost(BasePageExtension):
     The blogpost extension represents and records a blog article.
     """
 
-    ROOT_REVERSE_ID = "news"
-    TEMPLATE_DETAIL = "courses/cms/blogpost_detail.html"
+    PAGE = BLOGPOSTS_PAGE
 
     class Meta:
         db_table = "richie_blog_post"

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -14,6 +14,7 @@ from cms.models import Title
 from cms.models.pluginmodel import CMSPlugin
 
 from ...core.models import BasePageExtension, PagePluginMixin
+from ..defaults import CATEGORIES_PAGE
 
 
 class Category(BasePageExtension):
@@ -25,8 +26,7 @@ class Category(BasePageExtension):
     page that presents the thematic.
     """
 
-    ROOT_REVERSE_ID = "categories"
-    TEMPLATE_DETAIL = "courses/cms/category_detail.html"
+    PAGE = CATEGORIES_PAGE
 
     class Meta:
         db_table = "richie_category"

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -22,6 +22,7 @@ from filer.fields.image import FilerImageField
 from ...core.defaults import ALL_LANGUAGES
 from ...core.fields.multiselect import MultiSelectField
 from ...core.models import BasePageExtension, PagePluginMixin
+from ..defaults import COURSERUNS_PAGE, COURSES_PAGE
 from .category import Category
 from .organization import Organization
 
@@ -130,8 +131,7 @@ class Course(BasePageExtension):
     page that presents the course.
     """
 
-    ROOT_REVERSE_ID = "courses"
-    TEMPLATE_DETAIL = "courses/cms/course_detail.html"
+    PAGE = COURSES_PAGE
 
     class Meta:
         db_table = "richie_course"
@@ -338,7 +338,7 @@ class CourseRun(BasePageExtension):
         help_text=_("The list of languages in which the course content is available."),
     )
 
-    TEMPLATE_DETAIL = "courses/cms/course_run_detail.html"
+    PAGE = COURSERUNS_PAGE
 
     class Meta:
         db_table = "richie_course_run"

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -15,6 +15,7 @@ from cms.models import Title
 from cms.models.pluginmodel import CMSPlugin
 
 from ...core.models import BasePageExtension, PagePluginMixin
+from ..defaults import ORGANIZATIONS_PAGE
 
 
 class Organization(BasePageExtension):
@@ -31,8 +32,7 @@ class Organization(BasePageExtension):
         _("code"), db_index=True, max_length=100, null=True, blank=True
     )
 
-    ROOT_REVERSE_ID = "organizations"
-    TEMPLATE_DETAIL = "courses/cms/organization_detail.html"
+    PAGE = ORGANIZATIONS_PAGE
 
     class Meta:
         db_table = "richie_organization"

--- a/src/richie/apps/courses/models/person.py
+++ b/src/richie/apps/courses/models/person.py
@@ -15,6 +15,7 @@ from parler.fields import TranslatedField
 from parler.models import TranslatableModel, TranslatedFieldsModel
 
 from ...core.models import BasePageExtension, PagePluginMixin
+from ..defaults import PERSONS_PAGE
 
 
 class PersonTitle(TranslatableModel):
@@ -91,8 +92,7 @@ class Person(BasePageExtension):
         null=True,
     )
 
-    ROOT_REVERSE_ID = "persons"
-    TEMPLATE_DETAIL = "courses/cms/person_detail.html"
+    PAGE = PERSONS_PAGE
 
     class Meta:
         db_table = "richie_person"

--- a/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
@@ -27,8 +27,8 @@
           {% page_placeholder "categories" person_page %}
         {% endwith %}
       </div>
-      <div class="person-glimpse__content__wrapper__resume">
-        {% page_placeholder "resume" person_page %}
+      <div class="person-glimpse__content__wrapper__bio">
+        {% page_placeholder "bio" person_page %}
       </div>
     </div>
   </div>

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -30,7 +30,7 @@
 
     <div class="person-detail__card__content">
       <div class="person-detail__card__content__wrapper">
-        {% placeholder "resume" or %}
+        {% placeholder "bio" or %}
           <p class="person-detail__card__content__wrapper__empty">{% trans "Enter your bio here..." %}</p>
         {% endplaceholder %}
 

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -1,8 +1,6 @@
 """Parameters that define how the demo site will be built."""
 from django.conf import settings
 
-from richie.apps.courses import models
-
 NB_OBJECTS = {
     "courses": 30,
     "course_organizations": 3,
@@ -27,68 +25,48 @@ PAGES_INFO = {
     "home": {
         "title": {"en": "Home", "fr": "Accueil"},
         "in_navigation": False,
-        "kwargs": {"template": "richie/homepage.html"},
+        "is_homepage": True,
+        "template": "richie/homepage.html",
     },
-    "news": {
+    "blogposts": {
         "title": {"en": "News", "fr": "Actualités"},
         "in_navigation": True,
-        "kwargs": {
-            "reverse_id": models.BlogPost.ROOT_REVERSE_ID,
-            "template": "courses/cms/blogpost_list.html",
-        },
+        "template": "courses/cms/blogpost_list.html",
     },
     "courses": {
         "title": {"en": "Courses", "fr": "Cours"},
         "in_navigation": True,
-        "kwargs": {
-            "reverse_id": models.Course.ROOT_REVERSE_ID,
-            "template": "search/search.html",
-        },
+        "template": "search/search.html",
     },
     "categories": {
         "title": {"en": "Categories", "fr": "Catégories"},
         "in_navigation": True,
-        "kwargs": {
-            "reverse_id": models.Category.ROOT_REVERSE_ID,
-            "template": "courses/cms/category_list.html",
-        },
+        "template": "courses/cms/category_list.html",
     },
     "organizations": {
         "title": {"en": "Organizations", "fr": "Etablissements"},
         "in_navigation": True,
-        "kwargs": {
-            "reverse_id": models.Organization.ROOT_REVERSE_ID,
-            "template": "courses/cms/organization_list.html",
-        },
+        "template": "courses/cms/organization_list.html",
     },
     "persons": {
         "title": {"en": "Persons", "fr": "Personnes"},
         "in_navigation": True,
-        "kwargs": {
-            "reverse_id": models.Person.ROOT_REVERSE_ID,
-            "template": "courses/cms/person_list.html",
-        },
-    },
-    "dashboard": {
-        "title": {"en": "Dashboard", "fr": "Tableau de bord"},
-        "in_navigation": False,
-        "cms": False,
-        "kwargs": {"template": "richie/single_column.html"},
+        "template": "courses/cms/person_list.html",
     },
     "annex": {
         "title": {"en": "Annex", "fr": "Annexe"},
         "in_navigation": False,
-        "kwargs": {"template": "richie/single_column.html", "reverse_id": "annex"},
+        "template": "richie/single_column.html",
         "children": {
             "annex__about": {
                 "title": {"en": "About", "fr": "A propos"},
                 "in_navigation": True,
-                "kwargs": {"template": "richie/single_column.html"},
+                "template": "richie/single_column.html",
             }
         },
     },
 }
-PAGES_INFO.update(getattr(settings, "RICHIE_DEMO_PAGES_INFO", {}))
+
 
 LEVELS_INFO = {
     "title": {"en": "Level", "fr": "Niveau"},

--- a/src/richie/apps/demo/helpers.py
+++ b/src/richie/apps/demo/helpers.py
@@ -1,56 +1,5 @@
 """Helpers for the demo app of the Richie project."""
-from django.core.exceptions import ImproperlyConfigured
-
-from richie.apps.core.helpers import create_i18n_page
 from richie.apps.courses.factories import CategoryFactory
-
-
-def recursive_page_creation(site, pages_info, parent=None):
-    """
-    Recursively create page following tree structure with parent/children.
-
-    Arguments:
-        site (django.contrib.sites.models.Site): Site object which page will
-            be linked to.
-        pages (dict): Page items to create recursively such as 'children' key
-            value can be a dict to create child pages. The current page is
-            given to children for parent relation.
-
-    Keyword Arguments:
-        parent (cms.models.pagemodel.Page): Page used as a parent to create
-            page item from `pages` argument.
-
-    Returns:
-        dict: mapping of the page names passed in argument and the created page instances.
-    """
-    pages = {}
-
-    for name, info in pages_info.items():
-        page = create_i18n_page(
-            info["title"],
-            is_homepage=(name == "home"),
-            in_navigation=info.get("in_navigation", True),
-            published=True,
-            site=site,
-            parent=parent,
-            **info["kwargs"],
-        )
-
-        pages[name] = page
-
-        # Create children
-        if info.get("children", None):
-            children_pages = recursive_page_creation(
-                site, info["children"], parent=page
-            )
-            for child_name in children_pages:
-                if child_name in pages:
-                    raise ImproperlyConfigured(
-                        "Page names should be unique: {:s}".format(child_name)
-                    )
-            pages.update(children_pages)
-
-    return pages
 
 
 # pylint: disable=too-many-arguments

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -12,7 +12,7 @@ import factory
 from cms.api import add_plugin
 
 from richie.apps.core.factories import image_getter
-from richie.apps.core.helpers import create_text_plugin
+from richie.apps.core.helpers import create_text_plugin, recursive_page_creation
 from richie.apps.courses.factories import (
     VIDEO_SAMPLE_LINKS,
     BlogPostFactory,
@@ -33,10 +33,10 @@ from ...defaults import (
     SINGLECOLUMN_CONTENT,
     SUBJECTS_INFO,
 )
-from ...helpers import create_categories, recursive_page_creation
+from ...helpers import create_categories
 from ...utils import pick_image
 
-logger = logging.getLogger("richie.commands.core.create_demo_site")
+logger = logging.getLogger("richie.commands.demo.create_demo_site")
 
 
 def get_number_of_course_runs():

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -130,7 +130,7 @@ def create_demo_site():
             ),
             fill_organizations=person_organizations,
             fill_portrait=pick_image("portrait"),
-            fill_resume=True,
+            fill_bio=True,
             should_publish=True,
         )
         persons.append(person)

--- a/tests/apps/courses/test_cms_plugins_person.py
+++ b/tests/apps/courses/test_cms_plugins_person.py
@@ -71,14 +71,12 @@ class PersonPluginTestCase(CMSTestCase):
             "fr",
             **{"picture": image, "attributes": {"alt": "description du portrait"}}
         )
-        # Add resume to related placeholder
-        resume_placeholder = person_page.placeholders.get(slot="resume")
-        resume_en = add_plugin(
-            resume_placeholder, PlainTextPlugin, "en", **{"body": "public resume"}
+        # Add bio to related placeholder
+        bio_placeholder = person_page.placeholders.get(slot="bio")
+        bio_en = add_plugin(
+            bio_placeholder, PlainTextPlugin, "en", **{"body": "public bio"}
         )
-        add_plugin(
-            resume_placeholder, PlainTextPlugin, "fr", **{"body": "résumé public"}
-        )
+        add_plugin(bio_placeholder, PlainTextPlugin, "fr", **{"body": "résumé public"})
 
         # Create a page to add the plugin to
         page = create_i18n_page({"en": "A page", "fr": "Une page"})
@@ -108,8 +106,8 @@ class PersonPluginTestCase(CMSTestCase):
         # Now modify the person to have a draft different from the public version
         person.first_name = "Jiji"
         person.save()
-        resume_en.body = "draft resume"
-        resume_en.save()
+        bio_en.body = "draft bio"
+        bio_en.save()
 
         # Publishing the page again should make the plugin public
         page.publish("en")
@@ -139,13 +137,13 @@ class PersonPluginTestCase(CMSTestCase):
         # Person's portrait and its properties should be present
         # pylint: disable=no-member
         self.assertContains(response, image.file.name)
-        # Short resume should be present
+        # Short bio should be present
         self.assertContains(
             response,
-            '<div class="person-glimpse__content__wrapper__resume">public resume</div>',
+            '<div class="person-glimpse__content__wrapper__bio">public bio</div>',
             html=True,
         )
-        self.assertNotContains(response, "draft resume")
+        self.assertNotContains(response, "draft bio")
 
         # Same checks in French
         url = page.get_absolute_url(language="fr")
@@ -161,7 +159,7 @@ class PersonPluginTestCase(CMSTestCase):
         self.assertContains(response, image.file.name)
         self.assertContains(
             response,
-            '<div class="person-glimpse__content__wrapper__resume">résumé public</div>',
+            '<div class="person-glimpse__content__wrapper__bio">résumé public</div>',
             html=True,
         )
 
@@ -176,10 +174,10 @@ class PersonPluginTestCase(CMSTestCase):
         person = PersonFactory(first_name="Meimei")
         person_page = person.extended_object
 
-        # Add resume to related placeholder
-        resume_placeholder = person_page.placeholders.get(slot="resume")
-        resume_en = add_plugin(
-            resume_placeholder, PlainTextPlugin, "en", **{"body": "public resume"}
+        # Add bio to related placeholder
+        bio_placeholder = person_page.placeholders.get(slot="bio")
+        bio_en = add_plugin(
+            bio_placeholder, PlainTextPlugin, "en", **{"body": "public bio"}
         )
 
         # Create a page to add the plugin to
@@ -195,17 +193,17 @@ class PersonPluginTestCase(CMSTestCase):
         # The person plugin should still be visible on the draft page
         response = self.client.get(url)
         self.assertContains(response, "Meimei")
-        self.assertContains(response, "public resume")
+        self.assertContains(response, "public bio")
 
         # Now modify the person to have a draft different from the public version
         person.first_name = "Jiji"
         person.save()
-        resume_en.body = "draft resume"
-        resume_en.save()
+        bio_en.body = "draft bio"
+        bio_en.save()
 
         # The draft version of the person plugin should now be visible
         response = self.client.get(url)
         self.assertContains(response, "Jiji")
-        self.assertContains(response, "draft resume")
+        self.assertContains(response, "draft bio")
         self.assertNotContains(response, "Meimei")
-        self.assertNotContains(response, "public resume")
+        self.assertNotContains(response, "public bio")

--- a/tests/apps/courses/test_cms_wizards_blogpost.py
+++ b/tests/apps/courses/test_cms_wizards_blogpost.py
@@ -64,7 +64,7 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             "News",
             "richie/single_column.html",
             "en",
-            reverse_id=BlogPost.ROOT_REVERSE_ID,
+            reverse_id=BlogPost.PAGE["reverse_id"],
         )
         # We can submit a form with just the title set
         form = BlogPostWizardForm(data={"title": "My title"})
@@ -90,7 +90,7 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             "y" * 200,
             "richie/single_column.html",
             "en",
-            reverse_id=BlogPost.ROOT_REVERSE_ID,
+            reverse_id=BlogPost.PAGE["reverse_id"],
         )
 
         # A blogpost with a slug at the limit length should work
@@ -118,7 +118,7 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             "News",
             "richie/single_column.html",
             "en",
-            reverse_id=BlogPost.ROOT_REVERSE_ID,
+            reverse_id=BlogPost.PAGE["reverse_id"],
         )
 
         # Submit a title at max length
@@ -139,7 +139,7 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             "News",
             "richie/single_column.html",
             "en",
-            reverse_id=BlogPost.ROOT_REVERSE_ID,
+            reverse_id=BlogPost.PAGE["reverse_id"],
         )
 
         # Submit a title that is too long and a slug that is ok
@@ -162,7 +162,7 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             "News",
             "richie/single_column.html",
             "en",
-            reverse_id=BlogPost.ROOT_REVERSE_ID,
+            reverse_id=BlogPost.PAGE["reverse_id"],
         )
 
         # Submit a slug that is too long and a title that is ok
@@ -183,7 +183,7 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             "News",
             "richie/single_column.html",
             "en",
-            reverse_id=BlogPost.ROOT_REVERSE_ID,
+            reverse_id=BlogPost.PAGE["reverse_id"],
         )
 
         # Submit an invalid slug
@@ -206,7 +206,7 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             "News",
             "richie/single_column.html",
             "en",
-            reverse_id=BlogPost.ROOT_REVERSE_ID,
+            reverse_id=BlogPost.PAGE["reverse_id"],
         )
         # Create an existing page with a known slug
         BlogPostFactory(page_parent=parent_page, page_title="My title")
@@ -228,7 +228,7 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             form.errors,
             {
                 "slug": [
-                    "You must first create a parent page and set its `reverse_id` to `news`."
+                    "You must first create a parent page and set its `reverse_id` to `blogposts`."
                 ]
             },
         )

--- a/tests/apps/courses/test_cms_wizards_category.py
+++ b/tests/apps/courses/test_cms_wizards_category.py
@@ -64,7 +64,7 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "Categories",
             "richie/single_column.html",
             "en",
-            reverse_id=Category.ROOT_REVERSE_ID,
+            reverse_id=Category.PAGE["reverse_id"],
         )
         # We want to create the category from an ordinary page
         page = create_page("Any page", "richie/single_column.html", "en")
@@ -94,7 +94,7 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "Categories",
             "richie/single_column.html",
             "en",
-            reverse_id=Category.ROOT_REVERSE_ID,
+            reverse_id=Category.PAGE["reverse_id"],
         )
         # Create a category when visiting an existing category
         parent_category = CategoryFactory()
@@ -125,7 +125,7 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "y" * 200,
             "richie/single_column.html",
             "en",
-            reverse_id=Category.ROOT_REVERSE_ID,
+            reverse_id=Category.PAGE["reverse_id"],
         )
 
         # A category with a slug at the limit length should work
@@ -155,7 +155,7 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "Categories",
             "richie/single_column.html",
             "en",
-            reverse_id=Category.ROOT_REVERSE_ID,
+            reverse_id=Category.PAGE["reverse_id"],
         )
 
         # Submit a title at max length
@@ -177,7 +177,7 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "Categories",
             "richie/single_column.html",
             "en",
-            reverse_id=Category.ROOT_REVERSE_ID,
+            reverse_id=Category.PAGE["reverse_id"],
         )
 
         # Submit a title that is too long and a slug that is ok
@@ -201,7 +201,7 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "Sujects",
             "richie/single_column.html",
             "en",
-            reverse_id=Category.ROOT_REVERSE_ID,
+            reverse_id=Category.PAGE["reverse_id"],
         )
 
         # Submit a slug that is too long and a title that is ok
@@ -223,7 +223,7 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "Categories",
             "richie/single_column.html",
             "en",
-            reverse_id=Category.ROOT_REVERSE_ID,
+            reverse_id=Category.PAGE["reverse_id"],
         )
 
         # Submit an invalid slug
@@ -247,7 +247,7 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "Categories",
             "richie/single_column.html",
             "en",
-            reverse_id=Category.ROOT_REVERSE_ID,
+            reverse_id=Category.PAGE["reverse_id"],
         )
         # Create an existing page with a known slug
         CategoryFactory(page_parent=parent_page, page_title="My title")

--- a/tests/apps/courses/test_cms_wizards_course.py
+++ b/tests/apps/courses/test_cms_wizards_course.py
@@ -64,7 +64,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "Courses",
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
 
         any_page = create_page("Any page", "richie/single_column.html", "en")
@@ -97,7 +97,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "Courses",
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
 
         # We can submit a form omitting the slug
@@ -131,7 +131,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "y" * 200,
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
 
         # An organization with a slug at the limit length should work
@@ -168,7 +168,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "Courses",
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
 
         # Submit a title at max length
@@ -190,7 +190,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "Courses",
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
         # Submit a title that is too long and a slug that is ok
         invalid_data = {
@@ -218,7 +218,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "Courses",
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
         # Submit a slug that is too long and a title that is ok
         invalid_data = {
@@ -243,7 +243,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "Courses",
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
 
         # Submit an invalid slug
@@ -266,7 +266,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "Courses",
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
         # Create an existing page with a known slug
         CourseFactory(page_parent=parent_page, page_title="My title")

--- a/tests/apps/courses/test_cms_wizards_course_run.py
+++ b/tests/apps/courses/test_cms_wizards_course_run.py
@@ -157,7 +157,7 @@ class CourseRunCMSWizardTestCase(CMSTestCase):
             "p" * 100,
             "richie/single_column.html",
             "en",
-            reverse_id=Course.ROOT_REVERSE_ID,
+            reverse_id=Course.PAGE["reverse_id"],
         )
         course = CourseFactory(page_title="c" * 100, page_parent=root_page)
 

--- a/tests/apps/courses/test_cms_wizards_organization.py
+++ b/tests/apps/courses/test_cms_wizards_organization.py
@@ -175,7 +175,7 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
             "Organizations",
             "richie/single_column.html",
             "en",
-            reverse_id=Organization.ROOT_REVERSE_ID,
+            reverse_id=Organization.PAGE["reverse_id"],
         )
 
         # Submit an invalid slug
@@ -198,7 +198,7 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
             "Organizations",
             "richie/single_column.html",
             "en",
-            reverse_id=Organization.ROOT_REVERSE_ID,
+            reverse_id=Organization.PAGE["reverse_id"],
         )
         # Create an existing page with a known slug
         OrganizationFactory(page_parent=parent_page, page_title="My title")

--- a/tests/apps/courses/test_cms_wizards_person.py
+++ b/tests/apps/courses/test_cms_wizards_person.py
@@ -64,7 +64,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
         # create a PersonTitle object
         person_title = PersonTitleFactory()
@@ -99,7 +99,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "y" * 200,
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
         person_title = PersonTitleFactory()
 
@@ -136,7 +136,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
         person_title = PersonTitleFactory()
 
@@ -162,7 +162,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
         person_title = PersonTitleFactory()
 
@@ -192,7 +192,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
         person_title = PersonTitleFactory()
 
@@ -220,7 +220,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
 
         # Submit an invalid slug
@@ -243,7 +243,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
         person_title = PersonTitleFactory()
         # Create an existing page with a known slug
@@ -270,7 +270,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
         person_title = PersonTitleFactory()
 
@@ -294,7 +294,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
         person_title = PersonTitleFactory()
 
@@ -318,7 +318,7 @@ class PersonCMSWizardTestCase(CMSTestCase):
             "Persons",
             "richie/single_column.html",
             "en",
-            reverse_id=Person.ROOT_REVERSE_ID,
+            reverse_id=Person.PAGE["reverse_id"],
         )
 
         no_title_data = {

--- a/tests/apps/courses/test_factories_person.py
+++ b/tests/apps/courses/test_factories_person.py
@@ -36,20 +36,20 @@ class PersonFactoryTestCase(TestCase):
                 ),
             )
 
-    def test_factories_person_resume(self):
+    def test_factories_person_bio(self):
         """
-        PersonFactory should be able to generate plugins with a realistic resume for
+        PersonFactory should be able to generate plugins with a realistic bio for
         several languages.
         """
-        person = PersonFactory(page_languages=["fr", "en"], fill_resume=True)
+        person = PersonFactory(page_languages=["fr", "en"], fill_bio=True)
 
-        # Check that the resume plugins were created as expected
-        resume = person.extended_object.placeholders.get(slot="resume")
-        self.assertEqual(resume.cmsplugin_set.count(), 2)
+        # Check that the bio plugins were created as expected
+        bio = person.extended_object.placeholders.get(slot="bio")
+        self.assertEqual(bio.cmsplugin_set.count(), 2)
 
-        # The resume plugins should contain paragraphs
+        # The bio plugins should contain paragraphs
         for language in ["fr", "en"]:
-            resume_plugin = resume.cmsplugin_set.get(
+            bio_plugin = bio.cmsplugin_set.get(
                 plugin_type="CKEditorPlugin", language=language
             )
-            self.assertIn("<p>", resume_plugin.simple_text_ckeditor_simpletext.body)
+            self.assertIn("<p>", bio_plugin.simple_text_ckeditor_simpletext.body)

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -49,7 +49,7 @@ class PersonCMSTestCase(CMSTestCase):
         person = PersonFactory(
             page_title="My page title",
             fill_portrait=True,
-            fill_resume=True,
+            fill_bio=True,
             fill_categories=[published_category, unpublished_category],
             fill_organizations=[published_organization, unpublished_organization],
         )
@@ -156,7 +156,7 @@ class PersonCMSTestCase(CMSTestCase):
         person = PersonFactory(
             page_title="My page title",
             fill_portrait=True,
-            fill_resume=True,
+            fill_bio=True,
             fill_categories=[published_category, unpublished_category],
             fill_organizations=[published_organization, unpublished_organization],
         )


### PR DESCRIPTION
## Purpose

We had a management command to create full demo sites. But all Richie need to have required pages under which the different objects will be created (courses, organizations, persons, blog posts...). We need a command line to create only these required pages.

## Proposal

I refactored the management command that creates a demo site and added a new command line to create just the site structure. I placed it in the `courses` app because all sites need it.

