### PR TITLE
👌(layout) fix HTML validation warnings and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Add missing attribute "alt" on some "<img>" tags in templates,
 - Remove deprecated attribute "type" from some "<script>" tags in templates,
 - In the sandbox, make API calls work behind an htaccess by removing Basic
   Auth fallback,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix invalid "button" tag inside a "a" tag inside course glimpse,
 - Fix invalid attributes on "iframe" tag from djangocms_video plugin,
 - Fix invalid syntax in "sizes" attribute value on "<img>" tags,
 - Add url escaping on variables inside links from on social network badges,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix invalid syntax in "sizes" attribute value on "<img>" tags,
 - Add url escaping on variables inside links from on social network badges,
 - Fix invalid syntax in "srcset" attribute value on "<img>" tags,
 - Add missing attribute "alt" on some "<img>" tags in templates,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Remove deprecated attribute "type" from some "<script>" tags in templates,
 - In the sandbox, make API calls work behind an htaccess by removing Basic
   Auth fallback,
 - Fix React pagination role-element pair. Pagination should now be seen as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,20 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - In the sandbox, make API calls work behind an htaccess by removing Basic
   Auth fallback,
 - Fix React pagination role-element pair. Pagination should now be seen as a
-  navigational element by screen readers.
+  navigational element by screen readers,
+- Fix add plugin to team and organization on fragment_course_content template
+  when they are empty,
+- Remove deprecated attribute "type" from some "<script>" tags in templates,
+- Add missing attribute "alt" on some "<img>" tags in templates,
+- Fix invalid syntax in "srcset" attribute value on "<img>" tags,
+- Add url escaping on variables inside links on social network badges,
+- Fix invalid syntax in "sizes" attribute value on "<img>" tags,
+- Fix invalid attributes on "iframe" tag from djangocms_video plugin,
+- Fix invalid "button" tag inside a "a" tag inside course glimpse,
+- Fix invalid "role" value on pagination list with a "nav" tag around bullet
+  list instead,
+- Fix warning about multiple "h1" tags on homepage, section template will
+  always have a default level title to 2.
 
 ## [1.11.0] - 2019-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix invalid "role" value on pagination list with a "nav" tag around bullet
+  list instead,
 - Fix invalid "button" tag inside a "a" tag inside course glimpse,
 - Fix invalid attributes on "iframe" tag from djangocms_video plugin,
 - Fix invalid syntax in "sizes" attribute value on "<img>" tags,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix invalid attributes on "iframe" tag from djangocms_video plugin,
 - Fix invalid syntax in "sizes" attribute value on "<img>" tags,
 - Add url escaping on variables inside links from on social network badges,
 - Fix invalid syntax in "srcset" attribute value on "<img>" tags,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Add url escaping on variables inside links from on social network badges,
 - Fix invalid syntax in "srcset" attribute value on "<img>" tags,
 - Add missing attribute "alt" on some "<img>" tags in templates,
 - Remove deprecated attribute "type" from some "<script>" tags in templates,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix invalid syntax in "srcset" attribute value on "<img>" tags,
 - Add missing attribute "alt" on some "<img>" tags in templates,
 - Remove deprecated attribute "type" from some "<script>" tags in templates,
 - In the sandbox, make API calls work behind an htaccess by removing Basic

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -168,9 +168,39 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
         "dj_pagination.middleware.PaginationMiddleware",
     )
 
