### PR TITLE
Add a section "What you will learn" to the course page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a section "What you will learn" to the course page.
+
 ### Fixed
 
 - Fix language confusion when getting objects that are related to a course via

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -103,6 +103,10 @@ CMS_PLACEHOLDER_CONF = {
         "name": _("About the course"),
         "plugins": ["CKEditorPlugin"],
     },
+    "courses/cms/course_detail.html course_skills": {
+        "name": _("What you will learn"),
+        "plugins": ["CKEditorPlugin"],
+    },
     "courses/cms/course_detail.html course_format": {
         "name": _("Format"),
         "plugins": ["PlainTextPlugin"],
@@ -313,7 +317,10 @@ DJANGOCMS_VIDEO_TEMPLATES = [("full-width", _("Full width"))]
 RICHIE_PLAINTEXT_MAXLENGTH = {"course_introduction": 200, "bio": 150, "excerpt": 200}
 
 RICHIE_SIMPLETEXT_CONFIGURATION = [
-    {"placeholders": ["course_plan"], "ckeditor": "CKEDITOR_LIMITED_CONFIGURATION"},
+    {
+        "placeholders": ["course_skills", "course_plan"],
+        "ckeditor": "CKEDITOR_LIMITED_CONFIGURATION",
+    },
     {
         "placeholders": ["course_description"],
         "ckeditor": "CKEDITOR_LIMITED_CONFIGURATION",

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
@@ -17,6 +17,14 @@
 </div>
 {% endif %}
 
+{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_skills" %}
+<div class="course-detail__content__row course-detail__content__skills">
+  <h2 class="course-detail__content__row__title">{% trans "What you will learn" %}</h2>
+  <p>{% trans "At the end of this course, you will be able to:" %}</p>
+  {% page_placeholder "course_skills" page %}
+</div>
+{% endif %}
+
 {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_format" %}
 <div class="course-detail__content__row course-detail__content__format">
   <h2 class="course-detail__content__row__title">{% trans 'Format' %}</h2>

--- a/src/richie/plugins/simple_text_ckeditor/cms_plugins.py
+++ b/src/richie/plugins/simple_text_ckeditor/cms_plugins.py
@@ -49,13 +49,14 @@ class CKEditorPlugin(CMSPluginBase):
         else:
             placeholder = obj.placeholder
 
-        configuration = {}
         for configuration in SIMPLETEXT_CONFIGURATION:
             if (
                 "placeholders" not in configuration
                 or placeholder.slot in configuration["placeholders"]
             ):
                 break
+        else:
+            configuration = {}
 
         body_field = form.base_fields["body"]
         if configuration.get("max_length"):


### PR DESCRIPTION
## Purpose

We want to add a placeholder to describe what the student will learn by completing a course.

## Proposal

Description...

- Fix the plugin configuration specific to a placeholder,
- Add a new placeholder to the course detail page `course_skills`.
