### PR TITLE
Improve error messages in the "more options" modal in filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix "More options" modal for searchable filter values not based on MPTT
   paths (eg. "Person" in the sandbox environment).
+- Stop making failed API requests and instead show a helpful error message
+  in the "More options" modal for filter values when the user inputs their
+  first 1 or 2 characters.
 
 ### Security
 

--- a/src/frontend/js/components/SearchFilterGroupModal/_SearchFilterGroupModal.scss
+++ b/src/frontend/js/components/SearchFilterGroupModal/_SearchFilterGroupModal.scss
@@ -60,6 +60,10 @@
       border-right-width: 0;
     }
 
+    &__error {
+      padding: 1rem;
+    }
+
     &__values {
       margin: 0;
       padding: 0;

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -146,6 +146,12 @@ describe('<SearchFilterGroupModal />', () => {
       content => content.startsWith('Value #84') && content.includes('(12)'),
     );
 
+    // User starts typing, less than 3 characters
+    fetchMock.resetHistory();
+    fireEvent.change(field, { target: { value: 'us' } });
+    expect(fetchMock.called()).toEqual(false);
+    getByText('Type 3 characters or more to start searching.');
+
     // User inputs a search query
     fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=user', {
       objects: [{ id: 'L-12' }, { id: 'L-17' }],

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -41,6 +41,13 @@ const messages = defineMessages({
       'Test for the button to see more filter values than the top N that appear by default.',
     id: 'components.SearchFilterGroupModal.moreOptionsButton',
   },
+  queryTooShort: {
+    defaultMessage: 'Type 3 characters or more to start searching.',
+    description:
+      'Users need to enter at least 3 characters to search for more filter values; ' +
+      'this message informs them when they start typing.',
+    id: 'components.SearchFilterGroupModal.queryTooShort',
+  },
 });
 
 // The `setAppElement` needs to happen in proper code but breaks our testing environment.
@@ -74,7 +81,8 @@ export const SearchFilterGroupModal = ({
   }, [modalIsOpen]);
 
   useAsyncEffect(async () => {
-    if (!modalIsOpen) {
+    // We can't start using full-text search until our text query is at least 3 characters long.
+    if (!modalIsOpen || (query.length > 0 && query.length < 3)) {
       return;
     }
 
@@ -140,10 +148,16 @@ export const SearchFilterGroupModal = ({
             placeholder={`Search in ${filter.human_name}`}
           />
           {error ? (
-            <FormattedMessage
-              {...messages.error}
-              values={{ filterName: filter.human_name }}
-            />
+            <div className="search-filter-group-modal__form__error">
+              <FormattedMessage
+                {...messages.error}
+                values={{ filterName: filter.human_name }}
+              />
+            </div>
+          ) : query.length > 0 && query.length < 3 ? (
+            <div className="search-filter-group-modal__form__error">
+              <FormattedMessage {...messages.queryTooShort} />
+            </div>
           ) : (
             <ul className="search-filter-group-modal__form__values">
               {values.map(value => (


### PR DESCRIPTION
## Purpose

The "More options" modal for filter values was making request to the server as soon as the user started to type, and immediately showed a cryptic error message as it received an error for the server, because textual search only works in our API endpoints with 3 characters or more.

## Proposal

Stop sending useless API requests when users input 1 or 2 characters and show a helpful message in the modal instead.