### PR TITLE
Remove testing library cleanup

### DIFF
--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpse.spec.tsx
@@ -1,14 +1,12 @@
 import '../../testSetup';
 
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
 import { CourseGlimpse } from './CourseGlimpse';
 
 describe('components/CourseGlimpse', () => {
-  afterEach(cleanup);
-
   const course = {
     absolute_url: 'https://example/com/courses/42/',
     categories: ['24', '42'],

--- a/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/CourseGlimpseList.spec.tsx
@@ -1,6 +1,6 @@
 import '../../testSetup';
 
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
@@ -8,8 +8,6 @@ import { Course } from '../../types/Course';
 import { CourseGlimpseList } from './CourseGlimpseList';
 
 describe('components/CourseGlimpseList', () => {
-  afterEach(cleanup);
-
   it('renders a list of Courses into a list of CourseGlimpses', () => {
     const courses = [
       {

--- a/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/SearchFilterGroup.spec.tsx
@@ -1,6 +1,6 @@
 import '../../testSetup';
 
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
@@ -20,7 +20,6 @@ jest.mock('../SearchFilterValueParent/SearchFilterValueParent', () => ({
 
 describe('components/SearchFilterGroup', () => {
   beforeEach(jest.resetAllMocks);
-  afterEach(cleanup);
 
   it('renders the name of the filter with the values as SearchFilters', () => {
     const { getByText } = render(

--- a/src/frontend/js/components/SearchFilterValueLeaf/SearchFilterValueLeaf.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/SearchFilterValueLeaf.spec.tsx
@@ -1,6 +1,6 @@
 import '../../testSetup';
 
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
@@ -8,8 +8,6 @@ import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useC
 import { SearchFilterValueLeaf } from './SearchFilterValueLeaf';
 
 describe('components/SearchFilterValueLeaf', () => {
-  afterEach(cleanup);
-
   it('renders the name of the filter value', () => {
     const { getByLabelText } = render(
       <IntlProvider locale="en">

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
@@ -1,6 +1,6 @@
 import '../../testSetup';
 
-import { cleanup, fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, wait } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
@@ -22,10 +22,7 @@ describe('<SearchFilterValueParent />', () => {
     jest.spyOn(console, 'error');
   });
 
-  afterEach(() => {
-    cleanup();
-    jest.resetAllMocks();
-  });
+  afterEach(jest.resetAllMocks);
 
   it('renders the parent filter value and a button to show the children', () => {
     const { getByLabelText, queryByLabelText } = render(

--- a/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/SearchFilterValueParent.spec.tsx
@@ -16,12 +16,6 @@ import { SearchFilterValueParent } from './SearchFilterValueParent';
 const mockFetchList: jestMockOf<typeof fetchList> = fetchList as any;
 
 describe('<SearchFilterValueParent />', () => {
-  // Disable useless async act warnings
-  // TODO: remove this spy as soon as async act is available
-  beforeAll(() => {
-    jest.spyOn(console, 'error');
-  });
-
   afterEach(jest.resetAllMocks);
 
   it('renders the parent filter value and a button to show the children', () => {

--- a/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.spec.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/SearchFiltersPane.spec.tsx
@@ -1,6 +1,6 @@
 import '../../testSetup';
 
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
@@ -14,8 +14,6 @@ jest.mock('../SearchFilterGroup/SearchFilterGroup', () => ({
 }));
 
 describe('components/SearchFiltersPane', () => {
-  afterEach(cleanup);
-
   it('renders all our search filter groups', () => {
     const { getByText } = render(
       <IntlProvider locale="en">

--- a/src/frontend/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -50,15 +50,8 @@ describe('components/SearchSuggestField', () => {
     values: [],
   };
 
-  beforeEach(jest.resetAllMocks);
-
-  // Disable useless async act warnings
-  // TODO: remove this spy as soon as async act is available
-  beforeAll(() => {
-    jest.spyOn(console, 'error');
-  });
-
   afterEach(fetchMock.restore);
+  beforeEach(jest.resetAllMocks);
 
   it('renders', () => {
     const { getByPlaceholderText } = render(
@@ -249,6 +242,8 @@ describe('components/SearchSuggestField', () => {
     expect(queryByText('Subjects')).toEqual(null);
 
     fireEvent.click(getByText('Organization #27'));
+    await wait();
+
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
       query: '',
       type: 'QUERY_UPDATE',
@@ -325,6 +320,8 @@ describe('components/SearchSuggestField', () => {
     expect(queryByText('Subjects')).toEqual(null);
 
     fireEvent.click(getByText('Doctor Doom'));
+    await wait();
+
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
       filter: {
         base_path: null,

--- a/src/frontend/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/SearchSuggestField.spec.tsx
@@ -1,6 +1,6 @@
 import '../../testSetup';
 
-import { cleanup, fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, wait } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
@@ -58,7 +58,6 @@ describe('components/SearchSuggestField', () => {
     jest.spyOn(console, 'error');
   });
 
-  afterEach(cleanup);
   afterEach(fetchMock.restore);
 
   it('renders', () => {

--- a/src/frontend/js/data/useCourseSearch/useCourseSearch.spec.tsx
+++ b/src/frontend/js/data/useCourseSearch/useCourseSearch.spec.tsx
@@ -11,13 +11,6 @@ jest.mock('../getResourceList/getResourceList', () => ({
 }));
 const mockFetchList = fetchList as jestMockOf<typeof fetchList>;
 
-// This test uses async/await inside `useEffect`, which causes warnings due to the particular timing of
-// resolution for `await` with relation to react renders. For most scenarios, `act` takes care of this
-// scheduling, but `act` does not handle `async` functions and cannot be `await`ed yet.
-// TODO: Remove this when async act is available.
-// tslint:disable:no-console
-console.error = jest.fn();
-
 describe('data/useCourseSearch', () => {
   // Build a helper component with an out-of-scope function to let us reach our Hook from
   // our test cases.
@@ -46,7 +39,7 @@ describe('data/useCourseSearch', () => {
       offset: '0',
     });
 
-    act(() => doResolve('the response'));
+    await act(async () => doResolve('the response'));
     // Wait for the actual resolution under await
     await responseOne;
     expect(getLatestHookValue()).toEqual('the response');
@@ -70,7 +63,7 @@ describe('data/useCourseSearch', () => {
       organizations: ['43'],
     });
 
-    act(() => doResolve('another response'));
+    await act(async () => doResolve('another response'));
     // Wait for the actual resolution under await
     await responseTwo;
     expect(getLatestHookValue()).toEqual('another response');
@@ -91,7 +84,7 @@ describe('data/useCourseSearch', () => {
       offset: '0',
     });
 
-    act(() => doResolve('the response'));
+    await act(async () => doResolve('the response'));
     // Wait for the actual resolution under await
     await responseOne;
     expect(getLatestHookValue()).toEqual('the response');

--- a/src/frontend/js/data/useCourseSearch/useCourseSearch.spec.tsx
+++ b/src/frontend/js/data/useCourseSearch/useCourseSearch.spec.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import React from 'react';
 
 import { APIListRequestParams } from '../../types/api';
@@ -29,8 +29,6 @@ describe('data/useCourseSearch', () => {
   };
 
   beforeEach(jest.resetAllMocks);
-
-  afterEach(cleanup);
 
   it('gets the courses with the passed params', async () => {
     let doResolve: (value: any) => void;

--- a/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/useCourseSearchParams.spec.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import React from 'react';
 
 import * as mockWindow from '../../utils/indirection/window';
@@ -26,8 +26,6 @@ describe('data/useCourseSearchParams', () => {
     );
     jest.resetAllMocks();
   });
-
-  afterEach(cleanup);
 
   it('initializes with the URL query string', () => {
     mockWindow.location.search =

--- a/src/frontend/js/data/useFilterValue/useFilterValue.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/useFilterValue.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 
 import { FilterDefinition, FilterValue } from '../../types/filters';
@@ -22,8 +22,6 @@ describe('data/useFilterValue', () => {
   };
 
   beforeEach(jest.resetAllMocks);
-
-  afterEach(cleanup);
 
   it('returns the active [true] status of the filter value and a function to toggle it', () => {
     const mockDispatchCourseSearchParamsAction = jest.fn();


### PR DESCRIPTION
## Purpose

`testing-library` now automatically performs cleanup in `afterEach`, which means our manual `cleanup` calls are entirely useless.

- [x] We can simply remove them.


We mocked `console.error` in our tests to remove non-actionable `act` warnings from React when state updates were triggered by async functions.

We updated to React 16.9, which includes `async act`.

- [x] We can use it (and rely on its builtin use in `testing-library`) to drop these temporary mocks.