### PR TITLE
♻️(core) remove dependency to `factory` in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix production image by removing dependency to `factory` in production code,
 - Fail and return a meaningful error when an invalid slug is submitted in
   page creation wizards,
 - Fix person placeholders mistakenly showing on the organization page,

--- a/src/richie/apps/core/helpers.py
+++ b/src/richie/apps/core/helpers.py
@@ -1,7 +1,6 @@
 """
 Helpers that can be useful throughout the whole project
 """
-import random
 from functools import reduce
 from operator import or_
 
@@ -11,8 +10,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
 from django.utils.text import slugify
 
-import factory
-from cms.api import add_plugin, create_page, create_title
+from cms.api import create_page, create_title
 from cms.models import Page
 
 
@@ -44,7 +42,7 @@ def get_permissions(names):
     return permissions
 
 
-def create_i18n_page(title=None, languages=None, is_homepage=False, **kwargs):
+def create_i18n_page(title, languages=None, is_homepage=False, **kwargs):
     """
     Creating a multilingual page is not straightforward so we should have a helper
 
@@ -59,15 +57,7 @@ def create_i18n_page(title=None, languages=None, is_homepage=False, **kwargs):
     """
     kwargs["template"] = kwargs.get("template", "richie/single_column.html")
 
-    if title is None:
-        # Create realistic titles in each language with faker
-        languages = languages or [settings.LANGUAGE_CODE]
-        i18n_titles = {
-            language: factory.Faker("catch_phrase", locale=language).generate({})
-            for language in languages
-        }
-
-    elif isinstance(title, dict):
+    if isinstance(title, dict):
         # Check that the languages passed are coherent with the languages requested if any
         if languages:
             assert set(languages).issubset(title.keys())
@@ -113,66 +103,6 @@ def create_i18n_page(title=None, languages=None, is_homepage=False, **kwargs):
             page.publish(language)
 
     return page
-
-
-# pylint: disable=too-many-arguments
-def create_text_plugin(
-    page,
-    slot,
-    languages=None,
-    is_html=True,
-    max_nb_chars=None,
-    nb_paragraphs=None,
-    plugin_type="CKEditorPlugin",
-):
-    """
-    A common function to create and add a text plugin of any type instance to
-    a placeholder filled with some random text using Faker.
-
-    Arguments:
-        page (cms.models.pagemodel.Page): Instance of a Page used to search for
-            given slot (aka a placeholder name).
-        slot (string): A placeholder name available from page template.
-
-    Keyword Arguments:
-        languages (iterable): An iterable yielding language codes for which a text plugin should
-            be created. If ``None`` (default) it uses the default language from settings.
-        is_html (boolean): If True, every paragraph will be surrounded with an
-            HTML paragraph markup. Default is True.
-        max_nb_chars (integer): Number of characters limit to create each
-            paragraph. Default is None so a random number between 200 and 400
-            will be used at each paragraph.
-        nb_paragraphs (integer): Number of paragraphs to create in content.
-            Default is None so a random number between 2 and 4 will be used.
-        plugin_type (string or object): Type of plugin. Default use CKEditorPlugin
-            but you can use any other similar plugin that has a body attribute.
-
-    Returns:
-        object: Created plugin instance.
-    """
-    languages = languages or [settings.LANGUAGE_CODE]
-    container = "<p>{:s}</p>" if is_html else "{:s}"
-    nb_paragraphs = nb_paragraphs or random.randint(2, 4)
-
-    placeholder = page.placeholders.get(slot=slot)
-
-    for language in languages:
-        paragraphs = []
-        for _ in range(nb_paragraphs):
-            max_nb_chars = max_nb_chars or random.randint(200, 400)
-            paragraphs.append(
-                factory.Faker(
-                    "text", max_nb_chars=max_nb_chars, locale=language
-                ).generate({})
-            )
-        body = [container.format(p) for p in paragraphs]
-
-        add_plugin(
-            language=language,
-            placeholder=placeholder,
-            plugin_type=plugin_type,
-            body="".join(body),
-        )
 
 
 def recursive_page_creation(site, pages_info, parent=None):

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -17,9 +17,9 @@ from ..core.factories import (
     FilerImageFactory,
     PageExtensionDjangoModelFactory,
     PageFactory,
+    create_text_plugin,
     image_getter,
 )
