### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.0] - 2019-07-03
+
 ### Added
 
 - Add a section "What you will learn" to the course page.
@@ -392,7 +394,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.4.1...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.5.0...master
+[1.5.0]: https://github.com/openfun/richie/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/openfun/richie/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/openfun/richie/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/openfun/richie/compare/v1.2.0...v1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.4.1
+version = 1.5.0
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {


### PR DESCRIPTION
### Added

- Add a section "What you will learn" to the course page.

### Fixed

- Fix language confusion when getting objects that are related to a course via a plugin (organizations, categories and persons),
- Use empty image alt text & no link title text for course glimpses to comply with accessibility standards (existing alts & titles were redundant).
- Fix an issue that caused inconsistent UI and broken search results when selecting a suggestion in course search.