### PR TITLE
🐛(permissions) fix page permissions that were making pages private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix page permissions that ended-up being considered as view restrictions
+  making all organization and course pages private.
+
 ## [1.0.0] - 2019-05-29 🎉
 
 ### Added

--- a/src/richie/apps/courses/defaults.py
+++ b/src/richie/apps/courses/defaults.py
@@ -89,7 +89,7 @@ COURSE_ADMIN_ROLE = {
         "can_publish": False,
         "can_change_permissions": False,
         "can_move_page": True,
-        "can_view": True,
+        "can_view": False,  # beware: can_view = True makes it a view restriction...
         "grant_on": 5,  # page and descendants
     },
     "course_folder_permissions": {
@@ -184,7 +184,7 @@ ORGANIZATION_ADMIN_ROLE = {
         "can_publish": False,
         "can_change_permissions": False,
         "can_move_page": False,
-        "can_view": True,
+        "can_view": False,  # beware: can_view = True makes it a view restriction...
         "grant_on": 1,  # just the page
     },
     "organization_folder_permissions": {
@@ -201,7 +201,7 @@ ORGANIZATION_ADMIN_ROLE = {
         "can_publish": False,
         "can_change_permissions": False,
         "can_move_page": True,
-        "can_view": True,
+        "can_view": False,  # beware: can_view = True makes it a view restriction...
         "grant_on": 5,  # page and descendants
     },
     "courses_folder_permissions": {

--- a/tests/apps/courses/test_cms_wizards_course.py
+++ b/tests/apps/courses/test_cms_wizards_course.py
@@ -206,6 +206,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
             "richie/single_column.html",
             "en",
             reverse_id=Course.PAGE["reverse_id"],
+            published=True,
         )
 
         any_page = create_page("Any page", "richie/single_column.html", "en")
@@ -244,7 +245,7 @@ class CourseCMSWizardTestCase(CMSTestCase):
                 "can_publish": random.choice([True, False]),
                 "can_change_permissions": random.choice([True, False]),
                 "can_move_page": random.choice([True, False]),
-                "can_view": random.choice([True, False]),
+                "can_view": False,  # can_view = True would make it a view restriction...
                 "grant_on": random.randint(1, 5),
             },
             "course_folder_permissions": {
@@ -295,6 +296,11 @@ class CourseCMSWizardTestCase(CMSTestCase):
 
         # No other page permissions should have been created
         self.assertEqual(PagePermission.objects.count(), 2)
+
+        # The page should be public
+        page.publish("en")
+        response = self.client.get(page.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
 
     def test_cms_wizards_course_submit_form_from_organization_page(self):
         """

--- a/tests/apps/courses/test_cms_wizards_organization.py
+++ b/tests/apps/courses/test_cms_wizards_organization.py
@@ -238,6 +238,7 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
             "richie/single_column.html",
             "en",
             reverse_id="organizations",
+            published=True,
         )
 
         # Create a user with just the required permissions
@@ -275,7 +276,7 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
                 "can_publish": random.choice([True, False]),
                 "can_change_permissions": random.choice([True, False]),
                 "can_move_page": random.choice([True, False]),
-                "can_view": random.choice([True, False]),
+                "can_view": False,  # can_view = True would make it a view restriction...
                 "grant_on": random.randint(1, 5),
             },
             "organization_folder_permissions": {
@@ -291,7 +292,7 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
         organization = page.organization
 
         # The page and its related extension have been created as draft
-        self.assertEqual(Page.objects.count(), 3)
+        self.assertEqual(Page.objects.count(), 4)
         self.assertEqual(Page.objects.drafts().count(), 3)
         self.assertEqual(page.get_title(), "My title")
         # The slug should have been automatically set
@@ -321,6 +322,11 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
         folder_permission = FolderPermission.objects.get(group_id=role.group_id)
         for key, value in role_dict["organization_folder_permissions"].items():
             self.assertEqual(getattr(folder_permission, key), value)
+
+        # The page should be public
+        page.publish("en")
+        response = self.client.get(page.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
 
     def test_cms_wizards_organization_submit_form_max_lengths(self):
         """


### PR DESCRIPTION
## Purpose

The `PagePermission` model is actually a 2-headed snake... it can act as a permission if `can_view` is False but acts as a view restriction if `can_view` is True.

Said differently, the purpose of the `can_view` flag is not to define that some staff users have the right to view the page... its purpose is to define who can view the page on the frontend.

What we want here is a permission on admin pages for our staff users so `can_view` should be False.

## Proposal

- [x] write tests to surface the problem,
- [x] set `can_view` to False on all our page permissions.
