### PR TITLE
🐛(project) fix logo url in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix search API endpoints for categories, organizations & persons.
 
+## [1.7.3] - 2019-08-27
+
+### Fixed
+
+- Fix logo url in footer.
+
 ## [1.7.2] - 2019-08-26
 
 ### Fixed
@@ -479,7 +485,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.7.2...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.7.3...master
+[1.7.3]: https://github.com/openfun/richie/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/openfun/richie/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/openfun/richie/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/openfun/richie/compare/v1.6.1...v1.7.0

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -55,7 +55,7 @@
                 </div>
                 <div class="body-footer__brand">
                     <a href="/" class="body-footer__brand__link">
-                        <img src="{% static "images/logo.png" %}" class="body-footer__brand__logo" alt="">
+                        <img src="{% static "richie/images/logo.png" %}" class="body-footer__brand__logo" alt="">
                     </a>
                     {% include "social-networks/footer-badges.html" %}
                 </div>


### PR DESCRIPTION
## Purpose

In Release 1.7.2, the footer logo is pointing to a file that does not exist which raises a 500 error in production when using the manifest static files storage backend.

## Proposal

Cherry pick commits 90b7328 and e1dc722 to master.
