### PR TITLE
Add a standalone search field component

### DIFF
--- a/src/frontend/js/common/searchFields/getSuggestionsSection.spec.ts
+++ b/src/frontend/js/common/searchFields/getSuggestionsSection.spec.ts
@@ -6,7 +6,7 @@ import { getSuggestionsSection } from './getSuggestionsSection';
 const mockHandle: jest.Mock<typeof handle> = handle as any;
 jest.mock('../../utils/errors/handle');
 
-describe('utils/searchSuggest/getSuggestionsSection', () => {
+describe('common/searchFields/getSuggestionsSection', () => {
   afterEach(() => {
     fetchMock.restore();
   });

--- a/src/frontend/js/common/searchFields/getSuggestionsSection.ts
+++ b/src/frontend/js/common/searchFields/getSuggestionsSection.ts
@@ -1,6 +1,5 @@
 import take from 'lodash-es/take';
 import { stringify } from 'query-string';
-import { FormattedMessage } from 'react-intl';
 
 import { Suggestion } from '../../types/Suggestion';
 import { handle } from '../../utils/errors/handle';

--- a/src/frontend/js/common/searchFields/index.tsx
+++ b/src/frontend/js/common/searchFields/index.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import { APICourseSearchResponse } from '../../types/api';
+import {
+  SearchAutosuggestProps,
+  SearchSuggestion,
+  SearchSuggestionSection,
+} from '../../types/Suggestion';
+import { handle } from '../../utils/errors/handle';
+import { getSuggestionsSection } from './getSuggestionsSection';
+
+/**
+ * `react-autosuggest` callback to get a human string value from a Suggestion object.
+ * @param suggestion The relevant suggestion object.
+ */
+export const getSuggestionValue: SearchAutosuggestProps['getSuggestionValue'] = suggestion =>
+  suggestion.title;
+
+/**
+ * `react-autosuggest` callback to render one suggestion.
+ * @param suggestion Either a resource suggestion with a model name & a machine name, or the default
+ * suggestion with some text to render.
+ */
+export const renderSuggestion: SearchAutosuggestProps['renderSuggestion'] = suggestion => (
+  <span>{suggestion.title}</span>
+);
+
+/**
+ * `react-autosuggest` callback to build up the list of suggestions and sections whenever user
+ * interaction requires us to create or update that list.
+ * @param filters The general filters object as returned by the API on a course search.
+ * @param setSuggestions The suggestion setter method for the component using our helper.
+ * @param incomingValue The current value of the search suggest form field.
+ */
+export const onSuggestionsFetchRequested = async (
+  filters: APICourseSearchResponse['filters'],
+  setSuggestions: (suggestions: SearchSuggestionSection[]) => void,
+  incomingValue: string,
+) => {
+  if (incomingValue.length < 3) {
+    return setSuggestions([]);
+  }
+
+  // Fetch the suggestions for each resource-based section to build out the sections
+  let sections: SearchSuggestionSection[];
+  try {
+    sections = (await Promise.all(
+      Object.values(await filters)
+        .filter(filterdef => filterdef.is_autocompletable)
+        .map(filterdef =>
+          getSuggestionsSection(
+            filterdef.name,
+            filterdef.human_name,
+            incomingValue,
+          ),
+        ),
+      // We can assert this because of the catch below
+    )) as SearchSuggestionSection[];
+  } catch (error) {
+    return handle(error);
+  }
+
+  setSuggestions(
+    // Drop sections with no results as there's no use displaying them
+    sections.filter(section => !!section!.values.length),
+  );
+};
+
+/**
+ * Helper to pick out the relevant filter for a suggestion from the general filters object.
+ * @param filters The general filters object as returned by the API on a course search.
+ * @param suggestion The suggestion with which we're doing some work (eg. the suggestion the user selected).
+ */
+export const getRelevantFilter = (
+  filters: APICourseSearchResponse['filters'],
+  suggestion: SearchSuggestion,
+) => {
+  // Use the `kind` field on the suggestion to pick the relevant filter to update.
+  let filter = Object.values(filters).find(
+    fltr => fltr.name === suggestion.kind,
+  )!;
+
+  // We need a special-case to handle categories until we refactor the API to separate endpoints between
+  // kinds of categories
+  if (!filter) {
+    // Pick the filter to update based on the payload's path: it contains the relevant filter's page path
+    // (for eg. a meta-category or the "organizations" root page)
+    filter = Object.values(filters).find(
+      fltr =>
+        !!fltr.base_path &&
+        String(suggestion.id)
+          .substr(2)
+          .startsWith(fltr.base_path),
+    )!;
+  }
+
+  return filter;
+};

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -1,0 +1,247 @@
+import { fireEvent, render, wait } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { RootSearchSuggestField } from '.';
+import { location } from '../../utils/indirection/window';
+
+jest.mock('../../utils/indirection/window', () => ({
+  location: {
+    assign: jest.fn(),
+  },
+}));
+
+describe('<RootSearchSuggestField />', () => {
+  const subjects = {
+    base_path: '00030001',
+    has_more_values: false,
+    human_name: 'Subjects',
+    is_autocompletable: true,
+    is_searchable: true,
+    name: 'subjects',
+    values: [],
+  };
+
+  afterEach(fetchMock.restore);
+  afterEach(jest.resetAllMocks);
+
+  it('renders', () => {
+    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+      filters: {
+        subjects,
+      },
+    });
+
+    const { getByPlaceholderText } = render(
+      <IntlProvider locale="en">
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" />
+      </IntlProvider>,
+    );
+
+    // The placeholder text is shown in the input
+    getByPlaceholderText('Search for courses');
+    // The component should not issue any request "on load", before the user starts interacting
+    expect(fetchMock.called()).toEqual(false);
+  });
+
+  it('gets suggestions from the API when the user types 3 characters or more in the field', async () => {
+    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+      filters: {
+        subjects,
+      },
+    });
+    fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', [
+      {
+        id: 'L-000300010001',
+        title: 'Subject #311',
+      },
+    ]);
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=aut', []);
+
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <IntlProvider locale="en">
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" />
+      </IntlProvider>,
+    );
+
+    const field = getByPlaceholderText('Search for courses');
+
+    // Simulate the user entering some text in the autocomplete field
+    fireEvent.focus(field);
+
+    // No requests are made until the user enters at least 3 characters
+    fireEvent.change(field, { target: { value: 'au' } });
+    await wait();
+    expect(fetchMock.called()).toEqual(false);
+
+    fireEvent.change(field, { target: { value: 'aut' } });
+    await wait();
+
+    expect(
+      fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
+    ).toEqual(true);
+    expect(queryByText('Courses')).toEqual(null);
+
+    expect(
+      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
+    ).toEqual(true);
+    getByText('Subjects');
+    getByText('Subject #311');
+  });
+
+  it('goes to the course page when the user selects a course suggestion', async () => {
+    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+      filters: {
+        subjects,
+      },
+    });
+    fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', []);
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=aut', [
+      {
+        absolute_url: '/en/courses/42',
+        id: '42',
+        kind: 'courses',
+        title: 'Course #42',
+      },
+    ]);
+
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <IntlProvider locale="en">
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" />
+      </IntlProvider>,
+    );
+
+    const field = getByPlaceholderText('Search for courses');
+    fireEvent.focus(field);
+    fireEvent.change(field, { target: { value: 'aut' } });
+    await wait();
+
+    expect(
+      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
+    ).toEqual(true);
+    expect(queryByText('Subjects')).toEqual(null);
+
+    expect(
+      fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
+    ).toEqual(true);
+    getByText('Courses');
+    const course = getByText('Course #42');
+
+    fireEvent.click(course);
+    await wait();
+    expect(location.assign).toHaveBeenCalledWith('/en/courses/42');
+  });
+
+  it('goes to course search with the filter value activated when the user clicks on a suggestion', async () => {
+    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+      filters: {
+        subjects,
+      },
+    });
+    fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', [
+      {
+        id: 'L-000300010001',
+        kind: 'subjects',
+        title: 'Subject #311',
+      },
+    ]);
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=aut', []);
+
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <IntlProvider locale="en">
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" />
+      </IntlProvider>,
+    );
+
+    const field = getByPlaceholderText('Search for courses');
+    fireEvent.focus(field);
+    fireEvent.change(field, { target: { value: 'aut' } });
+    await wait();
+
+    expect(
+      fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
+    ).toEqual(true);
+    expect(queryByText('Courses')).toEqual(null);
+
+    expect(
+      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
+    ).toEqual(true);
+    getByText('Subjects');
+    const subject = getByText('Subject #311');
+
+    fireEvent.click(subject);
+    await wait();
+    expect(location.assign).toHaveBeenCalledWith(
+      '/en/courses/?limit=20&offset=0&subjects=L-000300010001',
+    );
+  });
+
+  it('moves to the search page with a search query when the user types a query and presses ENTER', async () => {
+    ['courses', 'subjects'].forEach(kind =>
+      fetchMock.get(`/api/v1.0/${kind}/autocomplete/?query=some%20query`, []),
+    );
+
+    const { getByPlaceholderText } = render(
+      <IntlProvider locale="en">
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" />
+      </IntlProvider>,
+    );
+
+    const field = getByPlaceholderText('Search for courses');
+
+    // Simulate the user typing in some text in the autocomplete field
+    fireEvent.focus(field);
+    fireEvent.change(field, { target: { value: 'some query' } });
+    fireEvent.keyDown(field, { keyCode: 13 });
+    await wait();
+
+    expect(location.assign).toHaveBeenCalledWith(
+      '/en/courses/?limit=20&offset=0&query=some%20query',
+    );
+  });
+
+  it('lets the user select the currently highlighted suggestion by pressing ENTER', async () => {
+    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+      filters: {
+        subjects,
+      },
+    });
+    fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', []);
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=aut', [
+      {
+        absolute_url: '/en/courses/42',
+        id: '42',
+        kind: 'courses',
+        title: 'Course #42',
+      },
+    ]);
+
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <IntlProvider locale="en">
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" />
+      </IntlProvider>,
+    );
+
+    const field = getByPlaceholderText('Search for courses');
+    fireEvent.focus(field);
+    fireEvent.change(field, { target: { value: 'aut' } });
+    await wait();
+
+    expect(
+      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
+    ).toEqual(true);
+    expect(queryByText('Subjects')).toEqual(null);
+
+    expect(
+      fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
+    ).toEqual(true);
+    getByText('Courses');
+    getByText('Course #42');
+
+    fireEvent.keyDown(field, { keyCode: 40 }); // Select the desired suggestion (there is only one)
+    fireEvent.keyDown(field, { keyCode: 13 }); // Press enter
+    await wait();
+    expect(location.assign).toHaveBeenCalledWith('/en/courses/42');
+  });
+});

