### PR TITLE
✨(core) make stylesheet links overridable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Make stylesheet links overridable in the base template
+
 ## [1.10.0] - 2019-10-08
 
 ### Added

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -40,7 +40,9 @@
 
         {% render_block "css" %}
 
+        {% block css_links %}
         <link rel="stylesheet" type="text/css" href="{% static 'richie/css/main.css' %}">
+        {% endblock css_links %}
     </head>
     <body>
         {% cms_toolbar %}


### PR DESCRIPTION
## Purpose

When integrating Richie as a third party app, we may want to namespace our main CSS with the project name to avoid conflicts between the main styles of the project and the Richie app.

## Proposal

- [x] Add a `css_links` block in Richie's base template
