### PR TITLE
Add toolbar menu item to regenerate the Elasticsearch index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add an Ajax toolbar menu item to regenerate the search index,
 - Add a React-powered component to handle login/signup and user status in
   the base template.
 

--- a/src/richie/apps/courses/admin.py
+++ b/src/richie/apps/courses/admin.py
@@ -15,7 +15,6 @@ from django.views.decorators.http import require_POST
 from cms.admin.placeholderadmin import FrontendEditableAdminMixin
 from cms.api import Page
 from cms.extensions import PageExtensionAdmin
-from cms.utils.admin import jsonify_request
 
 from ..core.admin import link_field
 from . import models
@@ -74,14 +73,12 @@ class CourseAdmin(FrontendEditableAdminMixin, PageExtensionAdmin):
                 publisher_is_draft=True, course__id=course_id
             )
         except Page.DoesNotExist:
-            return jsonify_request(
-                HttpResponseBadRequest(force_text(_("Course could not be found.")))
-            )
+            return HttpResponseBadRequest(force_text(_("Course could not be found.")))
 
         try:
             new_page = snapshot_course(page, request.user, simulate_only=False)
         except PermissionDenied as context:
-            return jsonify_request(HttpResponseForbidden(force_text(context)))
+            return HttpResponseForbidden(force_text(context))
 
         return JsonResponse({"id": new_page.course.id})
 

--- a/src/richie/apps/search/cms_toolbars.py
+++ b/src/richie/apps/search/cms_toolbars.py
@@ -1,0 +1,35 @@
+"""
+Toolbar extension for the search application
+"""
+from django.utils.translation import ugettext_lazy as _
+
+from cms.cms_toolbars import ADMIN_MENU_IDENTIFIER
+from cms.toolbar_base import CMSToolbar
+from cms.toolbar_pool import toolbar_pool
+from rest_framework.reverse import reverse
+
+
+@toolbar_pool.register
+class SearchToolbar(CMSToolbar):
+    """Customize the toolbar to add a button that regenerates the search index."""
+
+    def populate(self):
+        """
+        Show an item in the toolbar only to users who have the permission to regenerate the
+        search index.
+        """
+
+        if self.request.user.has_perm("search.can_manage_elasticsearch"):
+            # Get the action endpoint for API version 1. We hardcode it as only this
+            # piece of code will determine when to change the endpoint version.
+            url = reverse("bootstrap_elasticsearch", kwargs={"version": "1.0"})
+            admin_menu = self.toolbar.get_menu(ADMIN_MENU_IDENTIFIER)
+
+            # Create the new menu item as an Ajax call
+            admin_menu.add_ajax_item(
+                _("Regenerate search index..."),
+                action=url,
+                data={},
+                on_success=self.toolbar.REFRESH_PAGE,
+                position=3,
+            )

--- a/src/richie/apps/search/models.py
+++ b/src/richie/apps/search/models.py
@@ -1,0 +1,13 @@
+"""Declare and configure the models for richie's search application."""
+from django.db import models
+
+
+class SearchAccess(models.Model):
+    """A model with no database table to hold global custom permissions."""
+
+    class Meta:
+
+        managed = False
+        permissions = (
+            ("can_manage_elasticsearch", "Allow managing Elasticsearch indexes"),
+        )

--- a/src/richie/apps/search/urls.py
+++ b/src/richie/apps/search/urls.py
@@ -1,8 +1,11 @@
 """
 API Routes exposed by our Search app
 """
+from django.urls import path
+
 from rest_framework import routers
 
+from .views import bootstrap_elasticsearch
 from .viewsets.categories import CategoriesViewSet
 from .viewsets.courses import CoursesViewSet
 from .viewsets.organizations import OrganizationsViewSet
@@ -18,4 +21,12 @@ ROUTER.register(r"persons", PersonsViewSet, "persons")
 ROUTER.register(r"(?P<kind>\w+)", CategoriesViewSet, "categories")
 
 # Use the standard name for our urlpatterns so urls.py can import it effortlessly
-urlpatterns = ROUTER.urls
+urlpatterns = [
+    path(
+        r"bootstrap-elasticsearch",
+        bootstrap_elasticsearch,
+        name="bootstrap_elasticsearch",
+    )
+]
+
+urlpatterns += ROUTER.urls

