### PR TITLE
Release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.8.1] - 2019-08-29
+
 ### Fixed
 
 - Fix "More options" modal for searchable filter values not based on MPTT
@@ -504,7 +506,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.8.0...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.8.1...master
+[1.8.1]: https://github.com/openfun/richie/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/openfun/richie/compare/v1.7.3...v1.8.0
 [1.7.3]: https://github.com/openfun/richie/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/openfun/richie/compare/v1.7.1...v1.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.8.0
+version = 1.8.1
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/js/translations/fr_CA.po
+++ b/src/frontend/js/translations/fr_CA.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-05-24T16:39:58.245Z\n"
+"POT-Creation-Date: 2019-08-29T09:35:56.390Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -13,14 +13,28 @@ msgstr ""
 "Last-Translator: Samuel Paccoud (sampaccoud)\n"
 "Language-Team: French, Canada\n"
 "Language: fr_CA\n"
-"PO-Revision-Date: 2019-06-20 13:36\n"
+"PO-Revision-Date: 2019-08-29 11:54\n"
+
+#. [components.SearchFilterGroupModal.modalTitle] - Title for the modal to add more filter values in the search filters modal.
+#. defaultMessage is:
+#. Add filters for {filterName}
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "Add filters for {filterName}"
+msgstr ""
 
 #. [components.SearchFiltersPane.clearFilters] - Helper button in search filters pane in search page to remove all active filters
 #. defaultMessage is:
 #. Clear {activeFilterCount, number} active {activeFilterCount, plural, one {filter} other {filters}}
 #: i18n/js/components/SearchFiltersPane/SearchFiltersPane.json
 msgid "Clear {activeFilterCount, number} active {activeFilterCount, plural, one {filter} other {filters}}"
-msgstr "Remettre à zéro {activeFilterCount, number} {activeFilterCount, plural, one {filtre} other {filtres}} actifs"
+msgstr ""
+
+#. [components.SearchFilterGroupModal.closeModal] - Text for the button to close the search filters modal
+#. defaultMessage is:
+#. Close
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "Close"
+msgstr ""
 
 #. [components.CourseGlimpse.cover] - Placeholder text when the course we are glimpsing at is missing a cover image
 #. defaultMessage is:
@@ -29,12 +43,19 @@ msgstr "Remettre à zéro {activeFilterCount, number} {activeFilterCount, plural
 msgid "Cover"
 msgstr "Couverture"
 
-#. [components.CourseGlimpse.linkText] - Accessibility title for links on course glimpses.
+#. [components.PaginateCourseSearch.currentlyReadingLastPageN] - Accessibility helper in pagination, shown next to the current page number when it is the last page.
 #. defaultMessage is:
-#. Details page for {courseTitle}.
-#: i18n/js/components/CourseGlimpse/CourseGlimpse.json
-msgid "Details page for {courseTitle}."
-msgstr "Page de détails pour {courseTitle}."
+#. Currently reading last page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Currently reading last page {page}"
+msgstr ""
+
+#. [components.PaginateCourseSearch.currentlyReadingPageN] - Accessibility helper in pagination, shown next to the current page number when it is not the last page.
+#. defaultMessage is:
+#. Currently reading page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Currently reading page {page}"
+msgstr ""
 
 #. [components.SearchFiltersPane.title] - Title for the search filters pane in course search.
 #. defaultMessage is:
@@ -45,17 +66,53 @@ msgstr "Filtrer les cours"
 
 #. [components.SearchFilterValueParent.ariaHideChildren] - Accessibility message for the button to hide children of the current filter
 #. defaultMessage is:
-#. Hide child filters
+#. Hide additional filters for {filterValueName}
 #: i18n/js/components/SearchFilterValueParent/SearchFilterValueParent.json
-msgid "Hide child filters"
-msgstr "Masquer les filtres enfants"
+msgid "Hide additional filters for {filterValueName}"
+msgstr "Afficher moins de filtres pour {filterValueName}"
 
-#. [components.CourseGlimpse.logoAltText] - Alternate text for the course logo in a course glimpse.
+#. [components.PaginateCourseSearch.lastPageN] - Accessibility helper for pagination, added on the last page link.
 #. defaultMessage is:
-#. Logo for {courseTitle}
-#: i18n/js/components/CourseGlimpse/CourseGlimpse.json
-msgid "Logo for {courseTitle}"
-msgstr "Logo du cours {courseTitle}"
+#. Last page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Last page {page}"
+msgstr ""
+
+#. [components.SearchFilterGroupModal.moreOptionsButton] - Test for the button to see more filter values than the top N that appear by default.
+#. defaultMessage is:
+#. More options
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "More options"
+msgstr ""
+
+#. [components.PaginateCourseSearch.nextPageN] - Accessibility helper for pagination, added on the next page link.
+#. defaultMessage is:
+#. Next page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Next page {page}"
+msgstr ""
+
+#. [components.PaginateCourseSearch.pageN] - Accessibility helper for pagination, added on all page links for screen readers,
+#.       only shown next to "page 1" visually.
+#. defaultMessage is:
+#. Page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Page {page}"
+msgstr ""
+
+#. [components.PaginateCourseSearch.pagination] - Label for the pagination navigation in course search results.
+#. defaultMessage is:
+#. Pagination
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Pagination"
+msgstr ""
+
+#. [components.PaginateCourseSearch.previousPageN] - Accessibility helper for pagination, added on the previous page link.
+#. defaultMessage is:
+#. Previous page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Previous page {page}"
+msgstr ""
 
 #. [components.SearchSuggestField.searchFieldPlaceholder] - Placeholder text displayed in the search field when it is empty.
 #. defaultMessage is:
@@ -74,22 +131,29 @@ msgstr "Recherche de {query} dans les cours..."
 
 #. [components.SearchFilterValueParent.ariaShowChildren] - Accessibility message for the button to show children of the current filter
 #. defaultMessage is:
-#. Show child filters
+#. Show more filters for {filterValueName}
 #: i18n/js/components/SearchFilterValueParent/SearchFilterValueParent.json
-msgid "Show child filters"
-msgstr "Afficher les filtres enfants"
+msgid "Show more filters for {filterValueName}"
+msgstr "Afficher plus de filtres pour {filterValueName}"
 
-#. [components.CourseGlimpseList.courseCount] - Result count for course search. Appears right above search results
+#. [components.CourseGlimpseList.courseCount] - Result count & pagination information for course search. Appears right above search results
 #. defaultMessage is:
-#. Showing {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search
+#. Showing {start, number} to {end, number} of {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search
 #: i18n/js/components/CourseGlimpseList/CourseGlimpseList.json
-msgid "Showing {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search"
-msgstr "Affichage de {courseCount, number} {courseCount, plural, one {cours} other {cours}} correspondant à votre recherche"
+msgid "Showing {start, number} to {end, number} of {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search"
+msgstr ""
 
-#. [components.CourseGlimpse.startsOn] - Shows the start date for a course in a course glimpse in a short format such as Sep 4, '1986'
+#. [components.SearchFilterGroupModal.error] - Error message when the search for more filter value fails in the search filters modal.
 #. defaultMessage is:
-#. Starts on {date}
-#: i18n/js/components/CourseGlimpse/CourseGlimpse.json
-msgid "Starts on {date}"
-msgstr "Débute le {date}"
+#. There was an error while searching for {filterName}.
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "There was an error while searching for {filterName}."
+msgstr ""
+
+#. [components.SearchFilterGroupModal.queryTooShort] - Users need to enter at least 3 characters to search for more filter values; this message informs them when they start typing.
+#. defaultMessage is:
+#. Type at least 3 characters to start searching.
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "Type at least 3 characters to start searching."
+msgstr ""
 

--- a/src/frontend/js/translations/fr_FR.po
+++ b/src/frontend/js/translations/fr_FR.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-05-24T16:39:58.245Z\n"
+"POT-Creation-Date: 2019-08-29T09:35:56.390Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -13,14 +13,28 @@ msgstr ""
 "Last-Translator: Samuel Paccoud (sampaccoud)\n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
-"PO-Revision-Date: 2019-06-20 13:36\n"
+"PO-Revision-Date: 2019-08-29 11:54\n"
+
+#. [components.SearchFilterGroupModal.modalTitle] - Title for the modal to add more filter values in the search filters modal.
+#. defaultMessage is:
+#. Add filters for {filterName}
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "Add filters for {filterName}"
+msgstr "Ajouter des filtres pour {filterName}"
 
 #. [components.SearchFiltersPane.clearFilters] - Helper button in search filters pane in search page to remove all active filters
 #. defaultMessage is:
 #. Clear {activeFilterCount, number} active {activeFilterCount, plural, one {filter} other {filters}}
 #: i18n/js/components/SearchFiltersPane/SearchFiltersPane.json
 msgid "Clear {activeFilterCount, number} active {activeFilterCount, plural, one {filter} other {filters}}"
-msgstr "Remettre à zéro {activeFilterCount, number} {activeFilterCount, plural, one {filtre} other {filtres}} actifs"
+msgstr "Retirer {activeFilterCount, number} {activeFilterCount, plural, one {filtre actif} other {filtres actifs}}"
+
+#. [components.SearchFilterGroupModal.closeModal] - Text for the button to close the search filters modal
+#. defaultMessage is:
+#. Close
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "Close"
+msgstr "Fermer"
 
 #. [components.CourseGlimpse.cover] - Placeholder text when the course we are glimpsing at is missing a cover image
 #. defaultMessage is:
@@ -29,12 +43,19 @@ msgstr "Remettre à zéro {activeFilterCount, number} {activeFilterCount, plural
 msgid "Cover"
 msgstr "Couverture"
 
-#. [components.CourseGlimpse.linkText] - Accessibility title for links on course glimpses.
+#. [components.PaginateCourseSearch.currentlyReadingLastPageN] - Accessibility helper in pagination, shown next to the current page number when it is the last page.
 #. defaultMessage is:
-#. Details page for {courseTitle}.
-#: i18n/js/components/CourseGlimpse/CourseGlimpse.json
-msgid "Details page for {courseTitle}."
-msgstr "Page de détails pour {courseTitle}."
+#. Currently reading last page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Currently reading last page {page}"
+msgstr "Actuellement sur la dernière page: {page}"
+
+#. [components.PaginateCourseSearch.currentlyReadingPageN] - Accessibility helper in pagination, shown next to the current page number when it is not the last page.
+#. defaultMessage is:
+#. Currently reading page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Currently reading page {page}"
+msgstr "Actuellement sur la page {page}"
 
 #. [components.SearchFiltersPane.title] - Title for the search filters pane in course search.
 #. defaultMessage is:
@@ -45,17 +66,53 @@ msgstr "Filtrer les cours"
 
 #. [components.SearchFilterValueParent.ariaHideChildren] - Accessibility message for the button to hide children of the current filter
 #. defaultMessage is:
-#. Hide child filters
+#. Hide additional filters for {filterValueName}
 #: i18n/js/components/SearchFilterValueParent/SearchFilterValueParent.json
-msgid "Hide child filters"
-msgstr "Cacher les filtres enfants"
+msgid "Hide additional filters for {filterValueName}"
+msgstr "Cacher les filtres supplémentaires pour {filterValueName}"
 
-#. [components.CourseGlimpse.logoAltText] - Alternate text for the course logo in a course glimpse.
+#. [components.PaginateCourseSearch.lastPageN] - Accessibility helper for pagination, added on the last page link.
 #. defaultMessage is:
