### PR TITLE
🐛(settings) allow overriding default settings defined in Richie's mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow overriding Richie's default settings in inheriting configurations
+
 ## [1.8.2] - 2019-08-29
 
 ### Changed

--- a/src/richie/apps/courses/settings/mixins.py
+++ b/src/richie/apps/courses/settings/mixins.py
@@ -4,17 +4,16 @@ from configurations.utils import uppercase_attributes
 from .. import settings
 
 
+def apply_settings(cls):
+    """A decorator to set class attributes from imported settings."""
+    for key, value in uppercase_attributes(settings).items():
+        setattr(cls, key, value)
+    return cls
+
+
+@apply_settings
 class RichieCoursesConfigurationMixin:
     """
     A Django Configuration mixin to set sensible defaults for the settings of Richie's
     courses app.
     """
-
-    def __new__(cls):
-        """
-        Set all settings as attributes of this class so it can be used as a mixin in
-        Django Configuration.
-        """
-        for key, value in uppercase_attributes(settings).items():
-            setattr(cls, key, value)
-        return super().__new__(cls)

--- a/tests/apps/courses/test_settings_mixins.py
+++ b/tests/apps/courses/test_settings_mixins.py
@@ -1,0 +1,37 @@
+"""Unit test suite for Richie's default configuration mixin."""
+from django.test import TestCase
+
+from configurations import Configuration
+
+from richie.apps.courses.settings.mixins import RichieCoursesConfigurationMixin
+
+
+class SettingsMixinsTestCase(TestCase):
+    """Validate that RichieCoursesConfigurationMixin works as expected."""
+
+    def test_settings_mixins_value(self):
+        """
+        The configuration mixin should set default values for all settings listed
+        in apps/courses/settings/__init__.py.
+        """
+
+        class TestConfiguration(RichieCoursesConfigurationMixin, Configuration):
+            """A configuration class inheriting from Richie's configuration mixin."""
+
+        # pylint: disable=no-member
+        cms_templates = TestConfiguration().CMS_TEMPLATES
+        self.assertEqual(len(cms_templates), 14)
+        self.assertEqual(cms_templates[0][0], "courses/cms/course_detail.html")
+
+    def test_settings_mixins_override(self):
+        """
+        A configuration class inheriting from Richie's default configuration mixin
+        should be able to override the value of any setting.
+        """
+
+        class TestConfiguration(RichieCoursesConfigurationMixin, Configuration):
+            """A configuration class inheriting from Richie's configuration mixin."""
+
+            CMS_TEMPLATES = "new value"
+
+        self.assertEqual(TestConfiguration().CMS_TEMPLATES, "new value")


### PR DESCRIPTION
## Purpose

We were setting default values on the configuration mix instance. As a result it could not be overriden by class attributes on a configuration class inheriting from this mixin. 

## Proposal

We should set values on the configuration mixin as class attributes.
