### PR TITLE
🐛(project) add woff2 in manifest for newly added font

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include LICENSE
 include README.md
-recursive-include src/richie *.html *.png *.gif *.js *.css *.jpg *.jpeg *.po *.mo *.eot *.svg *.ttf *.woff
+recursive-include src/richie *.html *.png *.gif *.js *.css *.jpg *.jpeg *.po *.mo *.eot *.svg *.ttf *.woff *.woff2
 include src/richie/apps/core/static/fonts/icomoon/selection.json


### PR DESCRIPTION
## Purpose 

Commit edac2ac added a new woff2 font but it was not included in the Python package because woff2 was missing from the MANIFEST.in file.

## Proposal

Add *woff2 to [MANIFEST.in](https://github.com/openfun/richie/blob/master/MANIFEST.in)
