### PR TITLE
Don't keep stale user input when a suggestion is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   a plugin (organizations, categories and persons),
 - Use empty image alt text & no link title text for course glimpses to comply
   with accessibility standards (existing alts & titles were redundant).
+- Fix an issue that caused inconsistent UI and broken search results when
+  selecting a suggestion in course search.
 
 ## [1.4.1] - 2019-06-26
 

--- a/src/frontend/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -251,6 +251,10 @@ describe('components/SearchSuggestField', () => {
 
     fireEvent.click(getByText('Organization #27'));
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
+      query: '',
+      type: 'QUERY_UPDATE',
+    });
+    expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
       filter: {
         base_path: '0002',
         human_name: 'Organizations',

--- a/src/frontend/js/components/SearchSuggestField/SearchSuggestField.tsx
+++ b/src/frontend/js/components/SearchSuggestField/SearchSuggestField.tsx
@@ -182,6 +182,11 @@ export const SearchSuggestField = injectIntl(
         payload: String(suggestion.id),
         type: 'FILTER_ADD',
       });
+      // Clear the current search query as the selected suggestion was generated from the same user input
+      dispatchCourseSearchParamsUpdate({
+        query: '',
+        type: 'QUERY_UPDATE',
+      });
       // Reset the search field state: the task has been completed
       setValue('');
       setSuggestions([]);


### PR DESCRIPTION
## Purpose

As the user inputs text into the autocomplete search bar, it is used for our search-as-you-type interface, and also send to the API to compute suggestions.

When a user selects a suggestion, we need to remove the query added to params by search-as-you-type because the text entered by the user was already "consumed" by the action to select the suggestion.

Not doing this was causing inconsistent UI state and broken search results.

## Proposal

Clear the text query when the user selects a suggestion.