### PR TITLE
🐛(frontend) fix a 400 Bad Request issue in <RootSearchSuggestField />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Create a documentation & marketing website for the project. It lives under
   the `docs` folder and is deployed to Github Pages.
 
+### Fixed
+
+- Fix an API request issue that was breaking the `<RootSearchSuggestField />`
+  component.
+
 ## [1.12.0] - 2019-10-23
 
 ### Added

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -33,7 +33,7 @@ describe('<RootSearchSuggestField />', () => {
   afterEach(jest.resetAllMocks);
 
   it('renders', () => {
-    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
       filters: {
         subjects,
       },
@@ -55,7 +55,7 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('gets suggestions from the API when the user types 3 characters or more in the field', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
       filters: {
         subjects,
       },
@@ -103,7 +103,7 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('goes to the course page when the user selects a course suggestion', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
       filters: {
         subjects,
       },
@@ -149,7 +149,7 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('goes to course search with the filter value activated when the user clicks on a suggestion', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
       filters: {
         subjects,
       },
@@ -223,7 +223,7 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('lets the user select the currently highlighted suggestion by pressing ENTER', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=0&offset=0&scope=FILTERS', {
+    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
       filters: {
         subjects,
       },

--- a/src/frontend/js/components/RootSearchSuggestField/index.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.tsx
@@ -53,9 +53,9 @@ const filters: () => Promise<APICourseSearchResponse['filters']> = async () => {
   }
   hasInitiatedRequest = true;
   const response = await fetchList('courses', {
-    limit: '0',
+    limit: '1',
     offset: '0',
-    scope: 'FILTERS',
+    scope: 'filters',
   });
   if (response.status === requestStatus.SUCCESS) {
     return (filtersPromise = new Promise(resolve =>


### PR DESCRIPTION
## Purpose

To initialize itself and know which filters can be used for autocompletion, <RootSearchSuggestField /> waits for valid user input and makes a request on the course search endpoint with a `"filters"` scope.

This request was failing due to incorrect case on the `scope`, which needs to be `"filters"` instead of `"FILTERS"`, and an incorrect value for `limit`, which can't be 0 even though we're not expecting
any actual search results.

## Proposal

Change the request parameters and update the tests to reflect this.