### PR TITLE
Improve and complete strings in pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Stop making failed API requests and instead show a helpful error message
   in the "More options" modal for filter values when the user inputs their
   first 1 or 2 characters.
+- Improve pagination strings for localization.
 
 ### Security
 

--- a/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
@@ -27,27 +27,20 @@ describe('<PaginateCourseSearch />', () => {
     );
 
     getByText('Pagination');
-    getByText(
-      (content, element) =>
-        content.endsWith('1') &&
-        element.textContent === 'Currently reading Page 1',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('2') && element.textContent === 'Next Page 2',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('3') && element.textContent === 'Page 3',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('10') && element.textContent === 'Last Page 10',
-    );
+    // Accessibility helpers
+    getByText('Currently reading page 1');
+    getByText('Next page 2');
+    getByText('Page 3');
+    getByText('Last page 10');
+    // Visual pagination
+    getByText('Page 1');
+    getByText('3');
+    getByText('2');
+    getByText('10');
   });
 
   it('shows a pagination for course search (when on the last page)', () => {
-    const { getByText } = render(
+    const { getAllByText, getByText } = render(
       <IntlProvider locale="en">
         <CourseSearchParamsContext.Provider
           value={[
@@ -61,27 +54,20 @@ describe('<PaginateCourseSearch />', () => {
     );
 
     getByText('Pagination');
-    getByText(
-      (content, element) =>
-        content.endsWith('1') && element.textContent === 'Page 1',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('9') && element.textContent === 'Page 9',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('10') && element.textContent === 'Previous Page 10',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('11') &&
-        element.textContent === 'Currently reading Last Page 11',
-    );
+    // Common text for the first page
+    getAllByText('Page 1');
+    // Accessibility helpers
+    getByText('Page 9');
+    getByText('Previous page 10');
+    getByText('Currently reading last page 11');
+    // Visual pagination
+    getByText('9');
+    getByText('10');
+    getByText('11');
   });
 
   it('shows a pagination for course search (when on an arbitrary page)', () => {
-    const { getByText } = render(
+    const { getAllByText, getByText } = render(
       <IntlProvider locale="en">
         <CourseSearchParamsContext.Provider
           value={[
@@ -95,35 +81,22 @@ describe('<PaginateCourseSearch />', () => {
     );
 
     getByText('Pagination');
-    getByText(
-      (content, element) =>
-        content.endsWith('1') && element.textContent === 'Page 1',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('10') && element.textContent === 'Page 10',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('11') && element.textContent === 'Previous Page 11',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('12') &&
-        element.textContent === 'Currently reading Page 12',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('13') && element.textContent === 'Next Page 13',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('14') && element.textContent === 'Page 14',
-    );
-    getByText(
-      (content, element) =>
-        content.endsWith('35') && element.textContent === 'Last Page 35',
-    );
+    // Common text for the first page
+    getAllByText('Page 1');
+    // Accessibility helpers
+    getByText('Page 10');
+    getByText('Previous page 11');
+    getByText('Currently reading page 12');
+    getByText('Next page 13');
+    getByText('Page 14');
+    getByText('Last page 35');
+    // Visual pagination
+    getByText('10');
+    getByText('11');
+    getByText('12');
+    getByText('13');
+    getByText('14');
+    getByText('35');
   });
 
   it('does not render itself when there is only one page', () => {
@@ -158,10 +131,7 @@ describe('<PaginateCourseSearch />', () => {
     );
 
     getByText('Pagination');
-    const page2 = getByText(
-      (content, element) =>
-        content.endsWith('2') && element.textContent === 'Next Page 2',
-    );
+    const page2 = getByText('Next page 2');
 
     // Change pages when the user clicks on another page
     fireEvent.click(page2);
@@ -186,11 +156,7 @@ describe('<PaginateCourseSearch />', () => {
     );
 
     getByText('Pagination');
-    const currentPage1 = getByText(
-      (content, element) =>
-        content.endsWith('1') &&
-        element.textContent === 'Currently reading Page 1',
-    );
+    const currentPage1 = getByText('Currently reading page 1');
 
     // Don't do anything when the user clicks on the page they're currently on
     dispatchCourseSearchParamsUpdate.mockReset();

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -4,16 +4,47 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { CourseSearchParamsContext } from '../../data/useCourseSearchParams/useCourseSearchParams';
 
 const messages = defineMessages({
-  currentlyReading: {
-    defaultMessage: 'Currently reading',
+  currentlyReadingLastPageN: {
+    defaultMessage: 'Currently reading last page {page}',
     description:
-      'Accessibility helper in pagination, shown next to the current page number (Currently reading Page N)',
-    id: 'components.PaginateCourseSearch.currentlyReading',
+      'Accessibility helper in pagination, shown next to the current page number when it is the last page.',
+    id: 'components.PaginateCourseSearch.currentlyReadingLastPageN',
+  },
+  currentlyReadingPageN: {
+    defaultMessage: 'Currently reading page {page}',
+    description:
+      'Accessibility helper in pagination, shown next to the current page number when it is not the last page.',
+    id: 'components.PaginateCourseSearch.currentlyReadingPageN',
+  },
+  lastPageN: {
+    defaultMessage: 'Last page {page}',
+    description:
+      'Accessibility helper for pagination, added on the last page link.',
+    id: 'components.PaginateCourseSearch.lastPageN',
+  },
+  nextPageN: {
+    defaultMessage: 'Next page {page}',
+    description:
+      'Accessibility helper for pagination, added on the next page link.',
+    id: 'components.PaginateCourseSearch.nextPageN',
+  },
+  pageN: {
+    defaultMessage: 'Page {page}',
+    description: `Accessibility helper for pagination, added on all page links for screen readers,
+      only shown next to "page 1" visually.`,
+    id: 'components.PaginateCourseSearch.pageN',
   },
   pagination: {
     defaultMessage: 'Pagination',
-    description: 'Label for the pagination navigation in course search results',
+    description:
+      'Label for the pagination navigation in course search results.',
     id: 'components.PaginateCourseSearch.pagination',
+  },
+  previousPageN: {
+    defaultMessage: 'Previous page {page}',
+    description:
+      'Accessibility helper for pagination, added on the previous page link.',
+    id: 'components.PaginateCourseSearch.previousPageN',
   },
 });
 
@@ -84,12 +115,26 @@ export const PaginateCourseSearch = ({
                 <span className="paginate-course-search__list__item__page-number">
                   {/*  Help assistive technology users with some context */}
                   <span className="offscreen">
-                    <FormattedMessage {...messages.currentlyReading} />{' '}
+                    {page === maxPage ? (
+                      <FormattedMessage
+                        {...messages.currentlyReadingLastPageN}
+                        values={{ page }}
+                      />
+                    ) : (
+                      <FormattedMessage
+                        {...messages.currentlyReadingPageN}
+                        values={{ page }}
+                      />
+                    )}
                   </span>
-                  {page === maxPage && <span className="offscreen">Last </span>}
-                  {/* Show context "Page 1" on the first item to make it obvious this is pagination */}
-                  <span className={page !== 1 ? 'offscreen' : ''}>Page </span>
-                  {page}
+                  <span aria-hidden={true}>
+                    {/* Show context "Page 1" on the first item to make it obvious this is pagination */}
+                    {page === 1 ? (
+                      <FormattedMessage {...messages.pageN} values={{ page }} />
+                    ) : (
+                      page
+                    )}
+                  </span>
                 </span>
               </li>
             ) : (
@@ -105,16 +150,34 @@ export const PaginateCourseSearch = ({
                   }
                 >
                   {/*  Help assistive technology users with some context */}
-                  {page === currentPage - 1 && (
-                    <span className="offscreen">Previous </span>
-                  )}
-                  {page === currentPage + 1 && (
-                    <span className="offscreen">Next </span>
-                  )}
-                  {page === maxPage && <span className="offscreen">Last </span>}
-                  {/* Show context "Page 1" on the first item to make it obvious this is pagination */}
-                  <span className={page !== 1 ? 'offscreen' : ''}>Page </span>
-                  {page}
+                  <span className="offscreen">
+                    {page === maxPage ? (
+                      <FormattedMessage
+                        {...messages.lastPageN}
+                        values={{ page }}
+                      />
+                    ) : page === currentPage - 1 ? (
+                      <FormattedMessage
+                        {...messages.previousPageN}
+                        values={{ page }}
+                      />
+                    ) : page === currentPage + 1 ? (
+                      <FormattedMessage
+                        {...messages.nextPageN}
+                        values={{ page }}
+                      />
+                    ) : (
+                      <FormattedMessage {...messages.pageN} values={{ page }} />
+                    )}
+                  </span>
+                  <span aria-hidden={true}>
+                    {/* Show context "Page 1" on the first item to make it obvious this is pagination */}
+                    {page === 1 ? (
+                      <FormattedMessage {...messages.pageN} values={{ page }} />
+                    ) : (
+                      page
+                    )}
+                  </span>
                 </a>
               </li>
             )}


### PR DESCRIPTION
## Purpose

Visible pagination does not contain a lot of strings, but we have a few more strings for accessibility helpers that provide context along with the page numbers.

We previously attempted to do this "smartly" through the HTML structure of our interpolated strings. This is not ideal as it works for english and some other languages, but fails for other languages with a different grammar.

Also, we forgot a bunch of strings, which resulted in hardcoded english in our template.

## Proposal

Use a more straightforward structure for our JSX and put all content in strings, repeating it instead of concatenating them.