-#. Logo for {courseTitle}
-#: i18n/js/components/CourseGlimpse/CourseGlimpse.json
-msgid "Logo for {courseTitle}"
-msgstr "Logo du cours {courseTitle}"
+#. Last page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Last page {page}"
+msgstr "Dernière page: {page}"
+
+#. [components.SearchFilterGroupModal.moreOptionsButton] - Test for the button to see more filter values than the top N that appear by default.
+#. defaultMessage is:
+#. More options
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "More options"
+msgstr "Plus de choix"
+
+#. [components.PaginateCourseSearch.nextPageN] - Accessibility helper for pagination, added on the next page link.
+#. defaultMessage is:
+#. Next page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Next page {page}"
+msgstr "Page suivante: {page}"
+
+#. [components.PaginateCourseSearch.pageN] - Accessibility helper for pagination, added on all page links for screen readers,
+#.       only shown next to "page 1" visually.
+#. defaultMessage is:
+#. Page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Page {page}"
+msgstr "Page {page}"
+
+#. [components.PaginateCourseSearch.pagination] - Label for the pagination navigation in course search results.
+#. defaultMessage is:
+#. Pagination
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Pagination"
+msgstr "Pagination"
+
+#. [components.PaginateCourseSearch.previousPageN] - Accessibility helper for pagination, added on the previous page link.
+#. defaultMessage is:
+#. Previous page {page}
+#: i18n/js/components/PaginateCourseSearch/index.json
+msgid "Previous page {page}"
+msgstr "Page précédente: {page}"
 
 #. [components.SearchSuggestField.searchFieldPlaceholder] - Placeholder text displayed in the search field when it is empty.
 #. defaultMessage is:
@@ -74,22 +131,29 @@ msgstr "Recherche de {query} dans les cours..."
 
 #. [components.SearchFilterValueParent.ariaShowChildren] - Accessibility message for the button to show children of the current filter
 #. defaultMessage is:
-#. Show child filters
+#. Show more filters for {filterValueName}
 #: i18n/js/components/SearchFilterValueParent/SearchFilterValueParent.json
-msgid "Show child filters"
-msgstr "Afficher les filtres enfants"
+msgid "Show more filters for {filterValueName}"
+msgstr "Montrer plus de filtres pour {filterValueName}"
 
-#. [components.CourseGlimpseList.courseCount] - Result count for course search. Appears right above search results
+#. [components.CourseGlimpseList.courseCount] - Result count & pagination information for course search. Appears right above search results
 #. defaultMessage is:
-#. Showing {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search
+#. Showing {start, number} to {end, number} of {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search
 #: i18n/js/components/CourseGlimpseList/CourseGlimpseList.json
-msgid "Showing {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search"
-msgstr "{courseCount, number} {courseCount, plural, one {cours} other {cours}} correspondant à votre recherche"
+msgid "Showing {start, number} to {end, number} of {courseCount, number} {courseCount, plural, one {course} other {courses}} matching your search"
+msgstr "Résultats {start, number} à {end, number} sur {courseCount, number} {courseCount, plural, one {cours} other {cours}} correspondant à votre recherche"
 
-#. [components.CourseGlimpse.startsOn] - Shows the start date for a course in a course glimpse in a short format such as Sep 4, '1986'
+#. [components.SearchFilterGroupModal.error] - Error message when the search for more filter value fails in the search filters modal.
 #. defaultMessage is:
