### PR TITLE
⬆️((demo) add factory boy as dependency to the sandbox for demo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ ci =
 sandbox =
     django-configurations==2.1
     dockerflow==2018.4.0
+    factory-boy==2.12.0
     gunicorn==19.9.0
     psycopg2-binary==2.7.7
     sentry-sdk==0.7.14


### PR DESCRIPTION
## Purpose

Generating the demo site requires factory boy. Up to now it was added to the final image by our deployment tool. We have stopped building a custom image for Richie. 

## Proposal

We can add factory boy in the image as it is only going to be used for demo.
