### PR TITLE
✨(project) add a command to lint only what has changed since master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,10 @@ lint-back: \
   lint-back-bandit
 .PHONY: lint-back
 
+lint-back-diff: ## lint back-end python sources, but only what has changed since master
+	@bin/lint-back-diff
+.PHONY: lint-back-diff
+
 lint-back-black: ## lint back-end python sources with black
 	@echo 'lint:black started…'
 	@$(COMPOSE_TEST_RUN_APP) black src/richie/apps src/richie/plugins sandbox tests

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -61,8 +61,6 @@ function _docker_compose() {
 function _dc_run() {
     _set_user
 
-    echo "🐳(compose) run command: '$@'"
-
     user_args="--user=$USER_ID"
     if [ -z $USER_ID ]; then
         user_args=""

--- a/bin/lint-back-diff
+++ b/bin/lint-back-diff
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+DIFF_FILES="$(git diff --name-only master | grep -e .py$ | grep -v migrations | tr "\n" " ")" || true
+
+if [ -z "$DIFF_FILES" ]; then
+    echo "Nothing new to lint since master"
+    exit 0
+fi
+
+_dc_run --no-deps app pylint $DIFF_FILES
+_dc_run --no-deps app black $DIFF_FILES
+_dc_run --no-deps app flake8 $DIFF_FILES
+_dc_run --no-deps app isort --recursive --atomic $DIFF_FILES
+_dc_run --no-deps app bandit -qr $DIFF_FILES


### PR DESCRIPTION
## Purpose

The backend linters have become very slow, especially pylint. When working on a branch, we don't need to lint the whole project, but only what has changed. 

## Proposal

The idea of this command is to run the linters only on the files pointed by a `git diff --name-only master HEAD`.
