### PR TITLE
Course date l10n and course glimpse formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Improve english date on course page.
+- Improve course glimpse text formatting.
+
 ## [1.5.1] - 2019-07-11
 
 ### Fixed

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -119,14 +119,14 @@
           <dl>
             <dt>{% trans "Enrollment" %}</dt>
             <dd>
-              {% render_model run "enrollment_start" "enrollment_start,enrollment_end" "" "date:'SHORT_DATE_FORMAT'|default:'...'" as start %}
-              {% render_model run "enrollment_end" "enrollment_start,enrollment_end" "" "date:'SHORT_DATE_FORMAT'|default:'...'" as end %}
+              {% render_model run "enrollment_start" "enrollment_start,enrollment_end" "" "date:'DATE_FORMAT'|default:'...'" as start %}
+              {% render_model run "enrollment_end" "enrollment_start,enrollment_end" "" "date:'DATE_FORMAT'|default:'...'" as end %}
               {% trans "From" %} {{ start|safe }} {% trans "to" %} {{ end|safe }}
             </dd>
             <dt>{% trans "Course" %}</dt>
             <dd>
-              {% render_model run "start" "start,end" "" "date:'SHORT_DATE_FORMAT'|default:'...'" as start %}
-              {% render_model run "end" "start,end" "" "date:'SHORT_DATE_FORMAT'|default:'...'" as end %}
+              {% render_model run "start" "start,end" "" "date:'DATE_FORMAT'|default:'...'" as start %}
+              {% render_model run "end" "start,end" "" "date:'DATE_FORMAT'|default:'...'" as end %}
               {% trans "From" %} {{ start|safe }} {% trans "to" %} {{ end|safe }}
             </dd>
             <dt>{% trans "Languages" %}</dt><dd>{% render_model run "get_languages_display" "languages" %}</dd>

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -28,12 +28,12 @@
       </div>
       <div class="course-glimpse__footer">
           <p class="course-glimpse__footer__date">
-              {{ course_state.text|title }}<br>
+              {{ course_state.text|capfirst }}<br>
               {{ course_state.datetime|date:"DATE_FORMAT" }}
           </p>
           {% if course_state.call_to_action %}
           <div class="course-glimpse__footer__cta">
-              <button class="button">{{ course_state.call_to_action|title }}</button>
+              <button class="button">{{ course_state.call_to_action|capfirst }}</button>
           </div>
           {% endif %}
       </div>


### PR DESCRIPTION
## Purpose

Fulfills request "Date formating on english pages #569". Have english date go from "12/15/2019" to "Dec. 15, 2019" format.
Course glimpse is the only glimpse using "title" formatting. User feedback made us realize that.

## Proposal

- [x] Use DATE_FORMAT instead of SHORT_DATE_FORMAT to have "Dec. 15, 2019" instead of "12/15/2019". This makes the french date go from "15 déc. 2019" to "15 décembre 2019" because of l10n.
- [x] Make Course glimpse use "capfirst" formatting like the rest.

Fixes #569
