### PR TITLE
🔖(chore) bump release to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.0] - 2019-06-19
+
 ### Added
 
 - Add field on course to record effort (e.g 5 hours/day) and duration
@@ -339,7 +341,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.1.0...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.2.0...master
+[1.2.0]: https://github.com/openfun/richie/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/openfun/richie/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/openfun/richie/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/openfun/richie/compare/v1.0.0-beta.9...v1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.1.0
+version = 1.2.0
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {


### PR DESCRIPTION
## Added

- Add field on course to record effort (e.g 5 hours/day) and duration
  (e.g 4 weeks).
- Add a new plugin to easily create HTML sitemaps.

## Fixed

- Fix thumbnail definition for the image glimpse used on the search page.
