### PR TITLE
Move the search template title into react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Move the page title in Search so it can be placed correctly in the
+  page structure.
+
 ## [1.6.0] - 2019-07-25
 
 ### Added

--- a/src/frontend/js/components/Search/Search.tsx
+++ b/src/frontend/js/components/Search/Search.tsx
@@ -11,7 +11,11 @@ import { SearchFiltersPane } from '../SearchFiltersPane/SearchFiltersPane';
 import { SearchLoader } from '../SearchLoader/SearchLoader';
 import { SearchSuggestField } from '../SearchSuggestField/SearchSuggestField';
 
-export const Search = () => {
+interface SearchProps {
+  pageTitle?: string;
+}
+
+export const Search = ({ pageTitle }: SearchProps) => {
   const [courseSearchParams, setCourseSearchParams] = useCourseSearchParams();
   const courseSearchResponse = useCourseSearch(courseSearchParams);
 
@@ -30,20 +34,23 @@ export const Search = () => {
             }
           />
         </div>
-        {courseSearchResponse &&
-        courseSearchResponse.status === requestStatus.SUCCESS ? (
-          <div className="search__results">
-            <SearchSuggestField
-              filters={courseSearchResponse.content.filters}
-            />
-            <CourseGlimpseList
-              courses={courseSearchResponse.content.objects}
-              meta={courseSearchResponse.content.meta}
-            />{' '}
-          </div>
-        ) : (
-          <SearchLoader />
-        )}
+        <div className="search__results">
+          {pageTitle && <h1 className="search__results__title">{pageTitle}</h1>}
+          {courseSearchResponse &&
+          courseSearchResponse.status === requestStatus.SUCCESS ? (
+            <React.Fragment>
+              <SearchSuggestField
+                filters={courseSearchResponse.content.filters}
+              />
+              <CourseGlimpseList
+                courses={courseSearchResponse.content.objects}
+                meta={courseSearchResponse.content.meta}
+              />{' '}
+            </React.Fragment>
+          ) : (
+            <SearchLoader />
+          )}
+        </div>
       </CourseSearchParamsContext.Provider>
     </div>
   );

--- a/src/frontend/js/components/Search/_Search.scss
+++ b/src/frontend/js/components/Search/_Search.scss
@@ -35,5 +35,10 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
       @include sv-flex(1, 0, calc(100% - #{$richie-search-filters-width}));
       padding: $richie-search-results-padding;
     }
+
+    &__title {
+      padding: 1.5rem 0 0;
+      text-align: center;
+    }
   }
 }

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -47,12 +47,14 @@ document.addEventListener('DOMContentLoaded', event => {
         .join('');
       // Sanity check: only attempt to access and render components for which we do have a valid name
       if (isComponentName(componentName)) {
+        // Determine a lang (localeCode) based on the `data-locale` attribute
         const locale = element.getAttribute('data-locale') || 'en';
         let localeCode = locale;
         if (localeCode.match(/^.*_.*$/)) {
           localeCode = locale.split('_')[0];
         }
 
+        // Get `react-intl` lang specific parameters and data
         try {
           const localeData = await import(
             `react-intl/locale-data/${localeCode}`
@@ -62,6 +64,7 @@ document.addEventListener('DOMContentLoaded', event => {
           addLocaleData(Object.values(localeData));
         } catch (e) {}
 
+        // Load our own strings for the given lang
         let translatedMessages = null;
         try {
           translatedMessages = await import(`./translations/${locale}.json`);
@@ -69,10 +72,17 @@ document.addEventListener('DOMContentLoaded', event => {
 
         // Do get the component dynamically. We know this WILL produce a valid component thanks to the type guard
         const Component = componentLibrary[componentName];
+
+        // Get the incoming props to pass our component from the `data-props` attribute
+        const dataProps = element.getAttribute('data-props');
+        const props = dataProps
+          ? (JSON.parse(dataProps) as Parameters<typeof Component>[0])
+          : {};
+
         // Render the component inside an `IntlProvider` to be able to access translated strings
         ReactDOM.render(
           <IntlProvider locale={localeCode} messages={translatedMessages}>
-            <Component />
+            <Component {...props} />
           </IntlProvider>,
           element,
         );

--- a/src/frontend/scss/templates/search/_search.scss
+++ b/src/frontend/scss/templates/search/_search.scss
@@ -1,9 +1,5 @@
 $richie-template-search-margin: null !default;
-$richie-template-search-padding: 1rem 0 0 !default;
-
-$richie-template-search-title-margin: null !default;
-$richie-template-search-title-padding: null !default;
-$richie-template-search-title-textalign: center !default;
+$richie-template-search-padding: 0 !default;
 
 // Enable flex on the `.body-content` so children can grow to occupy the available vertical space
 .body-content--flex-mode {
@@ -30,11 +26,5 @@ $richie-template-search-title-textalign: center !default;
       display: flex;
       flex-direction: column;
     }
-  }
-
-  &__title {
-    margin: $richie-template-search-title-margin;
-    padding: $richie-template-search-title-padding;
-    text-align: $richie-template-search-title-textalign;
   }
 }

--- a/src/richie/apps/search/templates/search/search.html
+++ b/src/richie/apps/search/templates/search/search.html
@@ -15,12 +15,15 @@
 
 {% block content %}
   <div class="search-template">
-    <h1 class="search-template__title">{% page_attribute "page_title" %}</h1>
     <div class="search-template__content">
       {% with header_level=2 %}
         {% placeholder "content" %}
       {% endwith %}
-      <div class="fun-react fun-react--search" data-locale="{{ LANGUAGE_CODE|react_locale }}"></div>
+      <div
+        class="fun-react fun-react--search"
+        data-locale="{{ LANGUAGE_CODE|react_locale }}"
+        data-props='{"pageTitle": "{% page_attribute "page_title" %}"}'
+      ></div>
     </div>
   </div>
 {% endblock content %}

--- a/tests/apps/search/test_templates_search.py
+++ b/tests/apps/search/test_templates_search.py
@@ -1,4 +1,6 @@
 """End-to-end tests for the search page."""
+import re
+
 from django.test.utils import override_settings
 
 from cms.test_utils.testcases import CMSTestCase
@@ -26,10 +28,16 @@ class CourseCMSTestCase(CMSTestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(
-            response,
-            '<div class="fun-react fun-react--search" data-locale="en_US"></div>',
-            html=True,
+        self.assertIsNotNone(
+            re.search(
+                (
+                    r"<div[\\n ]*"
+                    r'class="fun-react fun-react--search"[\\n ]*'
+                    r'data-locale="en_US"[\\n ]*'
+                    r'data-props=\\\'{"pageTitle": "search"}\\\''
+                ),
+                str(response.content),
+            )
         )
 
         # In french, the Canadian french locale should get selected
@@ -37,8 +45,14 @@ class CourseCMSTestCase(CMSTestCase):
         url = page.get_absolute_url(language="fr")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(
-            response,
-            '<div class="fun-react fun-react--search" data-locale="fr_CA"></div>',
-            html=True,
+        self.assertIsNotNone(
+            re.search(
+                (
+                    r"<div[\\n ]*"
+                    r'class="fun-react fun-react--search"[\\n ]*'
+                    r'data-locale="fr_CA"[\\n ]*'
+                    r'data-props=\\\'{"pageTitle": "recherche"}\\\''
+                ),
+                str(response.content),
+            )
         )


### PR DESCRIPTION
## Purpose

Currently the Django template is responsible for displaying the page title on the search results, like on any other page. This is good in that it allows this title to be managed in the CMS. However, it is
troublesome in terms of page structure as we want to handle the search filters pane more cleanly.

## Proposal

To keep the title in the CMS while improving our page structure, we decided to pass the page title to the React frontend via a data attribute in the Django template. This lets us cleanly insert it in the relevant place in our markup.

In our opinion, this is a better compromise than hardcoding it in React (as we lose CMS management of the title, which should not happen if we can avoid it), or adding hacks to the CSS which can be more harmful in the longer term.
