### PR TITLE
🐛(sandbox) make API calls work behind an htaccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- In the sandbox, make API calls work behind an htaccess by removing Basic
+  Auth fallback,
 - Fix React pagination role-element pair. Pagination should now be seen as a
   navigational element by screen readers.
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -48,6 +48,9 @@ class DRFMixin:
 
     REST_FRAMEWORK = {
         "ALLOWED_VERSIONS": ("1.0",),
+        "DEFAULT_AUTHENTICATION_CLASSES": (
+            "rest_framework.authentication.SessionAuthentication",
+        ),
         "DEFAULT_VERSION": "1.0",
         "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
     }

--- a/tests/sandbox/test_settings.py
+++ b/tests/sandbox/test_settings.py
@@ -3,7 +3,13 @@ Test suite for Richie's main module
 """
 from unittest import mock
 
-from django.test import TestCase
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from rest_framework.response import Response
+from rest_framework.settings import DEFAULTS, api_settings
+
+from richie.apps.search.viewsets.courses import CoursesViewSet
 
 # sandbox
 from sandbox.settings import get_release
@@ -37,3 +43,40 @@ class GetReleaseTestCase(TestCase):
         """
         with self.assertRaises(KeyError):
             get_release()
+
+    @mock.patch.object(CoursesViewSet, "list", spec=True, return_value=Response({}))
+    def test_configuration_restframework_htaccess(self, _mock_list):
+        """The search API endpoint should work behind an htaccess."""
+        # First, check that API calls were broken with the default DRF configuration
+        # What was happening is that DRF defines Basic Authentication as a fallback by default
+        # and our query has a basic auth header with the username and password of the htaccess
+        # defined in nginx. Django was trying to authenticate a user with these credentials,
+        # which of course failed.
+        with override_settings(
+            REST_FRAMEWORK={
+                **settings.REST_FRAMEWORK,
+                "DEFAULT_AUTHENTICATION_CLASSES": DEFAULTS[
+                    "DEFAULT_AUTHENTICATION_CLASSES"
+                ],
+            }
+        ):
+            authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES
+
+        # The authentication classes are loaded before settings are overriden so we need
+        # to mock them on the APIView
+        with mock.patch(
+            "rest_framework.views.APIView.authentication_classes",
+            new_callable=mock.PropertyMock,
+            return_value=authentication_classes,
+        ):
+            response = self.client.get(
+                "/api/v1.0/courses/",
+                HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            )
+        self.assertEqual(response.status_code, 403)
+
+        # Check that the project configuration solves it
+        response = self.client.get(
+            "/api/v1.0/courses/", HTTP_AUTHORIZATION="Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Purpose

The DRF API calls were responding with a 403 status code for anonymous users, and were working for authenticated users. This was due to a Basic Auth fallback option in the default configuration of DRF's authentication backends.

For an anonymous user:
- The first authentication backend in the list of DRF's default backends (Django session authentication) does not try to authenticate because it does not see any cookie,
- The second backend (Basic Authentication) tries to authenticate because it sees an Authentication header. But this header is coming from the Nginx htaccess (and is not known by Django), so the authentication fails with a 403.

Removing the Basic Authentication backend allows anonymous users to be really considered as anonymous in Django.

## Proposal

- Remove Basic Auth fallback option from DRF's authentication backends,
- Add a test to validate that the site now works behind an htaccess.

Another alternative would have been that nginx does not pass the Basic Authentication headers. This can be done in [arnold](https://github.com/openfun/arnold) but we also don't want to allow basic authentication on our site so it had to be removed here as well.