--- a/src/frontend/js/components/RootSearchSuggestField/index.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.tsx
@@ -1,0 +1,176 @@
+import { stringify } from 'query-string';
+import React, { useState } from 'react';
+import Autosuggest from 'react-autosuggest';
+import { defineMessages, useIntl } from 'react-intl';
+
+import {
+  getRelevantFilter,
+  getSuggestionValue,
+  onSuggestionsFetchRequested,
+  renderSuggestion,
+} from '../../common/searchFields';
+import { fetchList } from '../../data/getResourceList/getResourceList';
+import { API_LIST_DEFAULT_PARAMS } from '../../settings';
+import { APICourseSearchResponse, requestStatus } from '../../types/api';
+import { FilterDefinition } from '../../types/filters';
+import {
+  isCourseSuggestion,
+  SearchAutosuggestProps,
+  SearchSuggestionSection,
+} from '../../types/Suggestion';
+import { location } from '../../utils/indirection/window';
+
+const messages = defineMessages({
+  searchFieldPlaceholder: {
+    defaultMessage: 'Search for courses',
+    description:
+      'Placeholder text displayed in the search field when it is empty.',
+    id: 'components.SearchSuggestField.searchFieldPlaceholder',
+  },
+});
+
+// Our search and autosuggestion pipeline operated based on filter definitions. Obviously, we can filters courses
+// by courses, but we still need a filter-definition-like config to run courses autocompletion.
+const coursesConfig: FilterDefinition = {
+  base_path: null,
+  has_more_values: false,
+  human_name: 'Courses',
+  is_autocompletable: true,
+  is_searchable: true,
+  name: 'courses',
+  values: [],
+};
+
+// We don't want to systematically load the filter on page load, when we render <RootSearchSuggestField />
+// Instead, we can create a promise for those filters, and only actually fetch them *once* the first time
+// we actually need them.
+let filtersPromise: Promise<APICourseSearchResponse['filters']>;
+let hasInitiatedRequest: boolean = false;
+const filters: () => Promise<APICourseSearchResponse['filters']> = async () => {
+  if (hasInitiatedRequest) {
+    return await filtersPromise;
+  }
+  hasInitiatedRequest = true;
+  const response = await fetchList('courses', {
+    limit: '0',
+    offset: '0',
+    scope: 'FILTERS',
+  });
+  if (response.status === requestStatus.SUCCESS) {
+    return (filtersPromise = new Promise(resolve =>
+      resolve({ ...response.content.filters, courses: coursesConfig }),
+    ));
+  } else {
+    throw new Error(response.error);
+  }
+};
+
+interface RootSearchSuggestFieldProps {
+  courseSearchPageUrl: string;
+}
+
+/**
+ * Component. Displays the main search field alon with any suggestions organized in relevant sections.
+ */
+export const RootSearchSuggestField = ({
+  courseSearchPageUrl,
+}: RootSearchSuggestFieldProps) => {
+  const intl = useIntl();
+
+  // Initialize hooks for the two pieces of state the controlled <Autosuggest> component needs to interact with:
+  // the current list of suggestions and the input value.
+  // Note: the input value is initialized from the courseSearchParams, ie. the `query` query string parameter
+  const [value, setValue] = useState('');
+  const [suggestions, setSuggestions] = useState<SearchSuggestionSection[]>([]);
+
+  // Helper to know if the user is currently highlighting a suggestion. This is necessary to make sure we do not
+  // override default `Autosuggest` behavior when we receive the ENTER keycode that triggers text search.
+  const [hasHighlightedSuggestion, setHasHighlightedSuggestion] = useState(
+    false,
+  );
+
+  const inputProps: SearchAutosuggestProps['inputProps'] = {
+    /**
+     * Callback triggered on every user input.
+     * @param _ Unused: change event.
+     * @param params Incoming parameters related to the change event.
+     * - `newValue` is the search suggest form field value.
+     */
+    onChange: (_, { newValue }) => {
+      // Always update the state
+      setValue(newValue);
+    },
+    onKeyDown: event => {
+      // When ther user presses enter from the search field, move to the course search view with
+      // whatever is currently in the field as a text query.
+      // Unless they are currently highlighting a suggestion, in which case we let Autosuggest handle it.
+      if (event.keyCode === 13 /* enter */ && !hasHighlightedSuggestion) {
+        location.assign(
+          `${courseSearchPageUrl}?${stringify({
+            ...API_LIST_DEFAULT_PARAMS,
+            query: value,
+          })}`,
+        );
+      }
+    },
+    placeholder: intl.formatMessage(messages.searchFieldPlaceholder),
+    value,
+  };
+
+  /**
+   * `react-autosuggest` callback triggered when the user picks a suggestion, to handle the interaction.
+   * Different interactions have different expected outcomes:
+   * - picking a course directs to the course detailed page (as this is a course search);
+   * - picking another resource suggestion adds that resource as a filter;
+   * - the default suggestion runs a full-text search on the content of the search suggest form field.
+   * @param _ Unused: selection event.
+   * @param suggestion `suggestion` as key to an anonymous object: the suggestion the user picked.
+   */
+  const onSuggestionSelected: SearchAutosuggestProps['onSuggestionSelected'] = async (
+    _,
+    { suggestion },
+  ) => {
+    // Course suggestions are treated differently: when the user finds a course they're interested in,
+    // we're just sending them to that's course page instead of the course search page.
+    if (isCourseSuggestion(suggestion)) {
+      return location.assign(suggestion.absolute_url);
+    }
+
+    // Get the relevant filter and move to the course search view with the selected suggestion as an
+    // active filter value.
+    const filter = getRelevantFilter(await filters(), suggestion);
+    location.assign(
+      `${courseSearchPageUrl}?${stringify({
+        ...API_LIST_DEFAULT_PARAMS,
+        [filter.name]: suggestion.id,
+      })}`,
+    );
+  };
+
+  return (
+    // TypeScript incorrectly infers the type of the Autosuggest suggestions prop as SearchSuggestion, which
+    // would be correct if we did not use sections, but is incorrect as it is.
+    <Autosuggest
+      getSectionSuggestions={section => section.values}
+      getSuggestionValue={getSuggestionValue}
+      inputProps={inputProps}
+      multiSection={true}
+      onSuggestionsClearRequested={() => setSuggestions([])}
+      onSuggestionsFetchRequested={async ({ value: incomingValue }) =>
+        onSuggestionsFetchRequested(
+          await filters(),
+          setSuggestions,
+          incomingValue,
+        )
+      }
+      onSuggestionHighlighted={({ suggestion }) =>
+        setHasHighlightedSuggestion(!suggestion)
+      }
+      onSuggestionSelected={onSuggestionSelected}
+      renderSectionTitle={section => section.title}
+      renderSuggestion={renderSuggestion}
+      shouldRenderSuggestions={val => val.length > 2}
+      suggestions={suggestions as any}
+    />
+  );
+};

