### PR TITLE
💄(layout) enable submenu in footer main menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Allow second level children in footer menu.
+
 ### Changed
 
 - Use SVG icons instead of an icon font.

--- a/src/frontend/scss/components/_footer.scss
+++ b/src/frontend/scss/components/_footer.scss
@@ -34,23 +34,48 @@ $richie-footer-poweredby-link-fontcolor: $white !default;
   color: $richie-footer-fontcolor;
   background: $richie-footer-background;
 
+  &__submenu {
+    @include sv-flex(1, 0, 100%);
+
+    &__list {
+      margin: 0;
+      padding: $richie-footer-menu-link-padding;
+      padding-top: 0;
+      list-style-type: none;
+
+      &__item {
+        &__link {
+          display: block;
+          font-weight: normal;
+          color: $richie-footer-menu-link-fontcolor;
+
+          &:hover {
+            color: $richie-footer-menu-link-fontcolor-hover;
+            text-decoration: none;
+          }
+        }
+      }
+    }
+  }
+
   &__menu {
     @include sv-flex(1, 0, 100%);
     display: flex;
     border-bottom: $richie-footer-menu-border;
 
     &__list {
+      display: flex;
       width: 100%;
       max-width: map-get($container-max-widths, 'xl');
       margin: 0 auto;
-      display: flex;
       flex-direction: row;
       flex-wrap: wrap;
       justify-content: center;
+      list-style-type: none;
 
       &__item {
         @include sv-flex(1, 0, 100%);
-        display: flex;
+        display: block;
         margin: $richie-footer-menu-item-margin;
         padding: $richie-footer-menu-item-padding;
         color: inherit;
@@ -59,10 +84,13 @@ $richie-footer-poweredby-link-fontcolor: $white !default;
           @include sv-flex(0, 0, auto);
           margin: $richie-footer-menu-item-margin-lg;
           padding: $richie-footer-menu-item-padding-lg;
+
+          & + & {
+            margin-left: 1rem;
+          }
         }
 
         &__link {
-          @include sv-flex(1, 0, 100%);
           display: block;
           padding: $richie-footer-menu-link-padding;
           font-weight: $richie-footer-menu-link-fontweight;

--- a/src/richie/apps/core/templates/menu/footer_menu.html
+++ b/src/richie/apps/core/templates/menu/footer_menu.html
@@ -1,4 +1,4 @@
-{% load cms_tags %}{% spaceless %}
+{% load menu_tags %}{% spaceless %}
 
 {% for child in children %}
     {% with children_slug=child.get_menu_title|slugify %}
@@ -8,12 +8,24 @@
             {% if child.sibling %} body-footer__menu__list__item--sibling{% endif %}
             {% if child.descendant %} body-footer__menu__list__item--descendant{% endif %}">
             <a class="body-footer__menu__list__item__link" href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">{{ child.get_menu_title }}</a>
-            {% comment %}Dropdown menu are not yet implemented since there is no need about it for now{% endcomment %}
-            {% comment %}{% if child.children %}
-            <ul>
-                {% show_menu from_level to_level extra_inactive extra_active template "" "" child %}
-            </ul>
-            {% endif %}{% endcomment %}
+
+            {% with grand_children=child.children %}
+                {% if grand_children %}
+                <div class="body-footer__submenu">
+                    <ul class="body-footer__submenu__list">
+                        {% for grand_child in grand_children %}
+                            <li class="body-footer__submenu__list__item
+                                {% if grand_child.selected %} body-footer__submenu__list__item--selected{% endif %}
+                                {% if grand_child.ancestor %} body-footer__submenu__list__item--ancestor{% endif %}
+                                {% if grand_child.sibling %} body-footer__submenu__list__item--sibling{% endif %}
+                                {% if grand_child.descendant %} body-footer__submenu__list__item--descendant{% endif %}">
+                                <a class="body-footer__submenu__list__item__link" href="{{ grand_child.attr.redirect_url|default:grand_child.get_absolute_url }}">{{ grand_child.get_menu_title }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                {% endif %}
+            {% endwith %}
         </li>
     {% endwith %}
 {% endfor %}

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -87,7 +87,7 @@
             <div class="body-footer">
                 <div class="body-footer__menu">
                     <ul class="body-footer__menu__list">
-                        {% show_menu_below_id "annex" 0 100 100 100 "menu/footer_menu.html" %}
+                        {% show_menu_below_id "annex" 0 2 100 100 "menu/footer_menu.html" %}
                     </ul>
                 </div>
                 <div class="body-footer__brand">


### PR DESCRIPTION
## Purpose

It has been required that footer main menu should be able to display a second
level menu if there is one.

## Proposal

This commit changed footer_menu.html template to enable to list direct
children of first level items. Note that this only display well if all first
level items have children, else it could seem a little bit empty.
