### PR TITLE
Wrap course detail sections in blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Add a variant option for course glimpses
+- Add a variant option for course glimpses.
+
+### Changed
+
+- Rename {% block title %} to {% block head_title %} to avoid collision with
+  H1 title.
 
 ## [1.11.0] - 2019-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Rename {% block title %} to {% block head_title %} to avoid collision with
-  H1 title.
+  H1 title,
+- Wrap each section of the course detail template in a block to allow partial
+  overrides.
 
 ## [1.11.0] - 2019-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Rename {% block title %} to {% block head_title %} to avoid collision with
   H1 title,
 - Wrap each section of the course detail template in a block to allow partial
-  overrides.
+  overrides,
+- Rename `course-detail__aside__run` selector to `course-detail__aside__runs`
+  in `course_detail.html` template to better reflect its content.
 
 ## [1.11.0] - 2019-10-11
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,19 @@ $ make migrate
   template(s) using icons from the icon font need to be updated to use SVG
   icons too.
 
+## 1.10.x to 1.11.x
+
+## Before switching
+
+- If you override `_course_detail.scss`, the `course-detail__aside__run` selector was renamed
+  to `course-detail__aside__runs` in our `course_detail.html` template.
+
+## 1.9.x to 1.10.x
+
+### Before switching
+
+- For each item in the [changelog](./CHANGELOG.md), check that your css overrides have no impact.
+
 ## 1.8.x to 1.9.x
 
 ### Before switching

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -3,7 +3,7 @@
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
         {% spaceless %}
-        <title>{% block title %}{{ SITE.name }}{% endblock title %}</title>
+        <title>{% block head_title %}{{ SITE.name }}{% endblock head_title %}</title>
         <meta name="viewport" content="width=device-width,initial-scale=1">
         {% block meta %}
             {% block meta_index_rules %}

--- a/src/richie/apps/core/templates/richie/fullwidth.html
+++ b/src/richie/apps/core/templates/richie/fullwidth.html
@@ -1,9 +1,9 @@
 {% extends "richie/base.html" %}
 {% load cms_tags %}
 
-{% block title %}
+{% block head_title %}
     {% page_attribute "page_title" %}
-{% endblock title %}
+{% endblock head_title %}
 
 {% block meta_opengraph_contextuals %}
     {% page_attribute "page_title" as page_title %}

--- a/src/richie/apps/core/templates/richie/homepage.html
+++ b/src/richie/apps/core/templates/richie/homepage.html
@@ -9,9 +9,9 @@
     <meta property="og:url" content="{{ SITE.web_url }}">
 {% endblock meta_opengraph_contextuals %}
 
-{% block title %}
+{% block head_title %}
     {% page_attribute "page_title" %}
-{% endblock title %}
+{% endblock head_title %}
 
 {% block content %}
     {% placeholder "maincontent" %}

--- a/src/richie/apps/core/templates/richie/single_column.html
+++ b/src/richie/apps/core/templates/richie/single_column.html
@@ -1,9 +1,9 @@
 {% extends "richie/base.html" %}
 {% load cms_tags %}
 
-{% block title %}
+{% block head_title %}
     {% page_attribute "page_title" %}