-from ..core.helpers import create_text_plugin
 from . import models
 from .defaults import ROLE_CHOICES
 

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -11,8 +11,8 @@ from django.test.utils import override_settings
 import factory
 from cms.api import add_plugin
 
-from richie.apps.core.factories import image_getter
-from richie.apps.core.helpers import create_text_plugin, recursive_page_creation
+from richie.apps.core.factories import create_text_plugin, image_getter
+from richie.apps.core.helpers import recursive_page_creation
 from richie.apps.courses.factories import (
     VIDEO_SAMPLE_LINKS,
     BlogPostFactory,

--- a/tests/apps/courses/test_cms_plugins_blogpost.py
+++ b/tests/apps/courses/test_cms_plugins_blogpost.py
@@ -35,7 +35,7 @@ class BlogPostPluginTestCase(CMSTestCase):
                 model = BlogPostPluginModel
                 fields = ["page"]
 
-        blog_page = create_i18n_page(published=True)
+        blog_page = create_i18n_page("my title", published=True)
         blogpost = BlogPostFactory(page_parent=blog_page)
         other_page_title = "other page"
         create_page(

--- a/tests/apps/courses/test_models_category.py
+++ b/tests/apps/courses/test_models_category.py
@@ -123,7 +123,7 @@ class CategoryModelsTestCase(TestCase):
         # which is there to exclude snapshots but also acts on the main course page and
         # checks its parent (so the root page) and the duplicate comes from the fact that
         # the parent has a draft and a public page... so "cms_pages" has a cardinality of 2
-        root_page = create_i18n_page(published=True)
+        root_page = create_i18n_page("my title", published=True)
 
         category = CategoryFactory(should_publish=True)
         course = CourseFactory(

--- a/tests/apps/courses/test_models_organization.py
+++ b/tests/apps/courses/test_models_organization.py
@@ -149,7 +149,7 @@ class OrganizationModelsTestCase(TestCase):
         # which is there to exclude snapshots but also acts on the main course page and
         # checks its parent (so the root page) and the duplicate comes from the fact that
         # the parent has a draft and a public page... so "cms_pages" has a cardinality of 2
-        root_page = create_i18n_page(published=True)
+        root_page = create_i18n_page("my title", published=True)
 
         organization = OrganizationFactory(should_publish=True)
         course = CourseFactory(

--- a/tests/apps/courses/test_models_person.py
+++ b/tests/apps/courses/test_models_person.py
@@ -147,7 +147,7 @@ class PersonModelsTestCase(TestCase):
         # which is there to exclude snapshots but also acts on the main course page and
         # checks its parent (so the root page) and the duplicate comes from the fact that
         # the parent has a draft and a public page... so "cms_pages" has a cardinality of 2
-        root_page = create_i18n_page(published=True)
+        root_page = create_i18n_page("my title", published=True)
 
         person = PersonFactory(should_publish=True)
         course = CourseFactory(

--- a/tests/apps/demo/test_helpers.py
+++ b/tests/apps/demo/test_helpers.py
@@ -16,7 +16,7 @@ class CoursesHelpersTestCase(CMSTestCase):
         The `create_categories` method should create the whole category tree and return
         only the leaf categories.
         """
-        page = create_i18n_page(title="Root page")
+        page = create_i18n_page("Root page")
         test_info = {
             "title": "Subject",
             "children": [

--- a/tests/apps/search/test_templates_search.py
+++ b/tests/apps/search/test_templates_search.py
@@ -13,7 +13,7 @@ class CourseCMSTestCase(CMSTestCase):
     def test_templates_search_content(self):
         """Validate the content of a page using the search template."""
         page = create_i18n_page(
-            title={"fr": "recherche", "en": "search"}, template="search/search.html"
+            {"fr": "recherche", "en": "search"}, template="search/search.html"
         )
 
         # The page should not be visible before it is published


### PR DESCRIPTION
## Purpose

The helpers.py file in richie.core is used in production and is depending on the `factory` third party lib.

## Proposal

The dependency to `factory` is because of two functions:

- the `create_text_plugin` function is actually only used in tests, let's move it to `factories.py`,
- the `create_i18n_page` function was using faker to generate random   title when the title was not passed. Let's make title a required field and let the page extension factories generate a random title if they need one (this will soon be refactored to make use of our new `PageFactory`).
