### PR TITLE
💄(courses) segment course runs on published course detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Our course search field now have a "Search" button with a magnifying
+- Segment course runs according to status on course detail page,
+- Our course search fields now have a "Search" button with a magnifying
   glass icon.
 
 ## [1.15.0] - 2019-12-02

--- a/bin/lint-back-diff
+++ b/bin/lint-back-diff
@@ -7,7 +7,7 @@ DIFF_WITH_TESTS="$(echo "$DIFF_FILES" | tr "\n" " ")" || true
 DIFF_NO_TESTS="$(echo "$DIFF_FILES" | grep -v tests/ | tr "\n" " ")" || true
 
 # List new untracked files
-UNTRACKED_FILES="$(git ls-files -o --exclude-standard)"
+UNTRACKED_FILES="$(git ls-files -o --exclude-standard | grep -e .py$ | grep -v migrations || true)"
 UNTRACKED_FILES_WITH_TESTS="$(echo "$UNTRACKED_FILES" | tr "\n" " ")" || true
 UNTRACKED_FILES_NO_TESTS="$(echo "$UNTRACKED_FILES" | grep -v tests/ | tr "\n" " ")" || true
 

--- a/src/frontend/scss/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_course_detail.scss
@@ -35,7 +35,7 @@ $richie-course-detail-run-background: $dodgerblue1 !default;
 $richie-course-detail-run-gutter: 0.5rem !default;
 $richie-course-detail-run-width-large: 33.33% !default;
 $richie-course-detail-run-margin: 0 !default;
-$richie-course-detail-run-padding: 1rem 2rem !default;
+$richie-course-detail-run-padding: 1rem 2rem 2rem !default;
 $richie-course-detail-run-fontcolor: $white !default;
 
 $richie-course-detail-synopsis-background: $dodgerblue1 !default;
@@ -409,14 +409,6 @@ $richie-course-detail-aside-main-org-background: $white !default;
       color: $richie-course-detail-run-fontcolor;
       background: $richie-course-detail-run-background;
 
