### PR TITLE
🐛(website) fix documentation build [REVERT]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,7 +574,7 @@ jobs:
             git config --global user.email "funmoocbot@users.noreply.github.com"
             git config --global user.name "FUN MOOC Bot"
             echo "machine github.com login funmoocbot password ${GH_TOKEN}" > ~/.netrc
-            cd ./website && yarn install && USE_SSH=true GIT_USER=funmoocbot yarn run publish-gh-pages
+            cd ./website && yarn install && GIT_USER=funmoocbot yarn run publish-gh-pages
 
 workflows:
   version: 2


### PR DESCRIPTION
This reverts commit 225ea8822e6c3b6b5387bc7759e1b1cf46da7f8f.

The change to the deployment command was unnecessary as the issues we were encountering were caused by an invalid token (which was not understood as such by us).

We can just revert them and everything works as intended with a valid token.