### PR TITLE
Add an API endpoint to get static search filter definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add an Ajax toolbar menu item to regenerate the search index,
 - Add a React-powered component to handle login/signup and user status in
   the base template.
+- Add an API endpoint to get static versions of the filter definitions.
 
 ### Changed
 

--- a/src/richie/apps/search/filter_definitions/courses.py
+++ b/src/richie/apps/search/filter_definitions/courses.py
@@ -203,6 +203,22 @@ class IndexableFilterDefinition(TermsQueryMixin, BaseFilterDefinition):
             for doc in search_query_response["hits"]["hits"]
         }
 
+    def get_static_definitions(self):
+        """
+        Build the static definition from the filter's base properties.
+        """
+        return {
+            self.name: {
+                "base_path": self.base_page.node.path if self.base_page else None,
+                "human_name": self.human_name,
+                "is_autocompletable": self.is_autocompletable,
+                "is_drilldown": self.is_drilldown,
+                "is_searchable": self.is_searchable,
+                "name": self.name,
+                "position": self.position,
+            }
+        }
+
     def get_faceted_definitions(self, facets, data, *args, **kwargs):
         """
         Build the filter definition's values from base definition and the faceted keys in the
@@ -286,17 +302,11 @@ class IndexableFilterDefinition(TermsQueryMixin, BaseFilterDefinition):
         return {
             self.name: {
                 # We always need to pass the base definition to the frontend
-                "base_path": self.base_page.node.path if self.base_page else None,
+                **self.get_static_definitions()[self.name],
                 # If values are removed due to `min_doc_count`, we are not returning them, and
                 # therefore by definition our filter `has_more_values`.
                 "has_more_values": has_more_values
                 or any(count < self.min_doc_count for count in key_count_map.values()),
-                "human_name": self.human_name,
-                "is_autocompletable": self.is_autocompletable,
-                "is_drilldown": self.is_drilldown,
-                "is_searchable": self.is_searchable,
-                "name": self.name,
-                "position": self.position,
                 "values": [
                     # Aggregate the information from right above to build the values
                     {"count": count, "human_name": key_i18n_name_map[key], "key": key}

--- a/src/richie/apps/search/urls.py
+++ b/src/richie/apps/search/urls.py
@@ -5,7 +5,7 @@ from django.urls import path
 
 from rest_framework import routers
 
-from .views import bootstrap_elasticsearch
+from .views import bootstrap_elasticsearch, filter_definitions
 from .viewsets.categories import CategoriesViewSet
 from .viewsets.courses import CoursesViewSet
 from .viewsets.organizations import OrganizationsViewSet
@@ -26,7 +26,8 @@ urlpatterns = [
         r"bootstrap-elasticsearch/",
         bootstrap_elasticsearch,
         name="bootstrap_elasticsearch",
-    )
+    ),
+    path(r"filter-definitions/", filter_definitions, name="filter_definitions"),
 ]
 
 urlpatterns += ROUTER.urls

--- a/src/richie/apps/search/urls.py
+++ b/src/richie/apps/search/urls.py
@@ -23,7 +23,7 @@ ROUTER.register(r"(?P<kind>\w+)", CategoriesViewSet, "categories")
 # Use the standard name for our urlpatterns so urls.py can import it effortlessly
 urlpatterns = [
     path(
-        r"bootstrap-elasticsearch",
+        r"bootstrap-elasticsearch/",
         bootstrap_elasticsearch,
         name="bootstrap_elasticsearch",
     )

--- a/tests/apps/search/test_cms_toolbars.py
+++ b/tests/apps/search/test_cms_toolbars.py
@@ -50,4 +50,4 @@ class SearchCMSToolbarTestCase(CheckToolbarMixin, CMSTestCase):
             toolbar = self.get_toolbar_for_page(page, user)
             item = method(toolbar, "Regenerate search index...", item_type=AjaxItem)
             if item:
-                self.assertEqual(item.action, "/api/v1.0/bootstrap-elasticsearch")
+                self.assertEqual(item.action, "/api/v1.0/bootstrap-elasticsearch/")

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -419,6 +419,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 ],
                 "filters": {
                     "availability": {
+                        "base_path": None,
                         "has_more_values": False,
                         "human_name": "Availability",
                         "is_autocompletable": False,
@@ -442,6 +443,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         ],
                     },
                     "languages": {
+                        "base_path": None,
                         "has_more_values": False,
                         "human_name": "Languages",
                         "is_autocompletable": False,
@@ -483,6 +485,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         ],
                     },
                     "new": {
+                        "base_path": None,
                         "has_more_values": False,
                         "human_name": "New courses",
                         "is_autocompletable": False,

--- a/tests/apps/search/test_query_courses_facets.py
+++ b/tests/apps/search/test_query_courses_facets.py
@@ -234,6 +234,7 @@ class FacetsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             content["filters"]["languages"],
             {
+                "base_path": None,
                 "has_more_values": True,
                 "human_name": "Languages",
                 "is_autocompletable": False,
@@ -303,6 +304,7 @@ class FacetsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             content["filters"]["languages"],
             {
+                "base_path": None,
                 "has_more_values": True,
                 "human_name": "Languages",
                 "is_autocompletable": False,
@@ -354,6 +356,7 @@ class FacetsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             content["filters"]["languages"],
             {
+                "base_path": None,
                 "has_more_values": True,
                 "human_name": "Languages",
                 "is_autocompletable": False,
@@ -413,6 +416,7 @@ class FacetsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             content["filters"]["languages"],
             {
+                "base_path": None,
                 "has_more_values": False,
                 "human_name": "Languages",
                 "is_autocompletable": False,
@@ -499,6 +503,7 @@ class FacetsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             content["filters"]["languages"],
             {
+                "base_path": None,
                 "has_more_values": True,
                 "human_name": "Languages",
                 "is_autocompletable": False,
@@ -582,6 +587,7 @@ class FacetsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             content["filters"]["languages"],
             {
+                "base_path": None,
                 "has_more_values": False,
                 "human_name": "Languages",
                 "is_autocompletable": False,
@@ -719,6 +725,7 @@ class FacetsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             content["filters"]["languages"],
             {
+                "base_path": None,
                 "has_more_values": True,
                 "human_name": "Languages",
                 "is_autocompletable": False,
@@ -774,6 +781,7 @@ class FacetsCoursesQueryTestCase(TestCase):
         self.assertEqual(
             content["filters"]["languages"],
             {
+                "base_path": None,
                 "has_more_values": True,
                 "human_name": "Languages",
                 "is_autocompletable": False,

--- a/tests/apps/search/test_views_bootstrap_elasticsearch.py
+++ b/tests/apps/search/test_views_bootstrap_elasticsearch.py
@@ -23,7 +23,7 @@ class BootstrapElasticsearchViewTestCase(CMSTestCase):
         # Add the necessary permission
         self.add_permission(user, "can_manage_elasticsearch")
 
-        url = "/api/v1.0/bootstrap-elasticsearch"
+        url = "/api/v1.0/bootstrap-elasticsearch/"
         response = self.client.post(url, follow=True)
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
@@ -44,7 +44,7 @@ class BootstrapElasticsearchViewTestCase(CMSTestCase):
         user = UserFactory(is_staff=True)
         self.client.login(username=user.username, password="password")
 
-        url = "/api/v1.0/bootstrap-elasticsearch"
+        url = "/api/v1.0/bootstrap-elasticsearch/"
         response = self.client.post(url, follow=True)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
@@ -61,7 +61,7 @@ class BootstrapElasticsearchViewTestCase(CMSTestCase):
         # Add the necessary permission
         self.add_permission(user, "can_manage_elasticsearch")
 
-        url = "/api/v1.0/bootstrap-elasticsearch"
+        url = "/api/v1.0/bootstrap-elasticsearch/"
 
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 405)
@@ -77,7 +77,7 @@ class BootstrapElasticsearchViewTestCase(CMSTestCase):
     @mock.patch("django.core.management.call_command")
     def test_views_bootstrap_elasticsearch_anonymous(self, mock_command):
         """An anonymous user should not be allowed to bootstrap ES."""
-        url = "/api/v1.0/bootstrap-elasticsearch"
+        url = "/api/v1.0/bootstrap-elasticsearch/"
         response = self.client.post(url, follow=True)
 
         self.assertEqual(response.status_code, 401)
@@ -94,7 +94,7 @@ class BootstrapElasticsearchViewTestCase(CMSTestCase):
         # Add the necessary permission
         self.add_permission(user, "can_manage_elasticsearch")
 
-        url = "/api/v1.0/bootstrap-elasticsearch"
+        url = "/api/v1.0/bootstrap-elasticsearch/"
         response = self.client.post(url, follow=True)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(

--- a/tests/apps/search/test_views_filter_definitions.py
+++ b/tests/apps/search/test_views_filter_definitions.py
@@ -1,0 +1,150 @@
+"""Test suite for the filter_definition view of richie's search app."""
+import json
+from unittest import mock
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.helpers import create_i18n_page
+from richie.apps.courses.factories import CategoryFactory
+from richie.apps.search.filter_definitions import FILTERS
+
+
+class FilterDefinitionsViewTestCase(CMSTestCase):
+    """
+    Test suite to validate the behavior of the `filter_definitions` view.
+    """
+
+    def tearDown(self):
+        """
+        Clear filter definitions cache for base pages. This helps us avoid breaking other
+        tests because we create page and use their related filters through the reverse id.
+        """
+        for filter_definition in FILTERS.values():
+            try:
+                # pylint: disable=protected-access
+                filter_definition._base_page = None
+            except AttributeError:
+                pass
+
+    def test_views_filter_definitions(self):
+        """
+        Returns an object with all the filter definitions, keyed by machine name.
+        """
+        # Create pages with expected `reverse_id` to ensure the base paths are returned
+        # as part of the filter definitions.
+        create_i18n_page(
+            {"en": "Organizations", "fr": "Organisations"},
+            reverse_id="organizations",
+            published=True,
+        )
+        create_i18n_page(
+            {"en": "Persons", "fr": "Personnes"}, reverse_id="persons", published=True
+        )
+        categories_page = create_i18n_page(
+            {"en": "Categories", "fr": "Catégories"}, published=True
+        )
+        CategoryFactory(
+            page_parent=categories_page,
+            page_reverse_id="subjects",
+            page_title={"en": "Subjects", "fr": "Sujets"},
+            should_publish=True,
+        )
+        CategoryFactory(
+            page_parent=categories_page,
+            page_reverse_id="levels",
+            page_title={"en": "Levels", "fr": "Niveaux"},
+            should_publish=True,
+        )
+
+        response = self.client.get("/api/v1.0/filter-definitions/")
+        self.assertEqual(
+            json.loads(response.content),
+            {
+                "new": {
+                    "base_path": None,
+                    "human_name": "New courses",
+                    "is_autocompletable": False,
+                    "is_drilldown": False,
+                    "is_searchable": False,
+                    "name": "new",
+                    "position": 0,
+                },
+                "availability": {
+                    "base_path": None,
+                    "human_name": "Availability",
+                    "is_autocompletable": False,
+                    "is_drilldown": True,
+                    "is_searchable": False,
+                    "name": "availability",
+                    "position": 1,
+                },
+                "subjects": {
+                    "base_path": "00030001",
+                    "human_name": "Subjects",
+                    "is_autocompletable": True,
+                    "is_drilldown": False,
+                    "is_searchable": True,
+                    "name": "subjects",
+                    "position": 2,
+                },
+                "levels": {
+                    "base_path": "00030002",
+                    "human_name": "Levels",
+                    "is_autocompletable": True,
+                    "is_drilldown": False,
+                    "is_searchable": True,
+                    "name": "levels",
+                    "position": 3,
+                },
+                "organizations": {
+                    "base_path": "0001",
+                    "human_name": "Organizations",
+                    "is_autocompletable": True,
+                    "is_drilldown": False,
+                    "is_searchable": True,
+                    "name": "organizations",
+                    "position": 4,
+                },
+                "languages": {
+                    "base_path": None,
+                    "human_name": "Languages",
+                    "is_autocompletable": False,
+                    "is_drilldown": False,
+                    "is_searchable": False,
+                    "name": "languages",
+                    "position": 5,
+                },
+                "persons": {
+                    "base_path": "0002",
+                    "human_name": "Persons",
+                    "is_autocompletable": True,
+                    "is_drilldown": False,
+                    "is_searchable": True,
+                    "name": "persons",
+                    "position": 5,
+                },
+            },
+        )
+
+    @mock.patch.object(
+        FILTERS["new"],
+        "get_static_definitions",
+        return_value={
+            "new": {
+                "base_path": None,
+                "human_name": "New courses",
+                "is_autocompletable": False,
+                "is_drilldown": False,
+                "is_searchable": False,
+                "name": "new",
+                "position": 0,
+            }
+        },
+    )
+    def test_views_filter_definitions_is_cached(self, mock_get_static_definitions):
+        """
+        Make sure we don't re-build the static filter definitions with each call.
+        """
+        self.client.get("/api/v1.0/filter-definitions/")
+        self.client.get("/api/v1.0/filter-definitions/")
+        self.assertEqual(mock_get_static_definitions.call_count, 1)

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -3,10 +3,10 @@ Tests for the course viewset
 """
 from unittest import mock
 
-from django.test import TestCase
 from django.utils import timezone
 
 import pytz
+from cms.test_utils.testcases import CMSTestCase
 from elasticsearch.exceptions import NotFoundError
 
 from richie.apps.search import ES_CLIENT
@@ -20,7 +20,7 @@ from richie.apps.search.indexers.courses import CoursesIndexer
     "format_es_object_for_api",
     side_effect=lambda es_course: "Course #{:n}".format(es_course["_id"]),
 )
-class CoursesViewsetsTestCase(TestCase):
+class CoursesViewsetsTestCase(CMSTestCase):
     """
     Test the API endpoints for courses (list and details)
     """
@@ -30,6 +30,7 @@ class CoursesViewsetsTestCase(TestCase):
         Make sure all our tests are timezone-agnostic. Some of them parse ISO datetimes and those
         would be broken if we did not enforce timezone normalization.
         """
