### PR TITLE
Refactor search for modularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change the way frontend search field components are configured.
+
 ## [1.13.0] - 2019-11-15
 
 ### Added

--- a/src/frontend/js/common/searchFields/index.tsx
+++ b/src/frontend/js/common/searchFields/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { APICourseSearchResponse } from 'types/api';
+import { StaticFilterDefinitions } from 'types/filters';
 import {
   SearchAutosuggestProps,
   SearchSuggestion,
@@ -33,7 +34,7 @@ export const renderSuggestion: SearchAutosuggestProps['renderSuggestion'] = sugg
  * @param incomingValue The current value of the search suggest form field.
  */
 export const onSuggestionsFetchRequested = async (
-  filters: APICourseSearchResponse['filters'],
+  filters: StaticFilterDefinitions,
   setSuggestions: (suggestions: SearchSuggestionSection[]) => void,
   incomingValue: string,
 ) => {
@@ -72,7 +73,7 @@ export const onSuggestionsFetchRequested = async (
  * @param suggestion The suggestion with which we're doing some work (eg. the suggestion the user selected).
  */
 export const getRelevantFilter = (
-  filters: APICourseSearchResponse['filters'],
+  filters: StaticFilterDefinitions,
   suggestion: SearchSuggestion,
 ) => {
   // Use the `kind` field on the suggestion to pick the relevant filter to update.

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -33,10 +33,8 @@ describe('<RootSearchSuggestField />', () => {
   afterEach(jest.resetAllMocks);
 
   it('renders', () => {
-    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
-      filters: {
-        subjects,
-      },
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      subjects,
     });
 
     const { getByPlaceholderText } = render(
@@ -55,11 +53,10 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('gets suggestions from the API when the user types 3 characters or more in the field', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
-      filters: {
-        subjects,
-      },
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      subjects,
     });
+
     fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', [
       {
         id: 'L-000300010001',
@@ -103,11 +100,10 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('goes to the course page when the user selects a course suggestion', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
-      filters: {
-        subjects,
-      },
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      subjects,
     });
+
     fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', []);
     fetchMock.get('/api/v1.0/courses/autocomplete/?query=aut', [
       {
@@ -149,11 +145,10 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('goes to course search with the filter value activated when the user clicks on a suggestion', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
-      filters: {
-        subjects,
-      },
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      subjects,
     });
+
     fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', [
       {
         id: 'L-000300010001',
@@ -196,6 +191,10 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('moves to the search page with a search query when the user types a query and presses ENTER', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      subjects,
+    });
+
     ['courses', 'subjects'].forEach(kind =>
       fetchMock.get(`/api/v1.0/${kind}/autocomplete/?query=some%20query`, []),
     );
@@ -223,11 +222,10 @@ describe('<RootSearchSuggestField />', () => {
   });
 
   it('lets the user select the currently highlighted suggestion by pressing ENTER', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=1&offset=0&scope=filters', {
-      filters: {
-        subjects,
-      },
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      subjects,
     });
+
     fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', []);
     fetchMock.get('/api/v1.0/courses/autocomplete/?query=aut', [
       {

--- a/src/frontend/js/components/RootSearchSuggestField/index.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.tsx
@@ -13,7 +13,7 @@ import { fetchList } from 'data/getResourceList';
 import { API_LIST_DEFAULT_PARAMS } from 'settings';
 import { APICourseSearchResponse, requestStatus } from 'types/api';
 import { CommonDataProps } from 'types/commonDataProps';
-import { FilterDefinition } from 'types/filters';
+import { FacetedFilterDefinition } from 'types/filters';
 import {
   isCourseSuggestion,
   SearchAutosuggestProps,
@@ -32,7 +32,7 @@ const messages = defineMessages({
 
 // Our search and autosuggestion pipeline operated based on filter definitions. Obviously, we can filters courses
 // by courses, but we still need a filter-definition-like config to run courses autocompletion.
-const coursesConfig: FilterDefinition = {
+const coursesConfig: FacetedFilterDefinition = {
   base_path: null,
   has_more_values: false,
   human_name: 'Courses',

--- a/src/frontend/js/components/RootSearchSuggestField/index.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.tsx
@@ -39,6 +39,7 @@ const coursesConfig: FacetedFilterDefinition = {
   is_autocompletable: true,
   is_searchable: true,
   name: 'courses',
+  position: 99,
   values: [],
 };
 

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -114,9 +114,7 @@ export const Search = ({
           {courseSearchResponse &&
           courseSearchResponse.status === requestStatus.SUCCESS ? (
             <React.Fragment>
-              <SearchSuggestField
-                filters={courseSearchResponse.content.filters}
-              />
+              <SearchSuggestField />
               <CourseGlimpseList
                 courses={courseSearchResponse.content.objects}
                 meta={courseSearchResponse.content.meta}

--- a/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
@@ -27,6 +27,7 @@ describe('components/SearchFilterGroup', () => {
     is_autocompletable: true,
     is_searchable: true,
     name: 'organizations',
+    position: 0,
     values: [
       {
         count: 4,

--- a/src/frontend/js/components/SearchFilterGroup/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import { SearchFilterGroupModal } from 'components/SearchFilterGroupModal';
 import { SearchFilterValueLeaf } from 'components/SearchFilterValueLeaf';
 import { SearchFilterValueParent } from 'components/SearchFilterValueParent';
-import { FilterDefinition } from 'types/filters';
+import { FacetedFilterDefinition } from 'types/filters';
 
 export interface SearchFilterGroupProps {
-  filter: FilterDefinition;
+  filter: FacetedFilterDefinition;
 }
 
 export const SearchFilterGroup = ({ filter }: SearchFilterGroupProps) => (

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -15,6 +15,7 @@ const filter = {
   is_autocompletable: true,
   is_searchable: true,
   name: 'universities',
+  position: 0,
   values: [
     {
       count: 4,

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -9,12 +9,12 @@ import ReactModal from 'react-modal';
 import { fetchList } from 'data/getResourceList';
 import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
 import { requestStatus } from 'types/api';
-import { FilterDefinition, FilterValue } from 'types/filters';
+import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { Nullable } from 'utils/types';
 import { useAsyncEffect } from 'utils/useAsyncEffect';
 
 interface SearchFilterGroupModalProps {
-  filter: FilterDefinition;
+  filter: FacetedFilterDefinition;
 }
 
 const messages = defineMessages({

--- a/src/frontend/js/components/SearchFilterValueLeaf/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/index.spec.tsx
@@ -22,6 +22,7 @@ describe('components/SearchFilterValueLeaf', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -58,6 +59,7 @@ describe('components/SearchFilterValueLeaf', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -92,6 +94,7 @@ describe('components/SearchFilterValueLeaf', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -133,6 +136,7 @@ describe('components/SearchFilterValueLeaf', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -156,6 +160,7 @@ describe('components/SearchFilterValueLeaf', () => {
         is_autocompletable: true,
         is_searchable: true,
         name: 'filter_name',
+        position: 0,
         values: [],
       },
       payload: '43',
@@ -181,6 +186,7 @@ describe('components/SearchFilterValueLeaf', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -204,6 +210,7 @@ describe('components/SearchFilterValueLeaf', () => {
         is_autocompletable: true,
         is_searchable: true,
         name: 'filter_name',
+        position: 0,
         values: [],
       },
       payload: '44',

--- a/src/frontend/js/components/SearchFilterValueLeaf/index.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { useFilterValue } from 'data/useFilterValue';
-import { FilterDefinition, FilterValue } from 'types/filters';
+import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 
 export interface SearchFilterValueLeafProps {
-  filter: FilterDefinition;
+  filter: FacetedFilterDefinition;
   value: FilterValue;
 }
 

--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -33,6 +33,7 @@ describe('<SearchFilterValueParent />', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'subjects',
+              position: 0,
               values: [],
             }}
             value={{
@@ -92,6 +93,7 @@ describe('<SearchFilterValueParent />', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'subjects',
+              position: 0,
               values: [],
             }}
             value={{
@@ -166,6 +168,7 @@ describe('<SearchFilterValueParent />', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'subjects',
+              position: 0,
               values: [],
             }}
             value={{
@@ -243,6 +246,7 @@ describe('<SearchFilterValueParent />', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -279,6 +283,7 @@ describe('<SearchFilterValueParent />', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -318,6 +323,7 @@ describe('<SearchFilterValueParent />', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -356,6 +362,7 @@ describe('<SearchFilterValueParent />', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -379,6 +386,7 @@ describe('<SearchFilterValueParent />', () => {
         is_autocompletable: true,
         is_searchable: true,
         name: 'filter_name',
+        position: 0,
         values: [],
       },
       payload: 'P-00040005',
@@ -404,6 +412,7 @@ describe('<SearchFilterValueParent />', () => {
               is_autocompletable: true,
               is_searchable: true,
               name: 'filter_name',
+              position: 0,
               values: [],
             }}
             value={{
@@ -427,6 +436,7 @@ describe('<SearchFilterValueParent />', () => {
         is_autocompletable: true,
         is_searchable: true,
         name: 'filter_name',
+        position: 0,
         values: [],
       },
       payload: 'P-00040005',

--- a/src/frontend/js/components/SearchFilterValueParent/index.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.tsx
@@ -6,7 +6,7 @@ import { fetchList } from 'data/getResourceList';
 import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
 import { useFilterValue } from 'data/useFilterValue';
 import { requestStatus } from 'types/api';
-import { FilterDefinition, FilterValue } from 'types/filters';
+import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { getMPTTChildrenPathMatcher } from 'utils/mptt';
 import { Nullable } from 'utils/types';
 import { useAsyncEffect } from 'utils/useAsyncEffect';
@@ -27,7 +27,7 @@ const messages = defineMessages({
 });
 
 interface SearchFilterValueParentProps {
-  filter: FilterDefinition;
+  filter: FacetedFilterDefinition;
   value: FilterValue;
 }
 

--- a/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
@@ -29,6 +29,7 @@ describe('components/SearchFiltersPane', () => {
                 is_autocompletable: true,
                 is_searchable: true,
                 name: 'categories',
+                position: 0,
                 values: [],
               },
               organizations: {
@@ -38,6 +39,7 @@ describe('components/SearchFiltersPane', () => {
                 is_autocompletable: true,
                 is_searchable: true,
                 name: 'organizations',
+                position: 1,
                 values: [],
               },
             }}
@@ -92,6 +94,7 @@ describe('components/SearchFiltersPane', () => {
                 is_autocompletable: true,
                 is_searchable: true,
                 name: 'categories',
+                position: 0,
                 values: [],
               },
               organizations: {
@@ -101,6 +104,7 @@ describe('components/SearchFiltersPane', () => {
                 is_autocompletable: true,
                 is_searchable: true,
                 name: 'organizations',
+                position: 1,
                 values: [],
               },
             }}

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -25,6 +25,7 @@ describe('components/SearchSuggestField', () => {
     is_autocompletable: false,
     is_searchable: false,
     name: 'levels',
+    position: 0,
     values: [],
   };
 
@@ -35,6 +36,7 @@ describe('components/SearchSuggestField', () => {
     is_autocompletable: true,
     is_searchable: true,
     name: 'organizations',
+    position: 1,
     values: [],
   };
 
@@ -45,6 +47,7 @@ describe('components/SearchSuggestField', () => {
     is_autocompletable: true,
     is_searchable: true,
     name: 'persons',
+    position: 2,
     values: [],
   };
 
@@ -55,6 +58,7 @@ describe('components/SearchSuggestField', () => {
     is_autocompletable: true,
     is_searchable: true,
     name: 'subjects',
+    position: 3,
     values: [],
   };
 
@@ -257,15 +261,7 @@ describe('components/SearchSuggestField', () => {
       type: 'QUERY_UPDATE',
     });
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
-      filter: {
-        base_path: '0002',
-        has_more_values: false,
-        human_name: 'Organizations',
-        is_autocompletable: true,
-        is_searchable: true,
-        name: 'organizations',
-        values: [],
-      },
+      filter: organizations,
       payload: 'L-00020007',
       type: 'FILTER_ADD',
     });
@@ -333,15 +329,7 @@ describe('components/SearchSuggestField', () => {
     await wait();
 
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
-      filter: {
-        base_path: null,
-        has_more_values: false,
-        human_name: 'Persons',
-        is_autocompletable: true,
-        is_searchable: true,
-        name: 'persons',
-        values: [],
-      },
+      filter: persons,
       payload: '73',
       type: 'FILTER_ADD',
     });

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -80,7 +80,7 @@ describe('components/SearchSuggestField', () => {
     getByPlaceholderText('Search for courses, organizations, categories');
   });
 
-  it('picks the query from the URL if there is one', async () => {
+  it('picks the query from the URL if there is one', () => {
     const { getByDisplayValue } = render(
       <IntlProvider locale="en">
         <CourseSearchParamsContext.Provider
@@ -372,7 +372,7 @@ describe('components/SearchSuggestField', () => {
     });
   });
 
-  it('searches as the user types', () => {
+  it('searches as the user types', async () => {
     ['organizations', 'persons', 'subjects'].forEach(kind =>
       fetchMock.get(`begin:/api/v1.0/${kind}/autocomplete/?query=`, []),
     );
@@ -404,18 +404,21 @@ describe('components/SearchSuggestField', () => {
     expect(dispatchCourseSearchParamsUpdate).not.toHaveBeenCalled();
 
     fireEvent.change(field, { target: { value: 'ric' } });
+    await wait();
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenCalledWith({
       query: 'ric',
       type: 'QUERY_UPDATE',
     });
 
     fireEvent.change(field, { target: { value: 'rich data driven' } });
+    await wait();
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenLastCalledWith({
       query: 'rich data driven',
       type: 'QUERY_UPDATE',
     });
 
     fireEvent.change(field, { target: { value: '' } });
+    await wait();
     expect(dispatchCourseSearchParamsUpdate).toHaveBeenLastCalledWith({
       query: '',
       type: 'QUERY_UPDATE',

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { IntlProvider } from 'react-intl';
 
 import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { FilterDefinition } from 'types/filters';
 import { SearchSuggestField } from '.';
 
 jest.mock('utils/indirection/window', () => ({ location: {} }));
@@ -17,49 +18,41 @@ jest.mock('lodash-es/debounce', () => (fn: any) => (...args: any[]) =>
 );
 
 describe('components/SearchSuggestField', () => {
-  // Make some filters we can reuse through our tests in <SearchSuggestField /> props
-  const levels = {
+  // Make some filters we can reuse through our tests with the filter definitions responses
+  const levels: FilterDefinition = {
     base_path: '00030002',
-    has_more_values: false,
     human_name: 'Levels',
     is_autocompletable: false,
     is_searchable: false,
     name: 'levels',
     position: 0,
-    values: [],
   };
 
-  const organizations = {
+  const organizations: FilterDefinition = {
     base_path: '0002',
-    has_more_values: false,
     human_name: 'Organizations',
     is_autocompletable: true,
     is_searchable: true,
     name: 'organizations',
     position: 1,
-    values: [],
   };
 
-  const persons = {
+  const persons: FilterDefinition = {
     base_path: null,
-    has_more_values: false,
     human_name: 'Persons',
     is_autocompletable: true,
     is_searchable: true,
     name: 'persons',
     position: 2,
-    values: [],
   };
 
-  const subjects = {
+  const subjects: FilterDefinition = {
     base_path: '00030001',
-    has_more_values: false,
     human_name: 'Subjects',
     is_autocompletable: true,
     is_searchable: true,
     name: 'subjects',
     position: 3,
-    values: [],
   };
 
   afterEach(fetchMock.restore);
@@ -71,7 +64,7 @@ describe('components/SearchSuggestField', () => {
         <CourseSearchParamsContext.Provider
           value={[{ limit: '999', offset: '0' }, jest.fn()]}
         >
-          <SearchSuggestField filters={{}} />
+          <SearchSuggestField />
         </CourseSearchParamsContext.Provider>
       </IntlProvider>,
     );
@@ -89,7 +82,7 @@ describe('components/SearchSuggestField', () => {
             jest.fn(),
           ]}
         >
-          <SearchSuggestField filters={{}} />
+          <SearchSuggestField />
         </CourseSearchParamsContext.Provider>
       </IntlProvider>,
     );
@@ -99,6 +92,13 @@ describe('components/SearchSuggestField', () => {
   });
 
   it('gets suggestions from the API when the user types something in the field', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      levels,
+      organizations,
+      persons,
+      subjects,
+    });
+
     fetchMock.get('/api/v1.0/subjects/autocomplete/?query=aut', [
       {
         id: 'L-000300010001',
@@ -114,9 +114,7 @@ describe('components/SearchSuggestField', () => {
         <CourseSearchParamsContext.Provider
           value={[{ limit: '999', offset: '0' }, jest.fn()]}
         >
-          <SearchSuggestField
-            filters={{ levels, organizations, persons, subjects }}
-          />
+          <SearchSuggestField />
         </CourseSearchParamsContext.Provider>
       </IntlProvider>,
     );
@@ -153,6 +151,13 @@ describe('components/SearchSuggestField', () => {
   });
 
   it('does not attempt to get or show any suggestions before the user types 3 characters', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      levels,
+      organizations,
+      persons,
+      subjects,
+    });
+
     ['organizations', 'persons', 'subjects'].forEach(kind =>
       fetchMock.get(`/api/v1.0/${kind}/autocomplete/?query=xyz`, []),
     );
@@ -162,9 +167,7 @@ describe('components/SearchSuggestField', () => {
         <CourseSearchParamsContext.Provider
           value={[{ limit: '999', offset: '0' }, jest.fn()]}
         >
-          <SearchSuggestField
-            filters={{ levels, organizations, persons, subjects }}
-          />
+          <SearchSuggestField />
         </CourseSearchParamsContext.Provider>
       </IntlProvider>,
     );
@@ -196,6 +199,13 @@ describe('components/SearchSuggestField', () => {
   });
 
   it('updates the search params when the user selects a filter suggestion', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      levels,
+      organizations,
+      persons,
+      subjects,
+    });
+
     fetchMock.get('/api/v1.0/organizations/autocomplete/?query=orga', [
       {
         id: 'L-00020007',
@@ -216,9 +226,7 @@ describe('components/SearchSuggestField', () => {
             dispatchCourseSearchParamsUpdate,
           ]}
         >
-          <SearchSuggestField
-            filters={{ levels, organizations, persons, subjects }}
-          />
+          <SearchSuggestField />
         </CourseSearchParamsContext.Provider>
       </IntlProvider>,
     );
@@ -268,6 +276,13 @@ describe('components/SearchSuggestField', () => {
   });
 
   it('updates the search params when the user selects a filter suggestion', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      levels,
+      organizations,
+      persons,
+      subjects,
+    });
+
     fetchMock.get('/api/v1.0/persons/autocomplete/?query=doct', [
       {
         id: '73',
@@ -288,9 +303,7 @@ describe('components/SearchSuggestField', () => {
             dispatchCourseSearchParamsUpdate,
           ]}
         >
-          <SearchSuggestField
-            filters={{ levels, organizations, persons, subjects }}
-          />
+          <SearchSuggestField />
         </CourseSearchParamsContext.Provider>
       </IntlProvider>,
     );
@@ -336,6 +349,13 @@ describe('components/SearchSuggestField', () => {
   });
 
   it('removes the search query when the user presses ENTER on an empty field', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      levels,
+      organizations,
+      persons,
+      subjects,
+    });
+
     ['organizations', 'persons', 'subjects'].forEach(kind =>
       fetchMock.get(`/api/v1.0/${kind}/autocomplete/?query=some%20query`, []),
     );
@@ -349,9 +369,7 @@ describe('components/SearchSuggestField', () => {
             dispatchCourseSearchParamsUpdate,
           ]}
         >
-          <SearchSuggestField
-            filters={{ levels, organizations, persons, subjects }}
-          />
+          <SearchSuggestField />
         </CourseSearchParamsContext.Provider>
       </IntlProvider>,
     );
@@ -373,6 +391,13 @@ describe('components/SearchSuggestField', () => {
   });
 
   it('searches as the user types', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', {
+      levels,
+      organizations,
+      persons,
+      subjects,
+    });
+
     ['organizations', 'persons', 'subjects'].forEach(kind =>
       fetchMock.get(`begin:/api/v1.0/${kind}/autocomplete/?query=`, []),
     );
@@ -386,9 +411,7 @@ describe('components/SearchSuggestField', () => {
             dispatchCourseSearchParamsUpdate,
           ]}
         >
-          <SearchSuggestField
-            filters={{ levels, organizations, persons, subjects }}
-          />
+          <SearchSuggestField />
         </CourseSearchParamsContext.Provider>
       </IntlProvider>,
     );

--- a/src/frontend/js/data/useFilterValue/index.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/index.spec.tsx
@@ -40,6 +40,7 @@ describe('data/useFilterValue', () => {
             is_autocompletable: false,
             is_searchable: false,
             name: 'organizations',
+            position: 0,
             values: [],
           }}
           value={{
@@ -61,6 +62,7 @@ describe('data/useFilterValue', () => {
         is_autocompletable: false,
         is_searchable: false,
         name: 'organizations',
+        position: 0,
         values: [],
       },
       payload: '87',
@@ -85,6 +87,7 @@ describe('data/useFilterValue', () => {
             is_autocompletable: true,
             is_searchable: true,
             name: 'organizations',
+            position: 0,
             values: [],
           }}
           value={{
@@ -106,6 +109,7 @@ describe('data/useFilterValue', () => {
         is_autocompletable: true,
         is_searchable: true,
         name: 'organizations',
+        position: 0,
         values: [],
       },
       payload: '87',

--- a/src/frontend/js/data/useFilterValue/index.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/index.spec.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
-import { FilterDefinition, FilterValue } from 'types/filters';
+import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { useFilterValue } from '.';
 
 describe('data/useFilterValue', () => {
@@ -13,7 +13,7 @@ describe('data/useFilterValue', () => {
     filter,
     value,
   }: {
-    filter: FilterDefinition;
+    filter: FacetedFilterDefinition;
     value: FilterValue;
   }) => {
     const hookValues = useFilterValue(filter, value);

--- a/src/frontend/js/data/useFilterValue/index.ts
+++ b/src/frontend/js/data/useFilterValue/index.ts
@@ -1,12 +1,12 @@
 import { useContext } from 'react';
 
 import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
-import { FilterDefinition, FilterValue } from 'types/filters';
+import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 
 type UseFilterValue = [boolean, () => void];
 
 export const useFilterValue = (
-  filter: FilterDefinition,
+  filter: FacetedFilterDefinition,
   value: FilterValue,
 ): UseFilterValue => {
   const [courseSearchParams, dispatchCourseSearchParamsUpdate] = useContext(

--- a/src/frontend/js/data/useStaticFilters/index.spec.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.spec.tsx
@@ -1,0 +1,104 @@
+import { act, render, wait } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import React from 'react';
+
+import { FilterDefinition } from 'types/filters';
+import { useStaticFilters } from '.';
+
+describe('data/useStaticFilters', () => {
+  // Build a helper component with an out-of-scope function to let us reach our Hook from
+  // our test cases.
+  let getLatestHookValues: any;
+  const TestComponent = ({ includeCoursesConfig = false }) => {
+    const hookValues = useStaticFilters(includeCoursesConfig);
+    getLatestHookValues = () => hookValues;
+    return <div />;
+  };
+
+  // Make some static filter definition to use throughout our tests
+  const levels: FilterDefinition = {
+    base_path: '00030002',
+    human_name: 'Levels',
+    is_autocompletable: false,
+    is_searchable: false,
+    name: 'levels',
+    position: 0,
+  };
+
+  const organizations: FilterDefinition = {
+    base_path: '0002',
+    human_name: 'Organizations',
+    is_autocompletable: true,
+    is_searchable: true,
+    name: 'organizations',
+    position: 1,
+  };
+
+  const persons: FilterDefinition = {
+    base_path: null,
+    human_name: 'Persons',
+    is_autocompletable: true,
+    is_searchable: true,
+    name: 'persons',
+    position: 2,
+  };
+
+  const subjects: FilterDefinition = {
+    base_path: '00030001',
+    human_name: 'Subjects',
+    is_autocompletable: true,
+    is_searchable: true,
+    name: 'subjects',
+    position: 3,
+  };
+
+  const staticFilterDefinitions = {
+    levels,
+    organizations,
+    persons,
+    subjects,
+  };
+
+  beforeEach(fetchMock.restore);
+
+  it('gets and returns the static filter definitions', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', staticFilterDefinitions);
+
+    render(<TestComponent />);
+
+    // No request is made until we actually use the hook's return value
+    await wait();
+    expect(fetchMock.called('/api/v1.0/filter-definitions/')).toEqual(false);
+
+    // useStaticFilters returns a promise for the static filter definitions
+    let filters;
+    await act(async () => (filters = await getLatestHookValues()()));
+    expect(filters).toEqual(staticFilterDefinitions);
+    expect(fetchMock.calls('/api/v1.0/filter-definitions/').length).toEqual(1);
+
+    // More calls return the filter but don't request on the API again
+    let filtersAgain;
+    await act(async () => (filtersAgain = await getLatestHookValues()()));
+    expect(filtersAgain).toEqual(staticFilterDefinitions);
+    expect(fetchMock.calls('/api/v1.0/filter-definitions/').length).toEqual(1);
+  });
+
+  it('includes a course config when requested', async () => {
+    fetchMock.get('/api/v1.0/filter-definitions/', staticFilterDefinitions);
+    render(<TestComponent includeCoursesConfig={true} />);
+
+    let filters;
+    await act(async () => (filters = await getLatestHookValues()()));
+    expect(filters).toEqual({
+      ...staticFilterDefinitions,
+      courses: {
+        base_path: null,
+        human_name: 'Courses',
+        is_autocompletable: true,
+        is_searchable: true,
+        name: 'courses',
+        position: 99,
+      },
+    });
+  });
+});

--- a/src/frontend/js/data/useStaticFilters/index.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.tsx
@@ -1,0 +1,54 @@
+import { useRef, useState } from 'react';
+
+import { FilterDefinition, StaticFilterDefinitions } from 'types/filters';
+import { Nullable } from 'utils/types';
+import { useAsyncEffect } from 'utils/useAsyncEffect';
+
+// Our search and autosuggestion pipeline operated based on filter definitions. Obviously, we can't filters
+// courses by courses, but we still need a filter-definition-like config to run courses autocompletion.
+const coursesConfig: FilterDefinition = {
+  base_path: null,
+  human_name: 'Courses',
+  is_autocompletable: true,
+  is_searchable: true,
+  name: 'courses',
+  position: 99,
+};
+
+/**
+ * Hook to provide static filter definitions to components as a promise while abstracting away
+ * data-fetching & caching logic.
+ * @param includeCoursesConfig Whether to include the courses filter-like configuration in the resulting definitions.
+ * @returns A getter function that returns a promise which will be resolved with the static filter definitions.
+ */
+export const useStaticFilters = (includeCoursesConfig = false) => {
+  const [needsFilters, setNeedsFilters] = useState(false);
+
+  const filtersResolver = useRef<
+    Nullable<(filters: StaticFilterDefinitions) => void>
+  >(null);
+  const [filtersPromise] = useState<Promise<StaticFilterDefinitions>>(
+    () => new Promise(resolve => (filtersResolver.current = resolve)),
+  );
+
+  useAsyncEffect(async () => {
+    if (needsFilters) {
+      const response = await fetch('/api/v1.0/filter-definitions/');
+      if (!response.ok) {
+        throw new Error('Failed to get filter definitions.');
+      }
+
+      const filters = await response.json();
+
+      filtersResolver.current!({
+        ...filters,
+        ...(includeCoursesConfig ? { courses: coursesConfig } : {}),
+      });
+    }
+  }, [needsFilters]);
+
+  return () => {
+    setNeedsFilters(true);
+    return filtersPromise!;
+  };
+};

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -1,5 +1,5 @@
 import { Course } from 'types/Course';
-import { FilterDefinition } from 'types/filters';
+import { FacetedFilterDefinition } from 'types/filters';
 import { Maybe } from 'utils/types';
 
 export enum requestStatus {
@@ -29,7 +29,7 @@ export interface APIListRequestParams {
 
 export interface APICourseSearchResponse {
   filters: {
-    [filterName: string]: FilterDefinition;
+    [filterName: string]: FacetedFilterDefinition;
   };
   meta: APIResponseListMeta;
   objects: Course[];

--- a/src/frontend/js/types/filters.ts
+++ b/src/frontend/js/types/filters.ts
@@ -18,22 +18,28 @@ export interface FilterValue {
  * Filter definitions give us information on a type of filter, eg. `organizations`, `availabilities`
  * @property `base_path` — MPTT path of the CMS page that matches the filter. This is useful here because
  * it appears in the path the pages for all filter values that are under that filter in the taxonomy.
- * @property `has_more_values` — Whether or not there are other values besides those in the `values` array
- * in the present response.
  * @property `human_name` — Internationalized human name for the filter.
  * @property `is_autocompletable` — whether the filter has an associated API endpoint for autocompletion.
  * @property `is_drilldown` — Whether the filter is limited to one active value at a time.
  * @property `is_searchable` — whether the filter has an associated API endpoint for full-text search.
  * @property `name` — Machine name for the filter (for use in API calls, query strings, etc.).
- * @property `values` — List of (faceted) available values for the filter.
  */
 export interface FilterDefinition {
   base_path: Nullable<string>;
-  has_more_values: boolean;
   human_name: string;
   is_autocompletable: boolean;
   is_drilldown?: boolean;
   is_searchable: boolean;
   name: string;
+}
+
+/**
+ * Faceted filter definitions add properties specifically relevant to a given search context.
+ * @property `has_more_values` — Whether or not there are other values besides those in the `values` array
+ * in the present response.
+ * @property `values` — List of (faceted) available values for the filter.
+ */
+export interface FacetedFilterDefinition extends FilterDefinition {
+  has_more_values: boolean;
   values: FilterValue[];
 }

--- a/src/frontend/js/types/filters.ts
+++ b/src/frontend/js/types/filters.ts
@@ -23,6 +23,7 @@ export interface FilterValue {
  * @property `is_drilldown` — Whether the filter is limited to one active value at a time.
  * @property `is_searchable` — whether the filter has an associated API endpoint for full-text search.
  * @property `name` — Machine name for the filter (for use in API calls, query strings, etc.).
+ * @property `position` — The index-based position of the filter on the filters pane.
  */
 export interface FilterDefinition {
   base_path: Nullable<string>;
@@ -31,6 +32,7 @@ export interface FilterDefinition {
   is_drilldown?: boolean;
   is_searchable: boolean;
   name: string;
+  position: number;
 }
 
 /**

--- a/src/frontend/js/types/filters.ts
+++ b/src/frontend/js/types/filters.ts
@@ -35,6 +35,10 @@ export interface FilterDefinition {
   position: number;
 }
 
+export interface StaticFilterDefinitions {
+  [filterName: string]: FilterDefinition;
+}
+
 /**
  * Faceted filter definitions add properties specifically relevant to a given search context.
  * @property `has_more_values` — Whether or not there are other values besides those in the `values` array


### PR DESCRIPTION
## Purpose

We want to unplug `<SearchSuggestField />` from `<Search />` so we can extract it and put it somewhere else on the page. Then, they can interact through the URL query string.

## Proposal

One key dependency between `<SearchSuggestField />` and the rest of `<Search />` is that `<SearchSuggestField />` needs the filter definitions to configure itself.

This can be solved, and we can improve `<RootSearchSuggestField />` in the process, by using our new `filter-definitions` API endpoint to directly get static filter definitions from those components.

- [x] update types to add newly available static filter definitions
- [x] create a hook with a simple API so components can access the static filter definitions
- [x] use the new hook in `<SearchSuggestField />` and `<RootSearchSuggestField />`