+    # Django applications from the highest priority to the lowest
     INSTALLED_APPS = (
-        # Django
+        # Richie stuff
+        "richie.apps.demo",
+        "richie.apps.search",
+        "richie.apps.courses",
+        "richie.apps.core",
+        "richie.plugins.html_sitemap",
+        "richie.plugins.large_banner",
+        "richie.plugins.plain_text",
+        "richie.plugins.section",
+        "richie.plugins.simple_picture",
+        "richie.plugins.simple_text_ckeditor",
+        "richie",
+        # Third party apps
+        "dj_pagination",
+        "dockerflow.django",
+        "parler",
+        "rest_framework",
+        # Django-cms
         "djangocms_admin_style",
+        "djangocms_googlemap",
+        "djangocms_link",
+        "djangocms_picture",
+        "djangocms_text_ckeditor",
+        "djangocms_video",
+        "cms",
+        "menus",
+        "sekizai",
+        "treebeard",
+        "filer",
+        "easy_thumbnails",
+        # Django
         "django.contrib.auth",
         "django.contrib.contenttypes",
         "django.contrib.sessions",
@@ -179,35 +209,6 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
         "django.contrib.sitemaps",
         "django.contrib.staticfiles",
         "django.contrib.messages",
-        # Django-cms
-        "cms",
-        "menus",
-        "sekizai",
-        "treebeard",
-        "djangocms_text_ckeditor",
-        "filer",
-        "easy_thumbnails",
-        "djangocms_link",
-        "djangocms_googlemap",
-        "djangocms_video",
-        "djangocms_picture",
-        # Richie stuff
-        "richie",
-        "richie.apps.core",
-        "richie.apps.courses",
-        "richie.apps.demo",
-        "richie.apps.search",
-        "richie.plugins.html_sitemap",
-        "richie.plugins.large_banner",
-        "richie.plugins.plain_text",
-        "richie.plugins.section",
-        "richie.plugins.simple_picture",
-        "richie.plugins.simple_text_ckeditor",
-        # Third party apps
-        "dj_pagination",
-        "dockerflow.django",
-        "parler",
-        "rest_framework",
     )
 
     # Languages

