### PR TITLE
Support feedback Week 23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Allow only formatted texts or images in course complementary information.
+- Allow only formatted texts or images in course complementary information,
+- Simplify why permissions are required to create Richie extension pages.
 
 ## [1.0.1] - 2019-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Allow only formatted texts or images in course complementary information.
+
 ## [1.0.1] - 2019-06-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Allow only formatted texts or images in course complementary information,
-- Simplify why permissions are required to create Richie extension pages.
+- Simplify why permissions are required to create Richie extension pages,
+- Show course creation wizard only on organization pages.
 
 ## [1.0.1] - 2019-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix page permissions that ended-up being considered as view restrictions
-  making all organization and course pages private.
+  making all organization and course pages private,
+- Fix giving permissions on a course filer folder to its organization admins.
 
 ## [1.0.0] - 2019-05-29 🎉
 

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -18,7 +18,6 @@ from cms.cms_wizards import (
 )
 from cms.forms.wizards import CreateCMSPageForm, CreateCMSSubPageForm, SlugWidget
 from cms.models import Page, PagePermission
-from cms.utils.page_permissions import user_can_add_page, user_can_add_subpage
 from cms.wizards.forms import BaseFormMixin
 from cms.wizards.wizard_base import Wizard
 from cms.wizards.wizard_pool import wizard_pool
@@ -118,40 +117,29 @@ class BaseWizardForm(BaseFormMixin, forms.Form):
         if cleaned_data.get("title") and not cleaned_data.get("slug"):
             cleaned_data["slug"] = slugify(cleaned_data["title"])[:200]
 
-        if self.parent_page:
-            # Check that the length of the slug is compatible with its parent page:
-            #  a page `path` is limited to 255 chars, therefore the course page slug should
-            # always be shorter than (255 - length of parent page path - 1 character for the "/")
-            length = len(self.parent_page.get_path()) + 1 + len(cleaned_data["slug"])
-            if length > 255:
-                raise forms.ValidationError(
-                    {
-                        "slug": [
-                            _(
-                                "This slug is too long. The length of the path built by "
-                                "prepending the slug of the parent page would be {:d} characters "
-                                "long and it should be less than 255".format(length)
-                            )
-                        ]
-                    }
-                )
+        # Check that the length of the slug is compatible with its parent page:
+        #  a page `path` is limited to 255 chars, therefore the course page slug should
+        # always be shorter than (255 - length of parent page path - 1 character for the "/")
+        length = len(self.parent_page.get_path()) + 1 + len(cleaned_data["slug"])
+        if length > 255:
+            raise forms.ValidationError(
+                {
+                    "slug": [
+                        _(
+                            "This slug is too long. The length of the path built by "
+                            "prepending the slug of the parent page would be {:d} characters "
+                            "long and it should be less than 255".format(length)
+                        )
+                    ]
+                }
+            )
 
-            if (
-                self.parent_page.get_child_pages()
-                .filter(title_set__slug=cleaned_data["slug"])
-                .exists()
-            ):
-                raise forms.ValidationError(
-                    {"slug": [_("This slug is already in use")]}
-                )
-
-            has_permission = user_can_add_subpage(self.user, target=self.page)
-
-        else:
-            has_permission = user_can_add_page(self.user)
-
-        if not has_permission:
-            raise PermissionDenied()
+        if (
+            self.parent_page.get_child_pages()
+            .filter(title_set__slug=cleaned_data["slug"])
+            .exists()
+        ):
+            raise forms.ValidationError({"slug": [_("This slug is already in use")]})
 
         return cleaned_data
 

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -223,25 +223,25 @@ class CourseWizardForm(BaseWizardForm):
 
         # Create a role for admins of this course (which will create a new user group and a new
         # Filer folder)
-        page_role = PageRole.objects.create(page=page, role=defaults.ADMIN)
+        course_page_role = PageRole.objects.create(page=page, role=defaults.ADMIN)
 
         # Associate permissions as defined in settings:
         # - Create Django permissions
