### PR TITLE
Handle unexpected calls on categories catchall API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Rename the `fun-react` class used to Django-React interop to `richie-react`.
 - Improve documentation on Django-React interop.
 
+### Fixed
+
+- Fix undefined behavior on hits on the categories API from unrelated requests,
+  return 404 errors instead.
+
 ## [1.12.1] - 2019-10-29
 
 ### Added

--- a/src/richie/apps/search/viewsets/categories.py
+++ b/src/richie/apps/search/viewsets/categories.py
@@ -71,7 +71,7 @@ class CategoriesViewSet(ViewSet):
         return Response(response_object)
 
     # pylint: disable=no-self-use,invalid-name,unused-argument
-    def retrieve(self, request, pk, version):
+    def retrieve(self, request, pk, version, kind):
         """
         Return a single item by ID
         """

--- a/tests/apps/search/test_viewsets_categories.py
+++ b/tests/apps/search/test_viewsets_categories.py
@@ -170,3 +170,23 @@ class CategoriesViewsetsTestCase(TestCase):
         # The client received a BadRequest response with the relevant data
         self.assertEqual(response.status_code, 400)
         self.assertTrue("limit" in response.data["errors"])
+
+    def test_viewsets_categories_catchall_retrieve(self):
+        """
+        Error case: unrelated requests end up in the categories ViewSet.
+        Since the categories ViewSet sits on a catchall URL, we need to make sure it returns
+        proper errors and does not raise eg. a 500 when called from an unexpected URL.
+        """
+        # The request is for a user instead of a category
+        response = self.client.get("/api/v1.0/users/42/", follow=True)
+        self.assertEqual(response.status_code, 404)
+
+    def test_viewsets_categories_catchall_search(self):
+        """
+        Error case: unrelated requests end up in the categories ViewSet.
+        Since the categories ViewSet sits on a catchall URL, we need to make sure it returns
+        proper errors and does not raise eg. a 500 when called from an unexpected URL.
+        """
+        # The request is for users instead of categories
+        response = self.client.get("/api/v1.0/users/", follow=True)
+        self.assertEqual(response.status_code, 404)

--- a/tests/apps/search/test_viewsets_categories.py
+++ b/tests/apps/search/test_viewsets_categories.py
@@ -6,10 +6,8 @@ from unittest import mock
 from django.test import TestCase
 
 from elasticsearch.exceptions import NotFoundError
-from rest_framework.test import APIRequestFactory
 
 from richie.apps.search import ES_CLIENT
-from richie.apps.search.viewsets.categories import CategoriesViewSet
 
 
 class CategoriesViewsetsTestCase(TestCase):
@@ -21,9 +19,6 @@ class CategoriesViewsetsTestCase(TestCase):
         """
         Happy path: the client requests an existing category, gets it back
         """
-        factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/categories/42")
-
         with mock.patch.object(
             ES_CLIENT,
             "get",
@@ -40,9 +35,7 @@ class CategoriesViewsetsTestCase(TestCase):
             },
         ):
             # Note: we need to use a separate argument for the ID as that is what the ViewSet uses
-            response = CategoriesViewSet.as_view({"get": "retrieve"})(
-                request, 42, version="1.0"
-            )
+            response = self.client.get("/api/v1.0/categories/42/")
 
         # The client received a proper response with the relevant category
         self.assertEqual(response.status_code, 200)
@@ -63,14 +56,9 @@ class CategoriesViewsetsTestCase(TestCase):
         """
         Error case: the client is asking for a category that does not exist
         """
-        factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/categories/43")
-
         # Act like the ES client would when we attempt to get a non-existent document
         with mock.patch.object(ES_CLIENT, "get", side_effect=NotFoundError):
-            response = CategoriesViewSet.as_view({"get": "retrieve"})(
-                request, 43, version="1.0"
-            )
+            response = self.client.get("/api/v1.0/categories/43/", follow=True)
 
         # The client received a standard NotFound response
         self.assertEqual(response.status_code, 404)
@@ -80,9 +68,6 @@ class CategoriesViewsetsTestCase(TestCase):
         """
         Happy path: the category is filtering the categories by name
         """
