### PR TITLE
🔖(chore) bump release to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.4.0] - 2019-06-26
+
 ### Added
 
 - Add a catchphrase on top of the course detail view.
@@ -367,7 +369,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.3.0...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.4.0...master
+[1.3.0]: https://github.com/openfun/richie/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/openfun/richie/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/openfun/richie/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/openfun/richie/compare/v1.0.1...v1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.3.0
+version = 1.4.0
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {


### PR DESCRIPTION
### Added

- Add a catchphrase on top of the course detail view.
- Allow configuring max length and CKeditor on specific placeholders for text
  plugins, and propose default configurations using this new feature.

### Changed

- Improve handling of organization-related images to prevent unwanted cropping
  of organization logos.
- Change the person bio to a plain text plugin.
