### PR TITLE
Fix language chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The language chooser should only show public languages,
 - Fix undefined behavior on hits on the categories API from unrelated requests,
   return 404 errors instead.
 - Improve React spinner component accessibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - The language chooser should only show public languages,
+- The language chooser shouldn't render an empty <ul> on sites with 1 language,
 - Fix undefined behavior on hits on the categories API from unrelated requests,
   return 404 errors instead.
 - Improve React spinner component accessibility.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,7 +18,11 @@ $ make migrate
 
 ## 1.12.x to 1.13.x
 
-If you override templates that contain React hooks, rename the `fun-react` class to`richie-react`.
+- If you override the `menu/language_menu.html` template, you should now include the <ul> tag in this
+  template and not in `richie/base.html` so that it does not render as an empty element on sites with
+  only one public language,
+- If you override templates that contain React hooks, rename the `fun-react` class to`richie-react`.
+
 
 ## 1.11.x to 1.12.x
 

--- a/src/richie/apps/core/templates/menu/language_menu.html
+++ b/src/richie/apps/core/templates/menu/language_menu.html
@@ -1,22 +1,26 @@
 {% load i18n menu_tags cms_tags %}{% spaceless %}
-{% get_current_language as current_language_code %}
+
 {% if languages|length > 1 %}
+  {% get_current_language as current_language_code %}
+  <ul class="topbar__menu__list topbar__menu__list--aside">
     {% for code, name in languages %}
-    {% get_language_info for code as lang %}
-        {% if code == current_language_code %}
-            <li class="topbar__menu__list__item topbar__menu__list__item--language topbar__menu__list__item--{{ code }} topbar__menu__list__item--active">
-                <a class="topbar__menu__list__item__link" href="{% page_language_url code %}"
-                title="{% blocktrans with code=lang.code|slice:":2" name=lang.name_translated %}{{ code }}, currently in {{ name }}{% endblocktrans %}">
-                    {{ lang.code|slice:":2" }}
-                </a>
-            </li>
-        {% else %}
-            <li class="topbar__menu__list__item topbar__menu__list__item--language topbar__menu__list__item--{{ code }}">
-                <a class="topbar__menu__list__item__link" href="{% page_language_url code %}"
-                title="{% blocktrans with code=lang.code|slice:":2" name=lang.name_translated %}{{ code }}, switch to {{ name }}{% endblocktrans %}">
-                    {{ lang.code|slice:":2" }}
-                </a>
-            </li>
-        {% endif %}
+      {% get_language_info for code as lang %}
+      {% if code == current_language_code %}
+        <li class="topbar__menu__list__item topbar__menu__list__item--language topbar__menu__list__item--{{ code }} topbar__menu__list__item--active">
+          <a class="topbar__menu__list__item__link" href="{% page_language_url code %}"
+             title="{% blocktrans with code=lang.code|slice:":2" name=lang.name_translated %}{{ code }}, currently in {{ name }}{% endblocktrans %}">
+            {{ lang.code|slice:":2" }}
+          </a>
+        </li>
+      {% else %}
+        <li class="topbar__menu__list__item topbar__menu__list__item--language topbar__menu__list__item--{{ code }}">
+          <a class="topbar__menu__list__item__link" href="{% page_language_url code %}"
+             title="{% blocktrans with code=lang.code|slice:":2" name=lang.name_translated %}{{ code }}, switch to {{ name }}{% endblocktrans %}">
+            {{ lang.code|slice:":2" }}
+          </a>
+        </li>
+      {% endif %}
     {% endfor %}
-{% endif %}{% endspaceless %}
+  </ul>
+{% endif %}
+{% endspaceless %}

--- a/src/richie/apps/core/templates/menu/language_menu.html
+++ b/src/richie/apps/core/templates/menu/language_menu.html
@@ -1,5 +1,4 @@
-{% load i18n menu_tags cms_tags%}{% spaceless %}
-{% get_available_languages as languages %}
+{% load i18n menu_tags cms_tags %}{% spaceless %}
 {% get_current_language as current_language_code %}
 {% if languages|length > 1 %}
     {% for code, name in languages %}

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -63,9 +63,7 @@
                     <ul class="topbar__menu__list">
                         {% show_menu 0 100 0 0 "menu/header_menu.html" %}
                     </ul>
-                    <ul class="topbar__menu__list topbar__menu__list--aside">
-                        {% language_chooser "menu/language_menu.html" %}
-                    </ul>
+                    {% language_chooser "menu/language_menu.html" %}
                     {% block userlogin %}
                     <div
                       class="richie-react richie-react--user-login"

--- a/tests/apps/core/test_language_chooser.py
+++ b/tests/apps/core/test_language_chooser.py
@@ -2,6 +2,8 @@
 """
 Unit tests for the language_chooser menu
 """
+from django.test.utils import override_settings
+
 from cms.api import create_page
 from cms.test_utils.testcases import CMSTestCase
 
@@ -11,7 +13,7 @@ from richie.apps.core.helpers import create_i18n_page
 class LanguageChooserTests(CMSTestCase):
     """Test the language chooser menu for available languages"""
 
-    def test_language_chooser_available_language(self):
+    def test_language_chooser_available_language_public(self):
         """
         Menu should always contain every available language from settings,
         no matter if the page has a translation or not
@@ -34,6 +36,45 @@ class LanguageChooserTests(CMSTestCase):
 
         self.assertContains(response, "en, currently in English")
         self.assertContains(response, "fr, switch to French")
+
+    @override_settings(
+        LANGUAGES=(("en", "English"), ("fr", "Français"), ("de", "Deutsch")),
+        CMS_LANGUAGES={
+            1: [
+                {"code": "fr", "hide_untranslated": False, "name": "Français"},
+                {"code": "de", "hide_untranslated": False, "name": "Deutsch"},
+                {
+                    "public": False,
+                    "code": "en",
+                    "hide_untranslated": False,
+                    "name": "English",
+                },
+            ]
+        },
+    )
+    def test_language_chooser_available_language_not_public(self):
+        """
+        Languages that are marked as not public should only be visible to staff users.
+        """
+        content = {
+            "de": "Sprachmenü test",
+            "en": "Language menu test",
+            "fr": "Test du menu de langues",
+        }
+        page = create_i18n_page(
+            content, published=True, template="richie/single_column.html"
+        )
+        url = page.get_absolute_url(language="fr")
+        response = self.client.get(url)
+
+        # English should not be in the language chooser as it is not public
+        self.assertContains(response, page.get_absolute_url(language="fr"))
+        self.assertContains(response, page.get_absolute_url(language="de"))
+        self.assertNotContains(response, page.get_absolute_url(language="en"))
+
+        self.assertContains(response, "fr, actuellement en Français")
+        self.assertContains(response, "de, basculer vers Allemand")
+        self.assertNotContains(response, "en, basculer vers Anglais")
 
     def test_language_chooser_available_language_with_translated_page(self):
         """


### PR DESCRIPTION
## Purpose

The language chooser was showing languages even when they were marked as "not public" in the settings.

## Proposal

- Remove the template tag that gets languages for the language chooser and rely on the languages variable already prepared by the language chooser template tag. It respects the public status of languages.
- Refactor the language chooser menu to include the `<ul>` tag so we can avoid having an empty `<ul>` on sites that have only one public language.
