### PR TITLE
🔖(chore) bump release to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2019-06-05
+
 ### Changed
 
 - Allow only formatted texts or images in course complementary information,
 - Simplify why permissions are required to create Richie extension pages,
 - Show course creation wizard only on organization pages.
+
+### Fixed
+
+- Fix giving permissions on a course filer folder to its organization admins.
 
 ## [1.0.1] - 2019-06-05
 
@@ -20,7 +26,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix page permissions that ended-up being considered as view restrictions
   making all organization and course pages private,
-- Fix giving permissions on a course filer folder to its organization admins.
 
 ## [1.0.0] - 2019-05-29 🎉
 
@@ -324,7 +329,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.0.1...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.1.0...master
+[1.1.0]: https://github.com/openfun/richie/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/openfun/richie/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/openfun/richie/compare/v1.0.0-beta.9...v1.0.0
 [1.0.0-beta.9]: https://github.com/openfun/richie/compare/v1.0.0-beta.8...v1.0.0-beta.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.0.1
+version = 1.1.0
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {


### PR DESCRIPTION
## Changed

- Allow only formatted texts or images in course complementary information,
- Simplify why permissions are required to create Richie extension pages,
- Show course creation wizard only on organization pages.

## Fixed

- Fix giving permissions on a course filer folder to its organization admins.
