### PR TITLE
✨(layout) add breadcrumbs on top of page details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add breadcrumbs element on all pages but the listing ones.
+
 ### Fixed
 
 - Translate login/signup on header.

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -48,6 +48,7 @@
 // Shared object styles
 @import './templates/menu/_menu';
 @import './templates/richie/single-column';
+@import './objects/breadcrumbs';
 @import './objects/course_glimpses';
 @import './objects/blogpost_glimpses';
 @import './objects/organization_glimpses';

--- a/src/frontend/scss/objects/_breadcrumbs.scss
+++ b/src/frontend/scss/objects/_breadcrumbs.scss
@@ -1,0 +1,30 @@
+$richie-breadcrumbs-separator: '›';
+
+.breadcrumbs {
+  @include make-container();
+  @include make-container-max-widths();
+  display: flex;
+  margin: 0 auto;
+  padding: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  list-style-type: none;
+  background: $richie-content-container-bg;
+
+  &__item {
+    @include sv-flex(0, 0, auto);
+    font-size: inherit;
+
+    & + & {
+      position: relative;
+      padding-left: 0.8rem;
+
+      &::before {
+        content: $richie-breadcrumbs-separator;
+        position: absolute;
+        top: 0;
+        left: 0.2rem;
+      }
+    }
+  }
+}

--- a/src/richie/apps/core/templates/menu/breadcrumb_item.html
+++ b/src/richie/apps/core/templates/menu/breadcrumb_item.html
@@ -1,0 +1,9 @@
+{% for ancestor in ancestors %}
+<li class="breadcrumbs__item">
+    {% if not forloop.last %}
+    <a href="{{ ancestor.get_absolute_url }}">{{ ancestor.get_menu_title }}</a>
+    {% else %}
+    <span class="active">{{ ancestor.get_menu_title }}</span>
+    {% endif %}
+</li>
+{% endfor %}

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -43,6 +43,11 @@
             {% endblock body_header %}
 
             <div class="body-content {% block bodycontent_classes %}{% endblock bodycontent_classes %}">
+            {% block breadcrumbs %}
+            <ul class="breadcrumbs">
+                {% block breadcrumbs_content %}{% show_breadcrumb 0 "menu/breadcrumb_item.html" %}{% endblock breadcrumbs_content %}
+            </ul>
+            {% endblock breadcrumbs %}
             {% block content %}{% endblock content %}
             </div>
 

--- a/src/richie/apps/core/templates/richie/homepage.html
+++ b/src/richie/apps/core/templates/richie/homepage.html
@@ -1,6 +1,8 @@
 {% extends "richie/base.html" %}
 {% load cms_tags %}
 
+{% block breadcrumbs %}{% endblock breadcrumbs %}
+
 {% block title %}
     {% page_attribute "page_title" %}
 {% endblock title %}

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
@@ -1,6 +1,8 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags i18n %}
 
+{% block breadcrumbs %}{% endblock breadcrumbs %}
+
 {% block content %}
 <div class="blogpost-glimpse-list">
   <h1 class="blogpost-glimpse-list__title">{{ current_page.get_title }}</h1>

--- a/src/richie/apps/courses/templates/courses/cms/category_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_list.html
@@ -1,6 +1,8 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags i18n %}
 
+{% block breadcrumbs %}{% endblock breadcrumbs %}
+
 {% block content %}
 <div class="category-glimpse-list">
   <h1 class="category-glimpse-list__title">{{ current_page.get_title }}</h1>

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -1,6 +1,8 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags i18n extra_tags thumbnail %}
 
+{% block breadcrumbs %}{% endblock breadcrumbs %}
+
 {% block meta %}
 {# Make sure course snapshot pages are not indexed by search engines #}
 {% if current_page.parent_page.course %}<meta name="robots" content="noindex">{% endif %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_list.html
@@ -1,6 +1,8 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags i18n %}
 
+{% block breadcrumbs %}{% endblock breadcrumbs %}
+
 {% block content %}
 <div class="organization-list">
   <h1 class="organization-list__title">{{ current_page.get_title }}</h1>

--- a/src/richie/apps/courses/templates/courses/cms/person_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_list.html
@@ -1,6 +1,8 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags i18n %}
 
+{% block breadcrumbs %}{% endblock breadcrumbs %}
+
 {% block content %}
 <div class="person-glimpse-list">
   <h1 class="person-glimpse-list__title">{{ current_page.get_title }}</h1>

--- a/src/richie/apps/search/templates/search/search.html
+++ b/src/richie/apps/search/templates/search/search.html
@@ -10,6 +10,8 @@
 
 {% block title %}{% page_attribute "page_title" %}{% endblock title %}
 
+{% block breadcrumbs %}{% endblock breadcrumbs %}
+
 {# Enable flex on the `.body-content` so children can grow to occupy the available vertical space #}
 {% block bodycontent_classes %}body-content--flex-mode{% endblock bodycontent_classes %}
 


### PR DESCRIPTION
## Purpose

Pages missed breadcrumbs which is a penalty for ergonomy, since we have more
than two page levels.

## Proposal

Here we add breadcrumbs as a common element from base template skeleton in
its own template block so on default it is enabled everywhere. However we do
not want to show it on homepage and first level page which are already
visually active in header menu, so we disable breadcrumbs block from all
page listing templates.

This does not involve any new tests since we stand on basical feature from
Django templates and DjangoCMS.
