### PR TITLE
Paginate course search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Paginate the course search results view.
 - Add a CSS class to move content offscreen so it's only available for users
   of assistive technologies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a CSS class to move content offscreen so it's only available for users
+  of assistive technologies.
+
 ## [1.6.1] - 2019-08-03
 
 ### Fixed

--- a/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.spec.tsx
@@ -25,32 +25,16 @@ describe('components/CourseGlimpseList', () => {
       <IntlProvider locale="en">
         <CourseGlimpseList
           courses={courses}
-          meta={{ limit: 20, offset: 0, total_count: 5 }}
+          meta={{ count: 20, offset: 0, total_count: 45 }}
         />
       </IntlProvider>,
     );
 
     expect(
-      getAllByText('Showing 5 courses matching your search').length,
+      getAllByText('Showing 1 to 20 of 45 courses matching your search').length,
     ).toEqual(1);
     // Both courses' titles are shown
     getByText('Course 44');
     getByText('Course 45');
-  });
-
-  it('shows the count twice if there are more than 8 courses to show', () => {
-    const courses = [] as Course[];
-    const { getAllByText } = render(
-      <IntlProvider locale="en">
-        <CourseGlimpseList
-          courses={courses}
-          meta={{ limit: 20, offset: 0, total_count: 42 }}
-        />
-      </IntlProvider>,
-    );
-
-    expect(
-      getAllByText('Showing 42 courses matching your search').length,
-    ).toEqual(2);
   });
 });

--- a/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.tsx
@@ -8,9 +8,10 @@ import { CourseGlimpse } from '../CourseGlimpse/CourseGlimpse';
 const messages = defineMessages({
   courseCount: {
     defaultMessage:
-      'Showing {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search',
+      'Showing {start, number} to {end, number} of {courseCount, number} ' +
+      '{courseCount, plural, one {course} other {courses}} matching your search',
     description:
-      'Result count for course search. Appears right above search results',
+      'Result count & pagination information for course search. Appears right above search results',
     id: 'components.CourseGlimpseList.courseCount',
   },
 });
@@ -29,20 +30,16 @@ export const CourseGlimpseList = ({
       <div className="course-glimpse-list__count">
         <FormattedMessage
           {...messages.courseCount}
-          values={{ courseCount: meta.total_count }}
+          values={{
+            courseCount: meta.total_count,
+            end: meta.offset + meta.count,
+            start: meta.offset + 1,
+          }}
         />
       </div>
       {courses.map(
         course => course && <CourseGlimpse course={course} key={course.id} />,
       )}
-      {meta.total_count > 8 ? (
-        <div className="course-glimpse-list__count">
-          <FormattedMessage
-            {...messages.courseCount}
-            values={{ courseCount: meta.total_count }}
-          />
-        </div>
-      ) : null}
     </div>
   );
 };

--- a/src/frontend/js/components/PaginateCourseSearch/_PaginateCourseSearch.scss
+++ b/src/frontend/js/components/PaginateCourseSearch/_PaginateCourseSearch.scss
@@ -1,0 +1,30 @@
+.paginate-course-search {
+  &__list {
+    display: flex;
+    margin: 1rem 0;
+    padding: 0;
+    justify-content: center;
+
+    &__item {
+      list-style-type: none;
+      display: flex;
+      padding: 0.5rem 1rem;
+      background: white;
+      border: 1px solid $dodgerblue1;
+
+      & + & {
+        border-left: 0;
+      }
+
+      &__page-number {
+        color: $dodgerblue1;
+        cursor: pointer;
+
+        &--current {
+          color: $gray40;
+          cursor: default;
+        }
+      }
+    }
+  }
+}

