### PR TITLE
Fix logo link in base footer

### DIFF
--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -95,7 +95,7 @@
                 </div>
                 <div class="body-footer__brand">
                     <a href="/" class="body-footer__brand__link">
-                        <img src="{% static "richie/images/logo.png" %}" class="body-footer__brand__logo" alt="">
+                        <img src="{% static "richie/images/logo.png" %}" class="body-footer__brand__logo" alt="{{ SITE.name }}">
                     </a>
                     {% include "social-networks/footer-badges.html" %}
                 </div>


### PR DESCRIPTION
## Purpose

The logo link in the footer used an empty alt text on the image, which is the only content for the link. This is incorrect as there is no text at all on the link for accessibility tech users.

## Proposal

We can just add `{{ SITE.name }}` like on the logo in the header.

Part of our effort on #888 