--- a/src/richie/apps/search/views.py
+++ b/src/richie/apps/search/views.py
@@ -1,0 +1,26 @@
+"""Views for richie's search application."""
+from django.contrib import messages
+from django.core import management
+from django.http import HttpResponse
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy as _
+
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+
+@api_view(["POST"])
+# pylint: disable=unused-argument
+def bootstrap_elasticsearch(request, version):
+    """Regenerate the Elasticsearch index."""
+    user = request.user
+    if not (user.is_staff and request.user.has_perm("search.can_manage_elasticsearch")):
+        return HttpResponse(
+            force_text(_("You are not allowed to manage the search index.")),
+            status=403 if request.user.is_authenticated else 401,
+        )
+
+    management.call_command("bootstrap_elasticsearch")
+
+    messages.info(request, _("The search index was successfully bootstrapped"))
+    return Response({})

--- a/tests/apps/core/utils.py
+++ b/tests/apps/core/utils.py
@@ -1,9 +1,11 @@
 """Test utils for the courses application"""
+import random
+from functools import reduce
 
 from django.test.client import RequestFactory
 
 from cms.middleware.toolbar import ToolbarMiddleware
-from cms.toolbar.items import Menu, ModalItem
+from cms.toolbar.items import ModalItem
 
 
 class CheckToolbarMixin:
@@ -12,10 +14,18 @@ class CheckToolbarMixin:
     CMS toolbar unit tests
     """
 
+    @staticmethod
+    def _get_items(toolbar, name, item_type):
+        """Get items matching a name and type throughout all menus of a toolbar."""
+        return reduce(
+            lambda acc, menu: acc + menu.find_items(item_type, name=name),
+            toolbar.menus.values(),
+            [],
+        )
+
     def check_active(self, toolbar, name, item_type=ModalItem):
         """The item should be present in the toolbar and active."""
-        page_menu_result = toolbar.find_items(Menu, name="Page")[0]
-        results = page_menu_result.item.find_items(item_type, name=name)
+        results = self._get_items(toolbar, name, item_type)
         self.assertEqual(len(results), 1)
         item = results[0].item
         self.assertFalse(item.disabled)
@@ -23,8 +33,7 @@ class CheckToolbarMixin:
 
     def check_disabled(self, toolbar, name, item_type=ModalItem):
         """The item should be present in the toolbar and disabled."""
-        page_menu_result = toolbar.find_items(Menu, name="Page")[0]
-        results = page_menu_result.item.find_items(item_type, name=name)
+        results = self._get_items(toolbar, name, item_type)
         self.assertEqual(len(results), 1)
         item = results[0].item
         self.assertTrue(item.disabled)
@@ -32,8 +41,7 @@ class CheckToolbarMixin:
 
     def check_missing(self, toolbar, name, item_type=ModalItem):
         """The item should not be in the toolbar."""
-        page_menu_result = toolbar.find_items(Menu, name="Page")[0]
-        results = page_menu_result.item.find_items(item_type, name=name)
+        results = self._get_items(toolbar, name, item_type)
         self.assertEqual(results, [])
 
     # pylint: disable=unused-argument
@@ -42,11 +50,17 @@ class CheckToolbarMixin:
         self.assertEqual(toolbar.get_left_items(), [])
 
     @staticmethod
-    def get_toolbar_for_page(page, user, edit, preview):
+    def get_toolbar_for_page(page, user, edit=None, preview=None):
         """
         This method is a helper to build a request to test the toolbar in different states
         for different users
         """
+        if edit is None:
+            edit = random.choice([True, False])
+
+        if preview is None:
+            preview = random.choice([True, False])
+
         url = page.get_absolute_url()
         factory = RequestFactory()
 

--- a/tests/apps/courses/test_admin_page_snapshot.py
+++ b/tests/apps/courses/test_admin_page_snapshot.py
@@ -133,14 +133,10 @@ class SnapshotPageAdminTestCase(CMSTestCase):
         url = "/en/admin/courses/course/{:d}/snapshot/".format(course.id)
         response = self.client.post(url, follow=True)
 
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(
-            content,
-            {
-                "status": 403,
-                "content": "You don't have sufficient permissions to snapshot this page.",
-            },
+            response.content,
+            b"You don't have sufficient permissions to snapshot this page.",
         )
         # No additional courses should have been created
         self.assertEqual(Course.objects.count(), 2)
@@ -164,14 +160,10 @@ class SnapshotPageAdminTestCase(CMSTestCase):
         url = "/en/admin/courses/course/{:d}/snapshot/".format(course.id)
         response = self.client.post(url, follow=True)
 
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(
-            content,
-            {
-                "status": 403,
-                "content": "You don't have sufficient permissions to snapshot this page.",
-            },
+            response.content,
+            b"You don't have sufficient permissions to snapshot this page.",
         )
         # No additional courses should have been created
         self.assertEqual(Course.objects.count(), 2)
@@ -229,14 +221,10 @@ class SnapshotPageAdminTestCase(CMSTestCase):
         with mock.patch("time.time", mock.MagicMock(return_value=1541946888)):
             response = self.client.post(url, follow=True)
 
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(
-            content,
-            {
-                "status": 403,
-                "content": "You don't have sufficient permissions to snapshot this page.",
-            },
+            response.content,
+            b"You don't have sufficient permissions to snapshot this page.",
         )
         # No additional courses should have been created
         self.assertEqual(Course.objects.count(), 2)
@@ -291,11 +279,8 @@ class SnapshotPageAdminTestCase(CMSTestCase):
         url = "/en/admin/courses/course/{:d}/snapshot/".format(snapshot.id)
         response = self.client.post(url, follow=True)
 
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        self.assertEqual(
-            content, {"status": 403, "content": "You can't snapshot a snapshot."}
-        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.content, b"You can't snapshot a snapshot.")
 
     def test_admin_page_snapshot_blocked_for_public_page(self):
         """