--- a/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
@@ -1,0 +1,200 @@
+import '../../testSetup';
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { PaginateCourseSearch } from '.';
+import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
+
+describe('<PaginateCourseSearch />', () => {
+  beforeEach(jest.resetAllMocks);
+
+  const dispatchCourseSearchParamsUpdate = jest.fn();
+
+  it('shows a pagination for course search (when on page 1)', () => {
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[
+            { limit: '20', offset: '0' },
+            dispatchCourseSearchParamsUpdate,
+          ]}
+        >
+          <PaginateCourseSearch courseSearchTotalCount={200} />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    getByText('Pagination');
+    getByText(
+      (content, element) =>
+        content.endsWith('1') &&
+        element.textContent === 'Currently reading Page 1',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('2') && element.textContent === 'Next Page 2',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('3') && element.textContent === 'Page 3',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('10') && element.textContent === 'Last Page 10',
+    );
+  });
+
+  it('shows a pagination for course search (when on the last page)', () => {
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[
+            { limit: '20', offset: '200' },
+            dispatchCourseSearchParamsUpdate,
+          ]}
+        >
+          <PaginateCourseSearch courseSearchTotalCount={211} />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    getByText('Pagination');
+    getByText(
+      (content, element) =>
+        content.endsWith('1') && element.textContent === 'Page 1',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('9') && element.textContent === 'Page 9',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('10') && element.textContent === 'Previous Page 10',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('11') &&
+        element.textContent === 'Currently reading Last Page 11',
+    );
+  });
+
+  it('shows a pagination for course search (when on an arbitrary page)', () => {
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[
+            { limit: '10', offset: '110' },
+            dispatchCourseSearchParamsUpdate,
+          ]}
+        >
+          <PaginateCourseSearch courseSearchTotalCount={345} />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    getByText('Pagination');
+    getByText(
+      (content, element) =>
+        content.endsWith('1') && element.textContent === 'Page 1',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('10') && element.textContent === 'Page 10',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('11') && element.textContent === 'Previous Page 11',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('12') &&
+        element.textContent === 'Currently reading Page 12',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('13') && element.textContent === 'Next Page 13',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('14') && element.textContent === 'Page 14',
+    );
+    getByText(
+      (content, element) =>
+        content.endsWith('35') && element.textContent === 'Last Page 35',
+    );
+  });
+
+  it('does not render itself when there is only one page', () => {
+    const { queryByText } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[
+            { limit: '20', offset: '0' },
+            dispatchCourseSearchParamsUpdate,
+          ]}
+        >
+          <PaginateCourseSearch courseSearchTotalCount={14} />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    expect(queryByText('Pagination')).toEqual(null);
+  });
+
+  it('updates the course search params when the user clicks on a page', () => {
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[
+            { limit: '20', offset: '0' },
+            dispatchCourseSearchParamsUpdate,
+          ]}
+        >
+          <PaginateCourseSearch courseSearchTotalCount={200} />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    getByText('Pagination');
+    const page2 = getByText(
+      (content, element) =>
+        content.endsWith('2') && element.textContent === 'Next Page 2',
+    );
+
+    // Change pages when the user clicks on another page
+    fireEvent.click(page2);
+    expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
+      offset: '20',
+      type: 'PAGE_CHANGE',
+    });
+  });
+
+  it('does not update the course search params when the user clicks on the current page', () => {
+    const { getByText } = render(
+      <IntlProvider locale="en">
+        <CourseSearchParamsContext.Provider
+          value={[
+            { limit: '20', offset: '0' },
+            dispatchCourseSearchParamsUpdate,
+          ]}
+        >
+          <PaginateCourseSearch courseSearchTotalCount={200} />
+        </CourseSearchParamsContext.Provider>
+      </IntlProvider>,
+    );
+
+    getByText('Pagination');
+    const currentPage1 = getByText(
+      (content, element) =>
+        content.endsWith('1') &&
+        element.textContent === 'Currently reading Page 1',
+    );
+
+    // Don't do anything when the user clicks on the page they're currently on
+    dispatchCourseSearchParamsUpdate.mockReset();
+    fireEvent.click(currentPage1);
+    expect(dispatchCourseSearchParamsUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -1,0 +1,124 @@
+import React, { useContext, useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
+
+const messages = defineMessages({
+  currentlyReading: {
+    defaultMessage: 'Currently reading',
+    description:
+      'Accessibility helper in pagination, shown next to the current page number (Currently reading Page N)',
+    id: 'components.PaginateCourseSearch.currentlyReading',
+  },
+  pagination: {
+    defaultMessage: 'Pagination',
+    description: 'Label for the pagination navigation in course search results',
+    id: 'components.PaginateCourseSearch.pagination',
+  },
+});
+
+interface PaginateCourseSearchProps {
+  courseSearchTotalCount: number;
+}
+
+export const PaginateCourseSearch = ({
+  courseSearchTotalCount,
+}: PaginateCourseSearchProps) => {
+  // Generate a unique ID per instance to ensure our aria-labelledby do not break if there are two
+  // or more instances of <PaginateCourseSearch /> on the page
+  const [componentId] = useState(Math.random());
+  const [courseSearchParams, dispatchCourseSearchParamsUpdate] = useContext(
+    CourseSearchParamsContext,
+  );
+
+  // Extract pagination information from params and search results meta
+  const limit = Number(courseSearchParams.limit);
+  const offset = Number(courseSearchParams.offset);
+  const currentPage = offset / limit + 1;
+  const maxPage = Math.ceil(courseSearchTotalCount / limit);
+
+  // Do not render anything if all the results fit on the first page with the current limit
+  if (maxPage === 1) {
+    return null;
+  }
+
+  // Create the default list of all the page numbers we intend to show
+  const pageList = [
+    1,
+    currentPage - 2,
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    currentPage + 2,
+    maxPage,
+  ]
+    // Filter out page numbers below 1 (when currentPage is 1 or 2)
+    .filter(page => page > 0)
+    // Filter out page numbers above the max (they do not have anything to display)
+    .filter(page => page <= maxPage)
+    // Drop duplicates (this is trivial as our pageList is sorted)
+    .filter((page, index, list) => page !== list[index - 1]);
+
+  return (
+    <div className="paginate-course-search">
+      <div id={`pagination-label-${componentId}`} className="offscreen">
+        <FormattedMessage {...messages.pagination} />
+      </div>
+      <ul
+        role="navigation"
+        aria-labelledby={`pagination-label-${componentId}`}
+        className="paginate-course-search__list"
+      >
+        {pageList.map((page, index) => (
+          <React.Fragment key={page}>
+            {/* Prepend a cell with "..." when the page number we're rendering does not follow the previous one */}
+            {page > (pageList[index - 1] || 0) + 1 && (
+              <li className="paginate-course-search__list__item">...</li>
+            )}
+            <li className="paginate-course-search__list__item">
+              {page === currentPage ? (
+                /* The current page needs different markup as it does not include a link */
+                <span
+                  className={`paginate-course-search__list__item__page-number
+                              paginate-course-search__list__item__page-number--current`}
+                >
+                  {/*  Help assistive technology users with some context */}
+                  <span className="offscreen">
+                    <FormattedMessage {...messages.currentlyReading} />{' '}
+                  </span>
+                  {page === maxPage && <span className="offscreen">Last </span>}
+                  {/* Show context "Page 1" on the first item to make it obvious this is pagination */}
+                  <span className={page !== 1 ? 'offscreen' : ''}>Page </span>
+                  {page}
+                </span>
+              ) : (
+                <a
+                  className="paginate-course-search__list__item__page-number"
+                  onClick={() =>
+                    dispatchCourseSearchParamsUpdate({
+                      // Pages are 1-indexed, we need to 0-index them to calculate the correct offset
+                      offset: String((page - 1) * limit),
+                      type: 'PAGE_CHANGE',
+                    })
+                  }
+                >
+                  {/*  Help assistive technology users with some context */}
+                  {page === currentPage - 1 && (
+                    <span className="offscreen">Previous </span>
+                  )}
+                  {page === currentPage + 1 && (
+                    <span className="offscreen">Next </span>
+                  )}
+                  {page === maxPage && <span className="offscreen">Last </span>}
+                  {/* Show context "Page 1" on the first item to make it obvious this is pagination */}
+                  <span className={page !== 1 ? 'offscreen' : ''}>Page </span>
+                  {page}
+                </a>
+              )}
+            </li>
+          </React.Fragment>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/frontend/js/components/Search/Search.tsx
+++ b/src/frontend/js/components/Search/Search.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../data/useCourseSearchParams/useCourseSearchParams';
 import { requestStatus } from '../../types/api';
 import { CourseGlimpseList } from '../CourseGlimpseList/CourseGlimpseList';
+import { PaginateCourseSearch } from '../PaginateCourseSearch';
 import { SearchFiltersPane } from '../SearchFiltersPane/SearchFiltersPane';
 import { SearchLoader } from '../SearchLoader/SearchLoader';
 import { SearchSuggestField } from '../SearchSuggestField/SearchSuggestField';
@@ -45,7 +46,12 @@ export const Search = ({ pageTitle }: SearchProps) => {
               <CourseGlimpseList
                 courses={courseSearchResponse.content.objects}
                 meta={courseSearchResponse.content.meta}
-              />{' '}
+              />
+              <PaginateCourseSearch
+                courseSearchTotalCount={
+                  courseSearchResponse.content.meta.total_count
+                }
+              />
             </React.Fragment>
           ) : (
             <SearchLoader />

--- a/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.tsx
@@ -1,10 +1,8 @@
 import React, { useContext } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import {
-  CourseSearchParamsContext,
-  defaultPagination,
-} from '../../data/useCourseSearchParams/useCourseSearchParams';
+import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
+import { API_LIST_DEFAULT_PARAMS } from '../../settings';
 import { APICourseSearchResponse } from '../../types/api';
 import { Nullable } from '../../utils/types';
 import { SearchFilterGroup } from '../SearchFilterGroup/SearchFilterGroup';
@@ -38,7 +36,7 @@ export const SearchFiltersPane = ({ filters }: SearchFiltersPaneProps) => {
   // Get all the currently active filters to show a count
   const activeFilters = Object.entries(courseSearchParams)
     // Drop filters that are irrelevant to the "clear" button
-    .filter(([key]) => !Object.keys(defaultPagination).includes(key))
+    .filter(([key]) => !Object.keys(API_LIST_DEFAULT_PARAMS).includes(key))
     // Only keep the values
     .map(entry => entry[1])
     // Drop undefined & null values

--- a/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.spec.tsx
@@ -7,6 +7,7 @@ import { useCourseSearchParams } from './useCourseSearchParams';
 jest.mock('../../utils/indirection/window', () => ({
   history: { pushState: jest.fn() },
   location: {},
+  scroll: jest.fn(),
 }));
 
 describe('data/useCourseSearchParams', () => {
@@ -83,6 +84,10 @@ describe('data/useCourseSearchParams', () => {
           '?languages=fr&limit=13&offset=39',
         );
       }
+      expect(mockWindow.scroll).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        top: 0,
+      });
     });
   });
 
@@ -113,6 +118,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?languages=en&limit=17&offset=0&query=some%20text%20query',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -144,6 +150,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?languages=fr&limit=999&offset=0&query=some%20new%20query',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -175,6 +182,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?languages=es&limit=999&offset=0',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -216,6 +224,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?limit=10&offset=0&organizations=L-00010003&organizations=L-00010009&organizations=L-00010017',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -255,6 +264,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?languages=en&languages=fr&languages=it&limit=10&offset=0',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -294,6 +304,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?limit=10&offset=0&organizations=L-00010003&organizations=L-00010017',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -332,6 +343,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?languages=de&languages=zh&limit=10&offset=0',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -371,6 +383,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?limit=999&offset=0&organizations=L-00010014&query=some%20query',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -407,6 +420,7 @@ describe('data/useCourseSearchParams', () => {
           query: 'some query',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -460,6 +474,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?levels=L-000200020005&limit=999&offset=0&query=a%20query&subjects=P-000200030012&subjects=L-000200030005',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -507,6 +522,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?levels=L-000200020005&limit=999&offset=0&query=some%20query&subjects=L-000200030005',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -557,6 +573,7 @@ describe('data/useCourseSearchParams', () => {
           '?levels=L-000200020005&limit=999&offset=0&query=some%20query' +
             '&subjects=P-000200030012&subjects=L-0002000300050013',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -604,6 +621,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?levels=L-000200020005&limit=999&offset=0&query=some%20query&subjects=L-0002000300050013',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -644,6 +662,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?level=L-000200010003&limit=999&offset=0',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
       {
         // Replace an existing value
@@ -673,6 +692,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?level=L-000200010002&limit=999&offset=0',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -706,6 +726,7 @@ describe('data/useCourseSearchParams', () => {
           offset: '0',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -750,6 +771,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?limit=999&offset=0&organizations=L00010011&query=some%20query',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
       {
         // Remove from a list of just one value
@@ -777,6 +799,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?limit=999&offset=0&query=some%20query',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -819,6 +842,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?limit=999&offset=0&query=some%20query',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -852,6 +876,7 @@ describe('data/useCourseSearchParams', () => {
           query: 'some query',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -886,6 +911,7 @@ describe('data/useCourseSearchParams', () => {
           organizations: ['L-00010003', 'L-00010009'],
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -922,6 +948,7 @@ describe('data/useCourseSearchParams', () => {
           organizations: 'L-00010011',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -964,6 +991,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?limit=999&offset=0&query=some%20query',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -1000,6 +1028,7 @@ describe('data/useCourseSearchParams', () => {
           query: 'some query',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -1036,6 +1065,7 @@ describe('data/useCourseSearchParams', () => {
           query: 'some query',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -1065,6 +1095,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '?limit=27&offset=0',
         );
+        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });

--- a/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.spec.tsx
@@ -46,18 +46,48 @@ describe('data/useCourseSearchParams', () => {
     mockWindow.location.search = '';
     render(<TestComponent />);
     const [courseSearchParams] = getLatestHookValues();
-    expect(courseSearchParams).toEqual({ limit: '999', offset: '0' });
+    expect(courseSearchParams).toEqual({ limit: '20', offset: '0' });
     // We need an update so the URL reflects the actual query params
     expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
     expect(mockWindow.history.pushState).toHaveBeenCalledWith(
       null,
       '',
-      '?limit=999&offset=0',
+      '?limit=20&offset=0',
     );
   });
 
+  describe('PAGE_CHANGE', () => {
+    it('updates the offset on the courseSearchParams & updates history', () => {
+      mockWindow.location.search = '?languages=fr&limit=13&offset=26';
+      render(<TestComponent />);
+      {
+        const [courseSearchParams, dispatch] = getLatestHookValues();
+        expect(courseSearchParams).toEqual({
+          languages: 'fr',
+          limit: '13',
+          offset: '26',
+        });
+        act(() => dispatch({ offset: '39', type: 'PAGE_CHANGE' }));
+      }
+      {
+        const [courseSearchParams] = getLatestHookValues();
+        expect(courseSearchParams).toEqual({
+          languages: 'fr',
+          limit: '13',
+          offset: '39',
+        });
+        expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+        expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+          null,
+          '',
+          '?languages=fr&limit=13&offset=39',
+        );
+      }
+    });
+  });
+
   describe('QUERY_UPDATE', () => {
-    it('sets the query on courseSearchParams & updates history', () => {
+    it('sets the query on courseSearchParams, resets pagination & updates history', () => {
       mockWindow.location.search = '?languages=en&limit=17&offset=5';
       render(<TestComponent />);
       {
@@ -74,14 +104,14 @@ describe('data/useCourseSearchParams', () => {
         expect(courseSearchParams).toEqual({
           languages: 'en',
           limit: '17',
-          offset: '5',
+          offset: '0',
           query: 'some text query',
         });
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           null,
           '',
-          '?languages=en&limit=17&offset=5&query=some%20text%20query',
+          '?languages=en&limit=17&offset=0&query=some%20text%20query',
         );
       }
     });
@@ -150,14 +180,14 @@ describe('data/useCourseSearchParams', () => {
   });
 
   describe('FILTER_ADD [non drilldown]', () => {
-    it('adds the value to the existing list for this filter & updates history', () => {
+    it('adds the value to the existing list for this filter, resets pagination & updates history', () => {
       mockWindow.location.search =
-        '?organizations=L-00010003&organizations=L-00010009&offset=999&limit=0';
+        '?organizations=L-00010003&organizations=L-00010009&offset=999&limit=10';
       render(<TestComponent />);
       {
         const [courseSearchParams, dispatch] = getLatestHookValues();
         expect(courseSearchParams).toEqual({
-          limit: '0',
+          limit: '10',
           offset: '999',
           organizations: ['L-00010003', 'L-00010009'],
         });
@@ -176,28 +206,28 @@ describe('data/useCourseSearchParams', () => {
       {
         const [courseSearchParams] = getLatestHookValues();
         expect(courseSearchParams).toEqual({
-          limit: '0',
-          offset: '999',
+          limit: '10',
+          offset: '0',
           organizations: ['L-00010003', 'L-00010009', 'L-00010017'],
         });
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           null,
           '',
-          '?limit=0&offset=999&organizations=L-00010003&organizations=L-00010009&organizations=L-00010017',
+          '?limit=10&offset=0&organizations=L-00010003&organizations=L-00010009&organizations=L-00010017',
         );
       }
     });
 
-    it('adds to the existing list for non-MPTT-formatted filter value keys', () => {
+    it('adds to the existing list for non-MPTT-formatted filter value keys and resets pagination', () => {
       mockWindow.location.search =
-        '?languages=en&languages=fr&offset=999&limit=0';
+        '?languages=en&languages=fr&offset=999&limit=10';
       render(<TestComponent />);
       {
         const [courseSearchParams, dispatch] = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: ['en', 'fr'],
-          limit: '0',
+          limit: '10',
           offset: '999',
         });
 
@@ -216,26 +246,26 @@ describe('data/useCourseSearchParams', () => {
         const [courseSearchParams] = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: ['en', 'fr', 'it'],
-          limit: '0',
-          offset: '999',
+          limit: '10',
+          offset: '0',
         });
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           null,
           '',
-          '?languages=en&languages=fr&languages=it&limit=0&offset=999',
+          '?languages=en&languages=fr&languages=it&limit=10&offset=0',
         );
       }
     });
 
-    it('creates a list with the existing single value and the new value & updates history', () => {
+    it('creates a list with the existing single value and the new value, resets pagination & updates history', () => {
       mockWindow.location.search =
-        '?organizations=L-00010003&offset=999&limit=0';
+        '?organizations=L-00010003&offset=999&limit=10';
       render(<TestComponent />);
       {
         const [courseSearchParams, dispatch] = getLatestHookValues();
         expect(courseSearchParams).toEqual({
-          limit: '0',
+          limit: '10',
           offset: '999',
           organizations: 'L-00010003',
         });
@@ -254,27 +284,27 @@ describe('data/useCourseSearchParams', () => {
       {
         const [courseSearchParams] = getLatestHookValues();
         expect(courseSearchParams).toEqual({
-          limit: '0',
-          offset: '999',
+          limit: '10',
+          offset: '0',
           organizations: ['L-00010003', 'L-00010017'],
         });
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           null,
           '',
-          '?limit=0&offset=999&organizations=L-00010003&organizations=L-00010017',
+          '?limit=10&offset=0&organizations=L-00010003&organizations=L-00010017',
         );
       }
     });
 
-    it('creates the new list for non-MPTT-formatted filter value keys', () => {
-      mockWindow.location.search = '?languages=de&offset=999&limit=0';
+    it('creates the new list for non-MPTT-formatted filter value keys and resets pagination', () => {
+      mockWindow.location.search = '?languages=de&offset=999&limit=10';
       render(<TestComponent />);
       {
         const [courseSearchParams, dispatch] = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'de',
-          limit: '0',
+          limit: '10',
           offset: '999',
         });
 
@@ -293,14 +323,14 @@ describe('data/useCourseSearchParams', () => {
         const [courseSearchParams] = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: ['de', 'zh'],
-          limit: '0',
-          offset: '999',
+          limit: '10',
+          offset: '0',
         });
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           null,
           '',
-          '?languages=de&languages=zh&limit=0&offset=999',
+          '?languages=de&languages=zh&limit=10&offset=0',
         );
       }
     });

--- a/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.ts
+++ b/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.ts
@@ -7,14 +7,19 @@ import { FilterDefinition } from '../../types/filters';
 import { history, location } from '../../utils/indirection/window';
 import { computeNewFilterValue } from './computeNewFilterValue';
 
+interface FilterResetAction {
+  type: 'FILTER_RESET';
+}
+
 interface FilterSingleAction {
   filter: FilterDefinition;
   payload: string;
   type: 'FILTER_ADD' | 'FILTER_REMOVE';
 }
 
-interface FilterResetAction {
-  type: 'FILTER_RESET';
+interface PageChangeAction {
+  offset: string;
+  type: 'PAGE_CHANGE';
 }
 
 interface QueryAction {
@@ -25,6 +30,7 @@ interface QueryAction {
 export type CourseSearchParamsReducerAction =
   | FilterResetAction
   | FilterSingleAction
+  | PageChangeAction
   | QueryAction;
 
 type CourseSearchParamsState = [
@@ -41,9 +47,17 @@ const courseSearchParamsReducer = (
   action: CourseSearchParamsReducerAction,
 ) => {
   switch (action.type) {
+    case 'PAGE_CHANGE':
+      return {
+        ...courseSearchParams,
+        offset: action.offset,
+      };
+
     case 'QUERY_UPDATE':
       return {
         ...courseSearchParams,
+        // Go back to page 1 when the query changes
+        offset: '0',
         // By replacing the empty string (the only falsy value we could receive for action.query) with `undefined`,
         // we keep a clean interface and ensure `stringify` removes `&query=` from the query string in history.
         query: action.query || undefined,
@@ -53,6 +67,8 @@ const courseSearchParamsReducer = (
     case 'FILTER_REMOVE':
       return {
         ...courseSearchParams,
+        // Go back to page 1 when the query changes
+        offset: '0',
         [action.filter.name]: computeNewFilterValue(
           courseSearchParams[action.filter.name],
           {

--- a/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.ts
+++ b/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.ts
@@ -1,6 +1,7 @@
 import { parse, stringify } from 'query-string';
 import { createContext, useEffect, useReducer } from 'react';
 
+import { API_LIST_DEFAULT_PARAMS } from '../../settings';
 import { APIListRequestParams } from '../../types/api';
 import { FilterDefinition } from '../../types/filters';
 import { history, location } from '../../utils/indirection/window';
@@ -35,11 +36,6 @@ export const CourseSearchParamsContext = createContext<CourseSearchParamsState>(
   [] as any,
 );
 
-export const defaultPagination = {
-  limit: '999',
-  offset: '0',
-};
-
 const courseSearchParamsReducer = (
   courseSearchParams: APIListRequestParams,
   action: CourseSearchParamsReducerAction,
@@ -70,7 +66,7 @@ const courseSearchParamsReducer = (
     case 'FILTER_RESET':
       // Remove all parameters and reset pagination
       return {
-        ...defaultPagination,
+        ...API_LIST_DEFAULT_PARAMS,
         limit: courseSearchParams.limit,
       };
   }
@@ -78,7 +74,7 @@ const courseSearchParamsReducer = (
 
 export const useCourseSearchParams = (): CourseSearchParamsState => {
   const bootstrapParams = {
-    ...defaultPagination,
+    ...API_LIST_DEFAULT_PARAMS,
     ...(parse(location.search) as APIListRequestParams),
   };
 

--- a/src/frontend/js/settings.ts
+++ b/src/frontend/js/settings.ts
@@ -1,4 +1,4 @@
 export const API_LIST_DEFAULT_PARAMS = {
-  limit: '999',
+  limit: '20',
   offset: '0',
 };

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -9,7 +9,7 @@ export enum requestStatus {
 }
 
 export interface APIResponseListMeta {
-  limit: number;
+  count: number;
   offset: number;
   total_count: number;
 }

--- a/src/frontend/js/utils/indirection/window.ts
+++ b/src/frontend/js/utils/indirection/window.ts
@@ -1,2 +1,2 @@
 // Layer of indirection to facilitate testing of code that would use location facilities
-export const { history, location } = window;
+export const { history, location, scroll } = window;

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -5,6 +5,7 @@
 // Our variables must be imported before Bootstrap code so they can override it
 @import './variables';
 @import './fonts';
+@import './utils';
 @import './mixins/shapes';
 @import './mixins/flexbox';
 @import './mixins/empty';

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -46,6 +46,7 @@
 @import './objects/react-autosuggest';
 
 // Frontend components objects styles
+@import '../js/components/PaginateCourseSearch/_PaginateCourseSearch';
 @import '../js/components/Search/_Search';
 @import '../js/components/SearchFilterGroup/_SearchFilterGroup';
 @import '../js/components/SearchFiltersPane/_SearchFiltersPane';

--- a/src/frontend/scss/_utils.scss
+++ b/src/frontend/scss/_utils.scss
@@ -1,0 +1,6 @@
+// Helper class to hide elements from sighted users and have accessibility devices still read them
+// to users that need it.
+.offscreen {
+  position: absolute;
+  left: -9999rem;
+}


### PR DESCRIPTION
## Purpose

On large richie instances, there can be hundreds of courses available to display. As the default view of the search page is non-filtered, the page could be slow to load with hundreds of courses to load from the API and display in complex glimpses with their cover images.

## Proposal

We can paginate the view down to a useful level (say, 20 courses by default) which keeps the page reasonably long and deals with performance issues.

- [x] add a pagination to the course search view, linked with the course search params
- [x] scroll to top when the user changes pages

Closes #754