### PR TITLE
Fix a template error in the person plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix missing author name on blogpost detail pages because of an error in
+  the person plugin template.
 - Fix search API endpoints for categories, organizations & persons.
 
 ## [1.7.3] - 2019-08-27

--- a/src/richie/apps/courses/templates/courses/plugins/person.html
+++ b/src/richie/apps/courses/templates/courses/plugins/person.html
@@ -2,9 +2,8 @@
 {% spaceless %}
 {% if current_page.publisher_is_draft or instance.check_publication is True %}
   {% if form_factor == "tag" %}
-    <a class="person-plugin-tag" href="{{ relevant_page.get_absolute_url }}"
-        title="{{ relevant_page.person.get_tile }}">
-      {{ relevant_page.person.get_tile }}
+    <a class="person-plugin-tag" href="{{ relevant_page.get_absolute_url }}">
+      {{ relevant_page.get_title }}
     </a>
   {% else %}
     {% include "courses/cms/fragment_person_glimpse.html" with person=relevant_page.person %}

--- a/tests/apps/courses/test_templates_blogpost_detail.py
+++ b/tests/apps/courses/test_templates_blogpost_detail.py
@@ -4,7 +4,11 @@ End-to-end tests for the blogpost detail view
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
-from richie.apps.courses.factories import BlogPostFactory, CategoryFactory
+from richie.apps.courses.factories import (
+    BlogPostFactory,
+    CategoryFactory,
+    PersonFactory,
+)
 
 
 class BlogPostCMSTestCase(CMSTestCase):
@@ -16,7 +20,12 @@ class BlogPostCMSTestCase(CMSTestCase):
         """
         Validate that the important elements are displayed on a published blogpost page
         """
-        blogpost = BlogPostFactory(page_title="Preums", fill_cover=True, fill_body=True)
+        author = PersonFactory(
+            page_title={"en": "Comte de Saint-Germain"}, should_publish=True
+        )
+        blogpost = BlogPostFactory(
+            page_title="Preums", fill_cover=True, fill_body=True, fill_author=[author]
+        )
         page = blogpost.extended_object
 
         # The page should not be visible before it is published
@@ -33,6 +42,7 @@ class BlogPostCMSTestCase(CMSTestCase):
         self.assertContains(
             response, '<h1 class="blogpost-detail__title">Preums</h1>', html=True
         )
+        self.assertContains(response, "Comte de Saint-Germain", html=True)
 
     def test_templates_blogpost_detail_cms_draft_content(self):
         """
@@ -43,12 +53,16 @@ class BlogPostCMSTestCase(CMSTestCase):
         self.client.login(username=user.username, password="password")
 
         category = CategoryFactory(page_title="Very interesting category")
+        author = PersonFactory(
+            page_title={"en": "Comte de Saint-Germain"}, should_publish=True
+        )
 
         blogpost = BlogPostFactory(
             page_title="Preums",
             fill_cover=True,
             fill_body=True,
             fill_categories=[category],
+            fill_author=[author],
         )
         page = blogpost.extended_object
 
@@ -61,6 +75,7 @@ class BlogPostCMSTestCase(CMSTestCase):
         self.assertContains(
             response, '<h1 class="blogpost-detail__title">Preums</h1>', html=True
         )
+        self.assertContains(response, "Comte de Saint-Germain", html=True)
 
         self.assertContains(
             response,


### PR DESCRIPTION
## Purpose

The person plugin, when used through its tag form, contained an error where `get_tile` was called instead `get_title`.

It was also called on the person object (which has no such method) instead of the related page (which does, and has the person's name as its title).

## Proposal

We simply fixed the error and added tests to make sure it works from now on.
