### PR TITLE
🐛(template) update fragment_course_content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Use SVG icons instead of an icon font.
 
+### Fixed
+
+- Fix add plugin to team and organization on fragment_course_content template
+  when they are empty.
+
 ## [1.9.2] - 2019-09-20
 
 ### Fixed

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
@@ -68,15 +68,13 @@
   <h2 class="section__title course-detail__content__row__title course-detail__content__organizations__title">
     {% trans 'Organizations' %}
   </h2>
-  {% if page|is_empty_placeholder:"course_organizations" %}
-    <p class="course-detail__content__organizations__placeholder">
-      {% trans "What are the organizations publishing this course?" %}
-    </p>
-  {% else %}
-    <div class="section__items course-detail__content__organizations__items">
-      {% page_placeholder "course_organizations" page %}
-    </div>
-  {% endif %}
+  <div class="section__items course-detail__content__organizations__items">
+    {% page_placeholder "course_organizations" page or %}
+      <p class="course-detail__content__organizations__placeholder">
+        {% trans "What are the organizations publishing this course?" %}
+      </p>
+    {% endpage_placeholder %}
+  </div>
 </section>
 {% endif %}
 
@@ -86,13 +84,11 @@
     {% trans 'Course team' %}
   </h2>
   {% with header_level=3 %}
-    {% if page|is_empty_placeholder:"course_team" %}
-      <p>{% trans 'Who are the teachers in the course team?' %}</p>
-    {% else %}
-      <div class="section__items course-detail__content__team__items">
-        {% page_placeholder "course_team" page %}
-      </div>
-    {% endif %}
+    <div class="section__items course-detail__content__team__items">
+      {% page_placeholder "course_team" page or %}
+        <p>{% trans 'Who are the teachers in the course team?' %}</p>
+      {% endpage_placeholder %}
+    </div>
   {% endwith %}
 </section>
 {% endif %}

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -242,6 +242,59 @@ class CourseCMSTestCase(CMSTestCase):
         # The draft and the published course runs should both be in the page
         self.assertContains(response, "<dd>English and french</dd>", html=True, count=2)
 
+    def test_templates_course_detail_placeholder(self):
+        """
+        Draft editing course page should contain all key placeholders when empty.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        course = CourseFactory(page_title="Very interesting course")
+        page = course.extended_object
+        url = "{:s}?edit".format(page.get_absolute_url(language="en"))
+        response = self.client.get(url)
+
+        pattern = (
+            r'<div class="course-detail__content__row course-detail__content__introduction">'
+            r'<div class="cms-placeholder'
+        )
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        pattern = (
+            r'<div class="course-detail__content__row course-detail__content__categories">'
+            r'<div class="cms-placeholder'
+        )
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        pattern = (
+            r'<div class="course-detail__content__row course-detail__content__teaser">'
+            r'<div class="cms-placeholder'
+        )
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        pattern = (
+            r'<h2 class="course-detail__content__row__title">About the course</h2>'
+            r'<div class="cms-placeholder'
+        )
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        pattern = (
+            r'<div class="section__items course-detail__content__organizations__items">'
+            r'<div class="cms-placeholder'
+        )
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        pattern = (
+            r'<div class="section__items course-detail__content__team__items">'
+            r'<div class="cms-placeholder'
+        )
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        pattern = (
+            r'<div class="course-detail__content__row course-detail__content__information">'
+            r'<div class="cms-placeholder'
+        )
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        pattern = (
+            r'<h3 class="course-detail__content__license__item__title">'
+            r'License for the course content</h3><div class="cms-placeholder'
+        )
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+
     def test_templates_course_detail_no_index(self):
         """
         A course snapshot page should not be indexable by search engine robots.


### PR DESCRIPTION
## Purpose
The placeholders for organizations and teams was different from the rest.
This older structure prevented you from adding plugins into them if you
did not already have one in it since they aren't in the template if you don't already have something.

## Proposal
This fixes it by using the template structure used for the other placeholders that work.
