### PR TITLE
⬆️ (circle) upgrade crowdin image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
   # translation management tool
   upload-i18n-strings:
     docker:
-      - image: fundocker/crowdin:2.0.27
+      - image: fundocker/crowdin:2.0.31
     working_directory: ~/fun
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add breadcrumbs element on all pages but the listing ones.
 
+### Changed
+
+- Upgrade crowdin image used in circle-ci to version 2.0.31 including
+  tar command.
+
 ### Fixed
 
 - Translate login/signup on header.


### PR DESCRIPTION
## Purpose

The circle-ci job uploading translations on crowdin is failing since few
days because there is an issue with the tar version used in our crowdin
image. We think it's a circle-ci regression, they remove the fallback on
their tools to use the good tar commad. We decided to add tar in our
crowdin image and to use it in our upload-i18n-strings job.

## Proposal

- [x] Upgrade crowdin image used in circle-ci to version 2.0.31 including tar command