### PR TITLE
Fix feedback on 1.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a home page to the site structure to avoid a 404 error on startup.
+
 ### Fixed
 
 - Fix error when one of the site's languages was not found in ALL_LANGUAGES.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix error when one of the site's languages was not found in ALL_LANGUAGES.
+
 ## [1.0.0-beta.9] - 2019-05-22
 
 ### Added

--- a/src/richie/apps/core/defaults.py
+++ b/src/richie/apps/core/defaults.py
@@ -1,5 +1,6 @@
 """Default settings for the core app of Richie."""
 from django.conf import global_settings, settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 
 # Group to add plugin to placeholder "Content"
@@ -21,3 +22,14 @@ ALL_LANGUAGES_DICT = dict(ALL_LANGUAGES)
 # Use "en" as default as it is the language that is most likely to be spoken by any visitor
 # when their preferred language, whatever it is, is unavailable
 LANGUAGES_DICT = dict(settings.LANGUAGES)
+
+# check that all languages in LANGUAGES are matching one of the languages in ALL_LANGUAGES
+for site_language in LANGUAGES_DICT:
+    generic_language_code = site_language.split("-")[0]
+    for language in ALL_LANGUAGES_DICT:
+        if language.startswith(generic_language_code):
+            break
+    else:
+        raise ImproperlyConfigured(
+            f'"{site_language:s}" in LANGUAGES does not match any language in ALL_LANGUAGES'
+        )

--- a/src/richie/apps/courses/defaults.py
+++ b/src/richie/apps/courses/defaults.py
@@ -237,6 +237,12 @@ ORGANIZATIONS_PAGE = {
 PERSONS_PAGE = {"reverse_id": "persons", "template": "courses/cms/person_detail.html"}
 
 PAGES_INFO = {
+    "home": {
+        "title": "Home",
+        "in_navigation": False,
+        "is_homepage": True,
+        "template": "richie/homepage.html",
+    },
     BLOGPOSTS_PAGE["reverse_id"]: {
         "title": "News",
         "in_navigation": True,

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -144,6 +144,7 @@ class Course(BasePageExtension):
         return (
             Person.objects.filter(**filter_dict)
             .select_related("extended_object")
+            .order_by("extended_object__person_plugins__cmsplugin_ptr__position")
             .distinct()
         )
 


### PR DESCRIPTION
## Purpose

This PR fixes a few bugs following feedback on 1.0.0-beta.9

## Proposal

- [x] Avoid errors caused by the site language being absent from the `ALL_LANGUAGES` setting:
    * If the exact site language is not found in `ALL_LANGUAGES`, look for a language with the same generic language code,
    * if a matching language is still not found, raise a configuration error at application startup.
- [x] Add a blank home page to the minimum site structure,
- [x] Fix randomly failing test on the `course.get_persons()` method.