### PR TITLE
✨(courses) allow icons to display on course detail and not on glimpse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
+- Display category icons on the course detail view but not on the glimpse,
 - Autosuggestion endpoints are diacritics insensitive.
 
 ## [1.6.1] - 2019-08-03

--- a/src/frontend/scss/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_course_detail.scss
@@ -19,7 +19,7 @@ $richie-course-detail-row-padding: 0.5rem 1rem 0 !default;
 $richie-course-detail-row-fontsize: 0.95rem !default;
 $richie-course-detail-row-title-fontcolor: $dodgerblue3 !default;
 
-$richie-course-detail-categories-padding: 0.5rem 1rem 0 !default;
+$richie-course-detail-categories-padding: 0 3rem 0 !default;
 $richie-course-detail-categories-justify: center !default;
 $richie-course-detail-categories-empty-fontcolor: $gray40 !default;
 $richie-course-detail-categories-empty-textalign: center !default;

--- a/src/frontend/scss/templates/courses/plugins/_category_plugin.scss
+++ b/src/frontend/scss/templates/courses/plugins/_category_plugin.scss
@@ -5,44 +5,39 @@ $richie-category-plugin-tag-background: $gray7;
 .category-plugin-tag {
   flex-grow: 0;
   flex-shrink: 0;
-  padding: $richie-category-plugin-tag-padding;
   color: $richie-category-plugin-tag-fontcolor;
-  background: $richie-category-plugin-tag-background;
+  margin-left: 0.5rem;
+  margin-top: 0.5rem;
   text-decoration: none;
 
   &:hover {
     color: $richie-category-plugin-tag-fontcolor;
   }
 
-  & + & {
-    margin-left: 0.5rem;
-  }
-}
-
-.category-plugin-icon {
-  color: white;
-
-  &:hover {
-    color: white;
+  &:first-of-type {
+    margin-left: 0;
   }
 
-  & + & {
-    margin-left: 0.5rem;
+  &__title {
+    padding: $richie-category-plugin-tag-padding;
+    background: $richie-category-plugin-tag-background;
   }
 
   &__figure {
     display: flex;
+    margin: 0;
 
     &__caption {
       align-self: flex-end;
-      padding: 0.5rem;
+      background: $richie-category-plugin-tag-background;
+      padding: $richie-category-plugin-tag-padding;
       color: inherit;
       white-space: nowrap;
     }
 
     &__image {
-      height: 2.5rem;
-      padding: 0 0.5rem;
+      height: 2rem;
+      padding: 0;
       border: 1px solid $gray80;
       border-left: none;
     }

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -518,8 +518,6 @@ class CategoryFactory(BLDPageExtensionDjangoModelFactory):
     and their related page in our tests.
     """
 
-    color = factory.Faker("hex_color")
-
     class Meta:
         model = models.Category
         exclude = [

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -147,8 +147,9 @@ CMS_PLACEHOLDER_CONF = {
         "plugins": ["CategoryPlugin"],
     },
     "courses/cms/course_detail.html course_icons": {
-        "name": _("Icons"),
+        "name": _("Icon"),
         "plugins": ["CategoryPlugin"],
+        "limits": {"CategoryPlugin": 1},
     },
     "courses/cms/course_detail.html course_organizations": {
         "name": _("Organizations"),

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -39,24 +39,17 @@
       </div>
       {% endif %}
 
+      {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_icons" or not current_page|is_empty_placeholder:"course_categories" %}
       <div class="course-detail__content__row course-detail__content__categories">
-          {% with form_factor="tag" %}
-            {% page_placeholder "course_categories" current_page or %}
+        {% with form_factor="tag" %}
+          {% placeholder "course_icons" %}
+          {% page_placeholder "course_categories" current_page or %}
+            {% if current_page.publisher_is_draft and current_page|is_empty_placeholder:"course_icons" %}
               <p class="course-detail__content__categories__placeholder">
                 {% trans "No associated categories" %}
               </p>
-            {% endpage_placeholder %}
-          {% endwith %}
-      </div>
-
-      {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_icons" %}
-      <div class="course-detail__content__row course-detail__content__icons">
-        {% with form_factor="icon" %}
-          {% placeholder "course_icons" or %}
-            <p class="course-detail__content__icons__empty">
-              {% trans "No associated icons" %}
-            </p>
-          {% endplaceholder %}
+            {% endif %}
+          {% endpage_placeholder %}
         {% endwith %}
       </div>
       {% endif %}

--- a/src/richie/apps/courses/templates/courses/plugins/category_plugin.html
+++ b/src/richie/apps/courses/templates/courses/plugins/category_plugin.html
@@ -2,31 +2,34 @@
 {% spaceless %}
 {% if current_page.publisher_is_draft or instance.check_publication is True %}
   {% if form_factor == "tag" %}
-    <a class="category-plugin-tag{% if relevant_page.publisher_is_draft %} category-plugin-tag--draft{% endif %}" href="{{ relevant_page.get_absolute_url }}">
-      {{ relevant_page.get_title }}
-    </a>
-  {% elif form_factor == "icon" %}
-    <a class="category-plugin-icon{% if relevant_page.publisher_is_draft %} category-plugin-icon--draft{% endif %}" href="{{ relevant_page.get_absolute_url }}">
+    <a
+      class="category-plugin-tag{% if relevant_page.publisher_is_draft %} category-plugin-tag--draft{% endif %}"
+      href="{{ relevant_page.get_absolute_url }}"
+    >
       {% get_placeholder_plugins "icon" relevant_page as icon_plugins %}
-      {% blockplugin icon_plugins.0 %}
-        <figure class="category-plugin-icon__figure">
-          <figcaption
-            class="category-plugin-icon__figure__caption"
-            style="background: {{ icon_plugins.0.page.category.color }};"
-          >
-            {{ relevant_page.get_title }}
-          </figcaption>
-          <img src="{% thumbnail instance.picture 40x40 crop upscale subject_location=instance.picture.subject_location %}"
+      {% if icon_plugins %}
+        {% blockplugin icon_plugins.0 %}
+          <figure class="category-plugin-tag__figure">
+            <figcaption
+              class="category-plugin-tag__figure__caption"
+              {% if relevant_page.category.color %}style="background: {{ relevant_page.category.color }};"{% endif %}
+            >
+              {{ relevant_page.get_title }}
+            </figcaption>
+            <img src="{% thumbnail instance.picture 40x40 crop upscale subject_location=instance.picture.subject_location %}"
             srcset="
-              {% thumbnail instance.picture 40x40 crop upscale subject_location=instance.picture.subject_location %} 40w,
-              {% if instance.picture.width >= 80 %}{% thumbnail instance.picture 80x80 crop upscale subject_location=instance.picture.subject_location %} 80w,{% endif %}
-              {% if instance.picture.width >= 120 %}{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
+            {% thumbnail instance.picture 40x40 crop upscale subject_location=instance.picture.subject_location %} 40w,
+            {% if instance.picture.width >= 80 %}{% thumbnail instance.picture 80x80 crop upscale subject_location=instance.picture.subject_location %} 80w,{% endif %}
+            {% if instance.picture.width >= 120 %}{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
             "
             sizes="40px"
-            class="category-plugin-icon__figure__image"
+            class="category-plugin-tag__figure__image"
             alt=""/>
-        </figure>
-      {% endblockplugin %}
+          </figure>
+        {% endblockplugin %}
+      {% else %}
+        <div class="category-plugin-tag__title">{{ relevant_page.get_title }}</div>
+      {% endif %}
     </a>
   {% elif form_factor == "mark" %}
     {% get_placeholder_plugins "icon" relevant_page as icon_plugins %}

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -229,22 +229,27 @@ ICONS_INFO = {
     "children": [
         {
             "page_title": {"en": "Academic", "fr": "Diplomant"},
+            "color": "#005c08",
             "fill_icon": pick_image("icons")("academic.png"),
         },
         {
             "page_title": {"en": "Accessible", "fr": "Accessible"},
+            "color": "#00a1d6",
             "fill_icon": pick_image("icons")("accessible.png"),
         },
         {
             "page_title": {"en": "Closed caption", "fr": "Sous-titres malentendants"},
+            "color": "#a11000",
             "fill_icon": pick_image("icons")("cc.png"),
         },
         {
             "page_title": {"en": "Certificate", "fr": "Certifiant"},
+            "color": "#ffc400",
             "fill_icon": pick_image("icons")("certificate.png"),
         },
         {
             "page_title": {"en": "Subtitles", "fr": "Sous-titres"},
+            "color": "#6d00ba",
             "fill_icon": pick_image("icons")("subtitles.png"),
         },
     ],

--- a/src/richie/apps/demo/helpers.py
+++ b/src/richie/apps/demo/helpers.py
@@ -5,6 +5,7 @@ from richie.apps.courses.factories import CategoryFactory
 # pylint: disable=too-many-arguments
 def create_categories(
     children=None,
+    color=None,
     fill_banner=True,
     fill_description=True,
     fill_icon=False,
@@ -44,6 +45,7 @@ def create_categories(
 
     """
     category = CategoryFactory(
+        color=color,
         fill_banner=fill_banner,
         fill_description=fill_description,
         fill_icon=fill_icon,

--- a/tests/apps/courses/test_factories_category.py
+++ b/tests/apps/courses/test_factories_category.py
@@ -2,7 +2,6 @@
 Unit tests for the Category factory
 """
 import os
-import re
 
 from django.test import TestCase
 
@@ -15,10 +14,9 @@ class CategoryFactoriesTestCase(TestCase):
     """
 
     def test_factories_category_color(self):
-        """The category factory should generate a random color."""
+        """The category factory should leave the color field null."""
         category = CategoryFactory()
-        pattern = r"^#[a-f0-9]{6}"
-        self.assertIsNotNone(re.search(pattern, category.color))
+        self.assertIsNone(category.color)
 
     def test_factories_category_logo(self):
         """

--- a/tests/apps/courses/test_templates_blogpost_detail.py
+++ b/tests/apps/courses/test_templates_blogpost_detail.py
@@ -66,7 +66,7 @@ class BlogPostCMSTestCase(CMSTestCase):
             response,
             (
                 '<a class="category-plugin-tag category-plugin-tag--draft" '
-                'href="{:s}">{:s}</a>'
+                'href="{:s}"><div class="category-plugin-tag__title">{:s}</div></a>'
             ).format(
                 category.extended_object.get_absolute_url(),
                 category.extended_object.get_title(),

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -93,7 +93,10 @@ class CourseCMSTestCase(CMSTestCase):
         for category in categories[:2]:
             self.assertContains(
                 response,
-                '<a class="category-plugin-tag" href="{:s}">{:s}</a>'.format(
+                (
+                    '<a class="category-plugin-tag" href="{:s}">'
+                    '<div class="category-plugin-tag__title">{:s}</div></a>'
+                ).format(
                     category.extended_object.get_absolute_url(),
                     category.extended_object.get_title(),
                 ),
@@ -104,9 +107,11 @@ class CourseCMSTestCase(CMSTestCase):
 
         # Only published icons should be present on the page
         pattern = (
-            r'<a class="category-plugin-icon" href="{link:s}"><figure'
-            r".*<figcaption.*{title:s}.*</figcaption>"
-            r'.*<img src="/media/filer_public_thumbnails/filer_public/.*icon\.jpg.*alt=""/>'
+            r'<a.*class="category-plugin-tag".*href="{link:s}".*>'
+            r'<figure class="category-plugin-tag__figure">'
+            r'<figcaption.*class="category-plugin-tag__figure__caption".*>'
+            r".*{title:s}.*</figcaption>"
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*icon\.jpg.*alt=""/>'
         )
 
         for icon in icons[:2]:
@@ -211,7 +216,10 @@ class CourseCMSTestCase(CMSTestCase):
         for category in categories[:2]:
             self.assertContains(
                 response,
-                '<a class="category-plugin-tag" href="{:s}">{:s}</a>'.format(
+                (
+                    '<a class="category-plugin-tag" href="{:s}">'
+                    '<div class="category-plugin-tag__title">{:s}</div></a>'
+                ).format(
                     category.extended_object.get_absolute_url(),
                     category.extended_object.get_title(),
                 ),
@@ -221,7 +229,10 @@ class CourseCMSTestCase(CMSTestCase):
         for category in categories[-2:]:
             self.assertContains(
                 response,
-                '<a class="{element:s} {element:s}--draft" href="{url:s}">{title:s}</a>'.format(
+                (
+                    '<a class="{element:s} {element:s}--draft" href="{url:s}">'
+                    '<div class="category-plugin-tag__title">{title:s}</div></a>'
+                ).format(
                     url=category.extended_object.get_absolute_url(),
                     element="category-plugin-tag",
                     title=category.extended_object.get_title(),

--- a/tests/apps/courses/test_templates_course_run_detail.py
+++ b/tests/apps/courses/test_templates_course_run_detail.py
@@ -93,7 +93,10 @@ class CourseRunCMSTestCase(CMSTestCase):
         for category in categories[:2]:
             self.assertContains(
                 response,
-                '<a class="category-plugin-tag" href="{:s}">{:s}</a>'.format(
+                (
+                    '<a class="category-plugin-tag" href="{:s}">'
+                    '<div class="category-plugin-tag__title">{:s}</div></a>'
+                ).format(
                     category.extended_object.get_absolute_url(),
                     category.extended_object.get_title(),
                 ),
@@ -204,17 +207,24 @@ class CourseRunCMSTestCase(CMSTestCase):
         for category in categories[:2]:
             self.assertContains(
                 response,
-                '<a class="category-plugin-tag" href="{:s}">{:s}</a>'.format(
+                (
+                    '<a class="category-plugin-tag" href="{:s}">'
+                    '<div class="category-plugin-tag__title">{:s}</div></a>'
+                ).format(
                     category.extended_object.get_absolute_url(),
                     category.extended_object.get_title(),
                 ),
                 html=True,
             )
+
         # Draft categories should also be present on the page with an annotation for styling
         for category in categories[-2:]:
             self.assertContains(
                 response,
-                '<a class="{element:s} {element:s}--draft" href="{url:s}">{title:s}</a>'.format(
+                (
+                    '<a class="{element:s} {element:s}--draft" href="{url:s}">'
+                    '<div class="category-plugin-tag__title">{title:s}</div></a>'
+                ).format(
                     url=category.extended_object.get_absolute_url(),
                     element="category-plugin-tag",
                     title=category.extended_object.get_title(),

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -95,7 +95,10 @@ class PersonCMSTestCase(CMSTestCase):
         # The published category should be on the page in its published version
         self.assertContains(
             response,
-            '<a class="category-plugin-tag" href="{:s}">{:s}</a>'.format(
+            (
+                '<a class="category-plugin-tag" href="{:s}">'
+                '<div class="category-plugin-tag__title">{:s}</div></a>'
+            ).format(
                 published_category.public_extension.extended_object.get_absolute_url(),
                 published_category.public_extension.extended_object.get_title(),
             ),
@@ -180,7 +183,10 @@ class PersonCMSTestCase(CMSTestCase):
         # The published category should be on the page in its published version
         self.assertContains(
             response,
-            '<a class="category-plugin-tag" href="{:s}">{:s}</a>'.format(
+            (
+                '<a class="category-plugin-tag" href="{:s}">'
+                '<div class="category-plugin-tag__title">{:s}</div></a>'
+            ).format(
                 published_category.public_extension.extended_object.get_absolute_url(),
                 published_category.public_extension.extended_object.get_title(),
             ),
@@ -191,7 +197,7 @@ class PersonCMSTestCase(CMSTestCase):
             response,
             (
                 '<a class="category-plugin-tag category-plugin-tag--draft" '
-                'href="{:s}">{:s}</a>'
+                'href="{:s}"><div class="category-plugin-tag__title">{:s}</div></a>'
             ).format(
                 unpublished_category.extended_object.get_absolute_url(),
                 unpublished_category.extended_object.get_title(),


### PR DESCRIPTION
## Purpose

In [v1.6.0](https://github.com/openfun/richie/releases/tag/v1.6.0) (PR https://github.com/openfun/richie/pull/758), we added a new separate placeholder to attach category icons to a course. With this design, it was not possible to add an icon to the course detail view without making it appear on its glimpse. 

## Proposal

In order to allow this use case, we refactored categories to display as icons when they have an image, regardless of the placeholder to which they are added on the course page.

The first category in the `course_icons` placeholder is still displayed on the glimpse but it is now possible to add icons to the course detail view via the old `course_categories` placeholder so that they don't appear on the glimpse.
