### PR TITLE
👷(circleci) fix test-back-mysql following mysql image upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
         environment:
           MYSQL_ROOT_PASSWORD:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: richie
+          MYSQL_DATABASE: test_richie
           MYSQL_USER: fun
           MYSQL_PASSWORD: pass
         command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
@@ -257,7 +257,7 @@ jobs:
       # services
       - image: circleci/postgres:9.6-ram
         environment:
-          POSTGRES_DB: richie
+          POSTGRES_DB: test_richie
           POSTGRES_USER: fun
           POSTGRES_PASSWORD: pass
       - image: fundocker/openshift-elasticsearch:6.6.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,6 @@ jobs:
       - image: circleci/mysql:5.6-ram
         environment:
           MYSQL_ROOT_PASSWORD:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: test_richie
           MYSQL_USER: fun
           MYSQL_PASSWORD: pass


### PR DESCRIPTION
## Purpose

A new `mysql:5.6` Docker image was published that broke our CI because our fun user was not allowed to create a database anymore. It is necessary because tests run on a specific database called `test_richie` that it creates if it is missing. 

## Proposal

Making sure the database is already created in the container when it starts fixes the bug.

I also changed the name of the database for Posgresql so that it doesn't need to create another one either...

I did not include a changelog because there is no change on Richie, only this repository's CI.