@@ -317,11 +302,8 @@ class SnapshotPageAdminTestCase(CMSTestCase):
         url = "/en/admin/courses/course/{:d}/snapshot/".format(public_course.id)
         response = self.client.post(url, follow=True)
 
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        self.assertEqual(
-            content, {"status": 400, "content": "Course could not be found."}
-        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, b"Course could not be found.")
 
     @override_settings(CMS_PERMISSION=False)
     def test_admin_page_snapshot_unknown_page(self):
@@ -339,8 +321,5 @@ class SnapshotPageAdminTestCase(CMSTestCase):
         url = "/en/admin/courses/course/1/snapshot/"
         response = self.client.post(url, follow=True)
 
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        self.assertEqual(
-            content, {"status": 400, "content": "Course could not be found."}
-        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, b"Course could not be found.")

--- a/tests/apps/courses/test_cms_toolbars.py
+++ b/tests/apps/courses/test_cms_toolbars.py
@@ -17,7 +17,7 @@ from richie.apps.courses.factories import (
     PersonFactory,
 )
 
-from .utils import CheckToolbarMixin
+from ..core.utils import CheckToolbarMixin
 
 
 # pylint: disable=too-many-ancestors

--- a/tests/apps/search/test_cms_toolbars.py
+++ b/tests/apps/search/test_cms_toolbars.py
@@ -1,0 +1,53 @@
+"""Test suite of the toolbar extension for search related it pages
+"""
+from django.contrib.auth.models import AnonymousUser, Permission
+
+from cms.api import create_page
+from cms.test_utils.testcases import CMSTestCase
+from cms.toolbar.items import AjaxItem
+
+from richie.apps.core.factories import UserFactory
+
+from ..core.utils import CheckToolbarMixin
+
+
+# pylint: disable=too-many-ancestors
+class SearchCMSToolbarTestCase(CheckToolbarMixin, CMSTestCase):
+    """Testing the integration of search related items in the toolbar."""
+
+    def test_cms_toolbars_search_bootstrap_elasticsearch(self):
+        """
+        Validate that the link to bootstrap elasticsearch is present on any page
+        but only for staff users with the required permission.
+        """
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        staff_with_permission = UserFactory(is_staff=True)
+        user_with_permission = UserFactory()
+        staff = UserFactory(is_staff=True)
+        user = UserFactory()
+        anonymous = AnonymousUser()
+
+        # Add permission to bootstrap ES for users concerned
+        can_manage = Permission.objects.get(codename="can_manage_elasticsearch")
+        staff_with_permission.user_permissions.add(can_manage)
+        user_with_permission.user_permissions.add(can_manage)
+
+        cases = [
+            (superuser, self.check_active),
+            (staff_with_permission, self.check_active),
+            (staff, self.check_missing),
+            (user_with_permission, self.check_absent),
+            (user, self.check_absent),
+            (anonymous, self.check_absent),
+        ]
+
+        # Create a page with nothing special
+        page = create_page(
+            "A page", template="richie/single_column.html", language="en"
+        )
+
+        for user, method in cases:
+            toolbar = self.get_toolbar_for_page(page, user)
+            item = method(toolbar, "Regenerate search index...", item_type=AjaxItem)
+            if item:
+                self.assertEqual(item.action, "/api/v1.0/bootstrap-elasticsearch")

