### PR TITLE
Increase courses & organizations numbers on demo site

### DIFF
--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from .utils import pick_image
 
 NB_OBJECTS = {
-    "courses": 30,
+    "courses": 75,
     "course_courseruns": 5,
     "course_icons": 3,
     "course_organizations": 3,
@@ -12,7 +12,7 @@ NB_OBJECTS = {
     "course_subjects": 2,
     "person_organizations": 3,
     "person_subjects": 3,
-    "organizations": 5,
+    "organizations": 15,
     "licences": 5,
     "persons": 50,
     "blogposts": 20,


### PR DESCRIPTION
## Purpose

We're using demo content to showcase richie's feature set as best we can.

In this instance, we want to make a better demo for the "More options" modal on filters, and for course pagination.

## Proposal

Increase the number or courses & organizations included in the demo site by default.
