### PR TITLE
🐛(courses) fix display glitch with youtube video iframe

### DIFF
--- a/src/frontend/scss/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_course_detail.scss
@@ -274,6 +274,9 @@ $richie-course-detail-aside-main-org-background: $white !default;
         width: calc(
           100% - #{$richie-course-detail-teaser-object-padding-horizontal * 2}
         );
+        min-height: calc(
+          100% - #{$richie-course-detail-teaser-object-padding-vertical * 2}
+        );
         border: 0;
       }
 


### PR DESCRIPTION
## Purpose

We recently fixed a display glitch in embedded video elements in course details pages. Our fix broke layout for YouTube videos.


## Proposal

Add back the height we removed as a `min-height` so both embedded videos and YouTube videos are displayed correctly.
