### PR TITLE
Improve pagination UX in course search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix "More options" modal for searchable filter values not based on MPTT
   paths (eg. "Person" in the sandbox environment).
+- Improve pagination UX by increasing contrast between the active page number
+  and others, and making button clickable areas larger.
 - Stop making failed API requests and instead show a helpful error message
   in the "More options" modal for filter values when the user inputs their
   first 1 or 2 characters.

--- a/src/frontend/js/components/PaginateCourseSearch/_PaginateCourseSearch.scss
+++ b/src/frontend/js/components/PaginateCourseSearch/_PaginateCourseSearch.scss
@@ -8,22 +8,28 @@
     &__item {
       list-style-type: none;
       display: flex;
-      padding: 0.5rem 1rem;
       background: white;
       border: 1px solid $dodgerblue1;
+      color: $dodgerblue1;
+      cursor: pointer;
 
       & + & {
         border-left: 0;
       }
 
-      &__page-number {
-        color: $dodgerblue1;
-        cursor: pointer;
+      &--current {
+        background: $dodgerblue1;
+        color: white;
+        cursor: default;
+      }
 
-        &--current {
-          color: $gray40;
-          cursor: default;
-        }
+      &--placeholder {
+        padding: 0.5rem 1rem;
+        cursor: default;
+      }
+
+      &__page-number {
+        padding: 0.5rem 1rem;
       }
     }
   }

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -73,15 +73,15 @@ export const PaginateCourseSearch = ({
           <React.Fragment key={page}>
             {/* Prepend a cell with "..." when the page number we're rendering does not follow the previous one */}
             {page > (pageList[index - 1] || 0) + 1 && (
-              <li className="paginate-course-search__list__item">...</li>
+              <li className="paginate-course-search__list__item paginate-course-search__list__item--placeholder">
+                ...
+              </li>
             )}
-            <li className="paginate-course-search__list__item">
-              {page === currentPage ? (
-                /* The current page needs different markup as it does not include a link */
-                <span
-                  className={`paginate-course-search__list__item__page-number
-                              paginate-course-search__list__item__page-number--current`}
-                >
+
+            {page === currentPage ? (
+              /* The current page needs different markup as it does not include a link */
+              <li className="paginate-course-search__list__item paginate-course-search__list__item--current">
+                <span className="paginate-course-search__list__item__page-number">
                   {/*  Help assistive technology users with some context */}
                   <span className="offscreen">
                     <FormattedMessage {...messages.currentlyReading} />{' '}
@@ -91,7 +91,9 @@ export const PaginateCourseSearch = ({
                   <span className={page !== 1 ? 'offscreen' : ''}>Page </span>
                   {page}
                 </span>
-              ) : (
+              </li>
+            ) : (
+              <li className="paginate-course-search__list__item">
                 <a
                   className="paginate-course-search__list__item__page-number"
                   onClick={() =>
@@ -114,8 +116,8 @@ export const PaginateCourseSearch = ({
                   <span className={page !== 1 ? 'offscreen' : ''}>Page </span>
                   {page}
                 </a>
-              )}
-            </li>
+              </li>
+            )}
           </React.Fragment>
         ))}
       </ul>


### PR DESCRIPTION
###  Purpose

Our pagination as implemented in course search had two flaws:

- low contrast difference between the currently active page button and other pages;
- small clickable zone, only clicks on the page number itself triggered a page change, not clicks on the button itself.

## Proposal

We made the clickable area encompass the whole page button, and used a reverse color scheme for the active page to make it more obvious for all users (and avoid a WCAG non-conformity for low contrast).

<img width="846" alt="Capture d’écran 2019-08-28 à 17 08 27" src="https://user-images.githubusercontent.com/1932937/63868247-7d9a3600-c9b6-11e9-8c12-634107224b95.png">

