### PR TITLE
Scale facet filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Show a "More options" button along with a modal to find more filter values
   for each filter in the search filters pane in course search.
 
-## Changed
+### Fixed
+
+- Fix search API endpoints for categories, organizations & persons.
+
+### Changed
 
 - Display category icons on the course detail view but not on the glimpse.
 - Autosuggestion endpoints are diacritics insensitive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Paginate the course search results view.
 - Add a CSS helper class make content available only for users
   of assistive technologies.
+- Show a "More options" button along with a modal to find more filter values
+  for each filter in the search filters pane in course search.
 
 ## Changed
 

--- a/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
@@ -2,6 +2,7 @@ import '../../testSetup';
 
 import { render } from '@testing-library/react';
 import React from 'react';
+import { IntlProvider } from 'react-intl';
 
 import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
 import { SearchFilterGroup } from './SearchFilterGroup';
@@ -23,30 +24,32 @@ describe('components/SearchFilterGroup', () => {
 
   it('renders the name of the filter with the values as SearchFilters', () => {
     const { getByText } = render(
-      <CourseSearchParamsContext.Provider
-        value={[{ limit: '999', offset: '0' }, jest.fn()]}
-      >
-        <SearchFilterGroup
-          filter={{
-            base_path: '0001',
-            human_name: 'Organizations',
-            is_autocompletable: true,
-            name: 'organizations',
-            values: [
-              {
-                count: 4,
-                human_name: 'Value One',
-                key: 'P-00010001',
-              },
-              {
-                count: 7,
-                human_name: 'Value Two',
-                key: 'L-00010002',
-              },
-            ],
-          }}
-        />
-      </CourseSearchParamsContext.Provider>,
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[{ limit: '999', offset: '0' }, jest.fn()]}
+        >
+          <SearchFilterGroup
+            filter={{
+              base_path: '0001',
+              human_name: 'Organizations',
+              is_autocompletable: true,
+              name: 'organizations',
+              values: [
+                {
+                  count: 4,
+                  human_name: 'Value One',
+                  key: 'P-00010001',
+                },
+                {
+                  count: 7,
+                  human_name: 'Value Two',
+                  key: 'L-00010002',
+                },
+              ],
+            }}
+          />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
     );
     // The filter group title and all filters are shown
     getByText('Organizations');

--- a/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { FilterDefinition } from '../../types/filters';
+import { SearchFilterGroupModal } from '../SearchFilterGroupModal';
 import { SearchFilterValueLeaf } from '../SearchFilterValueLeaf/SearchFilterValueLeaf';
 import { SearchFilterValueParent } from '../SearchFilterValueParent/SearchFilterValueParent';
 
@@ -30,5 +31,8 @@ export const SearchFilterGroup = ({ filter }: SearchFilterGroupProps) => (
         ),
       )}
     </div>
+    {filter.is_autocompletable ? (
+      <SearchFilterGroupModal filter={filter} />
+    ) : null}
   </fieldset>
 );

