### PR TITLE
⚡️(circleci) speed up CI by removing depending on linting for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -624,14 +624,14 @@ workflows:
               only: /.*/
       - test-back-mysql:
           requires:
-            - lint-back
+            - build-back
             - build-front-production
           filters:
             tags:
               only: /.*/
       - test-back-postgresql:
           requires:
-            - lint-back
+            - build-back
             - build-front-production
           filters:
             tags:


### PR DESCRIPTION
## Purpose

The idea was to not test code that did not pass linters. We are reconsidering this because:

- it is interesting to get a full feedback on linting and tests,
- the `lint-back` job takes more than 2 minutes that will be saved on build time,
- we don't think this will overload CircleCI with current resources.

## Proposal

In the CircleCI configuration file, remove dependency on the `lint-back` job for the `test-postgresql` and `test-back-mysql` jobs.
