### PR TITLE
🔖(chore) bump version to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.10.0] - 2019-10-08
+
 ### Added
 
 - Add plugin to embed organizations by their category on any page,
@@ -580,7 +582,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v1.9.2...master
+[unreleased]: https://github.com/openfun/richie/compare/v1.10.0...master
+[1.10.0]: https://github.com/openfun/richie/compare/v1.9.2...v1.10.0
 [1.9.2]: https://github.com/openfun/richie/compare/v1.9.1...v1.9.2
 [1.9.1]: https://github.com/openfun/richie/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/openfun/richie/compare/v1.8.3...v1.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 1.9.2
+version = 1.10.0
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {


### PR DESCRIPTION
### Added

- Add plugin to embed organizations by their category on any page,
- Display related organizations on category detail page,
- Add a variant option for organization glimpse,
- Allow tagging organizations with categories,
- Allow second level children in footer menu.

### Changed

- When displaying objects related to a category, include objects related to
  the categories' descendants,
- When displaying related objects on a category, respect page tree ordering,
- The filters pane in course search is now a sliding drawer on mobile,
- Use SVG icons instead of an icon font.

### Fixed

- Fix add plugin to team and organization on fragment_course_content template
  when they are empty.

### Removed

- Anti-pattern in factories to create related objects from the targeted page.
