### PR TITLE
✨(search) make autosuggestion diacritics insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a CSS class to move content offscreen so it's only available for users
   of assistive technologies.
 
+## Changed
+
+- Autosuggestion endpoints are diacritics insensitive.
+
 ## [1.6.1] - 2019-08-03
 
 ### Fixed

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -49,14 +49,15 @@ def perform_create_index(indexable, logger):
     # Create the new index
     logger.info('Creating a new Elasticsearch index "{:s}"...'.format(new_index))
     indices_client.create(index=new_index)
-    indices_client.put_mapping(
-        body=indexable.mapping, doc_type=indexable.document_type, index=new_index
-    )
 
     # The index needs to be closed before we set an analyzer
     indices_client.close(index=new_index)
     indices_client.put_settings(body=ANALYSIS_SETTINGS, index=new_index)
     indices_client.open(index=new_index)
+
+    indices_client.put_mapping(
+        body=indexable.mapping, doc_type=indexable.document_type, index=new_index
+    )
 
     # Populate the new index with data provided from our indexable class
     richie_bulk(indexable.get_es_documents(new_index))

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -36,6 +36,7 @@ class CategoriesIndexer:
             **{
                 "complete.{:s}".format(lang): {
                     "type": "completion",
+                    "analyzer": "simple_diacritics_insensitive",
                     # Allow filtering autocomplete results with a kindkey to match the value of
                     # the `kind` field of the object
                     "contexts": [{"name": "kind", "type": "category", "path": "kind"}],

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -53,7 +53,10 @@ class CoursesIndexer:
             # description, title, category names & organization names are handled
             # by `MULTILINGUAL_TEXT`
             **{
-                "complete.{:s}".format(lang): {"type": "completion"}
+                "complete.{:s}".format(lang): {
+                    "type": "completion",
+                    "analyzer": "simple_diacritics_insensitive",
+                }
                 for lang, _ in settings.LANGUAGES
             },
             # `persons_names` cannot be handled by `MULTILINGUAL_TEXT` because language

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -34,7 +34,10 @@ class OrganizationsIndexer:
             # Searchable
             # description & title are handled by `MULTILINGUAL_TEXT`
             **{
-                "complete.{:s}".format(lang): {"type": "completion"}
+                "complete.{:s}".format(lang): {
+                    "type": "completion",
+                    "analyzer": "simple_diacritics_insensitive",
+                }
                 for lang, _ in settings.LANGUAGES
             },
             # Not searchable

--- a/src/richie/apps/search/indexers/persons.py
+++ b/src/richie/apps/search/indexers/persons.py
@@ -33,7 +33,10 @@ class PersonsIndexer:
         "properties": {
             # Searchable
             **{
-                "complete.{:s}".format(lang): {"type": "completion"}
+                "complete.{:s}".format(lang): {
+                    "type": "completion",
+                    "analyzer": "simple_diacritics_insensitive",
+                }
                 for lang, _ in settings.LANGUAGES
             },
             **{

--- a/src/richie/apps/search/text_indexing.py
+++ b/src/richie/apps/search/text_indexing.py
@@ -136,6 +136,10 @@ ANALYSIS_SETTINGS = {
                     "asciifolding",
                 ],
             },
+            "simple_diacritics_insensitive": {
+                "tokenizer": "lowercase",
+                "filter": ["asciifolding"],
+            },
         },
         "tokenizer": {
             "trigram": {

--- a/tests/apps/search/test_autocomplete_organizations.py
+++ b/tests/apps/search/test_autocomplete_organizations.py
@@ -28,7 +28,7 @@ class AutocompleteOrganizationsTestCase(TestCase):
     Test organization autocomplete queries in a real-world situation with ElasticSearch.
     """
 
-    def execute_query(self, querystring=""):
+    def execute_query(self, querystring="", **extra):
         """
         Not a test.
         Prepare the ElasticSearch index and execute the query in it.
@@ -37,27 +37,36 @@ class AutocompleteOrganizationsTestCase(TestCase):
         organizations = [
             {
                 "complete": {
-                    "en": slice_string_for_completion("University of Paris 18")
+                    "en": slice_string_for_completion("University of Paris 18"),
+                    "fr": slice_string_for_completion("Université de Paris 18"),
                 },
                 "id": "25",
                 "path": "000000",
-                "title": {"en": "University of Paris 18"},
+                "title": {
+                    "en": "University of Paris 18",
+                    "fr": "Université de Paris 18",
+                },
             },
             {
                 "complete": {
-                    "en": slice_string_for_completion("School of bikeshedding")
+                    "en": slice_string_for_completion("School of bikeshedding"),
+                    "fr": slice_string_for_completion("École d'abri-vélo"),
                 },
                 "id": "34",
                 "path": "000001",
-                "title": {"en": "School of bikeshedding"},
+                "title": {"en": "School of bikeshedding", "fr": "École d'abri-vélo"},
             },
             {
                 "complete": {
-                    "en": slice_string_for_completion("University of Paris 19")
+                    "en": slice_string_for_completion("University of Paris 19"),
+                    "fr": slice_string_for_completion("Université de Paris 19"),
                 },
                 "id": "52",
                 "path": "000002",
-                "title": {"en": "University of Paris 19"},
+                "title": {
+                    "en": "University of Paris 19",
+                    "fr": "Université de Paris 19",
+                },
             },
         ]
 
@@ -66,16 +75,18 @@ class AutocompleteOrganizationsTestCase(TestCase):
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index=ORGANIZATIONS_INDEX)
+
+        # The index needs to be closed before we set an analyzer
+        indices_client.close(index=ORGANIZATIONS_INDEX)
+        indices_client.put_settings(body=ANALYSIS_SETTINGS, index=ORGANIZATIONS_INDEX)
+        indices_client.open(index=ORGANIZATIONS_INDEX)
+
         # Use the default organizations mapping from the Indexer
         indices_client.put_mapping(
             body=OrganizationsIndexer.mapping,
             doc_type="organization",
             index=ORGANIZATIONS_INDEX,
         )
-        # The index needs to be closed before we set an analyzer
-        indices_client.close(index=ORGANIZATIONS_INDEX)
-        indices_client.put_settings(body=ANALYSIS_SETTINGS, index=ORGANIZATIONS_INDEX)
-        indices_client.open(index=ORGANIZATIONS_INDEX)
         # Actually insert our organizations in the index
         actions = [
             {
@@ -96,7 +107,7 @@ class AutocompleteOrganizationsTestCase(TestCase):
         indices_client.refresh()
 
         response = self.client.get(
-            f"/api/v1.0/organizations/autocomplete/?{querystring:s}"
+            f"/api/v1.0/organizations/autocomplete/?{querystring:s}", **extra
         )
         self.assertEqual(response.status_code, 200)
 
@@ -113,6 +124,37 @@ class AutocompleteOrganizationsTestCase(TestCase):
         )
 
         all_organizations, response = self.execute_query(querystring="query=bik")
+        self.assertEqual(
+            [all_organizations[1]["id"]],
+            [organization["id"] for organization in response],
+        )
+
+    def test_autocomplete_diacritics_insensitive_query(self, *_):
+        """
+        Queries are diacritics insensitive.
+        """
+        all_organizations, response = self.execute_query(querystring="query=Üñî")
+        self.assertEqual(
+            [all_organizations[i]["id"] for i in [0, 2]],
+            [organization["id"] for organization in response],
+        )
+
+    def test_autocomplete_diacritics_insensitive_index(self, *_):
+        """
+        Index is diacritics insensitive.
+        """
+        all_organizations, response = self.execute_query(
+            querystring="query=universite", HTTP_ACCEPT_LANGUAGE="fr"
+        )
+        self.assertEqual(
+            [all_organizations[i]["id"] for i in [0, 2]],
+            [organization["id"] for organization in response],
+        )
+
+        # Sanity check for original, accented version
+        all_organizations, response = self.execute_query(
+            querystring="query=École", HTTP_ACCEPT_LANGUAGE="fr"
+        )
         self.assertEqual(
             [all_organizations[1]["id"]],
             [organization["id"] for organization in response],

--- a/tests/apps/search/test_autocomplete_persons.py
+++ b/tests/apps/search/test_autocomplete_persons.py
@@ -28,7 +28,7 @@ class AutocompletePersonsTestCase(TestCase):
     Test person autocomplete queries in a real-world situation with ElasticSearch.
     """
 
-    def execute_query(self, querystring=""):
+    def execute_query(self, querystring="", **extra):
         """
         Not a test.
         Prepare the ElasticSearch index and execute the query in it.
@@ -59,14 +59,17 @@ class AutocompletePersonsTestCase(TestCase):
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index=PERSONS_INDEX)
-        # Use the default persons mapping from the Indexer
-        indices_client.put_mapping(
-            body=PersonsIndexer.mapping, doc_type="person", index=PERSONS_INDEX
-        )
+
         # The index needs to be closed before we set an analyzer
         indices_client.close(index=PERSONS_INDEX)
         indices_client.put_settings(body=ANALYSIS_SETTINGS, index=PERSONS_INDEX)
         indices_client.open(index=PERSONS_INDEX)
+
+        # Use the default persons mapping from the Indexer
+        indices_client.put_mapping(
+            body=PersonsIndexer.mapping, doc_type="person", index=PERSONS_INDEX
+        )
+
         # Actually insert our persons in the index
         actions = [
             {
@@ -83,7 +86,9 @@ class AutocompletePersonsTestCase(TestCase):
         bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
         indices_client.refresh()
 
-        response = self.client.get(f"/api/v1.0/persons/autocomplete/?{querystring:s}")
+        response = self.client.get(
+            f"/api/v1.0/persons/autocomplete/?{querystring:s}", **extra
+        )
         self.assertEqual(response.status_code, 200)
 
         return persons, json.loads(response.content)
@@ -96,4 +101,22 @@ class AutocompletePersonsTestCase(TestCase):
         self.assertEqual([all_persons[1]["id"]], [person["id"] for person in response])
 
         all_persons, response = self.execute_query(querystring="query=épo")
+        self.assertEqual([all_persons[0]["id"]], [person["id"] for person in response])
+
+    def test_autocomplete_diacritics_insensitive_query(self, *_):
+        """
+        Queries are diacritics insensitive.
+        """
+        all_persons, response = self.execute_query(querystring="query=Mônsé")
+        self.assertEqual([all_persons[1]["id"]], [person["id"] for person in response])
+
+    def test_autocomplete_diacritics_insensitive_index(self, *_):
+        """
+        Index is diacritics insensitive.
+        """
+        all_persons, response = self.execute_query(querystring="query=eponine")
+        self.assertEqual([all_persons[0]["id"]], [person["id"] for person in response])
+
+        # Sanity check for original, accented version
+        all_persons, response = self.execute_query(querystring="query=Thénardier")
         self.assertEqual([all_persons[0]["id"]], [person["id"] for person in response])


### PR DESCRIPTION
## Purpose

Autosuggestion API endpoints treat accented characters as different from the non-accented versions of the same characters.

This is technically correct but is not intuitive for users who want to see the results they expect regardless of accents.

## Proposal

Create a custom analyzer that folds accented characters into their ascii version and use that for all our completion fields in our object mappings.


Closes #419.