### PR TITLE
💄(organizations) rework organization images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Improve handling of organization-related images to prevent unwanted cropping
+  of organization logos.
+
 ## [1.3.0] - 2019-06-20
 
 ### Changed

--- a/src/frontend/scss/objects/_organization_glimpses.scss
+++ b/src/frontend/scss/objects/_organization_glimpses.scss
@@ -15,7 +15,6 @@ $richie-org-glimpse-item-border: 1px solid $gray80 !default;
 $richie-org-glimpse-item-border-hover: 1px solid $firebrick6 !default;
 $richie-org-glimpse-item-border-radius: 0.25rem !default;
 
-$richie-org-glimpse-item-title-fontsize: 0.81rem !default;
 $richie-org-glimpse-item-title-fontcolor: $black !default;
 $richie-org-glimpse-item-title-textalign: center !default;
 
@@ -51,8 +50,10 @@ $richie-org-glimpse-item-empty-textalign: left !default;
 
 .organization-glimpse {
   $list-item-selector: &;
-  @include sv-flex(1, 0, calc(50% - #{$richie-org-glimpse-item-gutter * 2}));
   display: flex;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: calc(100% - #{$richie-org-glimpse-item-gutter * 2});
   margin: $richie-org-glimpse-item-gutter;
   padding: $richie-org-glimpse-item-padding;
   flex-direction: column;
@@ -61,34 +62,44 @@ $richie-org-glimpse-item-empty-textalign: left !default;
   background: $richie-org-glimpse-item-background;
   border: $richie-org-glimpse-item-border;
   border-radius: $richie-org-glimpse-item-border-radius;
-  @include media-breakpoint-up(md) {
-    @include sv-flex(1, 0, calc(25% - #{$richie-org-glimpse-item-gutter * 2}));
+
+  @include media-breakpoint-up(sm) {
+    flex-basis: calc(50% - #{$richie-org-glimpse-item-gutter * 2});
+  }
+
+  @include media-breakpoint-up(xl) {
+    flex-basis: calc(25% - #{$richie-org-glimpse-item-gutter * 2});
   }
 
   &__logo {
-    @include sv-flex(1, 0, auto);
-    display: flex;
     position: relative;
-    flex-direction: row;
-    justify-content: center;
-    align-content: center;
-    align-items: center;
+    width: 100%;
+    margin-bottom: 1rem;
+    padding-bottom: 56.25%; // Aspect ratio 16/9
 
-    img {
-      @include sv-flex(0, 0, auto);
-      max-width: 100%;
+    & > img {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center;
     }
 
     @include m-o-media_empty($background: $gray97);
   }
 
   &__title {
-    @include sv-flex(0, 0, auto);
+    flex-grow: 1;
+    flex-shrink: 0;
     display: flex;
     justify-content: center;
-    font-size: $richie-org-glimpse-item-title-fontsize;
-    color: $richie-org-glimpse-item-title-fontcolor;
+    align-items: center;
     text-align: $richie-org-glimpse-item-title-textalign;
+    color: $richie-org-glimpse-item-title-fontcolor;
   }
 
   &:hover,

--- a/src/frontend/scss/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_course_detail.scss
@@ -60,7 +60,7 @@ $richie-course-detail-aside-margin: 0 !default;
 $richie-course-detail-aside-padding: 0 !default;
 
 $richie-course-detail-aside-main-org-margin: 0 !default;
-$richie-course-detail-aside-main-org-padding: 1rem !default;
+$richie-course-detail-aside-main-org-padding: 2rem !default;
 $richie-course-detail-aside-main-org-background: $white !default;
 
 .course-detail {
@@ -386,15 +386,21 @@ $richie-course-detail-aside-main-org-background: $white !default;
     }
 
     &__main-org-logo {
+      position: relative;
+      display: block;
       margin: $richie-course-detail-aside-main-org-margin;
-      padding: $richie-course-detail-aside-main-org-padding;
       background: $richie-course-detail-aside-main-org-background;
+      padding: 0 0 56.25%; // Aspect ratio 16/9
+      // Use a border to emulate the padding as we need padding for aspect ratio enforcement
+      border: $richie-course-detail-aside-main-org-padding solid
+        $richie-course-detail-aside-main-org-background;
 
       img {
-        display: block;
-        width: auto;
-        max-width: 100%;
-        margin: auto;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        object-position: center;
       }
 
       @include m-o-media_empty($width: 100%, $height: 20vh, $absolute: false);

--- a/src/frontend/scss/templates/courses/cms/_organization_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_organization_detail.scss
@@ -1,9 +1,16 @@
 // Overridable & namespaced global variables
-$richie-org-detail-banner-logo-height: 15rem !default;
-$richie-org-detail-banner-logo-height-md: 20rem !default;
-$richie-org-detail-banner-logo-height-xl: 25rem !default;
+$richie-org-detail-logo-width: 12rem !default;
 
 .organization-detail {
+  $logo-width-base: $richie-org-detail-logo-width;
+  $logo-height-base: $logo-width-base * 9 / 16;
+
+  $logo-width-md: $logo-width-base * 4 / 3;
+  $logo-height-md: $logo-width-md * 9 / 16;
+
+  $logo-width-xl: $logo-width-base * 5 / 3;
+  $logo-height-xl: $logo-width-xl * 9 / 16;
+
   @include make-container();
   @include make-container-max-widths();
   padding-bottom: 1rem;
@@ -11,30 +18,23 @@ $richie-org-detail-banner-logo-height-xl: 25rem !default;
 
   &__banner {
     @include make-row();
-
-    // position & overflow are part of the img hack below
-    position: relative;
-    width: calc(100% + #{$grid-gutter-width});
-    height: $richie-org-detail-banner-logo-height;
-    overflow: hidden;
+    width: 100vw;
+    height: $logo-height-base;
 
     @include media-breakpoint-up(md) {
-      height: $richie-org-detail-banner-logo-height-md;
+      width: auto;
+      height: $logo-height-md;
     }
 
     @include media-breakpoint-up(xl) {
-      height: $richie-org-detail-banner-logo-height-xl;
+      height: $logo-height-xl;
     }
 
-    img {
-      // Hack to center+fill an image we have no control over and can't make into a background image
-      position: absolute;
-      top: -1000%;
-      right: -1000%;
-      bottom: -1000%;
-      left: -1000%;
-      min-width: 100%;
-      margin: auto;
+    & > img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
     }
 
     @include m-o-media_empty($background: $gray97);
@@ -46,57 +46,41 @@ $richie-org-detail-banner-logo-height-xl: 25rem !default;
     background: $white;
     border: 1px solid darken($light, 20%);
 
-    width: $richie-org-detail-banner-logo-height * 0.75;
-    height: $richie-org-detail-banner-logo-height * 0.75;
-    margin: (-$richie-org-detail-banner-logo-height * 0.75 / 2) auto
-      $grid-gutter-width;
+    width: $logo-width-base;
+    height: $logo-height-base;
+    margin: (-$logo-height-base / 2) auto 1rem;
+    padding: 0.5rem;
 
     @include media-breakpoint-up(md) {
-      float: right;
-      width: $richie-org-detail-banner-logo-height-md * 0.75;
-      height: $richie-org-detail-banner-logo-height-md * 0.75;
-      margin: (-$richie-org-detail-banner-logo-height-md / 2) 3rem
-        $grid-gutter-width;
+      width: $logo-width-md;
+      height: $logo-height-md;
+      margin: (-$logo-height-md / 2) auto 1rem;
     }
 
     @include media-breakpoint-up(xl) {
-      width: $richie-org-detail-banner-logo-height-xl * 0.75;
-      height: $richie-org-detail-banner-logo-height-xl * 0.75;
-      margin: (-$richie-org-detail-banner-logo-height-xl / 2) 8rem
-        $grid-gutter-width;
+      float: right;
+      width: $logo-width-xl;
+      height: $logo-height-xl;
+      margin: (-$logo-height-xl / 2) 8rem 1rem;
     }
 
     img {
-      // Hack to center+fill an image we have no control over and can't make into a background image
-      position: absolute;
-      top: -1000%;
-      right: -1000%;
-      bottom: -1000%;
-      left: -1000%;
-      // Make the width fixed so we can never overflow logos - we make the assumption most non-square
-      // logos would be wider as opposed to taller
       width: 100%;
-      min-height: 100%;
-      margin: auto;
+      height: 100%;
+      object-fit: contain;
+      object-position: center;
     }
 
     @include m-o-media_empty();
   }
 
   &__title {
-    $h1-calculated-height: $h1-font-size * $headings-line-height;
-    @include media-breakpoint-up(md) {
-      $logo-height: $richie-org-detail-banner-logo-height-md * 0.75;
-      $logo-overflow-height: $logo-height / 3;
-      margin: ($logo-overflow-height - $h1-calculated-height) / 2
-        $grid-gutter-width;
-    }
+    margin: 1rem;
 
     @include media-breakpoint-up(xl) {
-      $logo-height: $richie-org-detail-banner-logo-height-xl * 0.75;
-      $logo-overflow-height: $logo-height / 3;
-      margin: ($logo-overflow-height - $h1-calculated-height) / 2
-        $grid-gutter-width;
+      min-height: 6rem;
+      display: flex;
+      align-items: center;
     }
   }
 

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
@@ -7,13 +7,14 @@
       <p class="organization-glimpse__logo__empty">{% trans "Logo" %}</p>
     {% endget_placeholder_plugins %}
     {% blockplugin plugins.0 %}
-      <img src="{% thumbnail instance.picture 300x300 crop upscale subject_location=instance.picture.subject_location %}"
+      <img src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 300x300 crop upscale subject_location=instance.picture.subject_location %} 300w,
-          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-          {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x900 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+          {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w,
+          {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
+          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+          {% if instance.picture.width >= 800 %}{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
         "
-        sizes="300px"
+        sizes="100vw, (min-width: 576px) 50vw, (min-width: 1200px) 25vw"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization logo' %}{% endif %}"
       />
     {% endblockplugin %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
@@ -1,29 +1,30 @@
 {% load i18n cms_tags extra_tags thumbnail %}
 {% spaceless %}
-<div class="course-detail__aside__main-org-logo">
-  {% if organization %}
-    {% with organization_page=organization.extended_object %}
-      <a href="{{ organization_page.get_absolute_url }}" title="{{ organization_page.get_title }}">
-        {% get_placeholder_plugins "logo" organization_page as plugins or %}
-          <div class="course-detail__aside__main-org-logo__empty">{% trans "Main organization" %}</div>
-        {% endget_placeholder_plugins %}
-        {% blockplugin plugins.0 %}
-          <img src="{% thumbnail instance.picture 500x500 crop upscale subject_location=instance.picture.subject_location %}"
-            srcset="
-              {% thumbnail instance.picture 500x500 crop upscale subject_location=instance.picture.subject_location %} 500w,
-              {% if instance.picture.width >= 1000 %}{% thumbnail instance.picture 1000x1000 crop upscale subject_location=instance.picture.subject_location %} 1000w,{% endif %}
-              {% if instance.picture.width >= 1500 %}{% thumbnail instance.picture 1500x1500 crop upscale subject_location=instance.picture.subject_location %} 1500w{% endif %}
-            "
-            sizes="500px"
-            alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'main organization logo' %}{% endif %}"
-          />
-        {% endblockplugin %}
-      </a>
-    {% endwith %}
-  {% else %}
+{% if organization %}
+  {% with organization_page=organization.extended_object %}
+    <a href="{{ organization_page.get_absolute_url }}" title="{{ organization_page.get_title }}" class="course-detail__aside__main-org-logo">
+      {% get_placeholder_plugins "logo" organization_page as plugins or %}
+        <div class="course-detail__aside__main-org-logo__empty">{% trans "Main organization" %}</div>
+      {% endget_placeholder_plugins %}
+      {% blockplugin plugins.0 %}
+        <img src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
+          srcset="
+            {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w,
+            {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
+            {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+            {% if instance.picture.width >= 800 %}{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+          "
+          sizes="30vw"
+          alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'main organization logo' %}{% endif %}"
+        />
+      {% endblockplugin %}
+    </a>
+  {% endwith %}
+{% else %}
+  <div class="course-detail__aside__main-org-logo">
     <div class="course-detail__aside__main-org-logo__empty">
       {% trans "Main organization" %}
     </div>
-  {% endif %}
-</div>
+  </div>
+{% endif %}
 {% endspaceless %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -10,13 +10,15 @@
     {% endget_placeholder_plugins %}
     {% blockplugin plugins.0 %}
       <img
-        src="{% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %}"
+        src="{% thumbnail instance.picture 500x100 upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %} 1140w,
-          {% if instance.picture.width >= 2280 %}{% thumbnail instance.picture 2280x800 crop upscale subject_location=instance.picture.subject_location %} 2280w,{% endif %}
-          {% if instance.picture.width >= 3420 %}{% thumbnail instance.picture 3420x600 crop upscale subject_location=instance.picture.subject_location %} 3420w{% endif %}
+          {% thumbnail instance.picture 500x100 upscale subject_location=instance.picture.subject_location %} 500w,
+          {% thumbnail instance.picture 1000x200 upscale subject_location=instance.picture.subject_location %} 1000w,
+          {% if instance.picture.width >= 1500 %}{% thumbnail instance.picture 1500x300 upscale subject_location=instance.picture.subject_location %} 1500w,{% endif %}
+          {% if instance.picture.width >= 2000 %}{% thumbnail instance.picture 2000x400 upscale subject_location=instance.picture.subject_location %} 2000w{% endif %}
+          {% if instance.picture.width >= 2500 %}{% thumbnail instance.picture 2500x500 upscale subject_location=instance.picture.subject_location %} 2500w{% endif %}
         "
-        sizes="1140px"
+        sizes="100vw"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization banner' %}{% endif %}"
       />
     {% endblockplugin %}
@@ -28,13 +30,14 @@
     {% endget_placeholder_plugins %}
     {% blockplugin plugins.0 %}
       <img
-        src="{% thumbnail instance.picture 300x300 crop upscale subject_location=instance.picture.subject_location %}"
+        src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 300x300 crop upscale subject_location=instance.picture.subject_location %} 300w,
-          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-          {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x900 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+          {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w,
+          {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
+          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+          {% if instance.picture.width >= 800 %}{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
         "
-        sizes="300px"
+        sizes="12rem, (min-width: 768px) 16rem, (min-width: 1200px) 20rem"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization logo' %}{% endif %}"
       />
     {% endblockplugin %}

--- a/tests/apps/courses/test_cms_plugins_organization.py
+++ b/tests/apps/courses/test_cms_plugins_organization.py
@@ -115,7 +115,7 @@ class OrganizationPluginTestCase(CMSTestCase):
         # Organziation's logo should be present
         pattern = (
             r'<div class="organization-glimpse__logo">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*logo\.jpg__300x300'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*logo\.jpg__200x113'
             r'.*alt="my logo"'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))
@@ -133,7 +133,7 @@ class OrganizationPluginTestCase(CMSTestCase):
         )
         pattern = (
             r'<div class="organization-glimpse__logo">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*logo\.jpg__300x300'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*logo\.jpg__200x113'
             r'.*alt="my logo"'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))
@@ -198,7 +198,7 @@ class OrganizationPluginTestCase(CMSTestCase):
         # organization logo should have our default alt
         pattern = (
             r'<div class="organization-glimpse__logo">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*logo\.jpg__300x300'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*logo\.jpg__200x113'
             r'.*alt="organization logo"'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -279,9 +279,8 @@ class CourseCMSTestCase(CMSTestCase):
 
         self.assertEqual(response.status_code, 200)
         pattern = (
-            r'<div class="course-detail__aside__main-org-logo">'
-            r'<a href="{url:s}" title="{title:s}">'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*logo\.jpg__500x500'
+            r'<a href="{url:s}" title="{title:s}" class="course-detail__aside__main-org-logo">'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*logo\.jpg__200x113'
         ).format(
             url=organizations[0].extended_object.get_absolute_url(),
             title=organizations[0].extended_object.get_title(),


### PR DESCRIPTION
## Purpose

Organization logos & banners were cropped. This was not the expected outcome for logos. We decided to use a rectangular format for organization logos, and a thinner format for organization banners.

## Proposal

Update the CSS on all uses of organization logos to enforce our aspect ratio without ever cropping the images.

We also had to update srcsets with sizes to fit our expected sizes, and related styles and markup around organization logos.
