### PR TITLE
Fix "more options" modal for non-mptt-paths based filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix "More options" modal for searchable filter values not based on MPTT
+  paths (eg. "Person" in the sandbox environment).
+
 ## [1.8.0] - 2019-08-28
 
 ### Added

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -38,7 +38,7 @@ describe('<SearchFilterGroupModal />', () => {
       objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
     });
     fetchMock.get(
-      '/api/v1.0/courses/?scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      '/api/v1.0/courses/?scope=filters&universities_include=%28L-42%7CL-84%7CL-99%29',
       {
         filters: {
           universities: {
@@ -103,7 +103,7 @@ describe('<SearchFilterGroupModal />', () => {
       objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
     });
     fetchMock.get(
-      '/api/v1.0/courses/?scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      '/api/v1.0/courses/?scope=filters&universities_include=%28L-42%7CL-84%7CL-99%29',
       {
         filters: {
           universities: {
@@ -151,7 +151,7 @@ describe('<SearchFilterGroupModal />', () => {
       objects: [{ id: 'L-12' }, { id: 'L-17' }],
     });
     fetchMock.get(
-      '/api/v1.0/courses/?scope=filters&universities_include=.-%2812%7C17%29',
+      '/api/v1.0/courses/?scope=filters&universities_include=%28L-12%7CL-17%29',
       {
         filters: {
           universities: {
@@ -190,7 +190,7 @@ describe('<SearchFilterGroupModal />', () => {
       },
     );
     fetchMock.get(
-      '/api/v1.0/courses/?scope=filters&universities_include=.-%2803%7C66%29',
+      '/api/v1.0/courses/?scope=filters&universities_include=%28L-03%7CL-66%29',
       {
         filters: {
           universities: {
@@ -227,7 +227,7 @@ describe('<SearchFilterGroupModal />', () => {
       objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
     });
     fetchMock.get(
-      '/api/v1.0/courses/?scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      '/api/v1.0/courses/?scope=filters&universities_include=%28L-42%7CL-84%7CL-99%29',
       {
         filters: {
           universities: {
@@ -276,7 +276,7 @@ describe('<SearchFilterGroupModal />', () => {
       objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
     });
     fetchMock.get(
-      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_include=%28L-42%7CL-84%7CL-99%29',
       {
         filters: {
           universities: {
@@ -384,7 +384,7 @@ describe('<SearchFilterGroupModal />', () => {
       objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
     });
     fetchMock.get(
-      '/api/v1.0/courses/?scope=filters&universities_include=.-%2842%7C84%7C99%29',
+      '/api/v1.0/courses/?scope=filters&universities_include=%28L-42%7CL-84%7CL-99%29',
       { throws: new Error('Failed to search for universities') },
     );
 

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -91,8 +91,8 @@ export const SearchFilterGroupModal = ({
 
     const facetResponse = await fetchList('courses', {
       ...coursesSearchParams,
-      [`${filter.name}_include`]: `.-(${searchResponse.content.objects
-        .map(resource => resource.id.substr(2))
+      [`${filter.name}_include`]: `(${searchResponse.content.objects
+        .map(resource => resource.id)
         .join('|')})`,
       scope: 'filters',
     });


### PR DESCRIPTION
## Purpose

The "more options" modal for filter values in the search filters pane incorrectly made the assumption that all searchable filters were based on MPTT paths and built a regexp accordingly.

## Proposal

That is not the case: in our own sandbox environment, persons are not using those paths and the "more options" for persons modal is broken. 

We can simplify the regexp to make it work with every filter.