--- a/src/richie/apps/core/templates/djangocms_video/default/video_player.html
+++ b/src/richie/apps/core/templates/djangocms_video/default/video_player.html
@@ -1,0 +1,33 @@
+{% load i18n cms_tags %}
+{% comment %}
+This is a copy of original template from plugin just to clean <iframe> from
+obsolete attribute "frameborder" and invalid "allowfullscreen" attribute value.
+{% endcomment %}
+
+{% if instance.embed_link %}
+    {# show iframe if embed_link is provided #}
+    <iframe src="{{ instance.embed_link_with_parameters }}" {{ instance.attributes_str }} allowfullscreen></iframe>
+    {% with disabled=instance.embed_link %}
+        {% for plugin in instance.child_plugin_instances %}
+            {% render_plugin plugin %}
+        {% endfor %}
+    {% endwith %}
+{% else %}
+    {# render <source> or <track> plugins #}
+    <video controls {{ instance.attributes_str }}
+        {% if instance.poster %} poster="{{ instance.poster.url }}"{% endif %}>
+        {% for plugin in instance.child_plugin_instances %}
+            {% render_plugin plugin %}
+        {% endfor %}
+        {% trans "Your browser doesn't support this video format." %}
+    </video>
+{% endif %}
+
+{% comment %}
+    # Available variables:
+    {{ instance.template }}
+    {{ instance.label }}
+    {{ instance.embed_link }}
+    {{ instance.poster }}
+    {{ instance.attributes_str }}
+{% endcomment %}

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -112,8 +112,8 @@
         </div>
 
         {% render_block "js" %}
-        <script type="text/javascript" src="{% static 'richie/js/index.js' %}"></script>
-        <script type="text/javascript">
+        <script src="{% static 'richie/js/index.js' %}"></script>
+        <script>
         document.addEventListener('DOMContentLoaded', () => {
             // Get all topbar burger elements
             const $topbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.topbar__hamburger'), 0);

--- a/src/richie/apps/core/templates/richie/pagination.html
+++ b/src/richie/apps/core/templates/richie/pagination.html
@@ -4,53 +4,55 @@
 <div class="pagination">
   <div id="pagination-label" class="offscreen">{% trans "Pagination" %}</div>
 
-  <ul role="navigation" aria-labelledby="pagination-label" class="pagination__list">
-  {% for page in pages %}
-    {% if page %}
-      {% ifequal page page_obj.number %}
-        <li class="pagination__list__item pagination__list__item--current">
-          <span class="pagination__list__item__page-number">
-            <span class="offscreen">
-            {% if forloop.last %}
-              {% blocktrans %}Currently reading last page {{ page }}{% endblocktrans %}
-            {% else %}
-              {% blocktrans %}Currently reading page {{ page }}{% endblocktrans %}
-            {% endif %}
+  <nav aria-labelledby="pagination-label">
+    <ul class="pagination__list">
+    {% for page in pages %}
+      {% if page %}
+        {% ifequal page page_obj.number %}
+          <li class="pagination__list__item pagination__list__item--current">
+            <span class="pagination__list__item__page-number">
+              <span class="offscreen">
+              {% if forloop.last %}
+                {% blocktrans %}Currently reading last page {{ page }}{% endblocktrans %}
+              {% else %}
+                {% blocktrans %}Currently reading page {{ page }}{% endblocktrans %}
+              {% endif %}
+              </span>
+              <span aria-hidden="true">{% if page == 1 %}Page {{ page }}{% else %}{{ page }}{% endif %}</span>
             </span>
-            <span aria-hidden="true">{% if page == 1 %}Page {{ page }}{% else %}{{ page }}{% endif %}</span>
-          </span>
-        </li>
-      {% else %}
-        {% if page == 1 %}
-          <li class="pagination__list__item">
-            <a href="{{ request.path }}{% if getvars %}?{{ getvars|slice:"1:" }}{% endif %}" class="pagination__list__item__page-number">
-              {% blocktrans %}Page {{ page }}{% endblocktrans %}
-            </a>
           </li>
         {% else %}
-          <li class="pagination__list__item">
-            <a href="?page{{ page_suffix }}={{ page }}{{ getvars }}" class="pagination__list__item__page-number">
-              <span class="offscreen">
-                {% if page == page_obj.previous_page_number %}
-                  {% blocktrans %}Previous page {{ page }}{% endblocktrans %}
-                {% elif forloop.last %}
-                  {% blocktrans %}Last page {{ page }}{% endblocktrans %}
-                {% elif page == page_obj.next_page_number %}
-                  {% blocktrans %}Next page {{ page }}{% endblocktrans %}
-                {% else %}
-                  {% blocktrans %}Page {{ page }}{% endblocktrans %}
-                {% endif %}
-              </span>
-              <span aria-hidden="true">{{ page }}</span>
-            </a>
-          </li>
-        {% endif %}
-      {% endifequal %}
-    {% else %}
-      <li class="pagination__list__item pagination__list__item--placeholder">...</li>
-    {% endif %}
-  {% endfor %}
-  </ul>
+          {% if page == 1 %}
+            <li class="pagination__list__item">
+              <a href="{{ request.path }}{% if getvars %}?{{ getvars|slice:"1:" }}{% endif %}" class="pagination__list__item__page-number">
+                {% blocktrans %}Page {{ page }}{% endblocktrans %}
+              </a>
+            </li>
+          {% else %}
+            <li class="pagination__list__item">
+              <a href="?page{{ page_suffix }}={{ page }}{{ getvars }}" class="pagination__list__item__page-number">
+                <span class="offscreen">
+                  {% if page == page_obj.previous_page_number %}
+                    {% blocktrans %}Previous page {{ page }}{% endblocktrans %}
+                  {% elif forloop.last %}
+                    {% blocktrans %}Last page {{ page }}{% endblocktrans %}
+                  {% elif page == page_obj.next_page_number %}
+                    {% blocktrans %}Next page {{ page }}{% endblocktrans %}
+                  {% else %}
+                    {% blocktrans %}Page {{ page }}{% endblocktrans %}
+                  {% endif %}
+                </span>
+                <span aria-hidden="true">{{ page }}</span>
+              </a>
+            </li>
+          {% endif %}
+        {% endifequal %}
+      {% else %}
+        <li class="pagination__list__item pagination__list__item--placeholder">...</li>
+      {% endif %}
+    {% endfor %}
+    </ul>
+  </nav>
 </div>
 {% endif %}
 {% endspaceless %}

--- a/src/richie/apps/core/templates/social-networks/blogpost-badges.html
+++ b/src/richie/apps/core/templates/social-networks/blogpost-badges.html
@@ -24,7 +24,7 @@
             </svg>
         </a>
         <a
-            href="mailto:?subject={{ mailto_subject }}&amp;body={{ full_page_url }}"
+            href="mailto:?subject={{ mailto_subject|urlencode }}&amp;body={{ full_page_url|urlencode }}"
             class="social-network-badges__item"
             target="_blank"
             title="{% trans "Share by Email" %}"

--- a/src/richie/apps/core/templates/social-networks/course-badges.html
+++ b/src/richie/apps/core/templates/social-networks/course-badges.html
@@ -24,7 +24,7 @@
             </svg>
         </a>
         <a
-            href="mailto:?subject={{ shared_subject }}&amp;body={{ shared_sentence }}"
+            href="mailto:?subject={{ shared_subject|urlencode }}&amp;body={{ shared_sentence|urlencode }}"
             class="social-network-badges__item"
             target="_blank"
             title="{% trans "Share by Email" %}"

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -52,9 +52,9 @@
       <img
         src="{% thumbnail instance.picture 500x500 subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 500x500 subject_location=instance.picture.subject_location %} 500w,
-          {% if instance.picture.width >= 1000 %}{% thumbnail instance.picture 1000x1000 subject_location=instance.picture.subject_location %} 1000w,{% endif %}
-          {% if instance.picture.width >= 2000 %}{% thumbnail instance.picture 2000x2000 subject_location=instance.picture.subject_location %} 2000w{% endif %}
+          {% thumbnail instance.picture 500x500 subject_location=instance.picture.subject_location %} 500w
+          {% if instance.picture.width >= 1000 %},{% thumbnail instance.picture 1000x1000 subject_location=instance.picture.subject_location %} 1000w{% endif %}
+          {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x2000 subject_location=instance.picture.subject_location %} 2000w{% endif %}
         "
         sizes="500px"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'blog post cover image' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -17,9 +17,9 @@
       <img
         src="{% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %} 1140w,
-          {% if instance.picture.width >= 2280 %}{% thumbnail instance.picture 2280x800 crop upscale subject_location=instance.picture.subject_location %} 2280w,{% endif %}
-          {% if instance.picture.width >= 3420 %}{% thumbnail instance.picture 3420x600 crop upscale subject_location=instance.picture.subject_location %} 3420w{% endif %}
+          {% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %} 1140w
+          {% if instance.picture.width >= 2280 %},{% thumbnail instance.picture 2280x800 crop upscale subject_location=instance.picture.subject_location %} 2280w{% endif %}
+          {% if instance.picture.width >= 3420 %},{% thumbnail instance.picture 3420x600 crop upscale subject_location=instance.picture.subject_location %} 3420w{% endif %}
         "
         sizes="1140px"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'category banner' %}{% endif %}"
@@ -35,9 +35,9 @@
       <img
         src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w,
-          {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
-          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+          {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
+          {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+          {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
         "
         sizes="200px"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'category logo' %}{% endif %}"
@@ -52,9 +52,9 @@
         <img
           src="{% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %}"
           srcset="
-            {% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %} 60w,
-            {% if instance.picture.width >= 120 %}{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 80w,{% endif %}
-            {% if instance.picture.width >= 180 %}{% thumbnail instance.picture 180x180 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
+            {% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %} 60w
+            {% if instance.picture.width >= 120 %},{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 80w{% endif %}
+            {% if instance.picture.width >= 180 %},{% thumbnail instance.picture 180x180 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
           "
           sizes="60px"
           alt=""

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -81,23 +81,23 @@
 
       {% block cover %}
         {% if current_page.publisher_is_draft %}
-        <div class="course-detail__aside__cover">
-          {% get_placeholder_plugins "course_cover" as plugins or %}
-            <p class="course-detail__aside__cover__empty">{% trans 'Add an image for course cover on its glimpse.' %}</p>
-          {% endget_placeholder_plugins %}
-          {% blockplugin plugins.0 %}
-            <img
-              src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
-              srcset="
-                {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
-                {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-                {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
-              "
-              sizes="300px"
-              alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"
-            />
-          {% endblockplugin %}
-        </div>
+          <div class="course-detail__aside__cover">
+            {% get_placeholder_plugins "course_cover" as plugins or %}
+              <p class="course-detail__aside__cover__empty">{% trans 'Add an image for course cover on its glimpse.' %}</p>
+            {% endget_placeholder_plugins %}
+            {% blockplugin plugins.0 %}
+              <img
+                src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
+                srcset="
+                  {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w
+                  {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                  {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+                "
+                sizes="300px"
+                alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"
+              />
+            {% endblockplugin %}
+          </div>
         {% endif %}
       {% endblock cover %}
 

--- a/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
@@ -9,9 +9,9 @@
     {% blockplugin plugins.0 %}
     <img src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
       srcset="
-        {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
-        {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-        {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+        {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w
+        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+        {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
       "
       sizes="300px"
       alt=""

--- a/src/richie/apps/courses/templates/courses/cms/fragment_category_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_category_glimpse.html
@@ -10,9 +10,9 @@
       {% blockplugin plugins.0 %}
         <img src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
           srcset="
-            {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w,
-            {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
-            {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+            {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
+            {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+            {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
           "
           sizes="200px"
           alt=""

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -51,7 +51,7 @@
           </p>
           {% if course_state.call_to_action %}
           <div class="course-glimpse__footer__cta">
-              <button class="button">{{ course_state.call_to_action|capfirst }}</button>
+              <span class="button">{{ course_state.call_to_action|capfirst }}</span>
           </div>
           {% endif %}
       </div>

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -15,9 +15,9 @@
     {% blockplugin cover_plugins.0 %}
       <img src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
-          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-          {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+          {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w
+          {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+          {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
         "
         sizes="300px"
         {# alt forced to empty string for a11y because the image does not carry more information than the course title #}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
@@ -20,7 +20,7 @@
           {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
           {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
         "
-        sizes="100vw, (min-width: 576px) 50vw, (min-width: 1200px) 25vw"
+        sizes="(min-width: 576px) 50vw, (min-width: 1200px) 25vw, 100vw"
         alt=""
       />
     {% endblockplugin %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
@@ -15,10 +15,10 @@
     {% blockplugin plugins.0 %}
       <img src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w,
-          {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
-          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-          {% if instance.picture.width >= 800 %}{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+          {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w
+          {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+          {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+          {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
         "
         sizes="100vw, (min-width: 576px) 50vw, (min-width: 1200px) 25vw"
         alt=""

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
@@ -9,10 +9,10 @@
       {% blockplugin plugins.0 %}
         <img src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
           srcset="
-            {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w,
-            {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
-            {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-            {% if instance.picture.width >= 800 %}{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+            {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w
+            {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+            {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+            {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
           "
           sizes="30vw"
           alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'main organization logo' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
@@ -10,9 +10,9 @@
     {% blockplugin plugins.0 %}
       <img src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w,
-          {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
-          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+          {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
+          {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+          {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
         "
         sizes="200px"
         alt=""

--- a/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
@@ -9,9 +9,9 @@
     {% blockplugin plugins.0 %}
     <img src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
       srcset="
-        {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
-        {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-        {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+        {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w
+        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+        {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
       "
       sizes="300px"
       alt=""

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -42,7 +42,7 @@
           {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
           {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
         "
-        sizes="12rem, (min-width: 768px) 16rem, (min-width: 1200px) 20rem"
+        sizes="(min-width: 768px) 16rem, (min-width: 1200px) 20rem, 12rem"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization logo' %}{% endif %}"
       />
     {% endblockplugin %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -18,10 +18,10 @@
         src="{% thumbnail instance.picture 500x100 upscale subject_location=instance.picture.subject_location %}"
         srcset="
           {% thumbnail instance.picture 500x100 upscale subject_location=instance.picture.subject_location %} 500w,
-          {% thumbnail instance.picture 1000x200 upscale subject_location=instance.picture.subject_location %} 1000w,
-          {% if instance.picture.width >= 1500 %}{% thumbnail instance.picture 1500x300 upscale subject_location=instance.picture.subject_location %} 1500w,{% endif %}
-          {% if instance.picture.width >= 2000 %}{% thumbnail instance.picture 2000x400 upscale subject_location=instance.picture.subject_location %} 2000w{% endif %}
-          {% if instance.picture.width >= 2500 %}{% thumbnail instance.picture 2500x500 upscale subject_location=instance.picture.subject_location %} 2500w{% endif %}
+          {% thumbnail instance.picture 1000x200 upscale subject_location=instance.picture.subject_location %} 1000w
+          {% if instance.picture.width >= 1500 %},{% thumbnail instance.picture 1500x300 upscale subject_location=instance.picture.subject_location %} 1500w{% endif %}
+          {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x400 upscale subject_location=instance.picture.subject_location %} 2000w{% endif %}
+          {% if instance.picture.width >= 2500 %},{% thumbnail instance.picture 2500x500 upscale subject_location=instance.picture.subject_location %} 2500w{% endif %}
         "
         sizes="100vw"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization banner' %}{% endif %}"
@@ -37,10 +37,10 @@
       <img
         src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w,
-          {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
-          {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-          {% if instance.picture.width >= 800 %}{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+          {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w
+          {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+          {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+          {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
         "
         sizes="12rem, (min-width: 768px) 16rem, (min-width: 1200px) 20rem"
         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization logo' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -18,9 +18,9 @@
         <img
           src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
           srcset="
-            {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w,
-            {% if instance.picture.width >= 400 %}{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w,{% endif %}
-            {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+            {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
+            {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+            {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
           "
           sizes="200px"
           alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% blocktrans with title=current_page.get_title %}{{ title }} avatar{% endblocktrans %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/program_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_detail.html
@@ -19,9 +19,9 @@
       <img
         src="{% thumbnail instance.picture 500x500 subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 500x500 subject_location=instance.picture.subject_location %} 500w,
-          {% if instance.picture.width >= 1000 %}{% thumbnail instance.picture 1000x1000 subject_location=instance.picture.subject_location %} 1000w,{% endif %}
-          {% if instance.picture.width >= 2000 %}{% thumbnail instance.picture 2000x2000 subject_location=instance.picture.subject_location %} 2000w{% endif %}
+          {% thumbnail instance.picture 500x500 subject_location=instance.picture.subject_location %} 500w
+          {% if instance.picture.width >= 1000 %},{% thumbnail instance.picture 1000x1000 subject_location=instance.picture.subject_location %} 1000w{% endif %}
+          {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x2000 subject_location=instance.picture.subject_location %} 2000w{% endif %}
         "
         sizes="500px"
         alt="{% trans 'program cover image' %}"

--- a/src/richie/apps/courses/templates/courses/plugins/category_plugin.html
+++ b/src/richie/apps/courses/templates/courses/plugins/category_plugin.html
@@ -18,9 +18,9 @@
             </figcaption>
             <img src="{% thumbnail instance.picture 40x40 crop upscale subject_location=instance.picture.subject_location %}"
             srcset="
-            {% thumbnail instance.picture 40x40 crop upscale subject_location=instance.picture.subject_location %} 40w,
-            {% if instance.picture.width >= 80 %}{% thumbnail instance.picture 80x80 crop upscale subject_location=instance.picture.subject_location %} 80w,{% endif %}
-            {% if instance.picture.width >= 120 %}{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
+            {% thumbnail instance.picture 40x40 crop upscale subject_location=instance.picture.subject_location %} 40w
+            {% if instance.picture.width >= 80 %},{% thumbnail instance.picture 80x80 crop upscale subject_location=instance.picture.subject_location %} 80w{% endif %}
+            {% if instance.picture.width >= 120 %},{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
             "
             sizes="40px"
             class="category-plugin-tag__figure__image"
@@ -36,9 +36,9 @@
     {% blockplugin icon_plugins.0 %}
       <img src="{% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %}"
         srcset="
-          {% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %} 60w,
-          {% if instance.picture.width >= 120 %}{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 120w,{% endif %}
-          {% if instance.picture.width >= 180 %}{% thumbnail instance.picture 180x180 crop upscale subject_location=instance.picture.subject_location %} 180w{% endif %}
+          {% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %} 60w
+          {% if instance.picture.width >= 120 %},{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
+          {% if instance.picture.width >= 180 %},{% thumbnail instance.picture 180x180 crop upscale subject_location=instance.picture.subject_location %} 180w{% endif %}
         "
         sizes="60px"
         alt="{{ relevant_page.get_title }}"

--- a/src/richie/apps/courses/templates/courses/plugins/category_plugin.html
+++ b/src/richie/apps/courses/templates/courses/plugins/category_plugin.html
@@ -24,7 +24,7 @@
             "
             sizes="40px"
             class="category-plugin-tag__figure__image"
-            alt=""/>
+            alt="">
           </figure>
         {% endblockplugin %}
       {% else %}
@@ -42,7 +42,7 @@
         "
         sizes="60px"
         alt="{{ relevant_page.get_title }}"
-      />
+      >
     {% endblockplugin %}
   {% else %}
     {% include "courses/cms/fragment_category_glimpse.html" with category=relevant_page.category %}

--- a/src/richie/plugins/large_banner/templates/richie/large_banner/hero-intro.html
+++ b/src/richie/plugins/large_banner/templates/richie/large_banner/hero-intro.html
@@ -8,7 +8,7 @@
             <div class="hero-intro__body__content">{{ instance.content|safe }}</div>
         {% endif %}
         {% if instance.logo %}
-            <img src="{% thumbnail instance.logo 500x180 %}" class="hero-intro__body__logo" alt="{{ instance.logo_alt_text }}"/>
+            <img src="{% thumbnail instance.logo 500x180 %}" class="hero-intro__body__logo" alt="{{ instance.logo_alt_text }}">
         {% endif %}
     </div>
 </div>

--- a/src/richie/plugins/large_banner/templates/richie/large_banner/large_banner.html
+++ b/src/richie/plugins/large_banner/templates/richie/large_banner/large_banner.html
@@ -8,12 +8,12 @@
                     {% thumbnail instance.background_image 1900x450 crop=',0' %} 1900w,
                     {% thumbnail instance.background_image 1280x400 crop=',0' %} 1280w,
                     {% thumbnail instance.background_image 768x450 crop=',0' %} 768w"
-            alt="banner"/>
+            alt="banner">
     {% endif %}
     <div class="large-banner__body">
         <h1 class="large-banner__title">{{ instance.title }}</h1>
         {% if instance.logo %}
-            <img src="{% thumbnail instance.logo 200x100 crop='smart' %}" class="large-banner__logo" alt="{{ instance.logo_alt_text }}"/>
+            <img src="{% thumbnail instance.logo 200x100 crop='smart' %}" class="large-banner__logo" alt="{{ instance.logo_alt_text }}">
         {% endif %}
         {% if instance.content %}
             <div class="large-banner__content">{{ instance.content|safe }}</div>

--- a/src/richie/plugins/section/templates/richie/section/section_cadenced.html
+++ b/src/richie/plugins/section/templates/richie/section/section_cadenced.html
@@ -2,7 +2,7 @@
 
 <div class="section-container-cadenced">
     <section class="section">
-        <h{{ header_level|default:1 }} class="section__title">{{ instance.title }}</h{{ header_level|default:1 }}>
+        <h{{ header_level|default:2 }} class="section__title">{{ instance.title }}</h{{ header_level|default:2 }}>
         <div class="section__items">
             {% for plugin in instance.child_plugin_instances %}
                 {% with header_level=3 %}

--- a/src/richie/plugins/simple_picture/templates/richie/simple_picture/picture.html
+++ b/src/richie/plugins/simple_picture/templates/richie/simple_picture/picture.html
@@ -4,7 +4,7 @@
 <img src="{{ picture_info.src }}"
   {% if picture_info.srcset %} srcset="{{ picture_info.srcset }}"{% endif %}
   {% if picture_info.sizes %} sizes="{{ picture_info.sizes }}"{% endif %}
-  {% if picture_info.alt %} alt="{{ picture_info.alt }}"{% endif %}
+  alt="{% if picture_info.alt %}{{ picture_info.alt }}{% endif %}"
 >
 {% if picture_info.caption %}
     <figcaption>{{ picture_info.caption }}</figcaption>

--- a/src/richie/static/richie/README.md
+++ b/src/richie/static/richie/README.md
@@ -14,7 +14,7 @@ your `settings.INSTALLED_APPS` and load them in your main template, _e.g._:
         <!-- Load Richie's default styles -->
         <link rel="stylesheet" type="text/css" href="{% static 'richie/css/main.css' %}">
         <!-- Load Richie's front-end application -->
-        <script type="text/javascript" src="{% static 'richie/js/index.js' %}"></script>
+        <script src="{% static 'richie/js/index.js' %}"></script>
     </head>
     <body>
         <!-- Template content goes here -->

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -111,7 +111,7 @@ class CourseCMSTestCase(CMSTestCase):
             r'<figure class="category-plugin-tag__figure">'
             r'<figcaption.*class="category-plugin-tag__figure__caption".*>'
             r".*{title:s}.*</figcaption>"
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*icon\.jpg.*alt=""/>'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*icon\.jpg.*alt="">'
         )
 
         for icon in icons[:2]:


### PR DESCRIPTION
## Purpose

Issue #825 has reported some warnings and errors from HTML validator in almost all pages which should be resolved for sanity.

## Proposal

This pull request will fix every reported warnings and errors from issue except the one about missing `lang` attribute which has already been fixed in a previous commit about SEO.

- [x] Warning about deprecated `type` attribute on `<script>` tags;
- [x] Error on `srcset` attribute value on `<img>` tags;
- [x] Error on missing `alt` attribute on some `<img>` tags;
- [x] Error on `href` value on links with `mailto` content;
- [x] Error on `sizes` attribute value on `<img>` tags;
- [x] Error on obsolete `frameborder` attribute on `iframe`;
- [x] Warning about multiple `<h1>` on the same page (homepage);
- [x] Error on `<button>` inside `<a>` on course glimpses.
- [x] Error on invalid `role` value on pagination bullet list;