--- a/tests/apps/search/test_views_bootstrap_elasticsearch.py
+++ b/tests/apps/search/test_views_bootstrap_elasticsearch.py
@@ -1,0 +1,103 @@
+"""Test suite for the bootstrap_elasticsearch view of richie's search app."""
+import json
+from unittest import mock
+
+from django.contrib.messages import get_messages
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.factories import UserFactory
+
+
+class BootstrapElasticsearchViewTestCase(CMSTestCase):
+    """
+    Integration test suite to validate the behavior of the `bootstrap_elasticsearch` view.
+    """
+
+    @mock.patch("django.core.management.call_command")
+    def test_views_bootstrap_elasticsearch_with_permission(self, mock_command):
+        """Confirm triggering the search index bootstrapping works as expected."""
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add the necessary permission
+        self.add_permission(user, "can_manage_elasticsearch")
+
+        url = "/api/v1.0/bootstrap-elasticsearch"
+        response = self.client.post(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        self.assertEqual(content, {})
+
+        # Check the presence of a confirmation message
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(
+            str(messages[0]), "The search index was successfully bootstrapped"
+        )
+
+        mock_command.assert_called_once_with("bootstrap_elasticsearch")
+
+    @mock.patch("django.core.management.call_command")
+    def test_views_bootstrap_elasticsearch_no_permission(self, mock_command):
+        """Bootstrapping ES should be forbidden if the permission is not not granted."""
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        url = "/api/v1.0/bootstrap-elasticsearch"
+        response = self.client.post(url, follow=True)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.content, b"You are not allowed to manage the search index."
+        )
+        self.assertFalse(mock_command.called)
+
+    @mock.patch("django.core.management.call_command")
+    def test_views_bootstrap_elasticsearch_post_required(self, mock_command):
+        """Bootstrapping ES can only be triggered with a POST method."""
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add the necessary permission
+        self.add_permission(user, "can_manage_elasticsearch")
+
+        url = "/api/v1.0/bootstrap-elasticsearch"
+
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.put(url, follow=True)
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.delete(url, follow=True)
+        self.assertEqual(response.status_code, 405)
+
+        self.assertFalse(mock_command.called)
+
+    @mock.patch("django.core.management.call_command")
+    def test_views_bootstrap_elasticsearch_anonymous(self, mock_command):
+        """An anonymous user should not be allowed to bootstrap ES."""
+        url = "/api/v1.0/bootstrap-elasticsearch"
+        response = self.client.post(url, follow=True)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertFalse(mock_command.called)
+
+    @mock.patch("django.core.management.call_command")
+    def test_views_bootstrap_elasticsearch_not_staff_with_permission(
+        self, mock_command
+    ):
+        """A user with permissions that is not staff should not be allowed to bootstrap ES."""
+        user = UserFactory()
+        self.client.login(username=user.username, password="password")
+
+        # Add the necessary permission
+        self.add_permission(user, "can_manage_elasticsearch")
+
+        url = "/api/v1.0/bootstrap-elasticsearch"
+        response = self.client.post(url, follow=True)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.content, b"You are not allowed to manage the search index."
+        )
+        self.assertFalse(mock_command.called)


### PR DESCRIPTION
## Purpose

In some cases, staff user want to regenerate the search index from scratch.

## Proposal

We propose to trigger it via an Ajax menu item in the toolbar. Only staff users who were granted the
specific permission to manage the Elasticsearch index can do it.

We do it synchronously for the moment because:
- it should take less than 30 seconds,
- only authorized users can do it and it's rare,
- we want to avoid introducing a dependency to Celery or other asynchronous tasks handlers.