+        super().setUp()
         timezone.activate(pytz.utc)
 
     def test_viewsets_courses_retrieve(self, *_):
@@ -176,6 +177,7 @@ class CoursesViewsetsTestCase(TestCase):
                 "objects": ["Course #523", "Course #861"],
                 "filters": {
                     "availability": {
+                        "base_path": None,
                         "has_more_values": False,
                         "human_name": "Availability",
                         "is_autocompletable": False,
@@ -199,6 +201,7 @@ class CoursesViewsetsTestCase(TestCase):
                         ],
                     },
                     "languages": {
+                        "base_path": None,
                         "has_more_values": False,
                         "human_name": "Languages",
                         "is_autocompletable": False,
@@ -226,6 +229,7 @@ class CoursesViewsetsTestCase(TestCase):
                         ],
                     },
                     "new": {
+                        "base_path": None,
                         "has_more_values": False,
                         "human_name": "New courses",
                         "is_autocompletable": False,


### PR DESCRIPTION
## Purpose

We're refactoring our course search to make it more modular. One key part of this is to allow components to use search/autosuggest based on filters without making full course search requests first.

## Proposal

- [x] rework filter definitions to add a method that returns the static definition for a filter
- [x] all filter definitions have a `base_path` property
- [x] add an API route with the static filter definitions

While doing this, we noticed a missing trailing slack on the `bootstrap-elasticsearch` API url, and decided to add it.
