### PR TITLE
Add effort and duration to demo site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Replace first name, last name and person title by page title.
 
+### Fixed
+
+- Add missing translation when displaying effort and duration on the course.
+
 ## [1.2.0] - 2019-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Add course effort and duration values to demo site.
+
 ### Removed
 
 - Replace first name, last name and person title by page title.

--- a/src/richie/apps/core/fields/duration.py
+++ b/src/richie/apps/core/fields/duration.py
@@ -59,7 +59,7 @@ class CompositeDurationField(models.CharField):
     A custom charfield to store a duration in database as an integer and a time unit choice.
     """
 
-    description = _("Define a duration by a number of time units")
+    description = _("Define a duration as a number of time units")
 
     error_message = _("%(value)s is not a valid choice for a time unit.")
 

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -19,7 +19,7 @@ from ..core.factories import (
     create_text_plugin,
     image_getter,
 )
-from . import models
+from . import defaults, models
 from .defaults import ROLE_CHOICES
 
 VideoSample = namedtuple("VideoSample", ["label", "image", "url"])
@@ -190,6 +190,26 @@ class CourseFactory(PageExtensionDjangoModelFactory):
 
     # fields concerning the related page
     page_template = models.Course.PAGE["template"]
+
+    # pylint: disable=no-self-use
+    @factory.lazy_attribute
+    def duration(self):
+        """Generate a random duration for the course between 1 day and 10 months."""
+        return [
+            random.randint(1, 10),
+            random.choice(list(defaults.TIME_UNITS.keys())[2:]),
+        ]
+
+    # pylint: disable=no-self-use
+    @factory.lazy_attribute
+    def effort(self):
+        """Generate a random effort for the course between 1 minute/month and 10 hours/day."""
+        time_units = list(defaults.TIME_UNITS.keys())
+        return [
+            random.randint(1, 10),
+            random.choice(time_units[:2]),
+            random.choice(time_units[2:]),
+        ]
 
     @factory.post_generation
     # pylint: disable=unused-argument

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -94,11 +94,11 @@
         <dl>
           {% render_model_block course "duration,effort" %}
             {% if instance.duration or current_page.publisher_is_draft %}
-            <dt><span class="icon-duration"></span>duration:</dt>
+            <dt><span class="icon-duration"></span>{% trans "Duration:" %}</dt>
             <dd>{{ instance.get_duration_display|default:"NA" }}</dd>
             {% endif %}
             {% if instance.effort or current_page.publisher_is_draft %}
-            <dt><span class="icon-effort"></span>Effort:</dt>
+            <dt><span class="icon-effort"></span>{% trans "Effort:" %}</dt>
             <dd>{{ instance.get_effort_display|default:"NA" }}</dd>
             {% endif %}
           {% endrender_model_block %}

--- a/src/richie/plugins/html_sitemap/migrations/0001_initial.py
+++ b/src/richie/plugins/html_sitemap/migrations/0001_initial.py
@@ -55,7 +55,7 @@ class Migration(migrations.Migration):
                     "root_page",
                     models.ForeignKey(
                         blank=True,
-                        help_text='This page will be at the root of your sitemap (or its children if the "include root page" flag is unticked.',
+                        help_text='This page will be at the root of your sitemap (or its children if the "include root page" flag is unticked).',
                         limit_choices_to={"publisher_is_draft": True},
                         null=True,
                         on_delete=django.db.models.deletion.PROTECT,

--- a/src/richie/plugins/html_sitemap/models.py
+++ b/src/richie/plugins/html_sitemap/models.py
@@ -25,7 +25,7 @@ class HTMLSitemapPage(CMSPlugin):
         verbose_name=_("root page"),
         help_text=_(
             "This page will be at the root of your sitemap (or its children if the "
-            '"include root page" flag is unticked.'
+            '"include root page" flag is unticked).'
         ),
         blank=True,
         null=True,

--- a/tests/apps/courses/test_models_course.py
+++ b/tests/apps/courses/test_models_course.py
@@ -7,6 +7,7 @@ from django.test.client import RequestFactory
 
 from cms.api import create_page
 
+from richie.apps.core.factories import PageFactory
 from richie.apps.courses.factories import (
     CategoryFactory,
     CourseFactory,
@@ -14,7 +15,7 @@ from richie.apps.courses.factories import (
     OrganizationFactory,
     PersonFactory,
 )
-from richie.apps.courses.models import CourseRun
+from richie.apps.courses.models import Course, CourseRun
 
 # pylint: disable=too-many-public-methods
 
@@ -433,7 +434,7 @@ class CourseModelsTestCase(TestCase):
 
     def test_models_course_field_effort_default(self):
         """The effort field should default to None."""
-        course = CourseFactory()
+        course = Course.objects.create(extended_object=PageFactory())
         self.assertIsNone(course.effort)
 
     # Fields: duration
@@ -501,5 +502,5 @@ class CourseModelsTestCase(TestCase):
 
     def test_models_course_field_duration_default(self):
         """The duration field should default to None."""
-        course = CourseFactory()
+        course = Course.objects.create(extended_object=PageFactory())
         self.assertIsNone(course.duration)


### PR DESCRIPTION
## Purpose

We recently added on the course page the effort and duration fields. We forgot to fill them up in our demo site.

## Proposal

- generate random values for the effort and duration fields on the course factory,
- fix i18n when displaying these fields on the course detail view.