-        page_role.group.permissions.set(
+        course_page_role.group.permissions.set(
             get_permissions(defaults.COURSE_ADMIN_ROLE.get("django_permissions", []))
         )
 
         # - Create DjangoCMS page permissions
         PagePermission.objects.create(
-            group_id=page_role.group_id,
+            group_id=course_page_role.group_id,
             page=page,
             **defaults.COURSE_ADMIN_ROLE.get("course_page_permissions", {}),
         )
 
         # - Create the Django Filer folder permissions
         FolderPermission.objects.create(
-            folder_id=page_role.folder_id,
-            group_id=page_role.group_id,
+            folder_id=course_page_role.folder_id,
+            group_id=course_page_role.group_id,
             **defaults.COURSE_ADMIN_ROLE.get("course_folder_permissions", {}),
         )
 
@@ -263,7 +263,7 @@ class CourseWizardForm(BaseWizardForm):
 
             # Create page permissions on the course page for the admin group of the organization
             try:
-                page_role = PageRole.objects.only("group").get(
+                organization_page_role = PageRole.objects.only("group").get(
                     page=self.page, role=defaults.ADMIN
                 )
             except PageRole.DoesNotExist:
@@ -271,7 +271,7 @@ class CourseWizardForm(BaseWizardForm):
             else:
                 # - Create DjangoCMS page permissions
                 PagePermission.objects.create(
-                    group_id=page_role.group_id,
+                    group_id=organization_page_role.group_id,
                     page_id=course.extended_object_id,
                     **defaults.ORGANIZATION_ADMIN_ROLE.get(
                         "courses_page_permissions", {}
@@ -280,8 +280,8 @@ class CourseWizardForm(BaseWizardForm):
 
                 # - Create the Django Filer folder permissions
                 FolderPermission.objects.create(
-                    folder_id=page_role.folder_id,
-                    group_id=page_role.group_id,
+                    folder_id=course_page_role.folder_id,
+                    group_id=organization_page_role.group_id,
                     **defaults.ORGANIZATION_ADMIN_ROLE.get(
                         "courses_folder_permissions", {}
                     ),

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -117,6 +117,11 @@ CMS_PLACEHOLDER_CONF = {
     "courses/cms/course_detail.html course_information": {
         "name": _("Complementary information"),
         "plugins": ["SectionPlugin"],
+        "parent_classes": {
+            "CKEditorPlugin": ["SectionPlugin"],
+            "SimplePicturePlugin": ["SectionPlugin"],
+        },
+        "child_classes": {"SectionPlugin": ["CKEditorPlugin", "SimplePicturePlugin"]},
     },
     "courses/cms/course_detail.html course_license_content": {
         "name": _("License for the course content"),

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -55,11 +55,11 @@
         {% endget_placeholder_plugins %}
         {% blockplugin plugins.0 %}
           <img
-            src="{% thumbnail instance.picture 300x150 crop upscale subject_location=instance.picture.subject_location %}"
+            src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
             srcset="
-              {% thumbnail instance.picture 300x150 crop upscale subject_location=instance.picture.subject_location %} 300w,
-              {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x300 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-              {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x450 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+              {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
+              {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
+              {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
             "
             sizes="300px"
             alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
@@ -6,11 +6,11 @@
     <div class="blogpost-glimpse__media__empty">{% trans 'Cover' %}</div>
   {% endget_placeholder_plugins %}
   {% blockplugin plugins.0 %}
-  <img src="{% thumbnail instance.picture 300x150 crop upscale subject_location=instance.picture.subject_location %}"
+  <img src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
     srcset="
-      {% thumbnail instance.picture 300x150 crop upscale subject_location=instance.picture.subject_location %} 300w,
-      {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x300 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-      {% if instance.picture.width >= 1200 %}{% thumbnail instance.picture 1200x600 crop upscale subject_location=instance.picture.subject_location %} 1200w{% endif %}
+      {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
+      {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
+      {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
     "
     sizes="300px"
     alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'blog post cover image' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -6,11 +6,11 @@
     <p class="course-glimpse__media__empty">{% trans "Cover" %}</p>
   {% endget_placeholder_plugins %}
   {% blockplugin plugins.0 %}
-    <img src="{% thumbnail instance.picture 300x150 crop upscale subject_location=instance.picture.subject_location %}"
+    <img src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
       srcset="
-        {% thumbnail instance.picture 300x150 crop upscale subject_location=instance.picture.subject_location %} 300w,
-        {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x300 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-        {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x450 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+        {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
+        {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
+        {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
       "
       sizes="300px"
       alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"

--- a/tests/apps/courses/test_cms_plugins_blogpost.py
+++ b/tests/apps/courses/test_cms_plugins_blogpost.py
@@ -116,7 +116,7 @@ class BlogPostPluginTestCase(CMSTestCase):
         # Blogpost's cover should be present
         pattern = (
             r'<div class="blogpost-glimpse__media">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x150'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x170'
             r'.*alt="my cover"'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))
@@ -134,7 +134,7 @@ class BlogPostPluginTestCase(CMSTestCase):
         # pylint: disable=no-member
         pattern = (
             r'<div class="blogpost-glimpse__media">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x150'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x170'
             r'.*alt="my cover"'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))
@@ -199,7 +199,7 @@ class BlogPostPluginTestCase(CMSTestCase):
         # Blogpost cover should have our default alt
         pattern = (
             r'<div class="blogpost-glimpse__media">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x150'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x170'
             r'.*alt="blog post cover image"'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))

--- a/tests/apps/courses/test_cms_plugins_course.py
+++ b/tests/apps/courses/test_cms_plugins_course.py
@@ -156,7 +156,7 @@ class CoursePluginTestCase(TestCase):
         # The course's cover should be present
         pattern = (
             r'<div class="course-glimpse__media">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x150'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x170'
             r'.*alt="my cover"'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))
@@ -229,7 +229,7 @@ class CoursePluginTestCase(TestCase):
         # Course cover should have our default alt
         pattern = (
             r'<div class="course-glimpse__media">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x150'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x170'
             r'.*alt="course cover image"'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))

--- a/tests/apps/courses/test_cms_wizards_blogpost.py
+++ b/tests/apps/courses/test_cms_wizards_blogpost.py
@@ -4,8 +4,7 @@ Test suite for the wizard creating a new BlogPost page
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 
-from cms.api import create_page
-from cms.models import Page, PagePermission
+from cms.api import Page, create_page
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
@@ -53,46 +52,28 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             "cms.add_page",
             "cms.change_page",
         ]
-        required_page_permissions = ["can_add", "can_change"]
 
         url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), any_page.id)
 
         for permission_to_be_removed in required_permissions + [None]:
-            for page_permission_to_be_removed in required_page_permissions + [None]:
-                if (
-                    permission_to_be_removed is None
-                    and page_permission_to_be_removed is None
-                ):
-                    # This is the case of sufficient permissions treated in the next test
-                    continue
+            if permission_to_be_removed is None:
+                # This is the case of sufficient permissions treated in the next test
+                continue
 
-                altered_permissions = required_permissions.copy()
-                if permission_to_be_removed:
-                    altered_permissions.remove(permission_to_be_removed)
+            altered_permissions = required_permissions.copy()
+            if permission_to_be_removed:
+                altered_permissions.remove(permission_to_be_removed)
 
-                altered_page_permissions = required_page_permissions.copy()
-                if page_permission_to_be_removed:
-                    altered_page_permissions.remove(page_permission_to_be_removed)
+            user = UserFactory(is_staff=True, permissions=altered_permissions)
+            self.client.login(username=user.username, password="password")
 
-                user = UserFactory(is_staff=True, permissions=altered_permissions)
-                PagePermission.objects.create(
-                    page=any_page,
-                    user=user,
-                    can_add="can_add" in altered_page_permissions,
-                    can_change="can_change" in altered_page_permissions,
-                    can_delete=False,
-                    can_publish=False,
-                    can_move_page=False,
-                )
-                self.client.login(username=user.username, password="password")
+            # Let the authorized user get the page with all wizards listed
+            response = self.client.get(url)
 
-                # Let the authorized user get the page with all wizards listed
-                response = self.client.get(url)
-
-                # Check that our wizard to create blogposts is not on this page
-                self.assertNotContains(
-                    response, "new blog post", status_code=200, html=True
-                )
+            # Check that our wizard to create blogposts is not on this page
+            self.assertNotContains(
+                response, "new blog post", status_code=200, html=True
+            )
 
     def test_cms_wizards_blogpost_create_wizards_list_user_with_permissions(self):
         """
@@ -105,15 +86,6 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
         user = UserFactory(
             is_staff=True,
             permissions=["courses.add_blogpost", "cms.add_page", "cms.change_page"],
-        )
-        PagePermission.objects.create(
-            page=any_page,
-            user=user,
-            can_add=True,
-            can_change=True,
-            can_delete=False,
-            can_publish=False,
-            can_move_page=False,
         )
         self.client.login(username=user.username, password="password")
 
@@ -149,54 +121,29 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
             reverse_id=BlogPost.PAGE["reverse_id"],
         )
 
-        required_permissions = [
-            "courses.add_blogpost",
-            "cms.add_page",
-            "cms.change_page",
-        ]
-        required_page_permissions = ["can_add", "can_change"]
+        required_permissions = ["courses.add_blogpost"]
 
         for is_staff in [True, False]:
             for permission_to_be_removed in required_permissions + [None]:
-                for page_permission_to_be_removed in required_page_permissions + [None]:
-                    if (
-                        is_staff is True
-                        and permission_to_be_removed is None
-                        and page_permission_to_be_removed is None
-                    ):
-                        # This is the case of sufficient permissions treated in the next test
-                        continue
+                if is_staff is True and permission_to_be_removed is None:
+                    # This is the case of sufficient permissions treated in the next test
+                    continue
 
-                    altered_permissions = required_permissions.copy()
-                    if permission_to_be_removed:
-                        altered_permissions.remove(permission_to_be_removed)
+                altered_permissions = required_permissions.copy()
+                if permission_to_be_removed:
+                    altered_permissions.remove(permission_to_be_removed)
 
-                    altered_page_permissions = required_page_permissions.copy()
-                    if page_permission_to_be_removed:
-                        altered_page_permissions.remove(page_permission_to_be_removed)
+                user = UserFactory(is_staff=is_staff, permissions=altered_permissions)
 
-                    user = UserFactory(
-                        is_staff=is_staff, permissions=altered_permissions
-                    )
-                    PagePermission.objects.create(
-                        page=any_page,
-                        user=user,
-                        can_add="can_add" in altered_page_permissions,
-                        can_change="can_change" in altered_page_permissions,
-                        can_delete=False,
-                        can_publish=False,
-                        can_move_page=False,
-                    )
+                form = BlogPostWizardForm(
+                    data={"title": "My title"},
+                    wizard_language="en",
+                    wizard_user=user,
+                    wizard_page=any_page,
+                )
 
-                    form = BlogPostWizardForm(
-                        data={"title": "My title"},
-                        wizard_language="en",
-                        wizard_user=user,
-                        wizard_page=any_page,
-                    )
-
-                    with self.assertRaises(PermissionDenied):
-                        form.is_valid()
+                with self.assertRaises(PermissionDenied):
+                    form.is_valid()
 
     def test_cms_wizards_blogpost_submit_form(self):
         """
@@ -217,15 +164,6 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
         user = UserFactory(
             is_staff=True,
             permissions=["courses.add_blogpost", "cms.add_page", "cms.change_page"],
-        )
-        PagePermission.objects.create(
-            page=any_page,
-            user=user,
-            can_add=True,
-            can_change=True,
-            can_delete=False,
-            can_publish=False,
-            can_move_page=False,
         )
 
         # We can submit a form with just the title set

--- a/tests/apps/courses/test_cms_wizards_category.py
+++ b/tests/apps/courses/test_cms_wizards_category.py
@@ -4,8 +4,7 @@ Test suite for the wizard creating a new Category page
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 
-from cms.api import create_page
-from cms.models import Page, PagePermission
+from cms.api import Page, create_page
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
@@ -48,49 +47,27 @@ class CategoryCMSWizardTestCase(CMSTestCase):
         """
         any_page = create_page("page", "richie/single_column.html", "en")
 
-        required_permissions = [
-            "courses.add_category",
-            "cms.add_page",
-            "cms.change_page",
-        ]
-        required_page_permissions = ["can_add", "can_change"]
+        required_permissions = ["courses.add_category"]
 
         url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), any_page.id)
 
         for permission_to_be_removed in required_permissions + [None]:
-            for page_permission_to_be_removed in required_page_permissions + [None]:
-                if (
-                    permission_to_be_removed is None
-                    and page_permission_to_be_removed is None
-                ):
-                    # This is the case of sufficient permissions treated in the next test
-                    continue
+            if permission_to_be_removed is None:
+                # This is the case of sufficient permissions treated in the next test
+                continue
 
-                altered_permissions = required_permissions.copy()
-                if permission_to_be_removed:
-                    altered_permissions.remove(permission_to_be_removed)
+            altered_permissions = required_permissions.copy()
+            if permission_to_be_removed:
+                altered_permissions.remove(permission_to_be_removed)
 
-                altered_page_permissions = required_page_permissions.copy()
-                if page_permission_to_be_removed:
-                    altered_page_permissions.remove(page_permission_to_be_removed)
+            user = UserFactory(is_staff=True, permissions=altered_permissions)
+            self.client.login(username=user.username, password="password")
 
-                user = UserFactory(is_staff=True, permissions=altered_permissions)
-                PagePermission.objects.create(
-                    page=any_page,
-                    user=user,
-                    can_add="can_add" in altered_page_permissions,
-                    can_change="can_change" in altered_page_permissions,
-                    can_delete=False,
-                    can_publish=False,
-                    can_move_page=False,
-                )
-                self.client.login(username=user.username, password="password")
+            # Let the authorized user get the page with all wizards listed
+            response = self.client.get(url)
 
-                # Let the authorized user get the page with all wizards listed
-                response = self.client.get(url)
-
-                # Check that our wizard to create categories is not on this page
-                self.assertNotContains(response, "category", status_code=200, html=True)
+            # Check that our wizard to create categories is not on this page
+            self.assertNotContains(response, "category", status_code=200, html=True)
 
     def test_cms_wizards_category_create_wizards_list_user_with_permissions(self):
         """
@@ -103,15 +80,6 @@ class CategoryCMSWizardTestCase(CMSTestCase):
         user = UserFactory(
             is_staff=True,
             permissions=["courses.add_category", "cms.add_page", "cms.change_page"],
-        )
-        PagePermission.objects.create(
-            page=page,
-            user=user,
-            can_add=True,
-            can_change=True,
-            can_delete=False,
-            can_publish=False,
-            can_move_page=False,
         )
         self.client.login(username=user.username, password="password")
 
@@ -147,54 +115,29 @@ class CategoryCMSWizardTestCase(CMSTestCase):
             "en",
             reverse_id=Category.PAGE["reverse_id"],
         )
-        required_permissions = [
-            "courses.add_category",
-            "cms.add_page",
-            "cms.change_page",
-        ]
-        required_page_permissions = ["can_add", "can_change"]
+        required_permissions = ["courses.add_category"]
 
         for is_staff in [True, False]:
             for permission_to_be_removed in required_permissions + [None]:
-                for page_permission_to_be_removed in required_page_permissions + [None]:
-                    if (
-                        is_staff is True
-                        and permission_to_be_removed is None
-                        and page_permission_to_be_removed is None
-                    ):
-                        # This is the case of sufficient permissions treated in the next test
-                        continue
+                if is_staff is True and permission_to_be_removed is None:
+                    # This is the case of sufficient permissions treated in the next test
+                    continue
 
-                    altered_permissions = required_permissions.copy()
-                    if permission_to_be_removed:
-                        altered_permissions.remove(permission_to_be_removed)
+                altered_permissions = required_permissions.copy()
+                if permission_to_be_removed:
+                    altered_permissions.remove(permission_to_be_removed)
 
-                    altered_page_permissions = required_page_permissions.copy()
-                    if page_permission_to_be_removed:
-                        altered_page_permissions.remove(page_permission_to_be_removed)
+                user = UserFactory(is_staff=is_staff, permissions=altered_permissions)
 
-                    user = UserFactory(
-                        is_staff=is_staff, permissions=altered_permissions
-                    )
-                    PagePermission.objects.create(
-                        page=any_page,
-                        user=user,
-                        can_add="can_add" in altered_page_permissions,
-                        can_change="can_change" in altered_page_permissions,
-                        can_delete=False,
-                        can_publish=False,
-                        can_move_page=False,
-                    )
+                form = CategoryWizardForm(
+                    data={"title": "My title"},
+                    wizard_language="en",
+                    wizard_user=user,
+                    wizard_page=any_page,
+                )
 
-                    form = CategoryWizardForm(
-                        data={"title": "My title"},
-                        wizard_language="en",
-                        wizard_user=user,
-                        wizard_page=any_page,
-                    )
-
-                    with self.assertRaises(PermissionDenied):
-                        form.is_valid()
+                with self.assertRaises(PermissionDenied):
+                    form.is_valid()
 
     def test_cms_wizards_category_submit_form_from_any_page(self):
         """
@@ -215,15 +158,6 @@ class CategoryCMSWizardTestCase(CMSTestCase):
         user = UserFactory(
             is_staff=True,
             permissions=["courses.add_category", "cms.add_page", "cms.change_page"],
-        )
-        PagePermission.objects.create(
-            page=any_page,
-            user=user,
-            can_add=True,
-            can_change=True,
-            can_delete=False,
-            can_publish=False,
-            can_move_page=False,
         )
 
         # We can submit a form with just the title set
@@ -264,15 +198,6 @@ class CategoryCMSWizardTestCase(CMSTestCase):
         user = UserFactory(
             is_staff=True,
             permissions=["courses.add_category", "cms.add_page", "cms.change_page"],
-        )
-        PagePermission.objects.create(
-            page=parent_category.extended_object,
-            user=user,
-            can_add=True,
-            can_change=True,
-            can_delete=False,
-            can_publish=False,
-            can_move_page=False,
         )
 
         # We can submit a form with just the title set

--- a/tests/apps/courses/test_cms_wizards_course.py
+++ b/tests/apps/courses/test_cms_wizards_course.py
@@ -350,20 +350,6 @@ class CourseCMSWizardTestCase(CMSTestCase):
         plugin = OrganizationPluginModel.objects.first()
         self.assertEqual(plugin.page_id, organization.extended_object_id)
 
-        # A page permission should have been created for the organization admin role
-        page_permission = PagePermission.objects.get(
-            group_id=organization_page_role.group_id, page=page
-        )
-        for key, value in organization_role_dict["courses_page_permissions"].items():
-            self.assertEqual(getattr(page_permission, key), value)
-
-        # A Filer folder permission should have been created for the organization admin role
-        folder_permission = FolderPermission.objects.get(
-            group_id=organization_page_role.group_id
-        )
-        for key, value in organization_role_dict["courses_folder_permissions"].items():
-            self.assertEqual(getattr(folder_permission, key), value)
-
         # A page role should have been created for the course page
         self.assertEqual(page.roles.count(), 1)
         course_role = page.roles.get(role="ADMIN")
@@ -385,8 +371,36 @@ class CourseCMSWizardTestCase(CMSTestCase):
         self.assertEqual(
             FolderPermission.objects.filter(group_id=course_role.group_id).count(), 1
         )
-        folder_permission = FolderPermission.objects.get(group_id=course_role.group_id)
+        folder_permission = FolderPermission.objects.get(
+            group_id=course_role.group_id, folder_id=course_role.folder_id
+        )
         for key, value in course_role_dict["course_folder_permissions"].items():
+            self.assertEqual(getattr(folder_permission, key), value)
+
+        # A page permission should have been created for the organization admin role
+        self.assertEqual(
+            PagePermission.objects.filter(
+                group_id=organization_page_role.group_id
+            ).count(),
+            1,
+        )
+        page_permission = PagePermission.objects.get(
+            group_id=organization_page_role.group_id, page=page
+        )
+        for key, value in organization_role_dict["courses_page_permissions"].items():
+            self.assertEqual(getattr(page_permission, key), value)
+
+        # A Filer folder permission should have been created for the organization admin role
+        self.assertEqual(
+            FolderPermission.objects.filter(
+                group_id=organization_page_role.group_id
+            ).count(),
+            1,
+        )
+        folder_permission = FolderPermission.objects.get(
+            group_id=organization_page_role.group_id, folder_id=course_role.folder_id
+        )
+        for key, value in organization_role_dict["courses_folder_permissions"].items():
             self.assertEqual(getattr(folder_permission, key), value)
 
         # The page should be public

--- a/tests/apps/courses/test_cms_wizards_person.py
+++ b/tests/apps/courses/test_cms_wizards_person.py
@@ -4,8 +4,7 @@ Test suite for the wizard creating a new Person page
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 
-from cms.api import create_page
-from cms.models import Page, PagePermission
+from cms.api import Page, create_page
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
@@ -49,44 +48,26 @@ class PersonCMSWizardTestCase(CMSTestCase):
         page = create_page("page", "richie/single_column.html", "en")
 
         required_permissions = ["courses.add_person", "cms.add_page", "cms.change_page"]
-        required_page_permissions = ["can_add", "can_change"]
 
         url = "{:s}?page={:d}".format(reverse("cms_wizard_create"), page.id)
 
         for permission_to_be_removed in required_permissions + [None]:
-            for page_permission_to_be_removed in required_page_permissions + [None]:
-                if (
-                    permission_to_be_removed is None
-                    and page_permission_to_be_removed is None
-                ):
-                    # This is the case of sufficient permissions treated in the next test
-                    continue
+            if permission_to_be_removed is None:
+                # This is the case of sufficient permissions treated in the next test
+                continue
 
-                altered_permissions = required_permissions.copy()
-                if permission_to_be_removed:
-                    altered_permissions.remove(permission_to_be_removed)
+            altered_permissions = required_permissions.copy()
+            if permission_to_be_removed:
+                altered_permissions.remove(permission_to_be_removed)
 
-                altered_page_permissions = required_page_permissions.copy()
-                if page_permission_to_be_removed:
-                    altered_page_permissions.remove(page_permission_to_be_removed)
+            user = UserFactory(is_staff=True, permissions=altered_permissions)
+            self.client.login(username=user.username, password="password")
 
-                user = UserFactory(is_staff=True, permissions=altered_permissions)
-                PagePermission.objects.create(
-                    page=page,
-                    user=user,
-                    can_add="can_add" in altered_page_permissions,
-                    can_change="can_change" in altered_page_permissions,
-                    can_delete=False,
-                    can_publish=False,
-                    can_move_page=False,
-                )
-                self.client.login(username=user.username, password="password")
+            # Let the authorized user get the page with all wizards listed
+            response = self.client.get(url)
 
-                # Let the authorized user get the page with all wizards listed
-                response = self.client.get(url)
-
-                # Check that our wizard to create persons is not on this page
-                self.assertNotContains(response, "person", status_code=200, html=True)
+            # Check that our wizard to create persons is not on this page
+            self.assertNotContains(response, "person", status_code=200, html=True)
 
     def test_cms_wizards_person_create_wizards_list_user_with_permissions(self):
         """
@@ -99,15 +80,6 @@ class PersonCMSWizardTestCase(CMSTestCase):
         user = UserFactory(
             is_staff=True,
             permissions=["courses.add_person", "cms.add_page", "cms.change_page"],
-        )
-        PagePermission.objects.create(
-            page=page,
-            user=user,
-            can_add=True,
-            can_change=True,
-            can_delete=False,
-            can_publish=False,
-            can_move_page=False,
         )
         self.client.login(username=user.username, password="password")
 
@@ -143,54 +115,33 @@ class PersonCMSWizardTestCase(CMSTestCase):
             reverse_id=Person.PAGE["reverse_id"],
         )
 
-        required_permissions = ["courses.add_person", "cms.add_page", "cms.change_page"]
-        required_page_permissions = ["can_add", "can_change"]
+        required_permissions = ["courses.add_person"]
 
         for is_staff in [True, False]:
             for permission_to_be_removed in required_permissions + [None]:
-                for page_permission_to_be_removed in required_page_permissions + [None]:
-                    if (
-                        is_staff is True
-                        and permission_to_be_removed is None
-                        and page_permission_to_be_removed is None
-                    ):
-                        # This is the case of sufficient permissions treated in the next test
-                        continue
+                if is_staff is True and permission_to_be_removed is None:
+                    # This is the case of sufficient permissions treated in the next test
+                    continue
 
-                    altered_permissions = required_permissions.copy()
-                    if permission_to_be_removed:
-                        altered_permissions.remove(permission_to_be_removed)
+                altered_permissions = required_permissions.copy()
+                if permission_to_be_removed:
+                    altered_permissions.remove(permission_to_be_removed)
 
-                    altered_page_permissions = required_page_permissions.copy()
-                    if page_permission_to_be_removed:
-                        altered_page_permissions.remove(page_permission_to_be_removed)
+                user = UserFactory(is_staff=is_staff, permissions=altered_permissions)
 
-                    user = UserFactory(
-                        is_staff=is_staff, permissions=altered_permissions
-                    )
-                    PagePermission.objects.create(
-                        page=any_page,
-                        user=user,
-                        can_add="can_add" in altered_page_permissions,
-                        can_change="can_change" in altered_page_permissions,
-                        can_delete=False,
-                        can_publish=False,
-                        can_move_page=False,
-                    )
+                form = PersonWizardForm(
+                    data={
+                        "title": "A person",
+                        "first_name": "First name",
+                        "last_name": "Last name",
+                    },
+                    wizard_language="en",
+                    wizard_user=user,
+                    wizard_page=any_page,
+                )
 
-                    form = PersonWizardForm(
-                        data={
-                            "title": "A person",
-                            "first_name": "First name",
-                            "last_name": "Last name",
-                        },
-                        wizard_language="en",
-                        wizard_user=user,
-                        wizard_page=any_page,
-                    )
-
-                    with self.assertRaises(PermissionDenied):
-                        form.is_valid()
+                with self.assertRaises(PermissionDenied):
+                    form.is_valid()
 
     def test_cms_wizards_person_submit_form(self):
         """
@@ -213,15 +164,6 @@ class PersonCMSWizardTestCase(CMSTestCase):
         user = UserFactory(
             is_staff=True,
             permissions=["courses.add_person", "cms.add_page", "cms.change_page"],
-        )
-        PagePermission.objects.create(
-            page=any_page,
-            user=user,
-            can_add=True,
-            can_change=True,
-            can_delete=False,
-            can_publish=False,
-            can_move_page=False,
         )
 
         form = PersonWizardForm(

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -227,6 +227,27 @@ class PersonCMSTestCase(CMSTestCase):
         # The modified draft version of the published organization should not be visible
         self.assertNotContains(response, "modified title")
 
+    def test_templates_person_detail_organizations_empty(self):
+        """
+        The "Organizations" section should not be displayed when empty.
+        """
+        person = PersonFactory(should_publish=True)
+
+        # The "organizations" section should not be present on the public page
+        url = person.public_extension.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertContains(response, person.extended_object.get_title())
+        self.assertNotContains(response, "organization")
+
+        # But it should be present on the draft page
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        url = person.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertContains(response, person.extended_object.get_title())
+        self.assertContains(response, "organization-glimpse-list")
+
     def test_templates_person_detail_related_courses(self):
         """
         The courses to which a person has participated should appear on this person's detail page.


### PR DESCRIPTION
## Purpose

The improvements and fixes proposed here follow feedback by our support team.

## Proposal

- [x] Change image format on blog post and course glimpses to 300x170,
- [x] Allow only formatted text and image plugins in the course complementary information section,
- [x] Simplify permissions required to create Richie extension pages (we used to require permissions on the current page but it does not really make sense. We can just require the right to create a course, a blog post, etc.)
- [x] Show course creation wizard only on organization pages (it makes sure that the course being created is automatically linked to the current organization and that the organization's admin user group gets automatic access to the course),
- [x] Fix permission on courses filer folders for organization admin user groups,
- [x] Add a test to make sure that the `complementary information` section on courses is hidden when empty.