--- a/src/frontend/js/components/SearchFilterGroupModal/_SearchFilterGroupModal.scss
+++ b/src/frontend/js/components/SearchFilterGroupModal/_SearchFilterGroupModal.scss
@@ -1,0 +1,92 @@
+.search-filter-group-modal-overlay {
+  z-index: 10; // Make sure the overlay is above any random 0-1-2 z-indexes in content
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: rgba(0, 0, 0, 0.75);
+}
+
+.search-filter-group-modal-button {
+  width: 100%;
+  padding: $richie-search-filter-value-padding;
+  background: inherit;
+  color: $richie-search-filter-value-fontcolor;
+  border: none;
+  border-top: $richie-search-filter-value-divider-border;
+
+  &:hover,
+  &:focus {
+    color: $richie-search-filter-value-fontcolor-hover;
+  }
+}
+
+.search-filter-group-modal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border: 1px solid $gray80;
+  background: $richie-search-filters-background;
+  overflow: auto;
+  border-radius: 4px;
+  outline: none;
+  max-width: 30rem;
+  margin: 3rem auto;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  &__form {
+    flex-grow: 1;
+
+    &__title {
+      display: block;
+      margin: 0;
+      padding: 1rem;
+      text-align: center;
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+
+    &__input {
+      width: 100%;
+      padding: 0.5rem 1rem;
+      border: 1px solid $gray80;
+      border-left-width: 0;
+      border-right-width: 0;
+    }
+
+    &__values {
+      margin: 0;
+      padding: 0;
+      list-style-type: none;
+
+      &__item {
+        & > button {
+          width: 100%;
+          padding: 0.5rem 1rem;
+          text-align: left;
+          background: inherit;
+          border: none;
+          border-bottom: 1px solid $gray80;
+          color: inherit;
+        }
+      }
+    }
+  }
+
+  &__close {
+    flex-shrink: 0;
+    flex-grow: 0;
+    padding: 0.5rem 1rem;
+    background: white;
+    color: #08223c;
+    border-bottom: 0;
+    border-right: 0;
+    border-left: 0;
+  }
+}

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -1,0 +1,414 @@
+import { cleanup, fireEvent, render, wait } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { SearchFilterGroupModal } from '.';
+import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
+
+jest.mock('../../utils/errors/handle', () => ({ handle: jest.fn() }));
+
+const filter = {
+  base_path: '0001',
+  human_name: 'Universities',
+  is_autocompletable: true,
+  name: 'universities',
+  values: [
+    {
+      count: 4,
+      human_name: 'Value One',
+      key: 'P-00010001',
+    },
+    {
+      count: 7,
+      human_name: 'Value Two',
+      key: 'L-00010002',
+    },
+  ],
+};
+
+describe('<SearchFilterGroupModal />', () => {
+  beforeEach(fetchMock.restore);
+  afterEach(cleanup);
+
+  it('renders a button with a modal to search values for a given filter', async () => {
+    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
+      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
+    });
+    fetchMock.get(
+      '/api/v1.0/courses/?scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      {
+        filters: {
+          universities: {
+            values: [
+              {
+                count: 7,
+                human_name: 'Value #42',
+                key: '42',
+              },
+              {
+                count: 12,
+                human_name: 'Value #84',
+                key: '84',
+              },
+              {
+                count: 21,
+                human_name: 'Value #99',
+                key: '99',
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    const {
+      getByPlaceholderText,
+      getByText,
+      queryByPlaceholderText,
+      queryByText,
+    } = render(
+      <IntlProvider locale="en">
+        <SearchFilterGroupModal filter={filter} />
+      </IntlProvider>,
+    );
+
+    // The modal is not rendered
+    expect(queryByText('Add filters for Universities')).toEqual(null);
+    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+
+    // The modal is rendered
+    const openButton = getByText('More options');
+    fireEvent.click(openButton);
+    getByText('Add filters for Universities');
+    getByPlaceholderText('Search in Universities');
+
+    // Default search results are shown with their facet counts
+    await wait();
+    getByText(
+      content => content.startsWith('Value #42') && content.includes('(7)'),
+    );
+    getByText(
+      content => content.startsWith('Value #84') && content.includes('(12)'),
+    );
+    getByText(
+      content => content.startsWith('Value #99') && content.includes('(21)'),
+    );
+  });
+
+  it('searches as the user types', async () => {
+    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
+      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
+    });
+    fetchMock.get(
+      '/api/v1.0/courses/?scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      {
+        filters: {
+          universities: {
+            values: [
+              {
+                count: 7,
+                human_name: 'Value #42',
+                key: '42',
+              },
+              {
+                count: 12,
+                human_name: 'Value #84',
+                key: '84',
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    const { getByPlaceholderText, getByText } = render(
+      <IntlProvider locale="en">
+        <SearchFilterGroupModal filter={filter} />
+      </IntlProvider>,
+    );
+
+    // The modal is rendered
+    const openButton = getByText('More options');
+    fireEvent.click(openButton);
+    getByText('Add filters for Universities');
+    const field = getByPlaceholderText('Search in Universities');
+    fireEvent.focus(field);
+
+    // Default search results are shown with their facet counts
+    await wait();
+    getByText(
+      content => content.startsWith('Value #42') && content.includes('(7)'),
+    );
+    getByText(
+      content => content.startsWith('Value #84') && content.includes('(12)'),
+    );
+
+    // User inputs a search query
+    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=user', {
+      objects: [{ id: 'L-12' }, { id: 'L-17' }],
+    });
+    fetchMock.get(
+      '/api/v1.0/courses/?scope=filters&universities_include=.-%2812%7C17%29',
+      {
+        filters: {
+          universities: {
+            values: [
+              {
+                count: 7,
+                human_name: 'Value #12',
+                key: '12',
+              },
+              {
+                count: 12,
+                human_name: 'Value #17',
+                key: '17',
+              },
+            ],
+          },
+        },
+      },
+    );
+    fireEvent.change(field, { target: { value: 'user' } });
+
+    // New search results are shown with their facet counts
+    await wait();
+    getByText(
+      content => content.startsWith('Value #12') && content.includes('(7)'),
+    );
+    getByText(
+      content => content.startsWith('Value #17') && content.includes('(12)'),
+    );
+
+    // User further refines their search query
+    fetchMock.get(
+      '/api/v1.0/universities/?limit=20&offset=0&query=user%20input',
+      {
+        objects: [{ id: 'L-03' }, { id: 'L-66' }],
+      },
+    );
+    fetchMock.get(
+      '/api/v1.0/courses/?scope=filters&universities_include=.-%2803%7C66%29',
+      {
+        filters: {
+          universities: {
+            values: [
+              {
+                count: 12,
+                human_name: 'Value #03',
+                key: '03',
+              },
+              {
+                count: 2,
+                human_name: 'Value #17',
+                key: '17',
+              },
+            ],
+          },
+        },
+      },
+    );
+    fireEvent.change(field, { target: { value: 'user input' } });
+
+    // New search results are shown with their facet counts
+    await wait();
+    getByText(
+      content => content.startsWith('Value #03') && content.includes('(12)'),
+    );
+    getByText(
+      content => content.startsWith('Value #17') && content.includes('(2)'),
+    );
+  });
+
+  it('closes when the user clicks the close button', async () => {
+    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
+      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
+    });
+    fetchMock.get(
+      '/api/v1.0/courses/?scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      {
+        filters: {
+          universities: {
+            values: [],
+          },
+        },
+      },
+    );
+
+    const {
+      getByPlaceholderText,
+      getByText,
+      queryByPlaceholderText,
+      queryByText,
+    } = render(
+      <IntlProvider locale="en">
+        <SearchFilterGroupModal filter={filter} />
+      </IntlProvider>,
+    );
+
+    // The modal is not rendered
+    expect(queryByText('Add filters for Universities')).toEqual(null);
+    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+    expect(queryByText('Close')).toEqual(null);
+
+    // The modal is rendered
+    const openButton = getByText('More options');
+    fireEvent.click(openButton);
+    getByText('Add filters for Universities');
+    getByPlaceholderText('Search in Universities');
+
+    // User clicks on the close button
+    const closeButton = getByText('Close');
+    fireEvent.click(closeButton);
+
+    // The modal is not rendered any more
+    expect(queryByText('Add filters for Universities')).toEqual(null);
+    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+    expect(queryByText('Close')).toEqual(null);
+
+    await wait();
+  });
+
+  it('adds the value and closes when the user clicks a filter value', async () => {
+    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
+      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
+    });
+    fetchMock.get(
+      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      {
+        filters: {
+          universities: {
+            values: [
+              {
+                count: 7,
+                human_name: 'Value #42',
+                key: '42',
+              },
+              {
+                count: 12,
+                human_name: 'Value #84',
+                key: '84',
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    const dispatchCourseSearchParamsUpdate = jest.fn();
+    const {
+      getByPlaceholderText,
+      getByText,
+      queryByPlaceholderText,
+      queryByText,
+    } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[
+            { limit: '20', offset: '0' },
+            dispatchCourseSearchParamsUpdate,
+          ]}
+        >
+          <SearchFilterGroupModal filter={filter} />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    // The modal is not rendered
+    expect(queryByText('Add filters for Universities')).toEqual(null);
+    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+
+    // The modal is rendered
+    const openButton = getByText('More options');
+    fireEvent.click(openButton);
+    getByText('Add filters for Universities');
+    getByPlaceholderText('Search in Universities');
+
+    // Default search results are shown with their facet counts
+    await wait();
+    const value42 = getByText(
+      content => content.startsWith('Value #42') && content.includes('(7)'),
+    );
+    getByText(
+      content => content.startsWith('Value #84') && content.includes('(12)'),
+    );
+
+    // User clicks Value #42, it is added to course search params through a dispatched update
+    fireEvent.click(value42);
+    expect(dispatchCourseSearchParamsUpdate).toHaveBeenLastCalledWith({
+      filter,
+      payload: '42',
+      type: 'FILTER_ADD',
+    });
+
+    // The modal is not rendered any more
+    expect(queryByText('Add filters for Universities')).toEqual(null);
+    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+  });
+
+  it('shows an error message when it fails to search for values', async () => {
+    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
+      throws: new Error('Failed to search for universities'),
+    });
+
+    const {
+      getByPlaceholderText,
+      getByText,
+      queryByPlaceholderText,
+      queryByText,
+    } = render(
+      <IntlProvider locale="en">
+        <SearchFilterGroupModal filter={filter} />
+      </IntlProvider>,
+    );
+
+    // The modal is not rendered
+    expect(queryByText('Add filters for Universities')).toEqual(null);
+    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+
+    // The modal is rendered
+    const openButton = getByText('More options');
+    fireEvent.click(openButton);
+    getByText('Add filters for Universities');
+    getByPlaceholderText('Search in Universities');
+
+    // The search request failed, the error is logged and a message is displayed
+    await wait();
+    getByText('There was an error while searching for Universities.');
+  });
+
+  it('shows an error message when it fails to get the actual filter', async () => {
+    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
+      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
+    });
+    fetchMock.get(
+      '/api/v1.0/courses/?scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      { throws: new Error('Failed to search for universities') },
+    );
+
+    const {
+      getByPlaceholderText,
+      getByText,
+      queryByPlaceholderText,
+      queryByText,
+    } = render(
+      <IntlProvider locale="en">
+        <SearchFilterGroupModal filter={filter} />
+      </IntlProvider>,
+    );
+
+    // The modal is not rendered
+    expect(queryByText('Add filters for Universities')).toEqual(null);
+    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+
+    // The modal is rendered
+    const openButton = getByText('More options');
+    fireEvent.click(openButton);
+    getByText('Add filters for Universities');
+    getByPlaceholderText('Search in Universities');
+
+    // The filters request failed, the error is logged and a message is displayed
+    await wait();
+    getByText('There was an error while searching for Universities.');
+  });
+});

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -4,7 +4,7 @@ import {
   FormattedMessage,
   MessageDescriptor,
 } from 'react-intl';
