### PR TITLE
🔖(chore) bump version to 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.6.1] - 2019-08-03
+
 ### Fixed
 
 - Move the page title in Search so it can be placed correctly in the
@@ -442,7 +444,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.6.0...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.6.1...master
+[1.6.0]: https://github.com/openfun/richie/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/openfun/richie/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/openfun/richie/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/openfun/richie/compare/v1.5.0...v1.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.6.0
+version = 1.6.1
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {


### PR DESCRIPTION
### Fixed

- Move the page title in Search so it can be placed correctly in the page structure.

### Changed

- Use the "Exo 2" font throughout Richie.