-        factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/subjects/?query=Science&limit=2")
-
         mock_search.return_value = {
             "hits": {
                 "hits": [
@@ -113,9 +98,7 @@ class CategoriesViewsetsTestCase(TestCase):
             }
         }
 
-        response = CategoriesViewSet.as_view({"get": "list"})(
-            request, version="1.0", kind="subjects"
-        )
+        response = self.client.get("/api/v1.0/subjects/?query=Science&limit=2")
 
         # The client received a properly formatted response
         self.assertEqual(response.status_code, 200)
@@ -181,13 +164,8 @@ class CategoriesViewsetsTestCase(TestCase):
         """
         Error case: the client used an incorrectly formatted request
         """
-        factory = APIRequestFactory()
         # The request contains incorrect params: limit should be a positive integer
-        request = factory.get("/api/v1.0/subjects/?name=&limit=-2")
-
-        response = CategoriesViewSet.as_view({"get": "list"})(
-            request, version="1.0", kind="subjects"
-        )
+        response = self.client.get("/api/v1.0/subjects/?name=&limit=-2")
 
         # The client received a BadRequest response with the relevant data
         self.assertEqual(response.status_code, 400)

--- a/tests/apps/search/test_viewsets_organizations.py
+++ b/tests/apps/search/test_viewsets_organizations.py
@@ -6,10 +6,8 @@ from unittest import mock
 from django.test import TestCase
 
 from elasticsearch.exceptions import NotFoundError
-from rest_framework.test import APIRequestFactory
 
 from richie.apps.search import ES_CLIENT
-from richie.apps.search.viewsets.organizations import OrganizationsViewSet
 
 
 class OrganizationsViewsetsTestCase(TestCase):
@@ -21,9 +19,6 @@ class OrganizationsViewsetsTestCase(TestCase):
         """
         Happy path: the client requests an existing organization, gets it back
         """
-        factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/organizations/42")
-
         with mock.patch.object(
             ES_CLIENT,
             "get",
@@ -36,9 +31,7 @@ class OrganizationsViewsetsTestCase(TestCase):
             },
         ):
             # Note: we need to use a separate argument for the ID as that is what the ViewSet uses
-            response = OrganizationsViewSet.as_view({"get": "retrieve"})(
-                request, 42, version="1.0"
-            )
+            response = self.client.get("/api/v1.0/organizations/42/")
 
         # The client received a proper response with the relevant organization
         self.assertEqual(response.status_code, 200)
@@ -51,14 +44,9 @@ class OrganizationsViewsetsTestCase(TestCase):
         """
         Error case: the client is asking for an organization that does not exist
         """
-        factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/organizations/43")
-
         # Act like the ES client would when we attempt to get a non-existent document
         with mock.patch.object(ES_CLIENT, "get", side_effect=NotFoundError):
-            response = OrganizationsViewSet.as_view({"get": "retrieve"})(
-                request, 43, version="1.0"
-            )
+            response = self.client.get("/api/v1.0/organizations/43/", follow=True)
 
         # The client received a standard NotFound response
         self.assertEqual(response.status_code, 404)
@@ -72,9 +60,6 @@ class OrganizationsViewsetsTestCase(TestCase):
         """
         Happy path: the consumer is filtering the organizations by title
         """
-        factory = APIRequestFactory()
-        request = factory.get("/api/v1.0/organizations?query=Université&limit=2")
-
         mock_search.return_value = {
             "hits": {
                 "hits": [
@@ -97,7 +82,7 @@ class OrganizationsViewsetsTestCase(TestCase):
             }
         }
 
-        response = OrganizationsViewSet.as_view({"get": "list"})(request, version="1.0")
+        response = self.client.get("/api/v1.0/organizations/?query=Université&limit=2")
 
         # The client received a properly formatted response
         self.assertEqual(response.status_code, 200)
@@ -125,11 +110,8 @@ class OrganizationsViewsetsTestCase(TestCase):
         """
         Error case: the client used an incorrectly formatted request
         """
-        factory = APIRequestFactory()
         # The request contains incorrect params: limit should be a positive integer
-        request = factory.get("/api/v1.0/organizations?title=&limit=-2")
-
-        response = OrganizationsViewSet.as_view({"get": "list"})(request, version="1.0")
+        response = self.client.get("/api/v1.0/organizations/?title=&limit=-2")
 
         # The client received a BadRequest response with the relevant data
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Purpose

The categories ViewSet sits on a catchall url so it can receive requests for any "kind" of category in an intuitive way. This has a drawback though: unexpected requests might end up in our categories
routes.

## Proposal

We simply want to make sure those are handled properly and return eg. 404 errors, and do not raise 500s or return any unwanted data.