### PR TITLE
🚸(search) harmonize glimpse image size on search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix thumbnail definition for the image glimpse used on the search page.
+
 ## [1.1.0] - 2019-06-05
 
 ### Changed

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -286,19 +286,19 @@ DJANGOCMS_VIDEO_TEMPLATES = [("full-width", _("Full width"))]
 RICHIE_SIMPLEPICTURE_PRESETS = {
     # Formatting images for the courses search index
     "glimpse": {
-        "src": {"size": (300, 150), "crop": "smart"},
+        "src": {"size": (300, 170), "crop": "smart"},
         "srcset": [
             {
-                "options": {"size": (300, 150), "crop": "smart", "upscale": True},
+                "options": {"size": (300, 170), "crop": "smart", "upscale": True},
                 "descriptor": "300w",
             },
             {
-                "options": {"size": (600, 300), "crop": "smart", "upscale": True},
+                "options": {"size": (600, 340), "crop": "smart", "upscale": True},
                 "descriptor": "600w",
             },
             {
-                "options": {"size": (1200, 600), "crop": "smart", "upscale": True},
-                "descriptor": "1200w",
+                "options": {"size": (900, 560), "crop": "smart", "upscale": True},
+                "descriptor": "900w",
             },
         ],
         "sizes": "300px",


### PR DESCRIPTION
## Purpose

In ff1282e we modified the image size on course glimpses but we forgot to modify the thumbnail definition for the image used on the search page.

## Proposal

- [x] Set thumbnail size to 300x170 for the course glimpse on the search page.
