### PR TITLE
🚸(init) respect existing home page and multiple sites on init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Make sure the `recursive_page_creation` helper respects an existing home
+  page and plays well with multiple sites,
 - Configure Django settings to pass all heartbeat checks,
 - Make filter autosuggestions dynamic based on backend settings. Also runs
   separate autocompletion requests for each meta category and shows them

--- a/src/richie/apps/core/helpers.py
+++ b/src/richie/apps/core/helpers.py
@@ -127,8 +127,16 @@ def recursive_page_creation(site, pages_info, parent=None):
 
     for name, kwargs in pages_info.items():
         children = kwargs.pop("children", None)
+
+        if kwargs.get("is_homepage"):
+            query_params = {"is_home": True}
+        else:
+            query_params = {"reverse_id": name}
+
         try:
-            page = Page.objects.get(reverse_id=name, publisher_is_draft=False)
+            page = Page.objects.get(
+                publisher_is_draft=True, node__site=site, **query_params
+            )
         except Page.DoesNotExist:
             page = create_i18n_page(
                 site=site, parent=parent, published=True, reverse_id=name, **kwargs


### PR DESCRIPTION
## Purpose

The `richie_init` command was overriding existing home pages if they did not have a `reverse_id` set to `home`.

Also, the `recursive_page_creation` helper was not site aware so when calling it on multiple sites, the pages with the same name were retrieved for the wrong site.

## Proposal

- [x] add a filter parameter of the site when looking for existing pages,
- [x] look for a home page before creating a new one (not based on its `is_home` flag),
- [x] add tests to secure these 2 improved behaviors.
