### PR TITLE
Rework search view layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Rework `<Search />` layout to make it lighter and simpler.
 - Remove the "Exo 2" font from Richie. Use system `sans-serif` instead.
 - Rename the `fun-react` class used to Django-React interop to `richie-react`.
 - Improve documentation on Django-React interop.

--- a/src/frontend/js/components/Search/_styles.scss
+++ b/src/frontend/js/components/Search/_styles.scss
@@ -8,11 +8,46 @@ $richie-search-filters-background: $dodgerblue1 !default;
 $richie-search-results-padding: 0 1rem 0 2rem !default;
 
 .search {
+  position: relative;
   display: flex;
-  margin: $richie-search-margin;
-  padding: $richie-search-padding;
   flex-direction: row;
   flex-wrap: wrap;
+  justify-content: center;
+  margin: $richie-search-margin;
+  padding: $richie-search-padding;
+
+  &__header {
+    flex-basis: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem 0.5rem;
+    @include make-container-max-widths();
+
+    @include media-breakpoint-up(lg) {
+      flex-direction: row;
+      padding: 4rem;
+    }
+
+    &__title {
+      margin: 0 0 1rem 0;
+
+      @include media-breakpoint-up(lg) {
+        margin: 0 5rem 0 0;
+      }
+    }
+
+    & > .react-autosuggest__container {
+      width: 100%;
+
+      @include media-breakpoint-up(lg) {
+        flex-grow: 1;
+        width: auto;
+        margin: 0;
+      }
+    }
+  }
 
   &__filters {
     z-index: 1;
@@ -48,7 +83,7 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
     &__toggle {
       position: absolute;
       top: 1.25rem;
-      right: -3rem;
+      right: -3.5rem;
       width: 2.5rem;
       height: 2.5rem;
       padding: 8px;
@@ -77,27 +112,22 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
       max-width: calc(100% - #{$richie-search-filters-width});
       padding: $richie-search-results-padding;
     }
+  }
 
-    &__title {
-      padding: 1.5rem 0 0;
-      text-align: center;
-    }
+  &__overlay {
+    visibility: hidden;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background: black;
+    opacity: 0;
+    transition: 0.5s ease-in-out;
 
-    &__overlay {
-      visibility: hidden;
-      position: absolute;
-      top: 0;
-      left: 0;
-      bottom: 0;
-      right: 0;
-      background: black;
-      opacity: 0;
-      transition: 0.5s ease-in-out;
-
-      &--visible {
-        visibility: visible;
-        opacity: 0.75;
-      }
+    &--visible {
+      visibility: visible;
+      opacity: 0.75;
     }
   }
 }

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -47,7 +47,7 @@ describe('<Search />', () => {
     expect(queryByText('Loading search results...')).toBeNull();
   });
 
-  it('always shows the filters pane on large screens', () => {
+  it('always shows the filters pane on large screens', async () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', {
       meta: {
         total_count: 200,
@@ -61,6 +61,7 @@ describe('<Search />', () => {
         <Search context={commonDataProps} />
       </IntlProvider>,
     );
+    await wait();
 
     // The search filters pane is not hidden, there is no button to show/hide it
     expect(container.querySelector('.search-filters-pane')).toHaveAttribute(
@@ -70,7 +71,7 @@ describe('<Search />', () => {
     expect(container.querySelector('.search__filters__toggle')).toEqual(null);
   });
 
-  it('hides the filters pane on small screens by default and lets users show it', () => {
+  it('hides the filters pane on small screens by default and lets users show it', async () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', {
       meta: {
         total_count: 200,
@@ -84,6 +85,7 @@ describe('<Search />', () => {
         <Search context={commonDataProps} />
       </IntlProvider>,
     );
+    await wait();
 
     // The search filters pane is hidden, there is a button to show/hide it
     expect(container.querySelector('.search-filters-pane')).toHaveAttribute(

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -57,6 +57,15 @@ export const Search = ({
       <CourseSearchParamsContext.Provider
         value={[courseSearchParams, setCourseSearchParams]}
       >
+        <div className="search__header">
+          {pageTitle && <h1 className="search__header__title">{pageTitle}</h1>}
+          {courseSearchResponse &&
+          courseSearchResponse.status === requestStatus.SUCCESS ? (
+            <SearchSuggestField
+              filters={courseSearchResponse.content.filters}
+            />
+          ) : null}
+        </div>
         <div
           className={`search__filters ${
             !alwaysShowFilters && showFilters ? 'search__filters--active' : ''
@@ -110,13 +119,9 @@ export const Search = ({
           )}
         </div>
         <div className="search__results">
-          {pageTitle && <h1 className="search__results__title">{pageTitle}</h1>}
           {courseSearchResponse &&
           courseSearchResponse.status === requestStatus.SUCCESS ? (
             <React.Fragment>
-              <SearchSuggestField
-                filters={courseSearchResponse.content.filters}
-              />
               <CourseGlimpseList
                 courses={courseSearchResponse.content.objects}
                 meta={courseSearchResponse.content.meta}
@@ -132,16 +137,16 @@ export const Search = ({
               <FormattedMessage {...messages.spinnerText} />
             </Spinner>
           )}
-          {!alwaysShowFilters && (
-            <div
-              aria-hidden={true}
-              className={`search__results__overlay ${
-                showFilters ? 'search__results__overlay--visible' : ''
-              }`}
-              onClick={() => setShowFilters(false)}
-            />
-          )}
         </div>
+        {!alwaysShowFilters && (
+          <div
+            aria-hidden={true}
+            className={`search__overlay ${
+              showFilters ? 'search__overlay--visible' : ''
+            }`}
+            onClick={() => setShowFilters(false)}
+          />
+        )}
       </CourseSearchParamsContext.Provider>
     </div>
   );


### PR DESCRIPTION
## Purpose

The Search component was placing the title and search field inside a `search__results` div and pushing the filters pane to the very top of the page.

## Proposal

We now have a dedicated `search__header` area that helps us make the layout cleaner and lighter while keeping everything as easy to access as before.

Note: we took this opportunity to remove react test warnings on the `<Search />` component.