### PR TITLE
🐛(demo) fix and test the create_demo_site management command

### DIFF
--- a/src/richie/apps/core/helpers.py
+++ b/src/richie/apps/core/helpers.py
@@ -164,9 +164,10 @@ def recursive_page_creation(site, pages_info, parent=None):
     pages = {}
 
     for name, kwargs in pages_info.items():
+        children = kwargs.pop("children", None)
         try:
             page = Page.objects.get(reverse_id=name)
-        except Page.DoesNotExist():
+        except Page.DoesNotExist:
             page = create_i18n_page(
                 site=site, parent=parent, published=True, reverse_id=name, **kwargs
             )
@@ -174,10 +175,8 @@ def recursive_page_creation(site, pages_info, parent=None):
         pages[name] = page
 
         # Create children
-        if kwargs.get("children", None):
-            children_pages = recursive_page_creation(
-                site, kwargs["children"], parent=page
-            )
+        if children:
+            children_pages = recursive_page_creation(site, children, parent=page)
             for child_name in children_pages:
                 if child_name in pages:
                     raise ImproperlyConfigured(

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -3,6 +3,7 @@ from django.conf import settings
 
 NB_OBJECTS = {
     "courses": 30,
+    "course_courseruns": 5,
     "course_organizations": 3,
     "course_persons": 6,
     "course_subjects": 2,

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -44,7 +44,7 @@ def get_number_of_course_runs():
     Returns a random integer between 1 and 5. We make it a convenience method so that it can
     be mocked in tests.
     """
-    return random.randint(1, 5)
+    return random.randint(1, NB_OBJECTS["course_courseruns"])
 
 
 # pylint: disable=no-member
@@ -221,7 +221,7 @@ def create_demo_site():
         post = BlogPostFactory.create(
             page_in_navigation=True,
             page_languages=["en", "fr"],
-            page_parent=pages_created["news"],
+            page_parent=pages_created["blogposts"],
             fill_cover=pick_image("cover"),
             fill_excerpt=True,
             fill_body=True,
@@ -306,7 +306,7 @@ def create_demo_site():
             target=blogposts_section,
             name=content["blogposts_button_title"],
             template=content["button_template_name"],
-            internal_link=pages_created["news"],
+            internal_link=pages_created["blogposts"],
         )
 
         # Add highlighted organizations

--- a/tests/apps/demo/test_commands_create_demo_site.py
+++ b/tests/apps/demo/test_commands_create_demo_site.py
@@ -9,7 +9,15 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test.utils import override_settings
 
+from cms.models import CMSPlugin
 from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.courses import models
+from richie.apps.demo.management.commands.create_demo_site import (
+    NB_OBJECTS,
+    SUBJECTS_INFO,
+    create_demo_site,
+)
 
 
 class CreateDemoSiteCommandsTestCase(CMSTestCase):
@@ -42,3 +50,59 @@ class CreateDemoSiteCommandsTestCase(CMSTestCase):
         call_command("create_demo_site")
         mock_create.assert_called_once_with()
         mock_logger.assert_called_once_with("done")
+
+    @mock.patch.dict(
+        NB_OBJECTS,
+        {
+            "courses": 1,
+            "course_courseruns": 1,
+            "course_organizations": 1,
+            "course_persons": 1,
+            "course_subjects": 1,
+            "person_organizations": 1,
+            "person_subjects": 1,
+            "organizations": 1,
+            "licences": 1,
+            "persons": 1,
+            "blogposts": 1,
+            "blogpost_categories": 1,
+            "home_blogposts": 1,
+            "home_courses": 1,
+            "home_organizations": 1,
+            "home_subjects": 1,
+            "home_persons": 1,
+        },
+    )
+    @mock.patch.dict(
+        SUBJECTS_INFO,
+        {
+            "title": {"en": "Subject", "fr": "Subjet"},
+            "children": [
+                {
+                    "title": {"en": "Science", "fr": "Sciences"},
+                    "children": [
+                        {
+                            "title": {
+                                "en": "Agronomy and Agriculture",
+                                "fr": "Agronomie et Agriculture",
+                            }
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+    def test_commands_create_demo_site_method(self):
+        """
+        Validate that the create_demo_site method works (with a minimum number of pages because
+        it takes a lot of time).
+        """
+        create_demo_site()
+        self.assertEqual(models.BlogPost.objects.count(), 2)
+        self.assertEqual(models.Course.objects.count(), 2)
+        self.assertEqual(models.CourseRun.objects.count(), 2)
+        self.assertEqual(models.Category.objects.count(), 14)
+        self.assertEqual(models.Organization.objects.count(), 2)
+        self.assertEqual(models.Person.objects.count(), 2)
+        self.assertEqual(models.Licence.objects.count(), 1)
+        self.assertEqual(CMSPlugin.objects.count(), 296)


### PR DESCRIPTION
## Purpose

PR https://github.com/openfun/richie/pull/693 broke the `create_demo_site` management command. 

It's not the first time we break this command because it is not tested. This is historical because it takes too long to run.

## Proposal

I fixed the command and added a test to secure it, bringing it down to 4-5 seconds by mocking the number of objects that are created. It's still too long but at least we can be sure the command works.
