### PR TITLE
🐛(static) fix logo location that breaks static finder

### DIFF
--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -28,7 +28,7 @@
                 {% comment %}Since we are not able yet to get relevant image contextually for each content kind, we
                 keep the logo as the ressource image for all{% endcomment %}
                 {% block meta_opengraph_image %}
-                    <meta property="og:image" content="{{ SITE.web_url }}{% static "images/logo.png" %}">
+                    <meta property="og:image" content="{{ SITE.web_url }}{% static "richie/images/logo.png" %}">
                 {% endblock meta_opengraph_image %}
                 {% block meta_opengraph_contextuals %}
                     <meta property="og:title" content="{{ SITE.name }}">


### PR DESCRIPTION
## Purpose

The logo image location was modified but the SEO tag PR was opened before this and still had the old path. This error only appears after deployment because it is caused by the use of the Manifest
static storage backend.

## Proposal

Fix logo image location in base.html template.

Note: We should add tests in our CI to identify this type of issues earlier. I'm going to open an issue.

