### PR TITLE
Fix person detail maincontent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Improve the layout for the person details page.
+
 ### Fixed
 
 - Improve label text for the child filter toggle in Search.

--- a/src/frontend/scss/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_course_detail.scss
@@ -274,9 +274,6 @@ $richie-course-detail-aside-main-org-background: $white !default;
         width: calc(
           100% - #{$richie-course-detail-teaser-object-padding-horizontal * 2}
         );
-        height: calc(
-          100% - #{$richie-course-detail-teaser-object-padding-vertical * 2}
-        );
         border: 0;
       }
 

--- a/src/frontend/scss/templates/courses/cms/_person_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_person_detail.scss
@@ -1,4 +1,4 @@
-$richie-person-detail-media-width: 120px;
+$richie-person-detail-media-size: 10rem;
 
 .person-detail {
   @include make-container-max-widths();
@@ -6,54 +6,63 @@ $richie-person-detail-media-width: 120px;
   padding: 1rem $grid-gutter-width;
   background: $richie-content-container-bg;
 
-  &__title {
-    text-align: center;
-    @include media-breakpoint-up(lg) {
-      text-align: left;
-    }
-  }
-
   &__card {
-    @include m-o-card(
-      $padding: 1rem 0,
-      $background: $richie-course-glimpse-container-background,
-      $media-margin: 0,
-      $caption-width: $richie-course-glimpse-caption-width,
-      $caption-margin: $richie-course-glimpse-caption-margin,
-      $caption-padding: $richie-course-glimpse-caption-padding,
-      $caption-fontsize: $richie-course-glimpse-caption-fontsize,
-      $caption-background: $richie-course-glimpse-caption-background,
-      $content-flex-justify: flex-start,
-      $wrapper-padding: 0 0 0 1rem,
-      $foot-divider: $richie-course-glimpse-foot-divider,
-      $methodology: 'bem'
-    );
-    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    margin: 0 0 2rem;
 
-    @include media-breakpoint-up(lg) {
-      @include m-o-card(
-        $media-width: $richie-person-detail-media-width,
-        $methodology: 'bem'
-      );
+    @include media-breakpoint-up(sm) {
+      flex-direction: row;
     }
 
     &__media {
+      flex-grow: 0;
+      flex-shrink: 0;
+      align-self: center;
+      width: 10rem;
+      height: 10rem;
+      margin: 0 0 1rem;
+
+      @include media-breakpoint-up(sm) {
+        order: 1; // Media should be after content on larger screens
+        margin: 0 0 0 1rem;
+      }
+
+      & > img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        object-position: center;
+      }
+
       img {
         margin: 0 auto;
-        max-width: $richie-person-detail-media-width;
+        max-width: $richie-person-detail-media-size;
         border-radius: 100%;
       }
 
       @include m-o-media_empty(
         $width: 100%,
-        $height: 13vh,
+        $height: 10rem,
         $background: $gray97,
         $absolute: false
       );
     }
 
-    &__content__wrapper {
-      @include m-o-media_empty($width: 100%, $height: 13vh, $absolute: false);
+    &__content {
+      flex-grow: 1;
+
+      &__title {
+        text-align: center;
+
+        @include media-breakpoint-up(sm) {
+          text-align: left;
+        }
+      }
+
+      &__categories {
+        margin: 0 0 0.5rem;
+      }
     }
   }
 }

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -4,20 +4,6 @@
 {% block content %}
 {% with header_level=2 person=current_page.person %}
 <div class="person-detail">
-  <h1 class="person-detail__title">{% render_model current_page "title" %}</h1>
-
-  {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"categories" %}
-  <div class="person-detail__categories">
-    {% with form_factor="tag" %}
-      {% placeholder "categories" or %}
-        <p class="person-detail__categories__empty">
-          {% trans "No associated categories" %}
-        </p>
-      {% endplaceholder %}
-    {% endwith %}
-  </div>
-  {% endif %}
-
   <div class="person-detail__card">
     <div class="person-detail__card__media">
       {% get_placeholder_plugins "portrait" as plugins or %}
@@ -38,15 +24,26 @@
     </div>
 
     <div class="person-detail__card__content">
-      <div class="person-detail__card__content__wrapper">
-        {% placeholder "bio" or %}
-          <p class="person-detail__card__content__wrapper__empty">{% trans "Enter your bio here..." %}</p>
-        {% endplaceholder %}
+      <h1 class="person-detail__card__content__title">{% render_model current_page "title" %}</h1>
 
-        {% placeholder "maincontent" %}
+      {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"categories" %}
+      <div class="person-detail__card__content__categories">
+        {% with form_factor="tag" %}
+          {% placeholder "categories" or %}
+            <p class="person-detail__card__content__categories__empty">
+              {% trans "No associated categories" %}
+            </p>
+          {% endplaceholder %}
+        {% endwith %}
       </div>
+      {% endif %}
+      {% placeholder "bio" or %}
+        <p class="person-detail__card__content__empty">{% trans "Enter your bio here..." %}</p>
+      {% endplaceholder %}
     </div>
   </div>
+
+  {% placeholder "maincontent" %}
 
   {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"organizations" %}
   <div class="organization-glimpse-list">

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -88,7 +88,9 @@ class PersonCMSTestCase(CMSTestCase):
         )
         title = person.extended_object.get_title()
         self.assertContains(
-            response, f'<h1 class="person-detail__title">{title:s}</h1>', html=True
+            response,
+            f'<h1 class="person-detail__card__content__title">{title:s}</h1>',
+            html=True,
         )
         # The published category should be on the page in its published version
         self.assertContains(
@@ -170,7 +172,9 @@ class PersonCMSTestCase(CMSTestCase):
         )
         title = person.extended_object.get_title()
         self.assertContains(
-            response, f'<h1 class="person-detail__title">{title:s}</h1>', html=True
+            response,
+            f'<h1 class="person-detail__card__content__title">{title:s}</h1>',
+            html=True,
         )
 
         # The published category should be on the page in its published version


### PR DESCRIPTION
## Purpose

Person details pages used the maincontent placeholder inside the person card. This is not appropriate as it results in a broken layout.

## Proposal

We put it outside of the person card and took this opportunity to improve the layout of the person card in the person detailed page.

## Bonus

We fixed a display glitch with videos in course detail pages.