### PR TITLE
Refactor roles and permissions to add them to the demo site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Configure roles and permissions in the demo site.
+
 ### Changed
 
 - Factorize the code creating roles & permissions for organizations & courses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Factorize the code that creates roles and permissions for organizations.
+
 ## [1.5.2] - 2019-07-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Factorize the code that creates roles and permissions for organizations.
+- Factorize the code creating roles & permissions for organizations & courses.
 
 ## [1.5.2] - 2019-07-15
 

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -483,42 +483,10 @@ class OrganizationWizardForm(BaseWizardForm):
         """
         The parent form created the page.
         This method creates the associated organization.
-        It also creates a new role with:
-          - a user group to handle permissions for admins of this organization,
-          - a folder in Django Filer to store images related to this organization,
-          - all necessary permissions.
         """
         page = super().save()
-        Organization.objects.create(extended_object=page)
-
-        # Create a role for admins of this organization (which will create a new user group and
-        # a new Filer folder)
-        page_role = PageRole.objects.create(page=page, role=defaults.ADMIN)
-
-        # Associate permissions as defined in settings:
-        # - Create Django permissions
-        page_role.group.permissions.set(
-            get_permissions(
-                defaults.ORGANIZATION_ADMIN_ROLE.get("django_permissions", [])
-            )
-        )
-
-        # - Create DjangoCMS page permissions
-        PagePermission.objects.create(
-            group_id=page_role.group_id,
-            page=page,
-            **defaults.ORGANIZATION_ADMIN_ROLE.get("organization_page_permissions", {}),
-        )
-
-        # - Create the Django Filer folder permissions
-        FolderPermission.objects.create(
-            folder_id=page_role.folder_id,
-            group_id=page_role.group_id,
-            **defaults.ORGANIZATION_ADMIN_ROLE.get(
-                "organization_folder_permissions", {}
-            ),
-        )
-
+        organization = Organization.objects.create(extended_object=page)
+        organization.create_page_role()
         return page
 
 

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -161,6 +161,15 @@ class OrganizationFactory(BLDPageExtensionDjangoModelFactory):
                         **{"page": self.extended_object},
                     )
 
+    @factory.post_generation
+    # pylint: disable=unused-argument
+    def with_permissions(self, create, extracted, **kwargs):
+        """
+        Create a page role with related group, page permission and filer folder.
+        """
+        if create and extracted:
+            self.create_page_role()
+
 
 class PageRoleFactory(factory.django.DjangoModelFactory):
     """A factory to automatically generate random yet meaningful page roles."""

--- a/src/richie/apps/courses/models/role.py
+++ b/src/richie/apps/courses/models/role.py
@@ -69,12 +69,18 @@ class PageRole(models.Model):
         Validate the object before saving it and create a group if it does not exist yet.
         """
         self.full_clean(exclude=["group"])
+        page_id = str(self.page.id)
 
         # Create the related group the first time the instance is saved
         if not self.group_id:
-            self.group = Group.objects.create(
-                name=str(self)[: Group._meta.get_field("name").max_length]
-            )
+            name = str(self)[: Group._meta.get_field("name").max_length]
+
+            if Group.objects.filter(name=name).exists():
+                name = f"{name:s} [{page_id:s}]"[
+                    : Group._meta.get_field("name").max_length
+                ]
+
+            self.group = Group.objects.create(name=name)
 
         # Create the related filer folder the first time the instance is saved.
         # Why create this folder at the root and not below a parent `organization` folder?
@@ -82,9 +88,14 @@ class PageRole(models.Model):
         #   changed by a user via the interface and break the functionality,
         # - the filer search functionality only finds folders at the root, not nested folders.
         if not self.folder_id:
-            self.folder = Folder.objects.create(
-                name=str(self)[: Folder._meta.get_field("name").max_length]
-            )
+            name = str(self)[: Folder._meta.get_field("name").max_length]
+
+            if Folder.objects.filter(name=name).exists():
+                name = f"{name:s} [{page_id:s}]"[
+                    : Folder._meta.get_field("name").max_length
+                ]
+
+            self.folder = Folder.objects.create(name=name)
 
         super().save(
             force_insert=force_insert,

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -81,6 +81,7 @@ def create_demo_site():
         fill_description=True,
         fill_logo=pick_image("logo"),
         should_publish=True,
+        with_permissions=True,
     )
 
     # Generate each category tree and return a list of the leaf categories
@@ -185,6 +186,7 @@ def create_demo_site():
             ],
             should_publish=True,
         )
+        course.create_permissions_for_organization(course_organizations[0])
         courses.append(course)
 
         # Add a random number of course runs to the course


### PR DESCRIPTION
## Purpose

The roles and permissions (Django models, DjangoCMS pages and Django Filer folders) were created by page creation wizards.

We also need to create them in the demo site and when adding a page programmatically (e.g automatic imports).

## Proposal

I propose to factorize in the models the code that creates roles and permissions, so that it can easily be called from anywhere in the code base.

As a first use case, I added roles and permissions in the demo site.