-#. Starts on {date}
-#: i18n/js/components/CourseGlimpse/CourseGlimpse.json
-msgid "Starts on {date}"
-msgstr "Débute le {date}"
+#. There was an error while searching for {filterName}.
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "There was an error while searching for {filterName}."
+msgstr "La recherche de filtres pour {filterName} a rencontré une erreur."
+
+#. [components.SearchFilterGroupModal.queryTooShort] - Users need to enter at least 3 characters to search for more filter values; this message informs them when they start typing.
+#. defaultMessage is:
+#. Type at least 3 characters to start searching.
+#: i18n/js/components/SearchFilterGroupModal/index.json
+msgid "Type at least 3 characters to start searching."
+msgstr "Tapez 3 caractères ou plus pour commencer à chercher."
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {

--- a/src/richie/locale/fr_CA/LC_MESSAGES/django.po
+++ b/src/richie/locale/fr_CA/LC_MESSAGES/django.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: richie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-20 13:29+0000\n"
-"PO-Revision-Date: 2019-06-20 13:36\n"
+"POT-Creation-Date: 2019-08-28 15:20+0000\n"
+"PO-Revision-Date: 2019-08-29 11:54\n"
 "Last-Translator: Samuel Paccoud (sampaccoud)\n"
 "Language-Team: French, Canada\n"
 "Language: fr_CA\n"
@@ -22,7 +22,7 @@ msgstr "Plugins Richie"
 
 #: apps/core/fields/duration.py:62
 msgid "Define a duration as a number of time units"
-msgstr ""
+msgstr "Définir une durée avec un nombre d'unités de temps"
 
 #: apps/core/fields/duration.py:64 apps/core/fields/effort.py:77
 #, python-format
@@ -31,15 +31,15 @@ msgstr "%(value)s n'est pas un choix valide d'unité de temps."
 
 #: apps/core/fields/duration.py:209
 msgid "A composite duration should be a pair: number and time unit."
-msgstr "Une durée composite doit être une paire : nombre et unité de temps."
+msgstr "Une durée composite doit être une paire : nombre / unité de temps."
 
 #: apps/core/fields/duration.py:222
 msgid "A composite duration should be a round number of time units."
-msgstr "Un durée composite devrait être un nombre entier d'unités de temps."
+msgstr "Une durée composite doit être un nombre entier d'unités de temps."
 
 #: apps/core/fields/duration.py:230
 msgid "A composite duration should be positive."
-msgstr "Une durée composite devrait être positive."
+msgstr "Une durée composite doit être positive."
 
 #: apps/core/fields/effort.py:75
 msgid "Define an effort"
@@ -47,7 +47,7 @@ msgstr "Définir un effort"
 
 #: apps/core/fields/effort.py:244
 msgid "An effort should be a triplet: number, time unit and reference unit."
-msgstr "Un effort devrait être un triplet: nombre, unité de temps et unité de référence."
+msgstr "Un effort doit être un triplet: numéro / unité de temps / unité de référence."
 
 #: apps/core/fields/effort.py:257
 msgid "An effort should be a round number of time units."
@@ -55,11 +55,11 @@ msgstr "Un effort devrait être un nombre entier d'unités de temps."
 
 #: apps/core/fields/effort.py:264
 msgid "An effort should be positive."
-msgstr "Un effort devrait être positif."
+msgstr "Un effort doit être positif."
 
 #: apps/core/fields/effort.py:286
 msgid "The effort time unit should be shorter than the reference unit."
-msgstr "L'unité de temps d'effort doit être plus courte que l'unité de référence."
+msgstr "L'unité de temps d'effort doit être plus courte que l'unité de temps de référence."
 
 #: apps/core/fields/multiselect.py:27
 msgid "{:s} and {:s}"
@@ -95,7 +95,7 @@ msgstr "L'enregistrement de {:d} choix nécessite l'enregistrement d'un CharFiel
 msgid "Switch to %(lang.name_translated)s"
 msgstr "Basculer vers %(lang.name_translated)s"
 
-#: apps/core/templates/richie/base.html:60
+#: apps/core/templates/richie/base.html:63
 msgid "All Rights Reserved."
 msgstr "Tous droits réservés."
 
@@ -145,15 +145,15 @@ msgstr "Page Facebook"
 msgid "Twitter page"
 msgstr "Page Twitter"
 
-#: apps/courses/admin.py:71
+#: apps/courses/admin.py:77
 msgid "Course could not be found."
 msgstr "Le cours n'a pas pu être trouvé."
 
-#: apps/courses/admin.py:132
+#: apps/courses/admin.py:138
 msgid "See user group"
 msgstr "Voir le groupe d'utilisateurs"
 
-#: apps/courses/admin.py:133
+#: apps/courses/admin.py:139
 msgid "See filer folder"
 msgstr "Voir le dossier du classeur"
 
@@ -165,112 +165,112 @@ msgstr "License"
 msgid "{!s} settings"
 msgstr "Paramètres de {:s}"
 
-#: apps/courses/cms_toolbars.py:96
+#: apps/courses/cms_toolbars.py:105
 msgid "Snapshot this page..."
 msgstr "Prise d'un instantanée de cette page..."
 
-#: apps/courses/cms_toolbars.py:100
+#: apps/courses/cms_toolbars.py:109
 msgid "This will place a copy of this page as its child and move all its courseruns as children of its new copy."
-msgstr "Ceci copie la page vers une page enfant et les prestations de cours actuelles deviennent des enfants de cette copie."
+msgstr "Ceci copie la page vers une page enfant et les sessions de cours actuelles deviennent des enfants de cette copie."
 
-#: apps/courses/cms_wizards.py:68
+#: apps/courses/cms_wizards.py:58
 msgid "New page"
 msgstr "Nouvelle page"
 
-#: apps/courses/cms_wizards.py:72
+#: apps/courses/cms_wizards.py:62
 msgid "Create a new page next to the current page."
 msgstr "Créer une nouvelle page à côté de la page actuelle."
 
-#: apps/courses/cms_wizards.py:79
+#: apps/courses/cms_wizards.py:69
 msgid "New sub page"
 msgstr "Nouvelle sous-page"
 
-#: apps/courses/cms_wizards.py:83
+#: apps/courses/cms_wizards.py:73
 msgid "Create a page below the current page."
 msgstr "Créer une page sous la page actuelle."
 
-#: apps/courses/cms_wizards.py:98
+#: apps/courses/cms_wizards.py:88
 msgid "Page title"
 msgstr "Titre de la page"
 
-#: apps/courses/cms_wizards.py:99
+#: apps/courses/cms_wizards.py:89
 msgid "Title of the page in current language"
 msgstr "Titre de la page dans la langue actuelle"
 
-#: apps/courses/cms_wizards.py:106
+#: apps/courses/cms_wizards.py:96
 msgid "Page slug"
 msgstr "Chemin de la page"
 
-#: apps/courses/cms_wizards.py:107
+#: apps/courses/cms_wizards.py:97
 msgid "Slug of the page in current language"
 msgstr "Chemin de la page dans la langue actuelle"
 
-#: apps/courses/cms_wizards.py:129
+#: apps/courses/cms_wizards.py:119
 msgid "This slug is too long. The length of the path built by prepending the slug of the parent page would be {:d} characters long and it should be less than 255"
 msgstr "Ce chemin est trop long. Le lien construit en faisant précéder ce chemin par le lien de la page parente serait trop long de {:d} caractères et devrait être de moins de 255 caractères"
 
-#: apps/courses/cms_wizards.py:142
+#: apps/courses/cms_wizards.py:132
 msgid "This slug is already in use"
 msgstr "Ce chemin est déjà utilisé"
 
-#: apps/courses/cms_wizards.py:160
+#: apps/courses/cms_wizards.py:150
 #, python-brace-format
 msgid "You must first create a parent page and set its `reverse_id` to `{reverse}`."
 msgstr "Vous devez d’abord créer une page parente dont le 'reverse_id' est la valeur '{reverse} '."
 
-#: apps/courses/cms_wizards.py:319
+#: apps/courses/cms_wizards.py:261
 msgid "New course page"
 msgstr "Nouvelle page de cours"
 
-#: apps/courses/cms_wizards.py:320
+#: apps/courses/cms_wizards.py:262
 msgid "Create a new course page"
 msgstr "Créez une nouvelle page de cours"
 
-#: apps/courses/cms_wizards.py:335
+#: apps/courses/cms_wizards.py:277
 msgid "Snapshot the course"
 msgstr "Capture instantanée de ce cours"
 
-#: apps/courses/cms_wizards.py:337
+#: apps/courses/cms_wizards.py:279
 msgid "Tick this box if you want to snapshot the current version of the course and link the new course run to a new version of the course."
-msgstr "Cocher cette case si vous voulez faire une capture instantanée de la version actuelle du cours et attacher la nouvelle prestation de cours à une nouvelle version du cours."
+msgstr "Cocher cette case si vous voulez faire une capture instantanée de la version actuelle du cours et attacher la nouvelle session de cours à une nouvelle version du cours."
 
-#: apps/courses/cms_wizards.py:454
+#: apps/courses/cms_wizards.py:396
 msgid "New course run page"
-msgstr "Nouvelle page de prestation de cours"
+msgstr "Nouvelle page de session de cours"
 
-#: apps/courses/cms_wizards.py:455
+#: apps/courses/cms_wizards.py:397
 msgid "Create a new course run page"
-msgstr "Créez une nouvelle page de prestation de cours"
+msgstr "Créez une nouvelle page de session de cours"
 
-#: apps/courses/cms_wizards.py:539
+#: apps/courses/cms_wizards.py:449
 msgid "New organization page"
 msgstr "Nouvelle page d'institution"
 
-#: apps/courses/cms_wizards.py:540
+#: apps/courses/cms_wizards.py:450
 msgid "Create a new organization page"
 msgstr "Créer une nouvelle page d'institution"
 
-#: apps/courses/cms_wizards.py:605
+#: apps/courses/cms_wizards.py:515
 msgid "New category page"
 msgstr "Nouvelle page de catégorie"
 
-#: apps/courses/cms_wizards.py:606
+#: apps/courses/cms_wizards.py:516
 msgid "Create a new category page"
 msgstr "Créer une nouvelle page de catégorie"
 
-#: apps/courses/cms_wizards.py:657
+#: apps/courses/cms_wizards.py:567
 msgid "New blog post"
 msgstr "Nouveau message de blog"
 
-#: apps/courses/cms_wizards.py:658
+#: apps/courses/cms_wizards.py:568
 msgid "Create a new blog post"
 msgstr "Créer un nouveau message de blog"
 
-#: apps/courses/cms_wizards.py:709
+#: apps/courses/cms_wizards.py:619
 msgid "New person page"
 msgstr "Nouvelle page de personne"
 
-#: apps/courses/cms_wizards.py:710
+#: apps/courses/cms_wizards.py:620
 msgid "Create a new person page"
 msgstr "Créer une nouvelle page de personne"
 
@@ -318,15 +318,15 @@ msgstr "mois"
 msgid "months"
 msgstr "mois"
 
-#: apps/courses/helpers.py:32
+#: apps/courses/helpers.py:33
 msgid "You can't snapshot a snapshot."
 msgstr "Vous ne pouvez pas faire une capture instantanée d'une capture instantanée."
 
-#: apps/courses/helpers.py:45
+#: apps/courses/helpers.py:46
 msgid "You don't have sufficient permissions to snapshot this page."
 msgstr "Vous n'avez pas les permissions suffisantes pour faire une capture instantanée de cette page."
 
-#: apps/courses/helpers.py:61
+#: apps/courses/helpers.py:62
 msgid "Snapshot of {:s}"
 msgstr "Instantané de {:s}"
 
@@ -338,127 +338,125 @@ msgstr "message de blog"
 msgid "blog post plugin"
 msgstr "plugin pour message de blog"
 
-#: apps/courses/models/category.py:34
+#: apps/courses/models/category.py:36
 msgid "category"
 msgstr "catégorie"
 
-#: apps/courses/models/category.py:220
+#: apps/courses/models/category.py:218
 msgid "category plugin"
 msgstr "plugin de catégorie"
 
-#: apps/courses/models/course.py:37 apps/courses/models/course.py:38
+#: apps/courses/models/course.py:41 apps/courses/models/course.py:42
 msgid "enroll now"
-msgstr "s’inscrire maintenant"
+msgstr "s’inscrire"
 
-#: apps/courses/models/course.py:39
+#: apps/courses/models/course.py:43
 msgid "see details"
 msgstr "voir les détails"
 
-#: apps/courses/models/course.py:47
+#: apps/courses/models/course.py:51
 msgid "closing on"
-msgstr "termine le"
+msgstr "ouvert jusqu'au"
 
-#: apps/courses/models/course.py:48 apps/courses/models/course.py:49
+#: apps/courses/models/course.py:52 apps/courses/models/course.py:53
 msgid "starting on"
 msgstr "débute le"
 
-#: apps/courses/models/course.py:50
+#: apps/courses/models/course.py:54
 msgid "enrollment closed"
 msgstr "inscription fermée"
 
-#: apps/courses/models/course.py:51
+#: apps/courses/models/course.py:55
 msgid "on-going"
 msgstr "en cours"
 
-#: apps/courses/models/course.py:52
+#: apps/courses/models/course.py:56
 msgid "archived"
 msgstr "archivé"
 
-#: apps/courses/models/course.py:53
+#: apps/courses/models/course.py:57
 msgid "to be scheduled"
 msgstr "à planifier"
 
-#: apps/courses/models/course.py:80
+#: apps/courses/models/course.py:84
 msgid "forever open"
 msgstr "toujours ouvert"
 
-#: apps/courses/models/course.py:136
+#: apps/courses/models/course.py:140
 msgid "course"
 msgstr "cours"
 
-#: apps/courses/models/course.py:346
-#: apps/courses/templates/courses/cms/course_detail.html:128
+#: apps/courses/models/course.py:437
+#: apps/courses/templates/courses/cms/course_detail.html:139
 #: apps/courses/templates/courses/cms/course_run_detail.html:74
 msgid "Resource link"
 msgstr "Lien de la ressource"
 
-#: apps/courses/models/course.py:347
+#: apps/courses/models/course.py:438
 msgid "course start"
 msgstr "début du cours"
 
-#: apps/courses/models/course.py:348
+#: apps/courses/models/course.py:439
 msgid "course end"
 msgstr "fin du cours"
 
-#: apps/courses/models/course.py:350
+#: apps/courses/models/course.py:441
 msgid "enrollment start"
 msgstr "début des inscriptions"
 
-#: apps/courses/models/course.py:352
+#: apps/courses/models/course.py:443
 msgid "enrollment end"
 msgstr "fin des inscriptions"
 
-#: apps/courses/models/course.py:360
+#: apps/courses/models/course.py:451
 msgid "The list of languages in which the course content is available."
 msgstr "Les langues dans lesquelles le contenu du cours est disponible."
 
-#: apps/courses/models/course.py:367
+#: apps/courses/models/course.py:458
 msgid "course run"
-msgstr "prestation de cours"
+msgstr "session de cours"
 
-#: apps/courses/models/course.py:473
+#: apps/courses/models/course.py:564
 msgid "course plugin"
 msgstr "plugin de cours"
 
-#: apps/courses/models/course.py:489
+#: apps/courses/models/course.py:580
 msgid "name"
 msgstr "nom"
 
-#: apps/courses/models/course.py:491
-#: apps/courses/templates/courses/plugins/course_plugin.html:5
-#: plugins/large_banner/models.py:38
+#: apps/courses/models/course.py:582 plugins/large_banner/models.py:38
 msgid "logo"
 msgstr "logo"
 
-#: apps/courses/models/course.py:493
+#: apps/courses/models/course.py:584
 msgid "url"
 msgstr "url"
 
-#: apps/courses/models/course.py:494
+#: apps/courses/models/course.py:585
 msgid "content"
 msgstr "contenu"
 
-#: apps/courses/models/course.py:498
+#: apps/courses/models/course.py:589
 msgid "licence"
 msgstr "license"
 
-#: apps/courses/models/course.py:513
+#: apps/courses/models/course.py:604
 msgid "description"
 msgstr "description"
 
-#: apps/courses/models/course.py:517
+#: apps/courses/models/course.py:608
 msgid "licence plugin"
 msgstr "plugin de licence"
 
-#: apps/courses/models/organization.py:31
+#: apps/courses/models/organization.py:35
 msgid "code"
 msgstr "code"
 
-#: apps/courses/models/organization.py:38
+#: apps/courses/models/organization.py:42
 msgid "organization"
 msgstr "institution"
 
-#: apps/courses/models/organization.py:172
+#: apps/courses/models/organization.py:227
 msgid "organization plugin"
 msgstr "plugin d'institution"
 
@@ -466,7 +464,7 @@ msgstr "plugin d'institution"
 msgid "person"
 msgstr "personne"
 
-#: apps/courses/models/person.py:134
+#: apps/courses/models/person.py:131
 msgid "person plugin"
 msgstr "plugin de personne"
 
@@ -516,7 +514,7 @@ msgstr "Page de cours"
 
 #: apps/courses/settings/__init__.py:33
 msgid "Course run page"
-msgstr "Page de prestation de cours"
+msgstr "Page de session de cours"
 
 #: apps/courses/settings/__init__.py:34
 msgid "Organization list"
@@ -570,127 +568,140 @@ msgstr "Colonne unique"
 msgid "Main content"
 msgstr "Contenu principal"
 
-#: apps/courses/settings/__init__.py:88 apps/courses/settings/__init__.py:210
+#: apps/courses/settings/__init__.py:88 apps/courses/settings/__init__.py:229
 #: apps/courses/templates/courses/cms/blogpost_detail.html:38
-#: apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html:7
-#: apps/courses/templates/courses/cms/fragment_course_glimpse.html:7
+#: apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html:8
+#: apps/courses/templates/courses/cms/fragment_course_glimpse.html:8
 msgid "Cover"
 msgstr "Couverture"
 
 #: apps/courses/settings/__init__.py:93
+msgid "Catch phrase"
+msgstr "Slogan"
+
+#: apps/courses/settings/__init__.py:98
 msgid "Teaser"
 msgstr "Accroche"
 
-#: apps/courses/settings/__init__.py:98
+#: apps/courses/settings/__init__.py:103
+#: apps/courses/templates/courses/cms/fragment_course_content.html:11
 msgid "About the course"
 msgstr "À propos du cours"
 
-#: apps/courses/settings/__init__.py:102
+#: apps/courses/settings/__init__.py:107
 #: apps/courses/templates/courses/cms/fragment_course_content.html:22
+msgid "What you will learn"
+msgstr "Ce que vous apprendrez"
+
+#: apps/courses/settings/__init__.py:111
+#: apps/courses/templates/courses/cms/fragment_course_content.html:30
 msgid "Format"
 msgstr "Format"
 
-#: apps/courses/settings/__init__.py:106
-#: apps/courses/templates/courses/cms/fragment_course_content.html:31
+#: apps/courses/settings/__init__.py:115
+#: apps/courses/templates/courses/cms/fragment_course_content.html:39
 msgid "Prerequisites"
 msgstr "Prérequis"
 
-#: apps/courses/settings/__init__.py:110
+#: apps/courses/settings/__init__.py:119
 msgid "Team"
 msgstr "Équipe"
 
-#: apps/courses/settings/__init__.py:114
+#: apps/courses/settings/__init__.py:123
 msgid "Plan"
 msgstr "Plan"
 
-#: apps/courses/settings/__init__.py:118
+#: apps/courses/settings/__init__.py:127
 msgid "Complementary information"
 msgstr "Informations complémentaires"
 
-#: apps/courses/settings/__init__.py:127
-#: apps/courses/templates/courses/cms/fragment_course_content.html:94
+#: apps/courses/settings/__init__.py:136
+#: apps/courses/templates/courses/cms/fragment_course_content.html:110
 msgid "License for the course content"
 msgstr "Licence pour le contenu du cours"
 
-#: apps/courses/settings/__init__.py:132
-#: apps/courses/templates/courses/cms/fragment_course_content.html:103
+#: apps/courses/settings/__init__.py:141
+#: apps/courses/templates/courses/cms/fragment_course_content.html:119
 msgid "License for the content created by course participants"
 msgstr "Licence pour le contenu créé par les participants du cours"
 
-#: apps/courses/settings/__init__.py:137 apps/courses/settings/__init__.py:182
-#: apps/courses/settings/__init__.py:206
+#: apps/courses/settings/__init__.py:146 apps/courses/settings/__init__.py:201
+#: apps/courses/settings/__init__.py:225
 msgid "Categories"
 msgstr "Catégories"
 
-#: apps/courses/settings/__init__.py:141 apps/courses/settings/__init__.py:196
-#: apps/courses/templates/courses/cms/fragment_course_content.html:61
-#: apps/courses/templates/courses/cms/person_detail.html:53
-#: apps/search/defaults.py:105
+#: apps/courses/settings/__init__.py:150 apps/courses/settings/__init__.py:190
+msgid "Icon"
+msgstr ""
+
+#: apps/courses/settings/__init__.py:155 apps/courses/settings/__init__.py:215
+#: apps/courses/templates/courses/cms/fragment_course_content.html:69
+#: apps/courses/templates/courses/cms/person_detail.html:50
+#: apps/search/defaults.py:110
 msgid "Organizations"
 msgstr "Institutions"
 
-#: apps/courses/settings/__init__.py:145
+#: apps/courses/settings/__init__.py:159
 msgid "Assessment and Certification"
-msgstr "Évaluation et Certification"
+msgstr "Évaluation et Attestation"
 
-#: apps/courses/settings/__init__.py:150 apps/courses/settings/__init__.py:166
+#: apps/courses/settings/__init__.py:164 apps/courses/settings/__init__.py:180
 #: apps/courses/templates/courses/cms/category_detail.html:9
 #: apps/courses/templates/courses/cms/organization_detail.html:9
 msgid "Banner"
 msgstr "Bannière"
 
-#: apps/courses/settings/__init__.py:155 apps/courses/settings/__init__.py:171
+#: apps/courses/settings/__init__.py:169 apps/courses/settings/__init__.py:185
 #: apps/courses/templates/courses/cms/category_detail.html:27
 #: apps/courses/templates/courses/cms/fragment_category_glimpse.html:9
 #: apps/courses/templates/courses/cms/fragment_organization_glimpse.html:8
-#: apps/courses/templates/courses/cms/organization_detail.html:27
+#: apps/courses/templates/courses/cms/organization_detail.html:29
 msgid "Logo"
 msgstr "Logo"
 
-#: apps/courses/settings/__init__.py:160 apps/courses/settings/__init__.py:176
+#: apps/courses/settings/__init__.py:174 apps/courses/settings/__init__.py:195
 msgid "Description"
 msgstr "Description"
 
-#: apps/courses/settings/__init__.py:186
-#: apps/courses/templates/courses/cms/fragment_person_glimpse.html:8
-#: apps/courses/templates/courses/cms/person_detail.html:24
+#: apps/courses/settings/__init__.py:205
+#: apps/courses/templates/courses/cms/fragment_person_glimpse.html:10
+#: apps/courses/templates/courses/cms/person_detail.html:10
 msgid "Portrait"
 msgstr "Portrait"
 
-#: apps/courses/settings/__init__.py:191
+#: apps/courses/settings/__init__.py:210
 msgid "Bio"
 msgstr "Bio"
 
-#: apps/courses/settings/__init__.py:201
+#: apps/courses/settings/__init__.py:220
 msgid "Author"
 msgstr "Auteur"
 
-#: apps/courses/settings/__init__.py:215
+#: apps/courses/settings/__init__.py:234
 msgid "Excerpt"
 msgstr "Extrait"
 
-#: apps/courses/settings/__init__.py:220
+#: apps/courses/settings/__init__.py:239
 msgid "Body"
 msgstr "Corps"
 
-#: apps/courses/settings/__init__.py:281
+#: apps/courses/settings/__init__.py:321
 msgid "Button caesura"
 msgstr "Bouton caesura"
 
-#: apps/courses/settings/__init__.py:283
+#: apps/courses/settings/__init__.py:323
 msgid "Full width"
 msgstr "Pleine largeur"
 
 #: apps/courses/templates/courses/cms/blogpost_detail.html:17
-msgid "No author yet."
-msgstr "Pas d'auteur."
+msgid "No author yet"
+msgstr ""
 
 #: apps/courses/templates/courses/cms/blogpost_detail.html:30
 msgid "No categories yet."
 msgstr "Pas de catégories."
 
 #: apps/courses/templates/courses/cms/blogpost_detail.html:49
-#: apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html:17
 msgid "blog post cover image"
 msgstr "image de couverture de billet de blog"
 
@@ -702,7 +713,7 @@ msgstr "Aucun extrait de contenu"
 msgid "No body content"
 msgstr "Aucun contenu"
 
-#: apps/courses/templates/courses/cms/blogpost_list.html:16
+#: apps/courses/templates/courses/cms/blogpost_list.html:14
 msgid "No associated blogposts"
 msgstr "Aucun message de blogue associé"
 
@@ -714,21 +725,21 @@ msgstr "bannière de catégorie"
 msgid "category logo"
 msgstr "logo de catégorie"
 
-#: apps/courses/templates/courses/cms/category_detail.html:55
-#: apps/courses/templates/courses/cms/organization_detail.html:55
+#: apps/courses/templates/courses/cms/category_detail.html:73
+#: apps/courses/templates/courses/cms/organization_detail.html:58
 msgid "Related courses"
-msgstr "Cours connexes"
+msgstr "Cours offerts"
 
-#: apps/courses/templates/courses/cms/category_detail.html:74
+#: apps/courses/templates/courses/cms/category_detail.html:86
 msgid "Sub categories"
 msgstr "Sous-catégories"
 
-#: apps/courses/templates/courses/cms/category_detail.html:85
+#: apps/courses/templates/courses/cms/category_detail.html:97
 msgid "Related blogposts"
 msgstr "Billets de blog liés"
 
-#: apps/courses/templates/courses/cms/category_detail.html:104
-#: apps/courses/templates/courses/cms/organization_detail.html:74
+#: apps/courses/templates/courses/cms/category_detail.html:110
+#: apps/courses/templates/courses/cms/organization_detail.html:71
 msgid "Related persons"
 msgstr "Personnes liées"
 
@@ -749,60 +760,59 @@ msgstr "\n"
 msgid "Go to current version"
 msgstr "Accédez à la version actuelle"
 
-#: apps/courses/templates/courses/cms/course_detail.html:40
+#: apps/courses/templates/courses/cms/course_detail.html:49
 #: apps/courses/templates/courses/cms/course_run_detail.html:33
-#: apps/courses/templates/courses/cms/person_detail.html:14
+#: apps/courses/templates/courses/cms/person_detail.html:34
 msgid "No associated categories"
 msgstr "Aucune catégorie associée"
 
-#: apps/courses/templates/courses/cms/course_detail.html:54
+#: apps/courses/templates/courses/cms/course_detail.html:65
 msgid "Add an image for course cover on its glimpse."
 msgstr "Ajouter une image pour la couverture du cours sur son aperçu."
 
-#: apps/courses/templates/courses/cms/course_detail.html:65
-#: apps/courses/templates/courses/cms/fragment_course_glimpse.html:17
+#: apps/courses/templates/courses/cms/course_detail.html:76
 msgid "course cover image"
 msgstr "image de couverture du cours"
 
-#: apps/courses/templates/courses/cms/course_detail.html:97
+#: apps/courses/templates/courses/cms/course_detail.html:108
 msgid "Duration:"
-msgstr ""
+msgstr "Durée :"
 
-#: apps/courses/templates/courses/cms/course_detail.html:101
+#: apps/courses/templates/courses/cms/course_detail.html:112
 msgid "Effort:"
-msgstr ""
+msgstr "Effort :"
 
-#: apps/courses/templates/courses/cms/course_detail.html:110
+#: apps/courses/templates/courses/cms/course_detail.html:121
 msgid "Course runs"
-msgstr "Prestations de cours"
+msgstr "Sessions de cours"
 
-#: apps/courses/templates/courses/cms/course_detail.html:114
+#: apps/courses/templates/courses/cms/course_detail.html:125
 msgid "Enrollment"
 msgstr "Inscription"
 
-#: apps/courses/templates/courses/cms/course_detail.html:118
-#: apps/courses/templates/courses/cms/course_detail.html:124
+#: apps/courses/templates/courses/cms/course_detail.html:129
+#: apps/courses/templates/courses/cms/course_detail.html:135
 msgid "From"
 msgstr "Du"
 
-#: apps/courses/templates/courses/cms/course_detail.html:118
-#: apps/courses/templates/courses/cms/course_detail.html:124
+#: apps/courses/templates/courses/cms/course_detail.html:129
+#: apps/courses/templates/courses/cms/course_detail.html:135
 msgid "to"
 msgstr "au"
 
-#: apps/courses/templates/courses/cms/course_detail.html:120
+#: apps/courses/templates/courses/cms/course_detail.html:131
 msgid "Course"
 msgstr "Cours"
 
-#: apps/courses/templates/courses/cms/course_detail.html:126
+#: apps/courses/templates/courses/cms/course_detail.html:137
 #: apps/courses/templates/courses/cms/course_run_detail.html:59
-#: apps/search/defaults.py:66
+#: apps/search/defaults.py:69
 msgid "Languages"
 msgstr "Langues"
 
-#: apps/courses/templates/courses/cms/course_detail.html:147
+#: apps/courses/templates/courses/cms/course_detail.html:158
 msgid "No associated course runs"
-msgstr "Aucune prestation de cours n'est disponible"
+msgstr "Aucune session de cours n'est disponible"
 
 #: apps/courses/templates/courses/cms/course_run_detail.html:40
 msgid "Details"
@@ -824,78 +834,68 @@ msgstr "Début du cours"
 msgid "Course ends"
 msgstr "Fin du cours"
 
-#: apps/courses/templates/courses/cms/fragment_category_glimpse.html:19
-#, python-format
-msgid "%(title)s logo"
-msgstr "logo %(title)s"
-
 #: apps/courses/templates/courses/cms/fragment_course_content.html:5
 msgid "Add a video or teaser."
 msgstr "Ajouter une bande annonce ou une image."
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:11
-msgid "About the course..."
-msgstr "A propos du cours..."
-
 #: apps/courses/templates/courses/cms/fragment_course_content.html:14
-msgid "Enter here a short description of your course."
-msgstr "Entrez une courte description du cours."
+msgid "Enter here a description of your course."
+msgstr "Entrez une description de votre cours."
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:24
+#: apps/courses/templates/courses/cms/fragment_course_content.html:23
+msgid "At the end of this course, you will be able to:"
+msgstr "À la fin de ce cours, vous pourrez :"
+
+#: apps/courses/templates/courses/cms/fragment_course_content.html:32
 msgid "How is the course structured?"
 msgstr "Quelle est la structure du cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:33
+#: apps/courses/templates/courses/cms/fragment_course_content.html:41
 msgid "What are the prerequisites to follow this course?"
 msgstr "Quels sont les prérequis pour suivre ce cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:40
+#: apps/courses/templates/courses/cms/fragment_course_content.html:48
 msgid "Course plan"
 msgstr "Plan de cours"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:42
+#: apps/courses/templates/courses/cms/fragment_course_content.html:50
 msgid "Enter here the detailed course plan."
 msgstr "Détaillez ici le plan du cours."
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:49
+#: apps/courses/templates/courses/cms/fragment_course_content.html:57
 msgid "Assessment and certification"
-msgstr "Évaluation et Certification"
+msgstr "Évaluation et attestation"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:52
+#: apps/courses/templates/courses/cms/fragment_course_content.html:60
 msgid "How is progress evaluated and/or certified?"
-msgstr "Comment les étudiants sont ils évalués et/ou certifiés ?"
+msgstr "Comment les étudiants sont ils évalués ou attestés ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:65
+#: apps/courses/templates/courses/cms/fragment_course_content.html:73
 msgid "What are the organizations publishing this course?"
 msgstr "Quelles sont les institutions publiant ce cours?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:74
+#: apps/courses/templates/courses/cms/fragment_course_content.html:86
 msgid "Course team"
-msgstr "Équipe enseignante"
+msgstr "Équipe pédagogique"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:78
+#: apps/courses/templates/courses/cms/fragment_course_content.html:90
 msgid "Who are the teachers in the course team?"
-msgstr "Qui sont les membres de l’équipe enseignante ?"
+msgstr "Qui sont les enseignants de l’équipe pédagogique ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:91
+#: apps/courses/templates/courses/cms/fragment_course_content.html:107
 msgid "License"
 msgstr "Licence"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:97
+#: apps/courses/templates/courses/cms/fragment_course_content.html:113
 msgid "What is the license for the course content?"
 msgstr "Quelle est la licence pour le contenu du cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:106
+#: apps/courses/templates/courses/cms/fragment_course_content.html:122
 msgid "What is the license for the content created by course participants?"
 msgstr "Quelle est la licence pour le contenu créé par les participants du cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_organization_glimpse.html:18
-#: apps/courses/templates/courses/cms/organization_detail.html:38
-msgid "organization logo"
-msgstr "logo de l'institution"
-
-#: apps/courses/templates/courses/cms/fragment_organization_main_logo.html:8
-#: apps/courses/templates/courses/cms/fragment_organization_main_logo.html:25
+#: apps/courses/templates/courses/cms/fragment_organization_main_logo.html:7
+#: apps/courses/templates/courses/cms/fragment_organization_main_logo.html:26
 msgid "Main organization"
 msgstr "Institution principale"
 
@@ -903,37 +903,36 @@ msgstr "Institution principale"
 msgid "main organization logo"
 msgstr "logo de l'organisation principale"
 
-#: apps/courses/templates/courses/cms/fragment_person_glimpse.html:6
-msgid "avatar"
-msgstr "avatar"
-
-#: apps/courses/templates/courses/cms/fragment_person_glimpse.html:18
-#: apps/courses/templates/courses/cms/person_detail.html:35
-#, python-format
-msgid "%(title)s avatar"
-msgstr "avatar de %(title)s"
-
-#: apps/courses/templates/courses/cms/organization_detail.html:20
+#: apps/courses/templates/courses/cms/organization_detail.html:22
 msgid "organization banner"
 msgstr "bannière d'institution"
+
+#: apps/courses/templates/courses/cms/organization_detail.html:41
+msgid "organization logo"
+msgstr "logo de l'institution"
 
 #: apps/courses/templates/courses/cms/organization_list.html:14
 msgid "No organization yet"
 msgstr "Pas encore d'institution"
 
-#: apps/courses/templates/courses/cms/person_detail.html:43
+#: apps/courses/templates/courses/cms/person_detail.html:21
+#, python-format
+msgid "%(title)s avatar"
+msgstr "avatar de %(title)s"
+
+#: apps/courses/templates/courses/cms/person_detail.html:41
 msgid "Enter your bio here..."
 msgstr "Saisissez ici votre bio..."
 
-#: apps/courses/templates/courses/cms/person_detail.html:56
+#: apps/courses/templates/courses/cms/person_detail.html:53
 msgid "No associated organizations"
 msgstr "Aucune institution associée"
 
-#: apps/courses/templates/courses/cms/person_detail.html:65
+#: apps/courses/templates/courses/cms/person_detail.html:62
 msgid "Courses"
 msgstr "Cours"
 
-#: apps/courses/templates/courses/cms/person_detail.html:84
+#: apps/courses/templates/courses/cms/person_detail.html:75
 msgid "Blogposts"
 msgstr "Messages de blog"
 
@@ -941,43 +940,43 @@ msgstr "Messages de blog"
 msgid "No persons"
 msgstr "Pas de personnes"
 
-#: apps/search/defaults.py:41
+#: apps/search/defaults.py:44
 msgid "New courses"
 msgstr "Nouveaux cours"
 
-#: apps/search/defaults.py:45
+#: apps/search/defaults.py:48
 msgid "First session"
-msgstr "Première prestation"
+msgstr "Première session"
 
-#: apps/search/defaults.py:56
+#: apps/search/defaults.py:59
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: apps/search/defaults.py:81
+#: apps/search/defaults.py:84
 msgid "Subjects"
 msgstr "Sujets"
 
-#: apps/search/defaults.py:93
+#: apps/search/defaults.py:97
 msgid "Levels"
 msgstr "Niveaux"
 
-#: apps/search/defaults.py:116
+#: apps/search/defaults.py:122
 msgid "Persons"
 msgstr "Personnes"
 
-#: apps/search/filter_definitions/courses.py:253
+#: apps/search/filter_definitions/courses.py:379
 msgid "Open for enrollment"
 msgstr "Ouvert pour inscription"
 
-#: apps/search/filter_definitions/courses.py:254
+#: apps/search/filter_definitions/courses.py:380
 msgid "Coming soon"
 msgstr "À venir"
 
-#: apps/search/filter_definitions/courses.py:255
+#: apps/search/filter_definitions/courses.py:381
 msgid "On-going"
 msgstr "En cours"
 
-#: apps/search/filter_definitions/courses.py:256
+#: apps/search/filter_definitions/courses.py:382
 msgid "Archived"
 msgstr "Archivé"
 
@@ -987,11 +986,11 @@ msgstr "Plan de site HTML"
 
 #: plugins/html_sitemap/cms_plugins.py:72
 msgid "Press save to create a site map. You will then be able to add a child plugin for each subtree in your sitemap."
-msgstr "Appuyez sur Enregistrer pour créer une carte de site. Vous pourrez ensuite ajouter un plugin enfant pour chaque sous-branche dans votre plan de site."
+msgstr "Appuyez sur «Enregistrer» pour créer un plan de site. Vous pourrez ensuite ajouter un plugin enfant pour chaque sous-arbre de votre plan de site."
 
 #: plugins/html_sitemap/cms_plugins.py:82
 msgid "HTML sitemap page"
-msgstr "Page de carte du site HTML"
+msgstr "Page de site HTML"
 
 #: plugins/html_sitemap/models.py:25
 msgid "root page"
@@ -999,7 +998,7 @@ msgstr "page racine"
 
 #: plugins/html_sitemap/models.py:27
 msgid "This page will be at the root of your sitemap (or its children if the \"include root page\" flag is unticked)."
-msgstr ""
+msgstr "Cette page sera à la racine de votre plan de site (ou de ses enfants si «inclure la page racine» n'a pas été sélectionné)."
 
 #: plugins/html_sitemap/models.py:34
 msgid "max depth"
@@ -1007,15 +1006,15 @@ msgstr "profondeur maximale"
 
 #: plugins/html_sitemap/models.py:36
 msgid "Limit the level of nesting that your sitemap will contain below this page. An empty field or 0 equals to no limit."
-msgstr "Limitez le niveau d'imbriquage que votre plan de site contiendra sous cette page. Un champ vide ou 0 indique aucune limite."
+msgstr "Limitez la profondeur de votre plan de site sous cette page. Un champ vide ou égal à 0 correspond à une profondeur illimitée."
 
 #: plugins/html_sitemap/models.py:44
 msgid "in navigation"
-msgstr "dans la navigation"
+msgstr "dans le menu"
 
 #: plugins/html_sitemap/models.py:46
 msgid "Tick to exclude from sitemap the pages that are excluded from navigation."
-msgstr "Cocher pour exclure du plan de site les pages qui sont exclues de la navigation."
+msgstr "Sélectionner pour exclure du plan de site les pages qui sont exclues du menu."
 
 #: plugins/html_sitemap/models.py:51
 msgid "include root page"
@@ -1023,15 +1022,15 @@ msgstr "inclure la page racine"
 
 #: plugins/html_sitemap/models.py:53
 msgid "Tick to include the root page and its descendants. Untick to include only its descendants."
-msgstr "Cocher pour inclure la page racine et ses descendants. Décocher pour n'inclure que ses descendants."
+msgstr "Sélectionner pour inclure la page racine et ses descendants. Ne pas sélectionner pour n'inclure que les descendants de la page racine."
 
 #: plugins/html_sitemap/models.py:60
 msgid "HTML Sitemaps"
-msgstr "Plans de sites HTML"
+msgstr "Plans de site HTML"
 
 #: plugins/html_sitemap/models.py:66
 msgid "Sitemap"
-msgstr "Plan du site"
+msgstr "Plan de site"
 
 #: plugins/large_banner/cms_plugins.py:26
 msgid "Large Banner"
@@ -1065,7 +1064,7 @@ msgstr "Choisir un modèle d'affichage pour le plugin."
 msgid "Content"
 msgstr "Contenu"
 
-#: plugins/plain_text/cms_plugins.py:26
+#: plugins/plain_text/cms_plugins.py:29
 msgid "Plain text"
 msgstr "Texte brut"
 
@@ -1089,11 +1088,18 @@ msgstr "Modèle optionnel pour un rendu personnalisé."
 msgid "Image"
 msgstr "Image"
 
-#: plugins/simple_text_ckeditor/cms_plugins.py:27
+#: plugins/simple_text_ckeditor/cms_plugins.py:31
 msgid "Simple text"
 msgstr "Texte simple"
 
 #: plugins/simple_text_ckeditor/models.py:23
 msgid "body"
 msgstr "corps"
+
+#: plugins/simple_text_ckeditor/validators.py:16
+#, python-format
+msgid "Ensure this text has at most %(limit_value)d character (it has %(show_value)d)."
+msgid_plural "Ensure this text has at most %(limit_value)d characters (it has %(show_value)d)."
+msgstr[0] "Assurez-vous que ce texte a au maximum %(limit_value)d caractère (il a %(show_value)d)."
+msgstr[1] "Assurez-vous que ce texte a au maximum %(limit_value)d caractères (il a %(show_value)d)."
 

--- a/src/richie/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/richie/locale/fr_FR/LC_MESSAGES/django.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: richie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-06-20 13:29+0000\n"
-"PO-Revision-Date: 2019-06-20 13:36\n"
+"POT-Creation-Date: 2019-08-28 15:20+0000\n"
+"PO-Revision-Date: 2019-08-29 11:54\n"
 "Last-Translator: Samuel Paccoud (sampaccoud)\n"
 "Language-Team: French\n"
 "Language: fr_FR\n"
@@ -95,7 +95,7 @@ msgstr "L'enregistrement de {:d} choix nécessite l'enregistrement d'un CharFiel
 msgid "Switch to %(lang.name_translated)s"
 msgstr "Basculer vers %(lang.name_translated)s"
 
-#: apps/core/templates/richie/base.html:60
+#: apps/core/templates/richie/base.html:63
 msgid "All Rights Reserved."
 msgstr "Tous droits réservés."
 
@@ -145,15 +145,15 @@ msgstr "Page Facebook"
 msgid "Twitter page"
 msgstr "Page Twitter"
 
-#: apps/courses/admin.py:71
+#: apps/courses/admin.py:77
 msgid "Course could not be found."
 msgstr "Le cours n'a pas pu être trouvé."
 
-#: apps/courses/admin.py:132
+#: apps/courses/admin.py:138
 msgid "See user group"
 msgstr "Voir le groupe d'utilisateurs"
 
-#: apps/courses/admin.py:133
+#: apps/courses/admin.py:139
 msgid "See filer folder"
 msgstr "Voir le dossier du classeur"
 
@@ -165,112 +165,112 @@ msgstr "License"
 msgid "{!s} settings"
 msgstr "Paramètres de {:s}"
 
-#: apps/courses/cms_toolbars.py:96
+#: apps/courses/cms_toolbars.py:105
 msgid "Snapshot this page..."
 msgstr "Capture instantanée de cette page..."
 
-#: apps/courses/cms_toolbars.py:100
+#: apps/courses/cms_toolbars.py:109
 msgid "This will place a copy of this page as its child and move all its courseruns as children of its new copy."
 msgstr "Ceci copie la page vers une page enfant et les sessions de cours actuelles deviennent des enfants de cette copie."
 
-#: apps/courses/cms_wizards.py:68
+#: apps/courses/cms_wizards.py:58
 msgid "New page"
 msgstr "Nouvelle page"
 
-#: apps/courses/cms_wizards.py:72
+#: apps/courses/cms_wizards.py:62
 msgid "Create a new page next to the current page."
 msgstr "Créer une nouvelle page à côté de la page actuelle."
 
-#: apps/courses/cms_wizards.py:79
+#: apps/courses/cms_wizards.py:69
 msgid "New sub page"
 msgstr "Nouvelle sous-page"
 
-#: apps/courses/cms_wizards.py:83
+#: apps/courses/cms_wizards.py:73
 msgid "Create a page below the current page."
 msgstr "Créer une page sous la page actuelle."
 
-#: apps/courses/cms_wizards.py:98
+#: apps/courses/cms_wizards.py:88
 msgid "Page title"
 msgstr "Titre de la page"
 
-#: apps/courses/cms_wizards.py:99
+#: apps/courses/cms_wizards.py:89
 msgid "Title of the page in current language"
 msgstr "Titre de la page dans la langue actuelle"
 
-#: apps/courses/cms_wizards.py:106
+#: apps/courses/cms_wizards.py:96
 msgid "Page slug"
 msgstr "Chemin de la page"
 
-#: apps/courses/cms_wizards.py:107
+#: apps/courses/cms_wizards.py:97
 msgid "Slug of the page in current language"
 msgstr "Chemin de la page dans la langue actuelle"
 
-#: apps/courses/cms_wizards.py:129
+#: apps/courses/cms_wizards.py:119
 msgid "This slug is too long. The length of the path built by prepending the slug of the parent page would be {:d} characters long and it should be less than 255"
 msgstr "Ce chemin est trop long. Le lien construit en faisant précéder ce chemin par le lien de la page parente serait trop long de {:d} caractères et devrait être de moins de 255 caractères"
 
-#: apps/courses/cms_wizards.py:142
+#: apps/courses/cms_wizards.py:132
 msgid "This slug is already in use"
 msgstr "Ce chemin est déjà utilisé"
 
-#: apps/courses/cms_wizards.py:160
+#: apps/courses/cms_wizards.py:150
 #, python-brace-format
 msgid "You must first create a parent page and set its `reverse_id` to `{reverse}`."
 msgstr "Vous devez d’abord créer une page parente dont le 'reverse_id' est la valeur '{reverse} '."
 
-#: apps/courses/cms_wizards.py:319
+#: apps/courses/cms_wizards.py:261
 msgid "New course page"
 msgstr "Nouvelle page de cours"
 
-#: apps/courses/cms_wizards.py:320
+#: apps/courses/cms_wizards.py:262
 msgid "Create a new course page"
 msgstr "Créez une nouvelle page de cours"
 
-#: apps/courses/cms_wizards.py:335
+#: apps/courses/cms_wizards.py:277
 msgid "Snapshot the course"
 msgstr "Capture instantanée de ce cours"
 
-#: apps/courses/cms_wizards.py:337
+#: apps/courses/cms_wizards.py:279
 msgid "Tick this box if you want to snapshot the current version of the course and link the new course run to a new version of the course."
 msgstr "Cocher cette case si vous voulez faire une capture instantanée de la version actuelle du cours et attacher la nouvelle session de cours à une nouvelle version du cours."
 
-#: apps/courses/cms_wizards.py:454
+#: apps/courses/cms_wizards.py:396
 msgid "New course run page"
 msgstr "Nouvelle page de session de cours"
 
-#: apps/courses/cms_wizards.py:455
+#: apps/courses/cms_wizards.py:397
 msgid "Create a new course run page"
 msgstr "Créez une nouvelle page de session de cours"
 
-#: apps/courses/cms_wizards.py:539
+#: apps/courses/cms_wizards.py:449
 msgid "New organization page"
 msgstr "Nouvelle page d'établissement"
 
-#: apps/courses/cms_wizards.py:540
+#: apps/courses/cms_wizards.py:450
 msgid "Create a new organization page"
 msgstr "Créer une nouvelle page d'établissement"
 
-#: apps/courses/cms_wizards.py:605
+#: apps/courses/cms_wizards.py:515
 msgid "New category page"
 msgstr "Nouvelle page de catégorie"
 
-#: apps/courses/cms_wizards.py:606
+#: apps/courses/cms_wizards.py:516
 msgid "Create a new category page"
 msgstr "Créer une nouvelle page de catégorie"
 
-#: apps/courses/cms_wizards.py:657
+#: apps/courses/cms_wizards.py:567
 msgid "New blog post"
 msgstr "Nouveau billet de blog"
 
-#: apps/courses/cms_wizards.py:658
+#: apps/courses/cms_wizards.py:568
 msgid "Create a new blog post"
 msgstr "Créer un nouveau billet de blog"
 
-#: apps/courses/cms_wizards.py:709
+#: apps/courses/cms_wizards.py:619
 msgid "New person page"
 msgstr "Nouvelle page de personne"
 
-#: apps/courses/cms_wizards.py:710
+#: apps/courses/cms_wizards.py:620
 msgid "Create a new person page"
 msgstr "Créez une nouvelle page de personne"
 
@@ -318,15 +318,15 @@ msgstr "mois"
 msgid "months"
 msgstr "mois"
 
-#: apps/courses/helpers.py:32
+#: apps/courses/helpers.py:33
 msgid "You can't snapshot a snapshot."
 msgstr "Vous ne pouvez pas faire une capture instantanée d'une capture instantanée."
 
-#: apps/courses/helpers.py:45
+#: apps/courses/helpers.py:46
 msgid "You don't have sufficient permissions to snapshot this page."
 msgstr "Vous n'avez pas les permissions suffisantes pour faire une capture instantanée de cette page."
 
-#: apps/courses/helpers.py:61
+#: apps/courses/helpers.py:62
 msgid "Snapshot of {:s}"
 msgstr "Capture instantanée de {:s}"
 
@@ -338,127 +338,125 @@ msgstr "billet de blog"
 msgid "blog post plugin"
 msgstr "plugin de billet de blog"
 
-#: apps/courses/models/category.py:34
+#: apps/courses/models/category.py:36
 msgid "category"
 msgstr "catégorie"
 
-#: apps/courses/models/category.py:220
+#: apps/courses/models/category.py:218
 msgid "category plugin"
 msgstr "plugin de catégorie"
 
-#: apps/courses/models/course.py:37 apps/courses/models/course.py:38
+#: apps/courses/models/course.py:41 apps/courses/models/course.py:42
 msgid "enroll now"
 msgstr "s’inscrire maintenant"
 
-#: apps/courses/models/course.py:39
+#: apps/courses/models/course.py:43
 msgid "see details"
 msgstr "voir les détails"
 
-#: apps/courses/models/course.py:47
+#: apps/courses/models/course.py:51
 msgid "closing on"
 msgstr "termine le"
 
-#: apps/courses/models/course.py:48 apps/courses/models/course.py:49
+#: apps/courses/models/course.py:52 apps/courses/models/course.py:53
 msgid "starting on"
 msgstr "débute le"
 
-#: apps/courses/models/course.py:50
+#: apps/courses/models/course.py:54
 msgid "enrollment closed"
 msgstr "inscription fermée"
 
-#: apps/courses/models/course.py:51
+#: apps/courses/models/course.py:55
 msgid "on-going"
 msgstr "en cours"
 
-#: apps/courses/models/course.py:52
+#: apps/courses/models/course.py:56
 msgid "archived"
 msgstr "archivé"
 
-#: apps/courses/models/course.py:53
+#: apps/courses/models/course.py:57
 msgid "to be scheduled"
 msgstr "à programmer"
 
-#: apps/courses/models/course.py:80
+#: apps/courses/models/course.py:84
 msgid "forever open"
 msgstr "toujours ouvert"
 
-#: apps/courses/models/course.py:136
+#: apps/courses/models/course.py:140
 msgid "course"
 msgstr "cours"
 
-#: apps/courses/models/course.py:346
-#: apps/courses/templates/courses/cms/course_detail.html:128
+#: apps/courses/models/course.py:437
+#: apps/courses/templates/courses/cms/course_detail.html:139
 #: apps/courses/templates/courses/cms/course_run_detail.html:74
 msgid "Resource link"
 msgstr "Lien de la ressource"
 
-#: apps/courses/models/course.py:347
+#: apps/courses/models/course.py:438
 msgid "course start"
 msgstr "début du cours"
 
-#: apps/courses/models/course.py:348
+#: apps/courses/models/course.py:439
 msgid "course end"
 msgstr "fin du cours"
 
-#: apps/courses/models/course.py:350
+#: apps/courses/models/course.py:441
 msgid "enrollment start"
 msgstr "début des inscriptions"
 
-#: apps/courses/models/course.py:352
+#: apps/courses/models/course.py:443
 msgid "enrollment end"
 msgstr "fin des inscriptions"
 
-#: apps/courses/models/course.py:360
+#: apps/courses/models/course.py:451
 msgid "The list of languages in which the course content is available."
 msgstr "Les langues dans lesquelles le contenu du cours est disponible."
 
-#: apps/courses/models/course.py:367
+#: apps/courses/models/course.py:458
 msgid "course run"
 msgstr "session de cours"
 
-#: apps/courses/models/course.py:473
+#: apps/courses/models/course.py:564
 msgid "course plugin"
 msgstr "plugin de cours"
 
-#: apps/courses/models/course.py:489
+#: apps/courses/models/course.py:580
 msgid "name"
 msgstr "nom"
 
-#: apps/courses/models/course.py:491
-#: apps/courses/templates/courses/plugins/course_plugin.html:5
-#: plugins/large_banner/models.py:38
+#: apps/courses/models/course.py:582 plugins/large_banner/models.py:38
 msgid "logo"
 msgstr "logo"
 
-#: apps/courses/models/course.py:493
+#: apps/courses/models/course.py:584
 msgid "url"
 msgstr "url"
 
-#: apps/courses/models/course.py:494
+#: apps/courses/models/course.py:585
 msgid "content"
 msgstr "contenu"
 
-#: apps/courses/models/course.py:498
+#: apps/courses/models/course.py:589
 msgid "licence"
 msgstr "license"
 
-#: apps/courses/models/course.py:513
+#: apps/courses/models/course.py:604
 msgid "description"
 msgstr "description"
 
-#: apps/courses/models/course.py:517
+#: apps/courses/models/course.py:608
 msgid "licence plugin"
 msgstr "plugin de licence"
 
-#: apps/courses/models/organization.py:31
+#: apps/courses/models/organization.py:35
 msgid "code"
 msgstr "code"
 
-#: apps/courses/models/organization.py:38
+#: apps/courses/models/organization.py:42
 msgid "organization"
 msgstr "établissement"
 
-#: apps/courses/models/organization.py:172
+#: apps/courses/models/organization.py:227
 msgid "organization plugin"
 msgstr "plugin d'établissement"
 
@@ -466,7 +464,7 @@ msgstr "plugin d'établissement"
 msgid "person"
 msgstr "personnes"
 
-#: apps/courses/models/person.py:134
+#: apps/courses/models/person.py:131
 msgid "person plugin"
 msgstr "plugin de personne"
 
@@ -570,127 +568,140 @@ msgstr "Colonne unique"
 msgid "Main content"
 msgstr "Contenu principal"
 
-#: apps/courses/settings/__init__.py:88 apps/courses/settings/__init__.py:210
+#: apps/courses/settings/__init__.py:88 apps/courses/settings/__init__.py:229
 #: apps/courses/templates/courses/cms/blogpost_detail.html:38
-#: apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html:7
-#: apps/courses/templates/courses/cms/fragment_course_glimpse.html:7
+#: apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html:8
+#: apps/courses/templates/courses/cms/fragment_course_glimpse.html:8
 msgid "Cover"
 msgstr "Couverture"
 
 #: apps/courses/settings/__init__.py:93
+msgid "Catch phrase"
+msgstr "Slogan"
+
+#: apps/courses/settings/__init__.py:98
 msgid "Teaser"
 msgstr "Accroche"
 
-#: apps/courses/settings/__init__.py:98
+#: apps/courses/settings/__init__.py:103
+#: apps/courses/templates/courses/cms/fragment_course_content.html:11
 msgid "About the course"
 msgstr "À propos du cours"
 
-#: apps/courses/settings/__init__.py:102
+#: apps/courses/settings/__init__.py:107
 #: apps/courses/templates/courses/cms/fragment_course_content.html:22
+msgid "What you will learn"
+msgstr "Ce que vous allez apprendre"
+
+#: apps/courses/settings/__init__.py:111
+#: apps/courses/templates/courses/cms/fragment_course_content.html:30
 msgid "Format"
 msgstr "Format"
 
-#: apps/courses/settings/__init__.py:106
-#: apps/courses/templates/courses/cms/fragment_course_content.html:31
+#: apps/courses/settings/__init__.py:115
+#: apps/courses/templates/courses/cms/fragment_course_content.html:39
 msgid "Prerequisites"
 msgstr "Prérequis"
 
-#: apps/courses/settings/__init__.py:110
+#: apps/courses/settings/__init__.py:119
 msgid "Team"
 msgstr "Équipe"
 
-#: apps/courses/settings/__init__.py:114
+#: apps/courses/settings/__init__.py:123
 msgid "Plan"
 msgstr "Plan"
 
-#: apps/courses/settings/__init__.py:118
+#: apps/courses/settings/__init__.py:127
 msgid "Complementary information"
 msgstr "Informations complémentaires"
 
-#: apps/courses/settings/__init__.py:127
-#: apps/courses/templates/courses/cms/fragment_course_content.html:94
+#: apps/courses/settings/__init__.py:136
+#: apps/courses/templates/courses/cms/fragment_course_content.html:110
 msgid "License for the course content"
 msgstr "Licence pour le contenu du cours"
 
-#: apps/courses/settings/__init__.py:132
-#: apps/courses/templates/courses/cms/fragment_course_content.html:103
+#: apps/courses/settings/__init__.py:141
+#: apps/courses/templates/courses/cms/fragment_course_content.html:119
 msgid "License for the content created by course participants"
 msgstr "Licence pour le contenu créé par les participants du cours"
 
-#: apps/courses/settings/__init__.py:137 apps/courses/settings/__init__.py:182
-#: apps/courses/settings/__init__.py:206
+#: apps/courses/settings/__init__.py:146 apps/courses/settings/__init__.py:201
+#: apps/courses/settings/__init__.py:225
 msgid "Categories"
 msgstr "Catégories"
 
-#: apps/courses/settings/__init__.py:141 apps/courses/settings/__init__.py:196
-#: apps/courses/templates/courses/cms/fragment_course_content.html:61
-#: apps/courses/templates/courses/cms/person_detail.html:53
-#: apps/search/defaults.py:105
+#: apps/courses/settings/__init__.py:150 apps/courses/settings/__init__.py:190
+msgid "Icon"
+msgstr "Icône"
+
+#: apps/courses/settings/__init__.py:155 apps/courses/settings/__init__.py:215
+#: apps/courses/templates/courses/cms/fragment_course_content.html:69
+#: apps/courses/templates/courses/cms/person_detail.html:50
+#: apps/search/defaults.py:110
 msgid "Organizations"
 msgstr "Établissements"
 
-#: apps/courses/settings/__init__.py:145
+#: apps/courses/settings/__init__.py:159
 msgid "Assessment and Certification"
 msgstr "Évaluation et certification"
 
-#: apps/courses/settings/__init__.py:150 apps/courses/settings/__init__.py:166
+#: apps/courses/settings/__init__.py:164 apps/courses/settings/__init__.py:180
 #: apps/courses/templates/courses/cms/category_detail.html:9
 #: apps/courses/templates/courses/cms/organization_detail.html:9
 msgid "Banner"
 msgstr "Bannière"
 
-#: apps/courses/settings/__init__.py:155 apps/courses/settings/__init__.py:171
+#: apps/courses/settings/__init__.py:169 apps/courses/settings/__init__.py:185
 #: apps/courses/templates/courses/cms/category_detail.html:27
 #: apps/courses/templates/courses/cms/fragment_category_glimpse.html:9
 #: apps/courses/templates/courses/cms/fragment_organization_glimpse.html:8
-#: apps/courses/templates/courses/cms/organization_detail.html:27
+#: apps/courses/templates/courses/cms/organization_detail.html:29
 msgid "Logo"
 msgstr "Logo"
 
-#: apps/courses/settings/__init__.py:160 apps/courses/settings/__init__.py:176
+#: apps/courses/settings/__init__.py:174 apps/courses/settings/__init__.py:195
 msgid "Description"
 msgstr "Description"
 
-#: apps/courses/settings/__init__.py:186
-#: apps/courses/templates/courses/cms/fragment_person_glimpse.html:8
-#: apps/courses/templates/courses/cms/person_detail.html:24
+#: apps/courses/settings/__init__.py:205
+#: apps/courses/templates/courses/cms/fragment_person_glimpse.html:10
+#: apps/courses/templates/courses/cms/person_detail.html:10
 msgid "Portrait"
 msgstr "Portrait"
 
-#: apps/courses/settings/__init__.py:191
+#: apps/courses/settings/__init__.py:210
 msgid "Bio"
 msgstr "Bio"
 
-#: apps/courses/settings/__init__.py:201
+#: apps/courses/settings/__init__.py:220
 msgid "Author"
 msgstr "Auteur"
 
-#: apps/courses/settings/__init__.py:215
+#: apps/courses/settings/__init__.py:234
 msgid "Excerpt"
 msgstr "Extrait"
 
-#: apps/courses/settings/__init__.py:220
+#: apps/courses/settings/__init__.py:239
 msgid "Body"
 msgstr "Corps"
 
-#: apps/courses/settings/__init__.py:281
+#: apps/courses/settings/__init__.py:321
 msgid "Button caesura"
 msgstr "Bouton caesura"
 
-#: apps/courses/settings/__init__.py:283
+#: apps/courses/settings/__init__.py:323
 msgid "Full width"
 msgstr "Pleine largeur"
 
 #: apps/courses/templates/courses/cms/blogpost_detail.html:17
-msgid "No author yet."
-msgstr "Pas d'auteur."
+msgid "No author yet"
+msgstr "Pas d'auteur"
 
 #: apps/courses/templates/courses/cms/blogpost_detail.html:30
 msgid "No categories yet."
 msgstr "Pas de catégories."
 
 #: apps/courses/templates/courses/cms/blogpost_detail.html:49
-#: apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html:17
 msgid "blog post cover image"
 msgstr "image de couverture de billet de blog"
 
@@ -702,7 +713,7 @@ msgstr "Pas d'extrait"
 msgid "No body content"
 msgstr "Pas de contenu"
 
-#: apps/courses/templates/courses/cms/blogpost_list.html:16
+#: apps/courses/templates/courses/cms/blogpost_list.html:14
 msgid "No associated blogposts"
 msgstr "Pas de billets de blog associés"
 
@@ -714,21 +725,21 @@ msgstr "bannière de catégorie"
 msgid "category logo"
 msgstr "logo de catégorie"
 
-#: apps/courses/templates/courses/cms/category_detail.html:55
-#: apps/courses/templates/courses/cms/organization_detail.html:55
+#: apps/courses/templates/courses/cms/category_detail.html:73
+#: apps/courses/templates/courses/cms/organization_detail.html:58
 msgid "Related courses"
 msgstr "Cours associés"
 
-#: apps/courses/templates/courses/cms/category_detail.html:74
+#: apps/courses/templates/courses/cms/category_detail.html:86
 msgid "Sub categories"
 msgstr "Sous-catégories"
 
-#: apps/courses/templates/courses/cms/category_detail.html:85
+#: apps/courses/templates/courses/cms/category_detail.html:97
 msgid "Related blogposts"
 msgstr "Billets de blog liés"
 
-#: apps/courses/templates/courses/cms/category_detail.html:104
-#: apps/courses/templates/courses/cms/organization_detail.html:74
+#: apps/courses/templates/courses/cms/category_detail.html:110
+#: apps/courses/templates/courses/cms/organization_detail.html:71
 msgid "Related persons"
 msgstr "Personnes liées"
 
@@ -749,58 +760,57 @@ msgstr "\n"
 msgid "Go to current version"
 msgstr "Accédez à la version actuelle"
 
-#: apps/courses/templates/courses/cms/course_detail.html:40
+#: apps/courses/templates/courses/cms/course_detail.html:49
 #: apps/courses/templates/courses/cms/course_run_detail.html:33
-#: apps/courses/templates/courses/cms/person_detail.html:14
+#: apps/courses/templates/courses/cms/person_detail.html:34
 msgid "No associated categories"
 msgstr "Aucune catégorie associée"
 
-#: apps/courses/templates/courses/cms/course_detail.html:54
+#: apps/courses/templates/courses/cms/course_detail.html:65
 msgid "Add an image for course cover on its glimpse."
 msgstr "Ajouter une image pour la couverture du cours sur son aperçu."
 
-#: apps/courses/templates/courses/cms/course_detail.html:65
-#: apps/courses/templates/courses/cms/fragment_course_glimpse.html:17
+#: apps/courses/templates/courses/cms/course_detail.html:76
 msgid "course cover image"
 msgstr "image de couverture du cours"
 
-#: apps/courses/templates/courses/cms/course_detail.html:97
+#: apps/courses/templates/courses/cms/course_detail.html:108
 msgid "Duration:"
 msgstr "Durée :"
 
-#: apps/courses/templates/courses/cms/course_detail.html:101
+#: apps/courses/templates/courses/cms/course_detail.html:112
 msgid "Effort:"
 msgstr "Effort :"
 
-#: apps/courses/templates/courses/cms/course_detail.html:110
+#: apps/courses/templates/courses/cms/course_detail.html:121
 msgid "Course runs"
 msgstr "Sessions de cours"
 
-#: apps/courses/templates/courses/cms/course_detail.html:114
+#: apps/courses/templates/courses/cms/course_detail.html:125
 msgid "Enrollment"
 msgstr "Inscription"
 
-#: apps/courses/templates/courses/cms/course_detail.html:118
-#: apps/courses/templates/courses/cms/course_detail.html:124
+#: apps/courses/templates/courses/cms/course_detail.html:129
+#: apps/courses/templates/courses/cms/course_detail.html:135
 msgid "From"
 msgstr "Du"
 
-#: apps/courses/templates/courses/cms/course_detail.html:118
-#: apps/courses/templates/courses/cms/course_detail.html:124
+#: apps/courses/templates/courses/cms/course_detail.html:129
+#: apps/courses/templates/courses/cms/course_detail.html:135
 msgid "to"
 msgstr "au"
 
-#: apps/courses/templates/courses/cms/course_detail.html:120
+#: apps/courses/templates/courses/cms/course_detail.html:131
 msgid "Course"
 msgstr "Cours"
 
-#: apps/courses/templates/courses/cms/course_detail.html:126
+#: apps/courses/templates/courses/cms/course_detail.html:137
 #: apps/courses/templates/courses/cms/course_run_detail.html:59
-#: apps/search/defaults.py:66
+#: apps/search/defaults.py:69
 msgid "Languages"
 msgstr "Langues"
 
-#: apps/courses/templates/courses/cms/course_detail.html:147
+#: apps/courses/templates/courses/cms/course_detail.html:158
 msgid "No associated course runs"
 msgstr "Aucune session de cours n'est disponible"
 
@@ -824,78 +834,68 @@ msgstr "Début du cours"
 msgid "Course ends"
 msgstr "Fin du cours"
 
-#: apps/courses/templates/courses/cms/fragment_category_glimpse.html:19
-#, python-format
-msgid "%(title)s logo"
-msgstr "logo %(title)s"
-
 #: apps/courses/templates/courses/cms/fragment_course_content.html:5
 msgid "Add a video or teaser."
 msgstr "Ajouter une bande annonce ou une image."
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:11
-msgid "About the course..."
-msgstr "A propos du cours..."
-
 #: apps/courses/templates/courses/cms/fragment_course_content.html:14
-msgid "Enter here a short description of your course."
-msgstr "Entrez une courte description du cours."
+msgid "Enter here a description of your course."
+msgstr "Entrez ici une description du cours."
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:24
+#: apps/courses/templates/courses/cms/fragment_course_content.html:23
+msgid "At the end of this course, you will be able to:"
+msgstr "À la fin de ce cours, vous saurez :"
+
+#: apps/courses/templates/courses/cms/fragment_course_content.html:32
 msgid "How is the course structured?"
 msgstr "Quelle est la structure du cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:33
+#: apps/courses/templates/courses/cms/fragment_course_content.html:41
 msgid "What are the prerequisites to follow this course?"
 msgstr "Quels sont les prérequis pour suivre ce cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:40
+#: apps/courses/templates/courses/cms/fragment_course_content.html:48
 msgid "Course plan"
 msgstr "Plan de cours"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:42
+#: apps/courses/templates/courses/cms/fragment_course_content.html:50
 msgid "Enter here the detailed course plan."
 msgstr "Détaillez ici le plan du cours."
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:49
+#: apps/courses/templates/courses/cms/fragment_course_content.html:57
 msgid "Assessment and certification"
 msgstr "Evaluation et Certification"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:52
+#: apps/courses/templates/courses/cms/fragment_course_content.html:60
 msgid "How is progress evaluated and/or certified?"
 msgstr "Comment les étudiants sont ils évalués et/ou certifiés ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:65
+#: apps/courses/templates/courses/cms/fragment_course_content.html:73
 msgid "What are the organizations publishing this course?"
 msgstr "Qui sont les établissements publiant ce cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:74
+#: apps/courses/templates/courses/cms/fragment_course_content.html:86
 msgid "Course team"
 msgstr "Équipe pédagogique"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:78
+#: apps/courses/templates/courses/cms/fragment_course_content.html:90
 msgid "Who are the teachers in the course team?"
 msgstr "Qui sont les enseignants de l’équipe pédagogique ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:91
+#: apps/courses/templates/courses/cms/fragment_course_content.html:107
 msgid "License"
 msgstr "Licence"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:97
+#: apps/courses/templates/courses/cms/fragment_course_content.html:113
 msgid "What is the license for the course content?"
 msgstr "Quelle est la licence pour le contenu du cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_course_content.html:106
+#: apps/courses/templates/courses/cms/fragment_course_content.html:122
 msgid "What is the license for the content created by course participants?"
 msgstr "Quelle est la licence pour le contenu créé par les participants du cours ?"
 
-#: apps/courses/templates/courses/cms/fragment_organization_glimpse.html:18
-#: apps/courses/templates/courses/cms/organization_detail.html:38
-msgid "organization logo"
-msgstr "logo d'établissement"
-
-#: apps/courses/templates/courses/cms/fragment_organization_main_logo.html:8
-#: apps/courses/templates/courses/cms/fragment_organization_main_logo.html:25
+#: apps/courses/templates/courses/cms/fragment_organization_main_logo.html:7
+#: apps/courses/templates/courses/cms/fragment_organization_main_logo.html:26
 msgid "Main organization"
 msgstr "Etablissement principal"
 
@@ -903,37 +903,36 @@ msgstr "Etablissement principal"
 msgid "main organization logo"
 msgstr "logo d'établissement principal"
 
-#: apps/courses/templates/courses/cms/fragment_person_glimpse.html:6
-msgid "avatar"
-msgstr "avatar"
-
-#: apps/courses/templates/courses/cms/fragment_person_glimpse.html:18
-#: apps/courses/templates/courses/cms/person_detail.html:35
-#, python-format
-msgid "%(title)s avatar"
-msgstr "avatar de %(title)s"
-
-#: apps/courses/templates/courses/cms/organization_detail.html:20
+#: apps/courses/templates/courses/cms/organization_detail.html:22
 msgid "organization banner"
 msgstr "bannière d'établissement"
+
+#: apps/courses/templates/courses/cms/organization_detail.html:41
+msgid "organization logo"
+msgstr "logo d'établissement"
 
 #: apps/courses/templates/courses/cms/organization_list.html:14
 msgid "No organization yet"
 msgstr "Pas d'établissement"
 
-#: apps/courses/templates/courses/cms/person_detail.html:43
+#: apps/courses/templates/courses/cms/person_detail.html:21
+#, python-format
+msgid "%(title)s avatar"
+msgstr "avatar de %(title)s"
+
+#: apps/courses/templates/courses/cms/person_detail.html:41
 msgid "Enter your bio here..."
 msgstr "Saisissez ici votre bio..."
 
-#: apps/courses/templates/courses/cms/person_detail.html:56
+#: apps/courses/templates/courses/cms/person_detail.html:53
 msgid "No associated organizations"
 msgstr "Aucun établissement associé"
 
-#: apps/courses/templates/courses/cms/person_detail.html:65
+#: apps/courses/templates/courses/cms/person_detail.html:62
 msgid "Courses"
 msgstr "Cours"
 
-#: apps/courses/templates/courses/cms/person_detail.html:84
+#: apps/courses/templates/courses/cms/person_detail.html:75
 msgid "Blogposts"
 msgstr "Articles de blog"
 
@@ -941,43 +940,43 @@ msgstr "Articles de blog"
 msgid "No persons"
 msgstr "Pas de personnes"
 
-#: apps/search/defaults.py:41
+#: apps/search/defaults.py:44
 msgid "New courses"
 msgstr "Nouveaux cours"
 
-#: apps/search/defaults.py:45
+#: apps/search/defaults.py:48
 msgid "First session"
 msgstr "Première session"
 
-#: apps/search/defaults.py:56
+#: apps/search/defaults.py:59
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: apps/search/defaults.py:81
+#: apps/search/defaults.py:84
 msgid "Subjects"
 msgstr "Sujets"
 
-#: apps/search/defaults.py:93
+#: apps/search/defaults.py:97
 msgid "Levels"
 msgstr "Niveaux"
 
-#: apps/search/defaults.py:116
+#: apps/search/defaults.py:122
 msgid "Persons"
 msgstr "Personnes"
 
-#: apps/search/filter_definitions/courses.py:253
+#: apps/search/filter_definitions/courses.py:379
 msgid "Open for enrollment"
 msgstr "Ouvert pour inscription"
 
-#: apps/search/filter_definitions/courses.py:254
+#: apps/search/filter_definitions/courses.py:380
 msgid "Coming soon"
 msgstr "À venir"
 
-#: apps/search/filter_definitions/courses.py:255
+#: apps/search/filter_definitions/courses.py:381
 msgid "On-going"
 msgstr "En cours"
 
-#: apps/search/filter_definitions/courses.py:256
+#: apps/search/filter_definitions/courses.py:382
 msgid "Archived"
 msgstr "Archivé"
 
@@ -1065,7 +1064,7 @@ msgstr "Choisir un modèle pour afficher le plugin."
 msgid "Content"
 msgstr "Contenu"
 
-#: plugins/plain_text/cms_plugins.py:26
+#: plugins/plain_text/cms_plugins.py:29
 msgid "Plain text"
 msgstr "Texte brut"
 
@@ -1089,11 +1088,18 @@ msgstr "Modèle optionnel pour un rendu personnalisé."
 msgid "Image"
 msgstr "Image"
 
-#: plugins/simple_text_ckeditor/cms_plugins.py:27
+#: plugins/simple_text_ckeditor/cms_plugins.py:31
 msgid "Simple text"
 msgstr "Texte simple"
 
 #: plugins/simple_text_ckeditor/models.py:23
 msgid "body"
 msgstr "corps"
+
+#: plugins/simple_text_ckeditor/validators.py:16
+#, python-format
+msgid "Ensure this text has at most %(limit_value)d character (it has %(show_value)d)."
+msgid_plural "Ensure this text has at most %(limit_value)d characters (it has %(show_value)d)."
+msgstr[0] "Assurez-vous que ce texte a au maximum %(limit_value)d caractères (il en a %(show_value)d)."
+msgstr[1] "Assurez-vous que ce texte fait au maximum %(limit_value)d caractères (il en a %(show_value)d)."
 


### PR DESCRIPTION
### Fixed

- Fix "More options" modal for searchable filter values not based on MPTT paths (eg. "Person" in the sandbox environment).
- Improve pagination UX by increasing contrast between the active page number and others, and making button clickable areas larger.
- Stop making failed API requests and instead show a helpful error message in the "More options" modal for filter values when the user inputs their first 1 or 2 characters.
- Improve pagination strings for localization.

### Security

- Update the mixin-deep and set-value packages to safe versions.

- [x] update the repo copy of translations