### PR TITLE
Fix documentation build on the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,7 +574,7 @@ jobs:
             git config --global user.email "funmoocbot@users.noreply.github.com"
             git config --global user.name "FUN MOOC Bot"
             echo "machine github.com login funmoocbot password ${GH_TOKEN}" > ~/.netrc
-            cd ./website && yarn install && GIT_USER=funmoocbot yarn run publish-gh-pages
+            cd ./website && yarn install && USE_SSH=true GIT_USER=funmoocbot yarn run publish-gh-pages
 
 workflows:
   version: 2


### PR DESCRIPTION
## Purpose

Automated deployment to gh-pages in the CI fails because it runs with HTTPS and therefore hangs on an HTTP password prompt instead of using the git user token we generated for funmoocbot.

## Proposal

The `USE_SSH` environment variable should force it to use ssh to push to github and get rid of this password prompt.