-import Modal from 'react-modal';
+import ReactModal from 'react-modal';
 
 import { fetchList } from '../../data/getResourceList/getResourceList';
 import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
@@ -42,6 +42,14 @@ const messages = defineMessages({
     id: 'components.SearchFilterGroupModal.moreOptionsButton',
   },
 });
+
+// The `setAppElement` needs to happen in proper code but breaks our testing environment.
+// This workaround is not satisfactory but it allows us to both test <SearchFilterGroupModal />
+// and avoid compromising accessibility in real-world use.
+const isTestEnv = typeof jest !== 'undefined';
+if (!isTestEnv) {
+  ReactModal.setAppElement('#modal-exclude');
+}
 
 export const SearchFilterGroupModal = ({
   filter,
@@ -108,7 +116,8 @@ export const SearchFilterGroupModal = ({
       >
         <FormattedMessage {...messages.moreOptionsButton} />
       </button>
-      <Modal
+      <ReactModal
+        ariaHideApp={!isTestEnv}
         bodyOpenClassName="has-search-filter-group-modal"
         className="search-filter-group-modal"
         isOpen={modalIsOpen}
@@ -166,7 +175,7 @@ export const SearchFilterGroupModal = ({
         >
           <FormattedMessage {...messages.closeButton} />
         </button>
-      </Modal>
+      </ReactModal>
     </React.Fragment>
   );
 };

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.tsx
@@ -7,6 +7,7 @@ import { useFilterValue } from '../../data/useFilterValue/useFilterValue';
 import { requestStatus } from '../../types/api';
 import { FilterDefinition, FilterValue } from '../../types/filters';
 import { getMPTTChildrenPathMatcher } from '../../utils/mptt';
+import { Nullable } from '../../utils/types';
 import { useAsyncEffect } from '../../utils/useAsyncEffect';
 import { SearchFilterValueLeaf } from '../SearchFilterValueLeaf/SearchFilterValueLeaf';
 
@@ -54,11 +55,14 @@ export const SearchFilterValueParent = ({
   const childrenPathMatch = getMPTTChildrenPathMatcher(value.key);
   const childrenPathMatchRegexp = new RegExp(childrenPathMatch);
   // Hide children by default, unless at least one of them is currently active
-  const [showChildren, setShowChildren] = useState(
-    activeValuesList.some(activeValueKey =>
-      childrenPathMatchRegexp.test(activeValueKey),
-    ),
+  const hasActiveChildren = activeValuesList.some(activeValueKey =>
+    childrenPathMatchRegexp.test(activeValueKey),
   );
+  const [userShowChildren, setUserShowChildren] = useState(null as Nullable<
+    boolean
+  >);
+  const showChildren =
+    userShowChildren !== null ? !!userShowChildren : hasActiveChildren;
 
   const [children, setChildren] = useState([] as FilterValue[]);
   useAsyncEffect(async () => {
@@ -122,7 +126,7 @@ export const SearchFilterValueParent = ({
           aria-pressed={showChildren}
           className={`search-filter-value-parent__self__unfold ${showChildren &&
             'search-filter-value-parent__self__unfold--open'}`}
-          onClick={() => setShowChildren(!showChildren)}
+          onClick={() => setUserShowChildren(!showChildren)}
         >
           {showChildren ? '-' : '+'}
         </button>

--- a/src/frontend/js/types/Category.ts
+++ b/src/frontend/js/types/Category.ts
@@ -3,5 +3,3 @@ import { Resource } from './Resource';
 export interface Category extends Resource {
   logo: string | null;
 }
-
-export type CategoryForSuggestion = Pick<Category, 'id' | 'title'>;

--- a/src/frontend/js/types/Category.ts
+++ b/src/frontend/js/types/Category.ts
@@ -2,7 +2,6 @@ import { Resource } from './Resource';
 
 export interface Category extends Resource {
   logo: string | null;
-  title: string;
 }
 
 export type CategoryForSuggestion = Pick<Category, 'id' | 'title'>;

--- a/src/frontend/js/types/Course.ts
+++ b/src/frontend/js/types/Course.ts
@@ -24,7 +24,6 @@ export interface Course extends Resource {
     priority: number;
     text: string;
   };
-  title: string;
 }
 
 export type CourseForSuggestion = Pick<Course, 'absolute_url' | 'id' | 'title'>;

--- a/src/frontend/js/types/Course.ts
+++ b/src/frontend/js/types/Course.ts
@@ -25,5 +25,3 @@ export interface Course extends Resource {
     text: string;
   };
 }
-
-export type CourseForSuggestion = Pick<Course, 'absolute_url' | 'id' | 'title'>;

--- a/src/frontend/js/types/Organization.ts
+++ b/src/frontend/js/types/Organization.ts
@@ -2,7 +2,6 @@ import { Resource } from './Resource';
 
 export interface Organization extends Resource {
   logo: string | null;
-  title: string;
 }
 
 export type OrganizationForSuggestion = Pick<Organization, 'id' | 'title'>;

--- a/src/frontend/js/types/Organization.ts
+++ b/src/frontend/js/types/Organization.ts
@@ -3,5 +3,3 @@ import { Resource } from './Resource';
 export interface Organization extends Resource {
   logo: string | null;
 }
-
-export type OrganizationForSuggestion = Pick<Organization, 'id' | 'title'>;

--- a/src/frontend/js/types/Resource.ts
+++ b/src/frontend/js/types/Resource.ts
@@ -1,3 +1,4 @@
 export interface Resource {
   id: string;
+  title: string;
 }

--- a/src/frontend/js/types/Suggestion.ts
+++ b/src/frontend/js/types/Suggestion.ts
@@ -1,5 +1,3 @@
-import { FormattedMessage } from 'react-intl';
-
 /**
  * A Default suggestion shape for cases where we need one.
  */

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -48,6 +48,7 @@
     "@types/react": "16.9.2",
     "@types/react-autosuggest": "9.3.10",
     "@types/react-dom": "16.8.5",
+    "@types/react-modal": "3.8.2",
     "babel-jest": "24.9.0",
     "babel-loader": "8.0.6",
     "babel-plugin-react-intl": "4.1.12",
@@ -76,7 +77,8 @@
     "react": "16.9.0",
     "react-autosuggest": "9.4.3",
     "react-dom": "16.9.0",
-    "react-intl": "3.1.9"
+    "react-intl": "3.1.9",
+    "react-modal": "3.9.1"
   },
   "resolutions": {
     "@testing-library/react": "9.1.0",

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -45,13 +45,6 @@
 // Objects from Partials (eg. styles for templates produced by dependencies)
 @import './objects/react-autosuggest';
 
-// Frontend components objects styles
-@import '../js/components/PaginateCourseSearch/_PaginateCourseSearch';
-@import '../js/components/Search/_Search';
-@import '../js/components/SearchFilterGroup/_SearchFilterGroup';
-@import '../js/components/SearchFiltersPane/_SearchFiltersPane';
-@import '../js/components/SearchLoader/_SearchLoader';
-
 // Shared object styles
 @import './templates/menu/_menu';
 @import './templates/richie/single-column';
@@ -74,6 +67,14 @@
 @import './templates/richie/large_banner/large_banner';
 @import './templates/richie/large_banner/hero-intro';
 @import './templates/richie/section/section';
+
+// Frontend components objects styles
+@import '../js/components/PaginateCourseSearch/_PaginateCourseSearch';
+@import '../js/components/Search/_Search';
+@import '../js/components/SearchFilterGroup/_SearchFilterGroup';
+@import '../js/components/SearchFilterGroupModal/SearchFilterGroupModal';
+@import '../js/components/SearchFiltersPane/_SearchFiltersPane';
+@import '../js/components/SearchLoader/_SearchLoader';
 
 // Page component styles
 @import './components/header';

--- a/src/frontend/scss/objects/_search-filter-value.scss
+++ b/src/frontend/scss/objects/_search-filter-value.scss
@@ -1,5 +1,4 @@
 $richie-search-filter-value-padding: 0.4rem 0.5rem !default;
-$richie-search-filter-value-fontsize: 0.9rem !default;
 $richie-search-filter-value-fontcolor: rgba($white, 0.85) !default;
 $richie-search-filter-value-fontcolor-hover: $white !default;
 $richie-search-filter-value-divider-border: 1px solid $gray80 !default;
@@ -14,7 +13,6 @@ $richie-search-filter-value-active-divider-border: 1px solid $white !default;
   border: none;
   background: inherit;
   color: $richie-search-filter-value-fontcolor;
-  font-size: $richie-search-filter-value-fontsize;
   cursor: pointer;
 
   &:hover,

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1245,6 +1245,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-modal@3.8.2":
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.8.2.tgz#401309e624cde522d65c3ef04918dbe325383598"
+  integrity sha512-/Drs+XfHg9M60fy2Q63UUlhECXSNknDu3tnwFnbOhcdDjq03VD3hLCfv3X+BBzRqgu4TOu+TwEwBhgI8qdVAAQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@16.9.2":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
@@ -2979,6 +2986,11 @@ execa@^1.0.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
 
 exit@^0.1.2:
   version "0.1.2"
@@ -5940,6 +5952,21 @@ react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
 
+react-lifecycles-compat@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-modal@3.9.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.9.1.tgz#82ce53d110eea0d8f028f3315ef336d0baffa9b9"
+  integrity sha512-k+TUkhGWpIVHLsEyjNmlyOYL0Uz03fNZvlkhCImd1h+6fhNgTi6H6jexVXPVhD2LMMDzJyfugxMN+APN/em+eQ==
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^4.0.3"
+
 react-themeable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
@@ -7300,6 +7327,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.6.0:
   version "1.6.0"

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -9,66 +9,71 @@
         {% render_block "css" %}
 
         <link rel="stylesheet" type="text/css" href="{% static 'richie/css/main.css' %}">
-        <script type="text/javascript" src="{% static 'richie/js/index.js' %}"></script>
     </head>
     <body>
         {% cms_toolbar %}
-        {% block body_header %}
-        <nav class="topbar" id="main-menu">
-            <div class="topbar__brand">
-                <button class="topbar__hamburger"
-                        data-target="main-menu" aria-label="menu" aria-expanded="false">&#8801;</button>
-                <a href="/" class="topbar__brand__link">
-                    <img src="{% static "images/logo.png" %}" class="topbar__brand__logo" alt="{{ SITE.name }}">
-                </a>
-            </div>
-            <div class="topbar__menu">
-                <ul class="topbar__menu__list">
-                    {% show_menu 0 100 0 0 "menu/header_menu.html" %}
-                </ul>
-                <ul class="topbar__menu__list topbar__menu__list--aside">
-                    {% language_chooser "menu/language_menu.html" %}
-                    <li class="topbar__menu__list__item topbar__menu__list__item--cta-hollow">
-                        <a class="topbar__menu__list__item__link" href="#">Sign up</a>
-                    </li>
-                    <li class="topbar__menu__list__item topbar__menu__list__item--cta">
-                        <a class="topbar__menu__list__item__link" href="#">Login</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
-        {% endblock body_header %}
 
-        <div class="body-content {% block bodycontent_classes %}{% endblock bodycontent_classes %}">
-        {% block content %}{% endblock content %}
-        </div>
+        {# Wrap all body content in an ID'd element to easily remove it from view (using aria-hidden) #}
+        {# when a modal is open. This is important for accessibility. #}
+        <div id="modal-exclude">
+            {% block body_header %}
+            <nav class="topbar" id="main-menu">
+                <div class="topbar__brand">
+                    <button class="topbar__hamburger"
+                            data-target="main-menu" aria-label="menu" aria-expanded="false">&#8801;</button>
+                    <a href="/" class="topbar__brand__link">
+                        <img src="{% static "images/logo.png" %}" class="topbar__brand__logo" alt="{{ SITE.name }}">
+                    </a>
+                </div>
+                <div class="topbar__menu">
+                    <ul class="topbar__menu__list">
+                        {% show_menu 0 100 0 0 "menu/header_menu.html" %}
+                    </ul>
+                    <ul class="topbar__menu__list topbar__menu__list--aside">
+                        {% language_chooser "menu/language_menu.html" %}
+                        <li class="topbar__menu__list__item topbar__menu__list__item--cta-hollow">
+                            <a class="topbar__menu__list__item__link" href="#">Sign up</a>
+                        </li>
+                        <li class="topbar__menu__list__item topbar__menu__list__item--cta">
+                            <a class="topbar__menu__list__item__link" href="#">Login</a>
+                        </li>
+                    </ul>
+                </div>
+            </nav>
+            {% endblock body_header %}
 
-        {% block body_footer %}
-        <div class="body-footer">
-            <div class="body-footer__menu">
-                <ul class="body-footer__menu__list">
-                    {% show_menu_below_id "annex" 0 100 100 100 "menu/footer_menu.html" %}
-                </ul>
+            <div class="body-content {% block bodycontent_classes %}{% endblock bodycontent_classes %}">
+            {% block content %}{% endblock content %}
             </div>
-            <div class="body-footer__brand">
-                <a href="/" class="body-footer__brand__link">
-                    <img src="{% static "images/logo.png" %}" class="body-footer__brand__logo" alt="">
-                </a>
-                {% include "social-networks/footer-badges.html" %}
+
+            {% block body_footer %}
+            <div class="body-footer">
+                <div class="body-footer__menu">
+                    <ul class="body-footer__menu__list">
+                        {% show_menu_below_id "annex" 0 100 100 100 "menu/footer_menu.html" %}
+                    </ul>
+                </div>
+                <div class="body-footer__brand">
+                    <a href="/" class="body-footer__brand__link">
+                        <img src="{% static "images/logo.png" %}" class="body-footer__brand__logo" alt="">
+                    </a>
+                    {% include "social-networks/footer-badges.html" %}
+                </div>
+                <div class="body-footer__mentions">
+                    <p>{% now "Y" %} &copy; Acme {% blocktrans %}All Rights Reserved.{% endblocktrans %}</p>
+                </div>
+                <div class="body-footer__poweredby">
+                    <a href="https://github.com/openfun/richie" class="body-footer__poweredby__link">
+                        <small>Powered by</small>
+                        <strong>Richie</strong>
+                    </a>
+                </div>
             </div>
-            <div class="body-footer__mentions">
-                <p>{% now "Y" %} &copy; Acme {% blocktrans %}All Rights Reserved.{% endblocktrans %}</p>
-            </div>
-            <div class="body-footer__poweredby">
-                <a href="https://github.com/openfun/richie" class="body-footer__poweredby__link">
-                    <small>Powered by</small>
-                    <strong>Richie</strong>
-                </a>
-            </div>
+            {% endblock body_footer %}
         </div>
-        {% endblock body_footer %}
 
         {% render_block "js" %}
+        <script type="text/javascript" src="{% static 'richie/js/index.js' %}"></script>
         <script type="text/javascript">
         document.addEventListener('DOMContentLoaded', () => {
             // Get all topbar burger elements

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -334,7 +334,7 @@ class ItemSearchForm(SearchForm):
         # Add a match on the name field if it was handed by the client
         full_text = self.cleaned_data.get("query")
         if full_text:
-            clauses.append({"match": {"title.*": {"query": full_text}}})
+            clauses.append({"multi_match": {"query": full_text, "fields": ["title.*"]}})
 
         # Build the query around the clauses if there are any
         if clauses:

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -44,6 +44,7 @@ class CategoriesIndexer:
                 for lang, _ in settings.LANGUAGES
             },
             "is_meta": {"type": "boolean"},
+            "kind": {"type": "keyword"},
             "nb_children": {"type": "integer"},
             "path": {"type": "keyword"},
             # Not searchable

--- a/tests/apps/search/test_forms_search_items.py
+++ b/tests/apps/search/test_forms_search_items.py
@@ -121,8 +121,9 @@ class ItemSearchFormTestCase(TestCase):
                         "bool": {
                             "must": [
                                 {
-                                    "match": {
-                                        "title.*": {"query": "some phrase " "terms"}
+                                    "multi_match": {
+                                        "fields": ["title.*"],
+                                        "query": "some phrase " "terms",
                                     }
                                 }
                             ]
@@ -152,8 +153,9 @@ class ItemSearchFormTestCase(TestCase):
                             "must": [
                                 {"term": {"kind": "subjects"}},
                                 {
-                                    "match": {
-                                        "title.*": {"query": "some phrase " "terms"}
+                                    "multi_match": {
+                                        "fields": ["title.*"],
+                                        "query": "some phrase " "terms",
                                     }
                                 },
                             ]

--- a/tests/apps/search/test_query_categories.py
+++ b/tests/apps/search/test_query_categories.py
@@ -1,0 +1,154 @@
+"""Tests for actual searches for categories."""
+import json
+from unittest import mock
+
+from django.test import TestCase
+
+from elasticsearch.client import IndicesClient
+from elasticsearch.helpers import bulk
+
+from richie.apps.search import ES_CLIENT
+from richie.apps.search.indexers.categories import CategoriesIndexer
+from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
+
+CATEGORIES = [
+    {"id": "8312", "kind": "subjects", "title": {"en": "Literature"}},
+    {"id": "8399", "kind": "subjects", "title": {"en": "Science for beginners"}},
+    {"id": "8421", "kind": "levels", "title": {"en": "Bégînnêr"}},
+    {"id": "8476", "kind": "levels", "title": {"en": "Expert"}},
+]
+
+
+@mock.patch.object(  # Avoid messing up the development Elasticsearch index
+    CategoriesIndexer,
+    "index_name",
+    new_callable=mock.PropertyMock,
+    return_value="test_categories",
+)
+class CategoriesQueryTestCase(TestCase):
+    """
+    Test search queries on categories.
+    """
+
+    def execute_query(self, kind, querystring=""):
+        """
+        Not a test.
+        This method is doing the heavy lifting for the tests in this class: create and fill the
+        index with our categories so we can run our queries and check the results.
+        It also executes the query and returns the result from the API.
+        """
+        # Index these categories in Elasticsearch
+        indices_client = IndicesClient(client=ES_CLIENT)
+        # Delete any existing indexes so we get a clean slate
+        indices_client.delete(index="_all")
+        # Create an index we'll use to test the ES features
+        indices_client.create(index="test_categories")
+        indices_client.close(index="test_categories")
+        indices_client.put_settings(body=ANALYSIS_SETTINGS, index="test_categories")
+        indices_client.open(index="test_categories")
+
+        # Use the default categories mapping from the Indexer
+        indices_client.put_mapping(
+            body=CategoriesIndexer.mapping, doc_type="category", index="test_categories"
+        )
+
+        # Actually insert our categories in the index
+        actions = [
+            {
+                "_id": category["id"],
+                "_index": "test_categories",
+                "_op_type": "create",
+                "_type": "category",
+                "absolute_url": {"en": "en/url"},
+                "description": {"en": "en/description"},
+                "icon": {"en": "en/icon"},
+                "is_meta": False,
+                "logo": {"en": "en/logo"},
+                "nb_children": 0,
+                "path": category["id"],
+                **category,
+            }
+            for category in CATEGORIES
+        ]
+        bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
+        indices_client.refresh()
+
+        response = self.client.get(f"/api/v1.0/{kind:s}/?{querystring:s}")
+        self.assertEqual(response.status_code, 200)
+
+        return json.loads(response.content)
+
+    def test_query_all_categories_by_kind(self, *_):
+        """
+        Make sure all categories of a given kind are returned when there is no text query.
+        """
+        content = self.execute_query(kind="subjects")
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 2, "offset": 0, "total_count": 2},
+                "objects": [
+                    {
+                        "icon": "en/icon",
+                        "id": "8399",
+                        "is_meta": False,
+                        "logo": "en/logo",
+                        "nb_children": 0,
+                        "path": "8399",
+                        "title": "Science for beginners",
+                    },
+                    {
+                        "icon": "en/icon",
+                        "id": "8312",
+                        "is_meta": False,
+                        "logo": "en/logo",
+                        "nb_children": 0,
+                        "path": "8312",
+                        "title": "Literature",
+                    },
+                ],
+            },
+        )
+
+    def test_query_categories_by_text_and_kind(self, *_):
+        """
+        Make sure only categories matching the text query and kind are returned.
+        """
+        # Make a query without diacritics for an object with diacritics in its title
+        content = self.execute_query(kind="levels", querystring="query=beginner")
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 1, "offset": 0, "total_count": 1},
+                "objects": [
+                    {
+                        "icon": "en/icon",
+                        "id": "8421",
+                        "is_meta": False,
+                        "logo": "en/logo",
+                        "nb_children": 0,
+                        "path": "8421",
+                        "title": "Bégînnêr",
+                    }
+                ],
+            },
+        )
+        # Make a query with diacritics for an object without diacritics in its title
+        content = self.execute_query(kind="subjects", querystring="query=lįtérature")
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 1, "offset": 0, "total_count": 1},
+                "objects": [
+                    {
+                        "icon": "en/icon",
+                        "id": "8312",
+                        "is_meta": False,
+                        "logo": "en/logo",
+                        "nb_children": 0,
+                        "path": "8312",
+                        "title": "Literature",
+                    }
+                ],
+            },
+        )

--- a/tests/apps/search/test_query_organizations.py
+++ b/tests/apps/search/test_query_organizations.py
@@ -1,0 +1,141 @@
+"""Tests for actual searches for organizations."""
+import json
+from unittest import mock
+
+from django.test import TestCase
+
+from elasticsearch.client import IndicesClient
+from elasticsearch.helpers import bulk
+
+from richie.apps.search import ES_CLIENT
+from richie.apps.search.indexers.organizations import OrganizationsIndexer
+from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
+
+ORGANIZATIONS = [
+    {"id": "4214", "title": {"en": "Ünìversity of Paris 14"}},
+    {"id": "4209", "title": {"en": "ÙnĪversity of Lyon VI"}},
+    {"id": "4213", "title": {"en": "School of Lorem Ipsum"}},
+]
+
+
+@mock.patch.object(  # Avoid messing up the development Elasticsearch index
+    OrganizationsIndexer,
+    "index_name",
+    new_callable=mock.PropertyMock,
+    return_value="test_organizations",
+)
+class OrganizationsQueryTestCase(TestCase):
+    """
+    Test search queries on organizations.
+    """
+
+    def execute_query(self, querystring=""):
+        """
+        Not a test.
+        This method is doing the heavy lifting for the tests in this class: create and fill the
+        index with our organizations so we can run our queries and check the results.
+        It also executes the query and returns the result from the API.
+        """
+        # Index these organizations in Elasticsearch
+        indices_client = IndicesClient(client=ES_CLIENT)
+        # Delete any existing indexes so we get a clean slate
+        indices_client.delete(index="_all")
+        # Create an index we'll use to test the ES features
+        indices_client.create(index="test_organizations")
+        indices_client.close(index="test_organizations")
+        indices_client.put_settings(body=ANALYSIS_SETTINGS, index="test_organizations")
+        indices_client.open(index="test_organizations")
+
+        # Use the default organizations mapping from the Indexer
+        indices_client.put_mapping(
+            body=OrganizationsIndexer.mapping,
+            doc_type="organization",
+            index="test_organizations",
+        )
+
+        # Actually insert our organizations in the index
+        actions = [
+            {
+                "_id": organization["id"],
+                "_index": "test_organizations",
+                "_op_type": "create",
+                "_type": "organization",
+                "absolute_url": {"en": "en/url"},
+                "description": {"en": "en/description"},
+                "logo": {"en": "en/image"},
+                **organization,
+            }
+            for organization in ORGANIZATIONS
+        ]
+        bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
+        indices_client.refresh()
+
+        response = self.client.get(f"/api/v1.0/organizations/?{querystring:s}")
+        self.assertEqual(response.status_code, 200)
+
+        return json.loads(response.content)
+
+    def test_query_all_organizations(self, *_):
+        """
+        Make sure all organizations are returned when there is no query string.
+        """
+        content = self.execute_query()
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 3, "offset": 0, "total_count": 3},
+                "objects": [
+                    {
+                        "id": "4214",
+                        "logo": "en/image",
+                        "title": "Ünìversity of Paris 14",
+                    },
+                    {
+                        "id": "4209",
+                        "logo": "en/image",
+                        "title": "ÙnĪversity of Lyon VI",
+                    },
+                    {
+                        "id": "4213",
+                        "logo": "en/image",
+                        "title": "School of Lorem Ipsum",
+                    },
+                ],
+            },
+        )
+
+    def test_query_organizations_by_text(self, *_):
+        """
+        Make sure only organizations matching the text query are returned.
+        """
+        # Make a query without diacritics for an object with diacritics in its title
+        content = self.execute_query("query=univers")
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 2, "offset": 0, "total_count": 2},
+                "objects": [
+                    {
+                        "id": "4209",
+                        "logo": "en/image",
+                        "title": "ÙnĪversity of Lyon VI",
+                    },
+                    {
+                        "id": "4214",
+                        "logo": "en/image",
+                        "title": "Ünìversity of Paris 14",
+                    },
+                ],
+            },
+        )
+        # Make a query with diacritics for an object without diacritics in its title
+        content = self.execute_query("query=schøöl")
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 1, "offset": 0, "total_count": 1},
+                "objects": [
+                    {"id": "4213", "logo": "en/image", "title": "School of Lorem Ipsum"}
+                ],
+            },
+        )

