### PR TITLE
🐛(sitemap) filter out Course run items from "sitemap.xml"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Filter out Course runs from "sitemap.xml".
+
 ## [1.11.0] - 2019-10-11
 
 ### Added

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -9,8 +9,7 @@ from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.views.static import serve
 
-from cms.sitemaps import CMSSitemap
-
+from richie.apps.core.sitemaps import CourseRunFreeSitemap
 from richie.apps.search.urls import urlpatterns as search_urlpatterns
 
 # For now, we use URLPathVersioning to be consistent with fonzie. Fonzie uses it
@@ -21,7 +20,7 @@ API_PREFIX = r"v(?P<version>[0-9]+\.[0-9]+)"
 admin.autodiscover()
 
 urlpatterns = [
-    url(r"^sitemap\.xml$", sitemap, {"sitemaps": {"cmspages": CMSSitemap}}),
+    url(r"^sitemap\.xml$", sitemap, {"sitemaps": {"cmspages": CourseRunFreeSitemap}}),
     url(r"^api/{}/".format(API_PREFIX), include(search_urlpatterns)),
     url(r"^", include("filer.server.urls")),
 ]

--- a/src/richie/apps/core/sitemaps.py
+++ b/src/richie/apps/core/sitemaps.py
@@ -1,0 +1,16 @@
+"""
+Sitemap generators for contents
+"""
+from cms.sitemaps import CMSSitemap
+
+
+class CourseRunFreeSitemap(CMSSitemap):
+    """
+    A CMS pages sitemap which is free from Course run items.
+    """
+
+    def items(self):
+        titles = super().items()
+
+        # Exclude all page which have a non null course run attribute
+        return titles.filter(page__courserun__isnull=True)


### PR DESCRIPTION
## Purpose

Currently, the generated "sitemap.xml" contains all course run pages but they are not desired for SEO so they should not be included in Sitemap file.

This is related to opened issue #824 

## Proposal

This commit add a new custom Sitemap generator for cms pages which inherit from the one from DjangoCMS just to filter out Course run pages.