-      &__title {
-        margin: 0;
-        padding: 0 0.1rem 0;
-        font-size: 1.8rem;
-        line-height: 1.1;
-        text-align: center;
-      }
-
       @include m-o-media_empty(
         $width: 100%,
         $height: 10vh,
@@ -426,65 +418,61 @@ $richie-course-detail-aside-main-org-background: $white !default;
       );
 
       &__block {
+        &__title {
+          margin: 0;
+          padding: 0 0.1rem 0;
+          font-size: 1.8rem;
+          line-height: 1.1;
+          text-align: center;
+        }
+
         $block-selector: &;
 
         position: relative;
         margin: 0;
-        padding: 2rem 0;
+        padding: 2rem 0 0;
 
-        a {
-          color: $white;
-        }
+        &__detail {
+          padding: 2rem 0 0;
 
-        dt {
-          font-weight: bold;
-          text-transform: uppercase;
+          dt {
+            font-weight: bold;
+            text-transform: uppercase;
 
-          &:not(:first-child) {
-            margin-top: 0.8rem;
+            &:not(:first-child) {
+              margin-top: 0.8rem;
+            }
           }
-        }
 
-        dd {
-          margin-bottom: 0;
-        }
+          dd {
+            margin-bottom: 0;
+          }
 
-        &__cta {
-          display: block;
-          width: 100%;
-          padding: 0.3rem;
-          color: $white;
-          text-align: center;
-          text-transform: uppercase;
-          background: $dodgerblue5;
-          border: 0;
-
-          &:hover {
+          a {
+            display: block;
+            width: 100%;
+            padding: 0.3rem;
             color: $white;
-            text-decoration: none;
-            background: lighten($dodgerblue5, 5%);
-          }
-
-          &--archived,
-          &--projected {
-            color: $gray40;
-            background: $gray80;
+            text-align: center;
+            text-transform: uppercase;
+            background: $dodgerblue5;
+            border: 0;
 
             &:hover {
-              color: $gray40;
-              background: $gray80;
+              color: $white;
+              text-decoration: none;
+              background: lighten($dodgerblue5, 5%);
             }
           }
         }
 
-        & + #{$block-selector}::before {
-          content: '';
-          display: block;
-          width: 50%;
-          position: absolute;
-          top: 0;
-          left: 25%;
-          border-top: 1px solid darken($light, 20%);
+        &__list {
+          padding: 2rem 0 0 1rem;
+          margin: 0;
+
+          a {
+            color: $white;
+          }
         }
       }
     }

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -40,7 +40,7 @@ class CourseState(Mapping):
     STATE_CALLS_TO_ACTION = (
         _("enroll now"),
         _("enroll now"),
-        _("see details"),
+        None,
         None,
         None,
         None,
@@ -397,6 +397,16 @@ class Course(BasePageExtension):
             )
 
         return course_runs
+
+    def get_course_runs_dict(self):
+        """Returns a dict of course runs grouped by their state."""
+        course_runs_dict = {
+            i: [] for i in range(len(CourseState.STATE_CALLS_TO_ACTION))
+        }
+        for run in self.get_course_runs_for_language():
+            course_runs_dict[run.state["priority"]].append(run)
+
+        return dict(course_runs_dict)
 
     @property
     def state(self):

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -156,51 +156,67 @@
       {% endblock synopsis %}
 
       {% block runs %}
-        <div class="course-detail__aside__runs">
-          <h2 class="course-detail__aside__runs__title">{% trans 'Course runs' %}</h2>
-          {% for run in course.get_course_runs_for_language %}
-          <div class="course-detail__aside__runs__block">
-            <dl>
-              <dt>{% trans "Enrollment" %}</dt>
-              <dd>
-                {% render_model run "enrollment_start" "enrollment_start,enrollment_end" "" "date:'DATE_FORMAT'|default:'...'" as start %}
-                {% render_model run "enrollment_end" "enrollment_start,enrollment_end" "" "date:'DATE_FORMAT'|default:'...'" as end %}
-                {% trans "From" %} {{ start|safe }} {% trans "to" %} {{ end|safe }}
-              </dd>
-              <dt>{% trans "Course" %}</dt>
-              <dd>
-                {% render_model run "start" "start,end" "" "date:'DATE_FORMAT'|default:'...'" as start %}
-                {% render_model run "end" "start,end" "" "date:'DATE_FORMAT'|default:'...'" as end %}
-                {% trans "From" %} {{ start|safe }} {% trans "to" %} {{ end|safe }}
-              </dd>
-              <dt>{% trans "Languages" %}</dt><dd>{% render_model run "get_languages_display" "languages" %}</dd>
-              {% if current_page.publisher_is_draft %}
-              <dt>{% trans "Resource link" %}</dt>
-              <dd>
-                <a href="{{ run.resource_link }}">
-                  {% render_model run "resource_link" "resource_link" %}
-                </a>
-              </dd>
-              {% endif %}
-            </dl>
-            {% if run.state.call_to_action %}
-            <a class="course-detail__aside__runs__block__cta" href="{{ run.extended_object.get_absolute_url }}">
-              {{ run.state.call_to_action|capfirst }}
-            </a>
-            {% else %}
-            <a class="course-detail__aside__runs__block__cta course-detail__aside__runs__block__cta--projected" href="{{ run.extended_object.get_absolute_url }}">
-              {{ run.state.text|capfirst }}
-            </a>
+        {% with runs_dict=course.get_course_runs_dict %}
+          <div class="course-detail__aside__runs">
+            {% block runs_open %}
+              <div class="course-detail__aside__runs__block">
+                <h2 class="course-detail__aside__runs__block__title">{% trans 'Course runs' %}</h2>
+                {% for run in runs_dict.0|add:runs_dict.1 %}
+                  {% include "courses/cms/fragment_course_run.html" %}
+                {% empty %}
+                  <div class="course-detail__aside__runs__block__empty">{% trans "No open course runs" %}</div>
+                {% endfor %}
+              </div>
+            {% endblock runs_open %}
+
+            {% block runs_to_be_scheduled %}
+            {% if runs_dict.6 and current_page.publisher_is_draft %}
+              <div class="course-detail__aside__runs__block">
+                <h3 class="course-detail__aside__runs__block__title">
+                  {% trans "To be scheduled" context "Course runs to be scheduled (plural)" %}
+                </h3>
+                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.6 %}
+              </div>
             {% endif %}
+            {% endblock runs_to_be_scheduled %}
+
+            {% block runs_upcoming %}
+            {% if runs_dict.2 %}
+              <div class="course-detail__aside__runs__block">
+                <h3 class="course-detail__aside__runs__block__title">
+                  {% trans "Upcoming" context "Upcoming course runs (plural)" %}
+                </h3>
+                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.2 %}
+              </div>
+            {% endif %}
+            {% endblock runs_upcoming %}
+
+            {% block runs_ongoing %}
+            {% if runs_dict.3 or runs_dict.4 %}
+              <div class="course-detail__aside__runs__block">
+                <h3 class="course-detail__aside__runs__block__title">
+                  {% trans "Ongoing" context "Ongoing course runs (plural)" %}
+                </h3>
+                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.3|add:runs_dict.4 %}
+              </div>
+            {% endif %}
+            {% endblock runs_ongoing %}
+
+            {% block runs_archived %}
+            {% if runs_dict.5 %}
+              <div class="course-detail__aside__runs__block">
+                <h3 class="course-detail__aside__runs__block__title">
+                  {% trans "Archived" context "Archived course runs (plural)" %}
+                </h3>
+                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.5 %}
+              </div>
+            {% endif %}
+            {% endblock runs_archived %}
+
           </div>