-{% endblock title %}
+{% endblock head_title %}
 
 {% block meta_opengraph_contextuals %}
     {% page_attribute "page_title" as page_title %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -19,170 +19,188 @@
 
 {% block content %}{% spaceless %}
 <div class="course-detail">
-  {% spaceless %}
 
     {% with course=current_page.course header_level=2 %}
 
     <div class="course-detail__content course-detail__content--two">
 
-      {% if request.current_page.parent_page.course %}
-      <div class="course-detail__content__snapshot">
-        <div class="course-detail__content__snapshot__date">
-          {% blocktrans with creation_date=request.current_page.creation_date|date:"SHORT_DATE_FORMAT" %}
-          Archived on {{ creation_date }}
-          {% endblocktrans %}
-        </div>
-        <a href="{{ request.current_page.parent_page.get_absolute_url }}">{% trans "Go to current version" %}</a>
-      </div>
-      {% endif %}
-
-      <h1 class="course-detail__content__title">
+      {% block snapshot %}
         {% if request.current_page.parent_page.course %}
-          {{ request.current_page.parent_page.get_title }}
-        {% else %}
-          {% render_model request.current_page "title" %}
+        <div class="course-detail__content__snapshot">
+          <div class="course-detail__content__snapshot__date">
+            {% blocktrans with creation_date=request.current_page.creation_date|date:"SHORT_DATE_FORMAT" %}
+              Archived on {{ creation_date }}
+            {% endblocktrans %}
+          </div>
+          <a href="{{ request.current_page.parent_page.get_absolute_url }}">{% trans "Go to current version" %}</a>
+        </div>
         {% endif %}
-      </h1>
+      {% endblock snapshot %}
 
-      {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_introduction" %}
-      <div class="course-detail__content__row course-detail__content__introduction">
-        {% page_placeholder "course_introduction" current_page %}
-      </div>
-      {% endif %}
+      {% block title %}
+        <h1 class="course-detail__content__title">
+          {% if request.current_page.parent_page.course %}
+            {{ request.current_page.parent_page.get_title }}
+          {% else %}
+            {% render_model request.current_page "title" %}
+          {% endif %}
+        </h1>
+      {% endblock title %}
 
-      {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_icons" or not current_page|is_empty_placeholder:"course_categories" %}
-      <div class="course-detail__content__row course-detail__content__categories">
-        {% with form_factor="tag" %}
-          {% placeholder "course_icons" %}
-          {% page_placeholder "course_categories" current_page or %}
-            {% if current_page.publisher_is_draft and current_page|is_empty_placeholder:"course_icons" %}
-              <p class="course-detail__content__categories__placeholder">
-                {% trans "No associated categories" %}
-              </p>
-            {% endif %}
-          {% endpage_placeholder %}
-        {% endwith %}
-      </div>
-      {% endif %}
+      {% block introduction %}
+        {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_introduction" %}
+        <div class="course-detail__content__row course-detail__content__introduction">
+          {% page_placeholder "course_introduction" current_page %}
+        </div>
+        {% endif %}
+      {% endblock introduction %}
 
-      {% include "courses/cms/fragment_course_content.html" with page=current_page %}
+      {% block categories %}
+        {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_icons" or not current_page|is_empty_placeholder:"course_categories" %}
+        <div class="course-detail__content__row course-detail__content__categories">
+          {% with form_factor="tag" %}
+            {% placeholder "course_icons" %}
+            {% page_placeholder "course_categories" current_page or %}
+              {% if current_page.publisher_is_draft and current_page|is_empty_placeholder:"course_icons" %}
+                <p class="course-detail__content__categories__placeholder">
+                  {% trans "No associated categories" %}
+                </p>
+              {% endif %}
+            {% endpage_placeholder %}
+          {% endwith %}
+        </div>
+        {% endif %}
+      {% endblock categories %}
+
+      {% block fragment %}
+        {% include "courses/cms/fragment_course_content.html" with page=current_page %}
+      {% endblock fragment %}
     </div>
 
     <div class="course-detail__aside">
 
-      {% if current_page.publisher_is_draft %}
-      <div class="course-detail__aside__cover">
-        {% get_placeholder_plugins "course_cover" as plugins or %}
-          <p class="course-detail__aside__cover__empty">{% trans 'Add an image for course cover on its glimpse.' %}</p>
-        {% endget_placeholder_plugins %}
-        {% blockplugin plugins.0 %}
-          <img
-            src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
-            srcset="
-              {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
-              {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
-              {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
-            "
-            sizes="300px"
-            alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"
-          />
-        {% endblockplugin %}
-      </div>
-      {% endif %}
-
-      {% with main_organization=course.get_main_organization %}
-        {% if main_organization %}
-          {% if current_page.publisher_is_draft %}
-              {% if main_organization.check_publication is True %}
-                  {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
-              {% else %}
-                  {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization %}
-              {% endif %}
-          {# If the current page is the published version, show only the organizations that are published #}
-          {% elif main_organization.check_publication is True %}
-              {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
-          {% endif %}
-        {% else %}
-          {% include "courses/cms/fragment_organization_main_logo.html" with organization=None %}
-        {% endif %}
-      {% endwith %}
-
-      <div class="course-detail__aside__social-networks">
-        {% include "social-networks/course-badges.html" with page_title=request.current_page.get_title page_url=request.current_page.get_absolute_url %}
-      </div>
-
-      {% if course.duration or course.effort or current_page.publisher_is_draft %}
-      <div class="course-detail__aside__synopsis">
-        <dl>
-          {% render_model_block course "duration,effort" %}
-            {% if instance.duration or current_page.publisher_is_draft %}
-            <dt>
-              <svg role="img" class="icon course-detail__aside__synopsis__icon" aria-hidden="true">
-                <use xlink:href="{% static 'richie/icons.svg' %}#icon-clock" />
-              </svg>
-              {% trans "Duration:" %}
-            </dt>
-            <dd>{{ instance.get_duration_display|default:"NA" }}</dd>
-            {% endif %}
-            {% if instance.effort or current_page.publisher_is_draft %}
-            <dt>
-              <svg role="img" class="icon course-detail__aside__synopsis__icon" aria-hidden="true">
-                <use xlink:href="{% static 'richie/icons.svg' %}#icon-stopwatch" />
-              </svg>
-              {% trans "Effort:" %}
-            </dt>
-            <dd>{{ instance.get_effort_display|default:"NA" }}</dd>
-            {% endif %}
-          {% endrender_model_block %}
-        </dl>
-      </div>
-      {% endif %}
-
-      <div class="course-detail__aside__run">
-        <h2 class="course-detail__aside__run__title">{% trans 'Course runs' %}</h2>
-        {% for run in course.get_course_runs_for_language %}
-        <div class="course-detail__aside__run__block">
-          <dl>
-            <dt>{% trans "Enrollment" %}</dt>
-            <dd>
-              {% render_model run "enrollment_start" "enrollment_start,enrollment_end" "" "date:'DATE_FORMAT'|default:'...'" as start %}
-              {% render_model run "enrollment_end" "enrollment_start,enrollment_end" "" "date:'DATE_FORMAT'|default:'...'" as end %}
-              {% trans "From" %} {{ start|safe }} {% trans "to" %} {{ end|safe }}
-            </dd>
-            <dt>{% trans "Course" %}</dt>
-            <dd>
-              {% render_model run "start" "start,end" "" "date:'DATE_FORMAT'|default:'...'" as start %}
-              {% render_model run "end" "start,end" "" "date:'DATE_FORMAT'|default:'...'" as end %}
-              {% trans "From" %} {{ start|safe }} {% trans "to" %} {{ end|safe }}
-            </dd>
-            <dt>{% trans "Languages" %}</dt><dd>{% render_model run "get_languages_display" "languages" %}</dd>
-            {% if current_page.publisher_is_draft %}
-            <dt>{% trans "Resource link" %}</dt>
-            <dd>
-              <a href="{{ run.resource_link }}">
-                {% render_model run "resource_link" "resource_link" %}
-              </a>
-            </dd>
-            {% endif %}
-          </dl>
-          {% if run.state.call_to_action %}
-          <a class="course-detail__aside__run__block__cta" href="{{ run.extended_object.get_absolute_url }}">
-            {{ run.state.call_to_action|capfirst }}
-          </a>
-          {% else %}
-          <a class="course-detail__aside__run__block__cta course-detail__aside__run__block__cta--projected" href="{{ run.extended_object.get_absolute_url }}">
-            {{ run.state.text|capfirst }}
-          </a>
-          {% endif %}
+      {% block cover %}
+        {% if current_page.publisher_is_draft %}
+        <div class="course-detail__aside__cover">
+          {% get_placeholder_plugins "course_cover" as plugins or %}
+            <p class="course-detail__aside__cover__empty">{% trans 'Add an image for course cover on its glimpse.' %}</p>
+          {% endget_placeholder_plugins %}
+          {% blockplugin plugins.0 %}
+            <img
+              src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
+              srcset="
+                {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w,
+                {% if instance.picture.width >= 600 %}{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w,{% endif %}
+                {% if instance.picture.width >= 900 %}{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+              "
+              sizes="300px"
+              alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"
+            />
+          {% endblockplugin %}
         </div>
-        {% empty %}
-          <div class="course-detail__aside__run__empty">{% trans "No associated course runs" %}</div>
-        {% endfor %}
+        {% endif %}
+      {% endblock cover %}
+
+      {% block main_organization %}
+        {% with main_organization=course.get_main_organization %}
+          {% if main_organization %}
+            {% if current_page.publisher_is_draft %}
+                {% if main_organization.check_publication is True %}
+                    {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
+                {% else %}
+                    {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization %}
+                {% endif %}
+            {# If the current page is the published version, show only the organizations that are published #}
+            {% elif main_organization.check_publication is True %}
+                {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
+            {% endif %}
+          {% else %}
+            {% include "courses/cms/fragment_organization_main_logo.html" with organization=None %}
+          {% endif %}
+        {% endwith %}
+      {% endblock main_organization %}
+
+      {% block social_networks %}
+        <div class="course-detail__aside__social-networks">
+          {% include "social-networks/course-badges.html" with page_title=request.current_page.get_title page_url=request.current_page.get_absolute_url %}
+        </div>
+      {% endblock social_networks %}
+
+      {% block synopsis %}
+        {% if course.duration or course.effort or current_page.publisher_is_draft %}
+        <div class="course-detail__aside__synopsis">
+          <dl>
+            {% render_model_block course "duration,effort" %}
+              {% if instance.duration or current_page.publisher_is_draft %}
+              <dt>
+                <svg role="img" class="icon course-detail__aside__synopsis__icon" aria-hidden="true">
+                  <use xlink:href="{% static 'richie/icons.svg' %}#icon-clock" />
+                </svg>
+                {% trans "Duration:" %}
+              </dt>
+              <dd>{{ instance.get_duration_display|default:"NA" }}</dd>
+              {% endif %}
+              {% if instance.effort or current_page.publisher_is_draft %}
+              <dt>
+                <svg role="img" class="icon course-detail__aside__synopsis__icon" aria-hidden="true">
+                  <use xlink:href="{% static 'richie/icons.svg' %}#icon-stopwatch" />
+                </svg>
+                {% trans "Effort:" %}
+              </dt>
+              <dd>{{ instance.get_effort_display|default:"NA" }}</dd>
+              {% endif %}
+            {% endrender_model_block %}
+          </dl>
+        </div>
+        {% endif %}
+      {% endblock synopsis %}
+
+      {% block runs %}
+        <div class="course-detail__aside__run">
+          <h2 class="course-detail__aside__run__title">{% trans 'Course runs' %}</h2>
+          {% for run in course.get_course_runs_for_language %}
+          <div class="course-detail__aside__run__block">
+            <dl>
+              <dt>{% trans "Enrollment" %}</dt>
+              <dd>
+                {% render_model run "enrollment_start" "enrollment_start,enrollment_end" "" "date:'DATE_FORMAT'|default:'...'" as start %}
+                {% render_model run "enrollment_end" "enrollment_start,enrollment_end" "" "date:'DATE_FORMAT'|default:'...'" as end %}
+                {% trans "From" %} {{ start|safe }} {% trans "to" %} {{ end|safe }}
+              </dd>
+              <dt>{% trans "Course" %}</dt>
+              <dd>
+                {% render_model run "start" "start,end" "" "date:'DATE_FORMAT'|default:'...'" as start %}
+                {% render_model run "end" "start,end" "" "date:'DATE_FORMAT'|default:'...'" as end %}
+                {% trans "From" %} {{ start|safe }} {% trans "to" %} {{ end|safe }}
+              </dd>
+              <dt>{% trans "Languages" %}</dt><dd>{% render_model run "get_languages_display" "languages" %}</dd>
+              {% if current_page.publisher_is_draft %}
+              <dt>{% trans "Resource link" %}</dt>
+              <dd>
+                <a href="{{ run.resource_link }}">
+                  {% render_model run "resource_link" "resource_link" %}
+                </a>
+              </dd>
+              {% endif %}
+            </dl>
+            {% if run.state.call_to_action %}
+            <a class="course-detail__aside__run__block__cta" href="{{ run.extended_object.get_absolute_url }}">
+              {{ run.state.call_to_action|capfirst }}
+            </a>
+            {% else %}
+            <a class="course-detail__aside__run__block__cta course-detail__aside__run__block__cta--projected" href="{{ run.extended_object.get_absolute_url }}">
+              {{ run.state.text|capfirst }}
+            </a>
+            {% endif %}
+          </div>
+          {% empty %}
+            <div class="course-detail__aside__run__empty">{% trans "No associated course runs" %}</div>
+          {% endfor %}
+        </div>
       </div>
-    </div>
+    {% endblock runs %}
 
     {% endwith %}
 
-  {% endspaceless %}
 </div>
 {% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -156,10 +156,10 @@
       {% endblock synopsis %}
 
       {% block runs %}
-        <div class="course-detail__aside__run">
-          <h2 class="course-detail__aside__run__title">{% trans 'Course runs' %}</h2>
+        <div class="course-detail__aside__runs">
+          <h2 class="course-detail__aside__runs__title">{% trans 'Course runs' %}</h2>
           {% for run in course.get_course_runs_for_language %}
-          <div class="course-detail__aside__run__block">
+          <div class="course-detail__aside__runs__block">
             <dl>
               <dt>{% trans "Enrollment" %}</dt>
               <dd>
@@ -184,17 +184,17 @@
               {% endif %}
             </dl>
             {% if run.state.call_to_action %}
-            <a class="course-detail__aside__run__block__cta" href="{{ run.extended_object.get_absolute_url }}">
+            <a class="course-detail__aside__runs__block__cta" href="{{ run.extended_object.get_absolute_url }}">
               {{ run.state.call_to_action|capfirst }}
             </a>
             {% else %}
-            <a class="course-detail__aside__run__block__cta course-detail__aside__run__block__cta--projected" href="{{ run.extended_object.get_absolute_url }}">
+            <a class="course-detail__aside__runs__block__cta course-detail__aside__runs__block__cta--projected" href="{{ run.extended_object.get_absolute_url }}">
               {{ run.state.text|capfirst }}
             </a>
             {% endif %}
           </div>
           {% empty %}
-            <div class="course-detail__aside__run__empty">{% trans "No associated course runs" %}</div>
+            <div class="course-detail__aside__runs__empty">{% trans "No associated course runs" %}</div>
           {% endfor %}
         </div>
       </div>

--- a/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
@@ -1,11 +1,11 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags i18n extra_tags %}
 
-{% block title %}{% spaceless %}
+{% block head_title %}{% spaceless %}
   {% page_attribute "page_title" as course_run_title %}
   {% page_attribute "page_title" current_page.parent_page as course_title %}
   {{ course_run_title|capfirst }} - {{ course_title|capfirst }}
-{% endspaceless %}{% endblock title %}
+{% endspaceless %}{% endblock head_title %}
 
 {# Make sure the course run pages are not indexed by search engines #}
 {% block meta_index_rules %}<meta name="robots" content="noindex">{% endblock meta_index_rules %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_content.html
@@ -1,122 +1,144 @@
 {% load cms_tags i18n extra_tags %}
 
-<div class="course-detail__content__row course-detail__content__teaser">
-  {% page_placeholder "course_teaser" page or %}
-    <div class="course-detail__content__row course-detail__content__teaser__empty">{% trans 'Add a video or teaser.' %}</div>
-  {% endpage_placeholder %}
-</div>
-
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_description" %}
-<section class="course-detail__content__row course-detail__content__description">
-  <h2 class="course-detail__content__row__title">{% trans 'About the course' %}</h2>
-  {% with header_level=3 %}
-    {% page_placeholder "course_description" page or %}
-      <p>{% trans 'Enter here a description of your course.' %}</p>
+{% block teaser %}
+  <div class="course-detail__content__row course-detail__content__teaser">
+    {% page_placeholder "course_teaser" page or %}
+      <div class="course-detail__content__row course-detail__content__teaser__empty">{% trans 'Add a video or teaser.' %}</div>
     {% endpage_placeholder %}
-  {% endwith %}
-</section>
-{% endif %}
+  </div>
+{% endblock teaser %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_skills" %}
-<div class="course-detail__content__row course-detail__content__skills">
-  <h2 class="course-detail__content__row__title">{% trans "What you will learn" %}</h2>
-  <p>{% trans "At the end of this course, you will be able to:" %}</p>
-  {% page_placeholder "course_skills" page %}
-</div>
+{% block description %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_description" %}
+  <section class="course-detail__content__row course-detail__content__description">
+    <h2 class="course-detail__content__row__title">{% trans 'About the course' %}</h2>
+    {% with header_level=3 %}
+      {% page_placeholder "course_description" page or %}
+        <p>{% trans 'Enter here a description of your course.' %}</p>
+      {% endpage_placeholder %}
+    {% endwith %}
+  </section>
 {% endif %}
+{% endblock description %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_format" %}
-<section class="course-detail__content__row course-detail__content__format">
-  <h2 class="course-detail__content__row__title">{% trans 'Format' %}</h2>
-  {% page_placeholder "course_format" page or %}
-    <p>{% trans 'How is the course structured?' %}</p>
-  {% endpage_placeholder %}
-</section>
-{% endif %}
+{% block skills %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_skills" %}
+  <div class="course-detail__content__row course-detail__content__skills">
+    <h2 class="course-detail__content__row__title">{% trans "What you will learn" %}</h2>
+    <p>{% trans "At the end of this course, you will be able to:" %}</p>
+    {% page_placeholder "course_skills" page %}
+  </div>
+  {% endif %}
+{% endblock skills %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_prerequisites" %}
-<section class="course-detail__content__row course-detail__content__prerequisites">
-  <h2 class="course-detail__content__row__title">{% trans 'Prerequisites' %}</h2>
-  {% page_placeholder "course_prerequisites" page or %}
-    <p>{% trans 'What are the prerequisites to follow this course?' %}</p>
-  {% endpage_placeholder %}
-</section>
-{% endif %}
+{% block format %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_format" %}
+  <section class="course-detail__content__row course-detail__content__format">
+    <h2 class="course-detail__content__row__title">{% trans 'Format' %}</h2>
+    {% page_placeholder "course_format" page or %}
+      <p>{% trans 'How is the course structured?' %}</p>
+    {% endpage_placeholder %}
+  </section>
+  {% endif %}
+{% endblock format %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_plan" %}
-<section class="course-detail__content__row course-detail__content__plan">
-  <h2 class="course-detail__content__row__title">{% trans 'Course plan' %}</h2>
-  {% page_placeholder "course_plan" page or %}
-    <p>{% trans 'Enter here the detailed course plan.' %}</p>
-  {% endpage_placeholder %}
-</section>
-{% endif %}
+{% block prerequisites %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_prerequisites" %}
+  <section class="course-detail__content__row course-detail__content__prerequisites">
+    <h2 class="course-detail__content__row__title">{% trans 'Prerequisites' %}</h2>
+    {% page_placeholder "course_prerequisites" page or %}
+      <p>{% trans 'What are the prerequisites to follow this course?' %}</p>
+    {% endpage_placeholder %}
+  </section>
+  {% endif %}
+{% endblock prerequisites %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_assessment" %}
-<section class="course-detail__content__row course-detail__content__assessment">
-  <h2 class="course-detail__content__row__title">{% trans 'Assessment and certification' %}</h2>
-  {% page_placeholder "course_assessment" page or %}
-    <p class="course-detail__content__assessment__placeholder">
-      {% trans "How is progress evaluated and/or certified?" %}
-    </p>
-  {% endpage_placeholder %}
-</section>
-{% endif %}
+{% block plan %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_plan" %}
+  <section class="course-detail__content__row course-detail__content__plan">
+    <h2 class="course-detail__content__row__title">{% trans 'Course plan' %}</h2>
+    {% page_placeholder "course_plan" page or %}
+      <p>{% trans 'Enter here the detailed course plan.' %}</p>
+    {% endpage_placeholder %}
+  </section>
+  {% endif %}
+{% endblock plan %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_organizations" %}
-<section class="section course-detail__content__row course-detail__content__organizations">
-  <h2 class="section__title course-detail__content__row__title course-detail__content__organizations__title">
-    {% trans 'Organizations' %}
-  </h2>
-  <div class="section__items course-detail__content__organizations__items">
-    {% page_placeholder "course_organizations" page or %}
-      <p class="course-detail__content__organizations__placeholder">
-        {% trans "What are the organizations publishing this course?" %}
+{% block assessment %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_assessment" %}
+  <section class="course-detail__content__row course-detail__content__assessment">
+    <h2 class="course-detail__content__row__title">{% trans 'Assessment and certification' %}</h2>
+    {% page_placeholder "course_assessment" page or %}
+      <p class="course-detail__content__assessment__placeholder">
+        {% trans "How is progress evaluated and/or certified?" %}
       </p>
     {% endpage_placeholder %}
-  </div>
-</section>
-{% endif %}
+  </section>
+  {% endif %}
+{% endblock assessment %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_team" %}
-<section class="section course-detail__content__row course-detail__content__team">
-  <h2 class="section.title course-detail__content__row__title course-detail__content__team__title">
-    {% trans 'Course team' %}
-  </h2>
-  {% with header_level=3 %}
-    <div class="section__items course-detail__content__team__items">
-      {% page_placeholder "course_team" page or %}
-        <p>{% trans 'Who are the teachers in the course team?' %}</p>
+{% block organizations %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_organizations" %}
+  <section class="section course-detail__content__row course-detail__content__organizations">
+    <h2 class="section__title course-detail__content__row__title course-detail__content__organizations__title">
+      {% trans 'Organizations' %}
+    </h2>
+    <div class="section__items course-detail__content__organizations__items">
+      {% page_placeholder "course_organizations" page or %}
+        <p class="course-detail__content__organizations__placeholder">
+          {% trans "What are the organizations publishing this course?" %}
+        </p>
       {% endpage_placeholder %}
     </div>
-  {% endwith %}
-</section>
-{% endif %}
+  </section>
+  {% endif %}
+{% endblock organizations %}
 
-{% if page.publisher_is_draft or not page|is_empty_placeholder:"course_information" %}
-<div class="course-detail__content__row course-detail__content__information">
-  {% page_placeholder "course_information" page %}
-</div>
-{% endif %}
-
-<section class="course-detail__content__row course-detail__content__license">
-  <h2 class="course-detail__content__row__title course-detail__content__license__title">{% trans 'License' %}</h2>
-
-  <div class="course-detail__content__license__item">
-    <h3 class="course-detail__content__license__item__title">{% trans 'License for the course content' %}</h3>
-    {% with header_level=4 %}
-      {% page_placeholder "course_license_content" page or %}
-        <p>{% trans 'What is the license for the course content?' %}</p>
-      {% endpage_placeholder %}
+{% block team %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_team" %}
+  <section class="section course-detail__content__row course-detail__content__team">
+    <h2 class="section.title course-detail__content__row__title course-detail__content__team__title">
+      {% trans 'Course team' %}
+    </h2>
+    {% with header_level=3 %}
+      <div class="section__items course-detail__content__team__items">
+        {% page_placeholder "course_team" page or %}
+          <p>{% trans 'Who are the teachers in the course team?' %}</p>
+        {% endpage_placeholder %}
+      </div>
     {% endwith %}
-  </div>
+  </section>
+  {% endif %}
+{% endblock team %}
 
-  <div class="course-detail__content__license__item">
-    <h3 class="course-detail__content__license__item__title">{% trans 'License for the content created by course participants' %}</h3>
-    {% with header_level=4 %}
-      {% page_placeholder "course_license_participation" page or %}
-        <p>{% trans 'What is the license for the content created by course participants?' %}</p>
-      {% endpage_placeholder %}
-    {% endwith %}
+{% block information %}
+  {% if page.publisher_is_draft or not page|is_empty_placeholder:"course_information" %}
+  <div class="course-detail__content__row course-detail__content__information">
+    {% page_placeholder "course_information" page %}
   </div>
-</section>
+  {% endif %}
+{% endblock information %}
+
+{% block licenses %}
+  <section class="course-detail__content__row course-detail__content__license">
+    <h2 class="course-detail__content__row__title course-detail__content__license__title">{% trans 'License' %}</h2>
+
+    <div class="course-detail__content__license__item">
+      <h3 class="course-detail__content__license__item__title">{% trans 'License for the course content' %}</h3>
+      {% with header_level=4 %}
+        {% page_placeholder "course_license_content" page or %}
+          <p>{% trans 'What is the license for the course content?' %}</p>
+        {% endpage_placeholder %}
+      {% endwith %}
+    </div>
+
+    <div class="course-detail__content__license__item">
+      <h3 class="course-detail__content__license__item__title">{% trans 'License for the content created by course participants' %}</h3>
+      {% with header_level=4 %}
+        {% page_placeholder "course_license_participation" page or %}
+          <p>{% trans 'What is the license for the content created by course participants?' %}</p>
+        {% endpage_placeholder %}
+      {% endwith %}
+    </div>
+  </section>
+{% endblock licenses %}

--- a/src/richie/apps/search/templates/search/search.html
+++ b/src/richie/apps/search/templates/search/search.html
@@ -8,7 +8,7 @@
   {% endif %}
 {% endblock meta %}
 
-{% block title %}{% page_attribute "page_title" %}{% endblock title %}
+{% block head_title %}{% page_attribute "page_title" %}{% endblock head_title %}
 
 {% block breadcrumbs %}{% endblock breadcrumbs %}
 

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -339,7 +339,7 @@ class CourseCMSTestCase(CMSTestCase):
         response = self.prepare_to_test_state(CourseState(0, timezone.now()))
         self.assertContains(
             response,
-            '<a class="course-detail__aside__run__block__cta" '
+            '<a class="course-detail__aside__runs__block__cta" '
             'href="/en/my-course/my-course-run/">Enroll now</a>',
             html=True,
         )
@@ -349,8 +349,8 @@ class CourseCMSTestCase(CMSTestCase):
         response = self.prepare_to_test_state(CourseState(6))
         self.assertContains(
             response,
-            '<a class="course-detail__aside__run__block__cta '
-            'course-detail__aside__run__block__cta--projected" '
+            '<a class="course-detail__aside__runs__block__cta '
+            'course-detail__aside__runs__block__cta--projected" '
             'href="/en/my-course/my-course-run/">To be scheduled</a>',
             html=True,
         )


### PR DESCRIPTION
## Purpose

The projects using richie as a dependency should be able to override a precise portion of the course detail view without having to override the whole template.

This will ease maintenance on such projects.

## Proposal

- [x] wrap each section in the course detail template in a template block,
- [x] rename the `title` block in html head to `head_title` to avoid collision with the new H1 `title` block.

While working on this PR I had the chance to rename `course-detail__aside__run` selector to `course-detail__aside__runs` in `course_detail.html` template to reflect the fact that there are many course runs.
