### PR TITLE
🔧(sandbox) make X_FRAME_OPTIONS setting configurable

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -80,13 +80,7 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
 
     # Security
     ALLOWED_HOSTS = []
-    CSRF_COOKIE_SECURE = True
     SECRET_KEY = values.Value(None)
-    SECURE_BROWSER_XSS_FILTER = True
-    SECURE_CONTENT_TYPE_NOSNIFF = True
-    SESSION_COOKIE_SECURE = True
-    SILENCED_SYSTEM_CHECKS = values.ListValue([])
-    X_FRAME_OPTIONS = "DENY"
 
     # Application definition
     ROOT_URLCONF = "urls"
@@ -342,7 +336,25 @@ class Production(Base):
     DJANGO_ALLOWED_HOSTS="foo.com,foo.fr"
     """
 
+    # Security
     ALLOWED_HOSTS = values.ListValue(None)
+    CSRF_COOKIE_SECURE = True
+    SECURE_BROWSER_XSS_FILTER = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SESSION_COOKIE_SECURE = True
+    # System check reference:
+    # https://docs.djangoproject.com/en/2.2/ref/checks/#security
+    SILENCED_SYSTEM_CHECKS = values.ListValue(
+        [
+            # Allow the X_FRAME_OPTIONS to be set to "SAMEORIGIN"
+            "security.W019"
+        ]
+    )
+    # The X_FRAME_OPTIONS value should be set to "SAMEORIGIN" to display
+    # DjangoCMS frontend admin frames. Dockerflow raises a system check security
+    # warning with this setting, one should add "security.W019" to the
+    # SILENCED_SYSTEM_CHECKS setting (see above).
+    X_FRAME_OPTIONS = "SAMEORIGIN"
 
     # For static files in production, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always


### PR DESCRIPTION
## Purpose

The `X_FRAME_OPTIONS` setting should be set to `SAMEORIGIN` to allow DjangoCMS admin frames display; this requires to ignore a system check.

## Proposal

- [x] move security-related settings to the `Production` configuration
- [x] configure `X_FRAME_OPTIONS` to  `SAMEORIGIN` (and ignore related Django system check warning)