-          {% empty %}
-            <div class="course-detail__aside__runs__empty">{% trans "No associated course runs" %}</div>
-          {% endfor %}
-        </div>
+        {% endwith %}
       {% endblock runs %}
-
     </div>
-
     {% endwith %}
 
 </div>

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_run.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_run.html
@@ -1,0 +1,22 @@
+{% load cms_tags i18n extra_tags %}{% spaceless %}
+<div class="course-detail__aside__runs__block__detail">
+    <dl>
+        <dt>{% trans "Enrollment" %}</dt>
+        <dd>
+            {% blocktrans with enrollment_start=run.enrollment_start|date:'DATE_FORMAT'|default:'...' enrollment_end=run.enrollment_end|date:'DATE_FORMAT'|default:'...' %}
+                From {{ enrollment_start }} to {{ enrollment_end }}
+            {% endblocktrans %}    </dd>
+        <dt>{% trans "Course" %}</dt>
+        <dd>
+            {% blocktrans with start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' %}
+                From {{ start }} to {{ end }}
+            {% endblocktrans %}
+        </dd>
+        <dt>{% trans "Languages" %}</dt>
+        <dd>{% render_model run "get_languages_display" "languages" %}</dd>
+    </dl>
+    <a href="{{ run.extended_object.get_absolute_url }}">
+        {{ run.state.call_to_action|capfirst }}
+    </a>
+</div>
+{% endspaceless %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_runs_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_runs_list.html
@@ -1,0 +1,21 @@
+{% load cms_tags i18n extra_tags %}
+
+{% spaceless %}
+{% if course_runs %}
+<ul class="course-detail__aside__runs__block__list">
+    {% for run in course_runs %}
+    <li>
+        <a href="{{ run.extended_object.get_absolute_url }}">
+            {% if run.start  %}
+                {% blocktrans with title=run.extended_object.get_title|capfirst start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' %}
+                    {{ title }}, from {{ start }} to {{ end }}
+                {% endblocktrans %}
+            {% else %}
+                {{ run.extended_object.get_title|capfirst }}
+            {% endif %}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endspaceless %}

--- a/tests/apps/courses/test_models_course_run.py
+++ b/tests/apps/courses/test_models_course_run.py
@@ -351,7 +351,7 @@ class CourseRunModelsTestCase(TestCase):
             {
                 "priority": 2,
                 "text": "starting on",
-                "call_to_action": "see details",
+                "call_to_action": None,
                 "datetime": self.now + timedelta(hours=3),
             },
         )

--- a/tests/apps/courses/test_models_course_state.py
+++ b/tests/apps/courses/test_models_course_state.py
@@ -27,6 +27,15 @@ class CourseRunModelsTestCase(TestCase):
         super().setUp()
         self.now = timezone.now()
 
+    def create_run_ongoing_open(self, course):
+        """Create an on-going course run that is open for enrollment."""
+        return CourseRunFactory(
+            page_parent=course.extended_object,
+            start=self.now - timedelta(hours=1),
+            end=self.now + timedelta(hours=2),
+            enrollment_end=self.now + timedelta(hours=1),
+        )
+
     def create_run_ongoing_closed(self, course):
         """Create an on-going course run that is closed for enrollment."""
         return CourseRunFactory(
@@ -159,12 +168,7 @@ class CourseRunModelsTestCase(TestCase):
         Confirm course state when there is an on-going course run open for enrollment.
         """
         course = CourseFactory()
-        course_run = CourseRunFactory(
-            page_parent=course.extended_object,
-            start=self.now - timedelta(hours=1),
-            end=self.now + timedelta(hours=2),
-            enrollment_end=self.now + timedelta(hours=1),
-        )
+        course_run = self.create_run_ongoing_open(course)
         with self.assertNumQueries(2):
             state = course.state
         expected_state = CourseState(0, course_run.enrollment_end)

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -605,7 +605,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                     "text": "starting on",
                 },
                 {
-                    "call_to_action": "see details",
+                    "call_to_action": None,
                     "datetime": COURSE_RUNS["D"]["start"]
                     .isoformat()
                     .replace("+00:00", "Z"),
@@ -804,7 +804,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                     "text": "closing on",
                 },
                 {
-                    "call_to_action": "see details",
+                    "call_to_action": None,
                     "datetime": COURSE_RUNS["D"]["start"]
                     .isoformat()
                     .replace("+00:00", "Z"),


### PR DESCRIPTION
## Purpose

Segment course runs according to status on published course detail page. Show less details for ongoing and archived course run. Sections with no course run are not shown. The draft page segments the runs but shows everything.

## Proposal
Separate the course runs according to their state.
- open sub and running
- open/will open sub and upcoming
- closed sub and upcoming/running (less details)
- archived (less details)
- to be scheduled (not shown unless on draft)
The draft page segments the runs but shows everything.

Fixes #574 
