### PR TITLE
⚡️(helpers) make recursive_page_creation idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix error when one of the site's languages was not found in ALL_LANGUAGES.
+- The `richie_init` job is now idempotent and can thus be run multiple times.
 
 ## [1.0.0-beta.9] - 2019-05-22
 

--- a/src/richie/apps/core/helpers.py
+++ b/src/richie/apps/core/helpers.py
@@ -128,7 +128,7 @@ def recursive_page_creation(site, pages_info, parent=None):
     for name, kwargs in pages_info.items():
         children = kwargs.pop("children", None)
         try:
-            page = Page.objects.get(reverse_id=name)
+            page = Page.objects.get(reverse_id=name, publisher_is_draft=False)
         except Page.DoesNotExist:
             page = create_i18n_page(
                 site=site, parent=parent, published=True, reverse_id=name, **kwargs


### PR DESCRIPTION
## Purpose

When deploying Richie, we need to run management commands in jobs. We need those jobs to be idempotent. The recently introduced `richie_init` management command is not.

## Proposal

- [x] ensure that the `recursive_page_creation` helper can be run multiple times without failing or creating duplicates