### PR TITLE
Improve a string in the blogpost detail template

### DIFF
--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -14,7 +14,7 @@
       {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"author" %}
       <div class="blogpost-detail__subhead__author">
         {% page_placeholder "author" current_page or %}
-          <span class="blogpost-detail__subhead__author__empty">{% trans 'No author yet.' %}</span>
+          <span class="blogpost-detail__subhead__author__empty">{% trans 'No author yet' %}</span>
         {% endpage_placeholder %}
       </div>
       {% endif %}


### PR DESCRIPTION
## Purpose

The string shown in the blogpost detail template when a blogpost does not have an author - "No author yet." - should not have a period at the end as it is displayed between two dashes.

## Proposal

Just remove the period from the string in the template.