--- a/tests/apps/search/test_query_persons.py
+++ b/tests/apps/search/test_query_persons.py
@@ -1,0 +1,119 @@
+"""Tests for actual searches for persons."""
+import json
+from unittest import mock
+
+from django.test import TestCase
+
+from elasticsearch.client import IndicesClient
+from elasticsearch.helpers import bulk
+
+from richie.apps.search import ES_CLIENT
+from richie.apps.search.indexers.persons import PersonsIndexer
+from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
+
+PERSONS = [
+    {"id": "5918", "title": {"en": "John Brown"}},
+    {"id": "5987", "title": {"en": "John Blue"}},
+    {"id": "5912", "title": {"en": "Jåsōn Gold"}},
+]
+
+
+@mock.patch.object(  # Avoid messing up the development Elasticsearch index
+    PersonsIndexer,
+    "index_name",
+    new_callable=mock.PropertyMock,
+    return_value="test_persons",
+)
+class PersonsQueryTestCase(TestCase):
+    """
+    Test search queries on persons.
+    """
+
+    def execute_query(self, querystring=""):
+        """
+        Not a test.
+        This method is doing the heavy lifting for the tests in this class: create and fill the
+        index with our persons so we can run our queries and check the results.
+        It also executes the query and returns the result from the API.
+        """
+        # Index these persons in Elasticsearch
+        indices_client = IndicesClient(client=ES_CLIENT)
+        # Delete any existing indexes so we get a clean slate
+        indices_client.delete(index="_all")
+        # Create an index we'll use to test the ES features
+        indices_client.create(index="test_persons")
+        indices_client.close(index="test_persons")
+        indices_client.put_settings(body=ANALYSIS_SETTINGS, index="test_persons")
+        indices_client.open(index="test_persons")
+
+        # Use the default persons mapping from the Indexer
+        indices_client.put_mapping(
+            body=PersonsIndexer.mapping, doc_type="person", index="test_persons"
+        )
+
+        # Actually insert our persons in the index
+        actions = [
+            {
+                "_id": person["id"],
+                "_index": "test_persons",
+                "_op_type": "create",
+                "_type": "person",
+                "absolute_url": {"en": "en/url"},
+                "bio": {"en": "en/bio"},
+                "portrait": {"en": "en/image"},
+                **person,
+            }
+            for person in PERSONS
+        ]
+        bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
+        indices_client.refresh()
+
+        response = self.client.get(f"/api/v1.0/persons/?{querystring:s}")
+        self.assertEqual(response.status_code, 200)
+
+        return json.loads(response.content)
+
+    def test_query_all_persons(self, *_):
+        """
+        Make sure all persons are returned when there is no query string.
+        """
+        content = self.execute_query()
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 3, "offset": 0, "total_count": 3},
+                "objects": [
+                    {"id": "5918", "portrait": "en/image", "title": "John Brown"},
+                    {"id": "5987", "portrait": "en/image", "title": "John Blue"},
+                    {"id": "5912", "portrait": "en/image", "title": "Jåsōn Gold"},
+                ],
+            },
+        )
+
+    def test_query_persons_by_text(self, *_):
+        """
+        Make sure only persons matching the text query are returned.
+        """
+        # Make a query without diacritics for an object with diacritics in its title
+        content = self.execute_query("query=jason")
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 1, "offset": 0, "total_count": 1},
+                "objects": [
+                    {"id": "5912", "portrait": "en/image", "title": "Jåsōn Gold"}
+                ],
+            },
+        )
+        # Make a query with diacritics for an object without diacritics in its title
+        content = self.execute_query("query=jõhń")
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 2, "offset": 0, "total_count": 2},
+                "objects": [
+                    {"id": "5987", "portrait": "en/image", "title": "John Blue"},
+                    {"id": "5918", "portrait": "en/image", "title": "John Brown"},
+                ],
+            },
+        )

--- a/tests/apps/search/test_viewsets_categories.py
+++ b/tests/apps/search/test_viewsets_categories.py
@@ -161,7 +161,12 @@ class CategoriesViewsetsTestCase(TestCase):
                     "bool": {
                         "must": [
                             {"term": {"kind": "subjects"}},
-                            {"match": {"title.*": {"query": "Science"}}},
+                            {
+                                "multi_match": {
+                                    "query": "Science",
+                                    "fields": ["title.*"],
+                                }
+                            },
                         ]
                     }
                 }


### PR DESCRIPTION
## Purpose

In the search filters pane, we display the top N (by default 10) values for each filter, ordered by facet count. It makes sense to show the values with the most matching courses more prominently, but users might want to filter by other values, especially on Richie instances that host a large number of courses.

## Proposal

Add a button on said search filters that opens a modal with a search field that is specialized to that filter.

This will let users easily add any value for a given filter through a full-text search.