--- a/src/frontend/js/components/SearchSuggestField/SearchSuggestField.tsx
+++ b/src/frontend/js/components/SearchSuggestField/SearchSuggestField.tsx
@@ -10,12 +10,6 @@ import { handle } from '../../utils/errors/handle';
 import { getSuggestionsSection } from './getSuggestionsSection';
 
 const messages = defineMessages({
-  searchFieldDefaultSearch: {
-    defaultMessage: 'Search for {query} in courses...',
-    description: `Default query in the main search field. Lets users run a full text search
-      with whatever they have typed in.`,
-    id: 'components.SearchSuggestField.searchFieldDefaultSearch',
-  },
   searchFieldPlaceholder: {
     defaultMessage: 'Search for courses, organizations, categories',
     description:

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -15,15 +15,18 @@ import includes from 'lodash-es/includes';
 import startCase from 'lodash-es/startCase';
 
 // Import the top-level components that can be directly called from the CMS
+import { RootSearchSuggestField } from './components/RootSearchSuggestField';
 import { Search } from './components/Search/Search';
 import { handle } from './utils/errors/handle';
 // List them in an interface for type-safety when we call them. This will let us use the props for
 // any top-level component in a way TypeScript understand and accepts
 interface ComponentLibrary {
   Search: typeof Search;
+  RootSearchSuggestField: typeof RootSearchSuggestField;
 }
 // Actually create the component map that we'll use below to access our component classes
 const componentLibrary: ComponentLibrary = {
+  RootSearchSuggestField,
   Search,
 };
 // Type guard: ensures a given string (candidate) is indeed a proper key of the componentLibrary with a corresponding
@@ -82,9 +85,7 @@ document.addEventListener('DOMContentLoaded', event => {
 
         // Get the incoming props to pass our component from the `data-props` attribute
         const dataProps = element.getAttribute('data-props');
-        const props = dataProps
-          ? (JSON.parse(dataProps) as Parameters<typeof Component>[0])
-          : {};
+        const props = dataProps ? JSON.parse(dataProps) : {};
 
         // Render the component inside an `IntlProvider` to be able to access translated strings
         ReactDOM.render(

--- a/src/frontend/js/types/Suggestion.ts
+++ b/src/frontend/js/types/Suggestion.ts
@@ -18,11 +18,30 @@ interface GenericSuggestion {
 }
 
 /**
+ * Courses suggestions need their own type because they have the extra field `absolute_url`.
+ */
+interface CourseSuggestion extends GenericSuggestion {
+  absolute_url: string;
+  kind: 'courses';
+}
+
+/**
+ * We also need a way to help TypeScript discriminate between CourseSuggestions and GenericSuggestions
+ */
+export function isCourseSuggestion(
+  suggestion: Suggestion<string>,
+): suggestion is CourseSuggestion {
+  return suggestion.kind === 'courses';
+}
+
+/**
  * Utility type that allows a consumer to easily define the kinds of suggestions it supports and
  * get proper typechecking around them.
  */
 export type Suggestion<Kind extends string> = Kind extends 'default'
   ? DefaultSuggestion
+  : Kind extends 'courses'
+  ? CourseSuggestion
   : GenericSuggestion;
 
 /**
@@ -66,7 +85,7 @@ export type SuggestionSection<
  * Define the kind of suggestions our `<SearchSuggestField />` and `<RootSearchSuggestField />` components support.
  */
 export type SearchSuggestion = Suggestion<
-  'categories' | 'organizations' | 'persons'
+  'categories' | 'courses' | 'organizations' | 'persons'
 >;
 
 /**

--- a/src/frontend/js/types/Suggestion.ts
+++ b/src/frontend/js/types/Suggestion.ts
@@ -1,3 +1,5 @@
+import { AutosuggestProps } from 'react-autosuggest';
+
 /**
  * A Default suggestion shape for cases where we need one.
  */
@@ -59,3 +61,22 @@ export type SuggestionSection<
 > = S extends DefaultSuggestion
   ? DefaultSuggestionSection
   : ResourceSuggestionSection<GenericSuggestion>;
+
+/**
+ * Define the kind of suggestions our `<SearchSuggestField />` and `<RootSearchSuggestField />` components support.
+ */
+export type SearchSuggestion = Suggestion<
+  'categories' | 'organizations' | 'persons'
+>;
+
+/**
+ * Derive from `SearchSuggestion` the kind of suggestion sections our `<SearchSuggestField />` and
+ * `<RootSearchSuggestField />` components support
+ */
+export type SearchSuggestionSection = SuggestionSection<SearchSuggestion>;
+
+/**
+ * Helper to typecheck `react-autosuggest` expected props. Defines what is acceptable as a suggestion
+ * throughout our code related to this instance of `<Autosuggest />`.
+ */
+export type SearchAutosuggestProps = AutosuggestProps<SearchSuggestion>;

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -598,6 +598,9 @@ class CoursesIndexer:
         full objects.
         """
         return {
+            "absolute_url": get_best_field_language(
+                es_document["_source"]["absolute_url"], language
+            ),
             "id": es_document["_id"],
             "kind": "courses",
             "title": get_best_field_language(es_document["_source"]["title"], language),

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -441,7 +441,7 @@ class CoursesIndexersTestCase(TestCase):
         es_course = {
             "_id": 93,
             "_source": {
-                "absolute_url": {"en": "campo-qui-format-do"},
+                "absolute_url": {"en": "/en/campo-qui-format-do"},
                 "categories": [43, 86],
                 "cover_image": {"en": "cover_image.jpg"},
                 "icon": {"en": "icon.jpg"},
@@ -457,5 +457,10 @@ class CoursesIndexersTestCase(TestCase):
         }
         self.assertEqual(
             CoursesIndexer.format_es_document_for_autocomplete(es_course, "en"),
-            {"id": 93, "kind": "courses", "title": "Duis eu arcu erat"},
+            {
+                "absolute_url": "/en/campo-qui-format-do",
+                "id": 93,
+                "kind": "courses",
+                "title": "Duis eu arcu erat",
+            },
         )


### PR DESCRIPTION
## Purpose

Reuse parts of what we built for <SearchSuggestField /> to make <RootSearchSuggestField />, a React-powered course search field that can live anywhere in Richie, independently from <Search />.

## Proposal

Since most of its features are pretty different from those in the original <SearchSuggestField />, we found it preferable to create a new component, and try to reuse as much of the actual logic as possible.

- [x] refactor `<SearchSuggestField />` to make parts reusable
- [x] add `absolute_url` to course suggestions
- [x] create a new standalone course search field
