### PR TITLE
Refactor search for modularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `<Search />` no longer includes the search bar and page title. Those are
+  expected to be included in the Django template. The rationale for this
+  change is to give users more freedom with their DOM & page structure.
+
 ## [1.14.1] - 2019-11-23
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,8 @@ $ make migrate
 
 ## Unreleased
 
+- Users who changed the `search.html` template need to update it to include the page title and search bar themselves. They need to add a `<h1>` where they wish on the page, and the `<SearchSuggestField />` component through the django-react interop somewhere on the page too.
+
 ## 1.13.x to 1.14.x
 
 - If you reused any React components in Django templates through `richie-react`, you should know
@@ -37,7 +39,7 @@ $ make migrate
 
 - A login/signup component was added at the top right of all pages. It comes with new url routes
   that you must add to your project:
-  * In your project's `urls.py` non-i18n patterns, add user-related API endpoints via richie's
+  - In your project's `urls.py` non-i18n patterns, add user-related API endpoints via richie's
     core app urls:
     ```diff
     ...
@@ -53,7 +55,7 @@ $ make migrate
         ...
     ]
     ```
-  * In your project's `urls.py` i18n patterns, add Django contrib auths urls:
+  - In your project's `urls.py` i18n patterns, add Django contrib auths urls:
     ```diff
     urlpatterns += i18n_patterns(
         ...
@@ -61,7 +63,7 @@ $ make migrate
         ...
     )
     ```
-  * In your project's settings, configure login and logout redirect urls:
+  - In your project's settings, configure login and logout redirect urls:
     ```diff
     ...
     + LOGIN_REDIRECT_URL = "/"
@@ -71,7 +73,6 @@ $ make migrate
   template and not in `richie/base.html` so that it does not render as an empty element on sites with
   only one public language,
 - If you override templates that contain React hooks, rename the `fun-react` class to`richie-react`.
-
 
 ## 1.11.x to 1.12.x
 

--- a/docs/django-react-interop.md
+++ b/docs/django-react-interop.md
@@ -60,24 +60,36 @@ Interactions will send the user to the `courseSearchPageUrl` url passed in the p
 It also autocompletes user input with course names and allows users to go directly to the course page if they select a course name among the selected results.
 
 Props:
+
 - `courseSearchPageUrl` [required] — URL for the course search page users should be sent to when they select a suggestion that is not a course, or launch a search with text terms.
 - `context` [optional] — see [context](#context).
 
 ### &lt;Search /&gt;
 
-Renders the full-page course search engine interface, including the search bar, search results, and filters pane.
+Renders the full-page course search engine interface, including the search results, and filters pane, but not the suggest field (which can be added separately with `<SearchSuggestField />`) nor the page title.
 
 NB: the `Search` Django template basically renders just this page. If you need this, use it instead. It is included here for completeness' sake.
 
 Props:
-- `pageTitle` [required] — title for the page, will be used inside the `<h1>` in the rendered component.
+
 - `context` [required] — see [context](#context).
+
+### &lt;SearchSuggestField /&gt;
+
+Renders the course search bar that interacts directly with `<Search />`.
+
+It automatically communicates with `<Search />` through browser history APIs and a shared React provider. This one, unlike `<RootSearchSuggestField />`, is meant to be used in combination with `<Search />` (on the same page).
+
+Props:
+
+- `context` [optional] — see [context](#context).
 
 ### &lt;UserLogin /&gt;
 
 Renders a component that uses the `/users/whoami` endpoint to determine if the user is logged in and show them the appropriate interface: Signup/Login buttons or their name along with a Logout button.
 
 Props:
+
 - `loginUrl` [required] — the URL where the user is sent when they click on "Log in";
 - `logoutUrl` [required] — a link that logs the user out and redirects them (can be the standard django logout URL);
 - `signupUrl` [required] — the URL where the user is sent when they click on "Sign up".

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { useCourseSearchParams } from 'data/useCourseSearchParams';
 
 const messages = defineMessages({
   currentlyReadingLastPageN: {
@@ -58,9 +58,10 @@ export const PaginateCourseSearch = ({
   // Generate a unique ID per instance to ensure our aria-labelledby do not break if there are two
   // or more instances of <PaginateCourseSearch /> on the page
   const [componentId] = useState(Math.random());
-  const [courseSearchParams, dispatchCourseSearchParamsUpdate] = useContext(
-    CourseSearchParamsContext,
-  );
+  const [
+    courseSearchParams,
+    dispatchCourseSearchParamsUpdate,
+  ] = useCourseSearchParams();
 
   // Extract pagination information from params and search results meta
   const limit = Number(courseSearchParams.limit);

--- a/src/frontend/js/components/Root/index.spec.tsx
+++ b/src/frontend/js/components/Root/index.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { getByText, render } from '@testing-library/react';
+import { Root } from '.';
+
+jest.mock('components/UserLogin', () => ({
+  UserLogin: () => 'user login component rendered',
+}));
+
+jest.mock('components/RootSearchSuggestField', () => ({
+  RootSearchSuggestField: ({ exampleProp }: { exampleProp: string }) =>
+    `root search suggest field component rendered with ${exampleProp}`,
+}));
+
+describe('<Root />', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(jest.restoreAllMocks);
+
+  it('finds all richie-react containers and renders the relevant components into them with their passed props', () => {
+    // Create the containers for the two components we're about to render
+    const userLoginContainer = document.createElement('div');
+    userLoginContainer.setAttribute(
+      'class',
+      'richie-react richie-react--user-login',
+    );
+    document.body.append(userLoginContainer);
+    const rootSearchSuggestFieldContainer = document.createElement('div');
+    rootSearchSuggestFieldContainer.setAttribute(
+      'class',
+      'richie-react richie-react--root-search-suggest-field',
+    );
+    rootSearchSuggestFieldContainer.setAttribute(
+      'data-props',
+      JSON.stringify({ exampleProp: 'the prop value' }),
+    );
+    document.body.append(rootSearchSuggestFieldContainer);
+
+    // Render the root component, passing the elements in need of frontend rendering
+    render(
+      <IntlProvider locale="en">
+        <Root
+          richieReactSpots={[
+            userLoginContainer,
+            rootSearchSuggestFieldContainer,
+          ]}
+        />
+      </IntlProvider>,
+    );
+
+    getByText(userLoginContainer, 'user login component rendered');
+    getByText(
+      rootSearchSuggestFieldContainer,
+      'root search suggest field component rendered with the prop value',
+    );
+  });
+
+  it('prints a console warning and still renders everything else when it fails to find a component', () => {
+    // Create the containers for the component we're about to render
+    const userLoginContainer = document.createElement('div');
+    userLoginContainer.setAttribute(
+      'class',
+      'richie-react richie-react--user-login',
+    );
+    document.body.append(userLoginContainer);
+    // On the other hand, <UserFeedback /> is not a component that exists in Richie
+    const userFeedbackContainer = document.createElement('div');
+    userFeedbackContainer.setAttribute(
+      'class',
+      'richie-react richie-react--user-feedback',
+    );
+    document.body.append(userFeedbackContainer);
+
+    // Render the root component, passing our real element and our bogus one
+    render(
+      <IntlProvider locale="en">
+        <Root richieReactSpots={[userLoginContainer, userFeedbackContainer]} />
+      </IntlProvider>,
+    );
+
+    getByText(userLoginContainer, 'user login component rendered');
+    expect(userFeedbackContainer.innerHTML).toEqual('');
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to load React component: no such component in Library UserFeedback',
+    );
+  });
+});

--- a/src/frontend/js/components/Root/index.tsx
+++ b/src/frontend/js/components/Root/index.tsx
@@ -7,6 +7,7 @@ import ReactDOM from 'react-dom';
 import { RootSearchSuggestField } from 'components/RootSearchSuggestField';
 import { Search } from 'components/Search';
 import { UserLogin } from 'components/UserLogin';
+import { HistoryContext, useHistory } from 'data/useHistory';
 
 // List the top-level components that can be directly called from the Django templates in an interface
 // for type-safety when we call them. This will let us use the props for any top-level component in a
@@ -35,6 +36,8 @@ interface RootProps {
 }
 
 export const Root = ({ richieReactSpots }: RootProps) => {
+  const history = useHistory();
+
   const portals = richieReactSpots.map((element: Element) => {
     // Generate a component name. It should be a key of the componentLibrary object / ComponentLibrary interface
     const componentName = startCase(
@@ -62,5 +65,7 @@ export const Root = ({ richieReactSpots }: RootProps) => {
     }
   });
 
-  return <React.Fragment>{portals}</React.Fragment>;
+  return (
+    <HistoryContext.Provider value={history}>{portals}</HistoryContext.Provider>
+  );
 };

--- a/src/frontend/js/components/Root/index.tsx
+++ b/src/frontend/js/components/Root/index.tsx
@@ -6,6 +6,7 @@ import ReactDOM from 'react-dom';
 
 import { RootSearchSuggestField } from 'components/RootSearchSuggestField';
 import { Search } from 'components/Search';
+import { SearchSuggestField } from 'components/SearchSuggestField';
 import { UserLogin } from 'components/UserLogin';
 import { HistoryContext, useHistory } from 'data/useHistory';
 
@@ -13,14 +14,16 @@ import { HistoryContext, useHistory } from 'data/useHistory';
 // for type-safety when we call them. This will let us use the props for any top-level component in a
 // way TypeScript understand and accepts
 interface ComponentLibrary {
-  Search: typeof Search;
   RootSearchSuggestField: typeof RootSearchSuggestField;
+  Search: typeof Search;
+  SearchSuggestField: typeof SearchSuggestField;
   UserLogin: typeof UserLogin;
 }
 // Actually create the component map that we'll use below to access our component classes
 const componentLibrary: ComponentLibrary = {
   RootSearchSuggestField,
   Search,
+  SearchSuggestField,
   UserLogin,
 };
 // Type guard: ensures a given string (candidate) is indeed a proper key of the componentLibrary with a corresponding

--- a/src/frontend/js/components/Root/index.tsx
+++ b/src/frontend/js/components/Root/index.tsx
@@ -1,0 +1,66 @@
+import get from 'lodash-es/get';
+import includes from 'lodash-es/includes';
+import startCase from 'lodash-es/startCase';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { RootSearchSuggestField } from 'components/RootSearchSuggestField';
+import { Search } from 'components/Search';
+import { UserLogin } from 'components/UserLogin';
+
+// List the top-level components that can be directly called from the Django templates in an interface
+// for type-safety when we call them. This will let us use the props for any top-level component in a
+// way TypeScript understand and accepts
+interface ComponentLibrary {
+  Search: typeof Search;
+  RootSearchSuggestField: typeof RootSearchSuggestField;
+  UserLogin: typeof UserLogin;
+}
+// Actually create the component map that we'll use below to access our component classes
+const componentLibrary: ComponentLibrary = {
+  RootSearchSuggestField,
+  Search,
+  UserLogin,
+};
+// Type guard: ensures a given string (candidate) is indeed a proper key of the componentLibrary with a corresponding
+// component. This is a runtime check but it allows TS to check the component prop types at compile time
+function isComponentName(
+  candidate: keyof ComponentLibrary | string,
+): candidate is keyof ComponentLibrary {
+  return includes(Object.keys(componentLibrary), candidate);
+}
+
+interface RootProps {
+  richieReactSpots: Element[];
+}
+
+export const Root = ({ richieReactSpots }: RootProps) => {
+  const portals = richieReactSpots.map((element: Element) => {
+    // Generate a component name. It should be a key of the componentLibrary object / ComponentLibrary interface
+    const componentName = startCase(
+      get(element.className.match(/richie-react--([a-zA-Z-]*)/), '[1]') || '',
+    )
+      .split(' ')
+      .join('');
+    // Sanity check: only attempt to access and render components for which we do have a valid name
+    if (isComponentName(componentName)) {
+      // Do get the component dynamically. We know this WILL produce a valid component thanks to the type guard
+      const Component = componentLibrary[componentName];
+
+      // Get the incoming props to pass our component from the `data-props` attribute
+      const dataProps = element.getAttribute('data-props');
+      const props = dataProps ? JSON.parse(dataProps) : {};
+
+      return ReactDOM.createPortal(<Component {...props} />, element);
+    } else {
+      // Emit a warning at runtime when we fail to find a matching component for an element that required one
+      console.warn(
+        'Failed to load React component: no such component in Library ' +
+          componentName,
+      );
+      return null;
+    }
+  });
+
+  return <React.Fragment>{portals}</React.Fragment>;
+};

--- a/src/frontend/js/components/Search/_styles.scss
+++ b/src/frontend/js/components/Search/_styles.scss
@@ -16,7 +16,7 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
 
   &__filters {
     z-index: 1;
-    flex-grow: 1;
+    flex-grow: 0;
     flex-shrink: 0;
     flex-basis: 100%;
     background: $richie-search-filters-background;
@@ -27,6 +27,7 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
     min-height: 100vh;
 
     position: absolute;
+    top: 0;
     left: 0;
     max-width: 85vw;
     transform: translateX(-100.1%);
@@ -65,7 +66,6 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
   }
 
   &__results {
-    position: relative;
     flex-grow: 1;
     flex-shrink: 0;
     flex-basis: 100%;
@@ -76,11 +76,6 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
       flex-basis: calc(100% - #{$richie-search-filters-width});
       max-width: calc(100% - #{$richie-search-filters-width});
       padding: $richie-search-results-padding;
-    }
-
-    &__title {
-      padding: 1.5rem 0 0;
-      text-align: center;
     }
 
     &__overlay {
@@ -97,6 +92,12 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
       &--visible {
         visibility: visible;
         opacity: 0.75;
+      }
+    }
+
+    & > .spinner-container {
+      @include media-breakpoint-up(lg) {
+        margin-top: 15rem;
       }
     }
   }

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -1,10 +1,12 @@
 import 'testSetup';
 
-import { act, fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, wait } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
+import { stringify } from 'query-string';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
+import { History, HistoryContext } from 'data/useHistory';
 import { Search } from '.';
 
 let mockMatches = false;
@@ -17,6 +19,14 @@ jest.mock('utils/indirection/window', () => ({
 }));
 
 describe('<Search />', () => {
+  const historyPushState = jest.fn();
+  const historyReplaceState = jest.fn();
+  const makeHistoryOf: (params: any) => History = params => [
+    { state: params, title: '', url: `/search?${stringify(params)}` },
+    historyPushState,
+    historyReplaceState,
+  ];
+
   const commonDataProps = {
     assets: {
       icons: '/icons.svg',
@@ -35,7 +45,11 @@ describe('<Search />', () => {
 
     const { getByText, queryByText } = render(
       <IntlProvider locale="en">
-        <Search context={commonDataProps} />
+        <HistoryContext.Provider
+          value={makeHistoryOf({ limit: '20', offset: '0' })}
+        >
+          <Search context={commonDataProps} />
+        </HistoryContext.Provider>
       </IntlProvider>,
     );
 
@@ -58,7 +72,11 @@ describe('<Search />', () => {
     mockMatches = true;
     const { container } = render(
       <IntlProvider locale="en">
-        <Search context={commonDataProps} />
+        <HistoryContext.Provider
+          value={makeHistoryOf({ limit: '20', offset: '0' })}
+        >
+          <Search context={commonDataProps} />
+        </HistoryContext.Provider>
       </IntlProvider>,
     );
     await wait();
@@ -82,7 +100,11 @@ describe('<Search />', () => {
     mockMatches = false;
     const { container, getByText, queryByText } = render(
       <IntlProvider locale="en">
-        <Search context={commonDataProps} />
+        <HistoryContext.Provider
+          value={makeHistoryOf({ limit: '20', offset: '0' })}
+        >
+          <Search context={commonDataProps} />
+        </HistoryContext.Provider>
       </IntlProvider>,
     );
     await wait();

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -7,10 +7,7 @@ import { SearchFiltersPane } from 'components/SearchFiltersPane';
 import { SearchSuggestField } from 'components/SearchSuggestField';
 import { Spinner } from 'components/Spinner';
 import { useCourseSearch } from 'data/useCourseSearch';
-import {
-  CourseSearchParamsContext,
-  useCourseSearchParams,
-} from 'data/useCourseSearchParams';
+import { useCourseSearchParams } from 'data/useCourseSearchParams';
 import { requestStatus } from 'types/api';
 import { CommonDataProps } from 'types/commonDataProps';
 import { matchMedia } from 'utils/indirection/window';
@@ -44,7 +41,7 @@ export const Search = ({
   context,
   pageTitle,
 }: SearchProps & CommonDataProps) => {
-  const [courseSearchParams, setCourseSearchParams] = useCourseSearchParams();
+  const [courseSearchParams] = useCourseSearchParams();
   const courseSearchResponse = useCourseSearch(courseSearchParams);
 
   const alwaysShowFilters = matchMedia('(min-width: 992px)').matches;
@@ -54,93 +51,89 @@ export const Search = ({
 
   return (
     <div className="search">
-      <CourseSearchParamsContext.Provider
-        value={[courseSearchParams, setCourseSearchParams]}
+      <div
+        className={`search__filters ${
+          !alwaysShowFilters && showFilters ? 'search__filters--active' : ''
+        }`}
       >
-        <div
-          className={`search__filters ${
-            !alwaysShowFilters && showFilters ? 'search__filters--active' : ''
-          }`}
-        >
-          <SearchFiltersPane
-            aria-hidden={alwaysShowFilters ? false : !showFilters}
-            filters={
-              courseSearchResponse &&
-              courseSearchResponse.status === requestStatus.SUCCESS
-                ? courseSearchResponse.content.filters
-                : null
-            }
-            id={referenceId}
-          />
-          {!alwaysShowFilters && (
-            <button
-              aria-expanded={showFilters}
-              aria-controls={referenceId}
-              className={'search__filters__toggle'}
-              onClick={() => setShowFilters(!showFilters)}
-            >
-              {showFilters ? (
-                <React.Fragment>
-                  <svg
-                    aria-hidden={true}
-                    role="img"
-                    className="icon search__filters__toggle__icon"
-                  >
-                    <use xlinkHref={`${context.assets.icons}#icon-cross`} />
-                  </svg>{' '}
-                  <span className="offscreen">
-                    <FormattedMessage {...messages.hideFiltersPane} />
-                  </span>
-                </React.Fragment>
-              ) : (
-                <React.Fragment>
-                  <svg
-                    aria-hidden={true}
-                    role="img"
-                    className="icon search__filters__toggle__icon"
-                  >
-                    <use xlinkHref={`${context.assets.icons}#icon-filter`} />
-                  </svg>
-                  <span className="offscreen">
-                    <FormattedMessage {...messages.showFiltersPane} />
-                  </span>
-                </React.Fragment>
-              )}
-            </button>
-          )}
-        </div>
-        <div className="search__results">
-          {pageTitle && <h1 className="search__results__title">{pageTitle}</h1>}
-          {courseSearchResponse &&
-          courseSearchResponse.status === requestStatus.SUCCESS ? (
-            <React.Fragment>
-              <SearchSuggestField />
-              <CourseGlimpseList
-                courses={courseSearchResponse.content.objects}
-                meta={courseSearchResponse.content.meta}
-              />
-              <PaginateCourseSearch
-                courseSearchTotalCount={
-                  courseSearchResponse.content.meta.total_count
-                }
-              />
-            </React.Fragment>
-          ) : (
-            <Spinner size="large">
-              <FormattedMessage {...messages.spinnerText} />
-            </Spinner>
-          )}
-          {!alwaysShowFilters && (
-            <div
-              aria-hidden={true}
-              className={`search__results__overlay ${
-                showFilters ? 'search__results__overlay--visible' : ''
-              }`}
-              onClick={() => setShowFilters(false)}
+        <SearchFiltersPane
+          aria-hidden={alwaysShowFilters ? false : !showFilters}
+          filters={
+            courseSearchResponse &&
+            courseSearchResponse.status === requestStatus.SUCCESS
+              ? courseSearchResponse.content.filters
+              : null
+          }
+          id={referenceId}
+        />
+        {!alwaysShowFilters && (
+          <button
+            aria-expanded={showFilters}
+            aria-controls={referenceId}
+            className={'search__filters__toggle'}
+            onClick={() => setShowFilters(!showFilters)}
+          >
+            {showFilters ? (
+              <React.Fragment>
+                <svg
+                  aria-hidden={true}
+                  role="img"
+                  className="icon search__filters__toggle__icon"
+                >
+                  <use xlinkHref={`${context.assets.icons}#icon-cross`} />
+                </svg>{' '}
+                <span className="offscreen">
+                  <FormattedMessage {...messages.hideFiltersPane} />
+                </span>
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                <svg
+                  aria-hidden={true}
+                  role="img"
+                  className="icon search__filters__toggle__icon"
+                >
+                  <use xlinkHref={`${context.assets.icons}#icon-filter`} />
+                </svg>
+                <span className="offscreen">
+                  <FormattedMessage {...messages.showFiltersPane} />
+                </span>
+              </React.Fragment>
+            )}
+          </button>
+        )}
+      </div>
+      <div className="search__results">
+        {pageTitle && <h1 className="search__results__title">{pageTitle}</h1>}
+        {courseSearchResponse &&
+        courseSearchResponse.status === requestStatus.SUCCESS ? (
+          <React.Fragment>
+            <SearchSuggestField />
+            <CourseGlimpseList
+              courses={courseSearchResponse.content.objects}
+              meta={courseSearchResponse.content.meta}
             />
-          )}
-        </div>
-      </CourseSearchParamsContext.Provider>
+            <PaginateCourseSearch
+              courseSearchTotalCount={
+                courseSearchResponse.content.meta.total_count
+              }
+            />
+          </React.Fragment>
+        ) : (
+          <Spinner size="large">
+            <FormattedMessage {...messages.spinnerText} />
+          </Spinner>
+        )}
+        {!alwaysShowFilters && (
+          <div
+            aria-hidden={true}
+            className={`search__results__overlay ${
+              showFilters ? 'search__results__overlay--visible' : ''
+            }`}
+            onClick={() => setShowFilters(false)}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -4,7 +4,6 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { CourseGlimpseList } from 'components/CourseGlimpseList';
 import { PaginateCourseSearch } from 'components/PaginateCourseSearch';
 import { SearchFiltersPane } from 'components/SearchFiltersPane';
-import { SearchSuggestField } from 'components/SearchSuggestField';
 import { Spinner } from 'components/Spinner';
 import { useCourseSearch } from 'data/useCourseSearch';
 import { useCourseSearchParams } from 'data/useCourseSearchParams';
@@ -33,14 +32,7 @@ const messages = defineMessages({
   },
 });
 
-interface SearchProps {
-  pageTitle?: string;
-}
-
-export const Search = ({
-  context,
-  pageTitle,
-}: SearchProps & CommonDataProps) => {
+export const Search = ({ context }: CommonDataProps) => {
   const [courseSearchParams] = useCourseSearchParams();
   const courseSearchResponse = useCourseSearch(courseSearchParams);
 
@@ -104,11 +96,9 @@ export const Search = ({
         )}
       </div>
       <div className="search__results">
-        {pageTitle && <h1 className="search__results__title">{pageTitle}</h1>}
         {courseSearchResponse &&
         courseSearchResponse.status === requestStatus.SUCCESS ? (
           <React.Fragment>
-            <SearchSuggestField />
             <CourseGlimpseList
               courses={courseSearchResponse.content.objects}
               meta={courseSearchResponse.content.meta}

--- a/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
@@ -1,10 +1,11 @@
 import 'testSetup';
 
 import { render } from '@testing-library/react';
+import { stringify } from 'query-string';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
-import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { History, HistoryContext } from 'data/useHistory';
 import { SearchFilterGroup } from '.';
 
 jest.mock('components/SearchFilterValueLeaf', () => ({
@@ -20,6 +21,14 @@ jest.mock('components/SearchFilterValueParent', () => ({
 }));
 
 describe('components/SearchFilterGroup', () => {
+  const historyPushState = jest.fn();
+  const historyReplaceState = jest.fn();
+  const makeHistoryOf: (params: any) => History = params => [
+    { state: params, title: '', url: `/search?${stringify(params)}` },
+    historyPushState,
+    historyReplaceState,
+  ];
+
   const filter = {
     base_path: '0001',
     has_more_values: true,
@@ -47,11 +56,11 @@ describe('components/SearchFilterGroup', () => {
   it('renders the name of the filter with the values as SearchFilters', () => {
     const { getByText } = render(
       <IntlProvider locale="en">
-        <CourseSearchParamsContext.Provider
-          value={[{ limit: '999', offset: '0' }, jest.fn()]}
+        <HistoryContext.Provider
+          value={makeHistoryOf({ limit: '20', offset: '0' })}
         >
           <SearchFilterGroup filter={filter} />
-        </CourseSearchParamsContext.Provider>
+        </HistoryContext.Provider>
       </IntlProvider>,
     );
     // The filter group title and all filters are shown
@@ -64,11 +73,11 @@ describe('components/SearchFilterGroup', () => {
   it('does not render the "More options" button & modal if the filter is not searchable', () => {
     const { queryByText } = render(
       <IntlProvider locale="en">
-        <CourseSearchParamsContext.Provider
-          value={[{ limit: '999', offset: '0' }, jest.fn()]}
+        <HistoryContext.Provider
+          value={makeHistoryOf({ limit: '20', offset: '0' })}
         >
           <SearchFilterGroup filter={{ ...filter, is_searchable: false }} />
-        </CourseSearchParamsContext.Provider>
+        </HistoryContext.Provider>
       </IntlProvider>,
     );
 
@@ -78,11 +87,11 @@ describe('components/SearchFilterGroup', () => {
   it('does not render the "More options" button & modal if there are no more values to find', () => {
     const { queryByText } = render(
       <IntlProvider locale="en">
-        <CourseSearchParamsContext.Provider
-          value={[{ limit: '999', offset: '0' }, jest.fn()]}
+        <HistoryContext.Provider
+          value={makeHistoryOf({ limit: '20', offset: '0' })}
         >
           <SearchFilterGroup filter={{ ...filter, has_more_values: false }} />
-        </CourseSearchParamsContext.Provider>
+        </HistoryContext.Provider>
       </IntlProvider>,
     );
 

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   defineMessages,
   FormattedMessage,
@@ -7,7 +7,7 @@ import {
 import ReactModal from 'react-modal';
 
 import { fetchList } from 'data/getResourceList';
-import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { useCourseSearchParams } from 'data/useCourseSearchParams';
 import { requestStatus } from 'types/api';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { Nullable } from 'utils/types';
@@ -67,9 +67,10 @@ export const SearchFilterGroupModal = ({
   const [error, setError] = useState(null as Nullable<MessageDescriptor>);
 
   // We need the current course search params to get the facet counts
-  const [coursesSearchParams, dispatchCourseSearchParamsUpdate] = useContext(
-    CourseSearchParamsContext,
-  );
+  const [
+    coursesSearchParams,
+    dispatchCourseSearchParamsUpdate,
+  ] = useCourseSearchParams();
 
   // When the modal is closed, reset state so the user gets a brand-new one if they come back
   useEffect(() => {

--- a/src/frontend/js/components/SearchFilterValueParent/index.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.tsx
@@ -1,9 +1,9 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { SearchFilterValueLeaf } from 'components/SearchFilterValueLeaf';
 import { fetchList } from 'data/getResourceList';
-import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { useCourseSearchParams } from 'data/useCourseSearchParams';
 import { useFilterValue } from 'data/useFilterValue';
 import { requestStatus } from 'types/api';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
@@ -39,7 +39,7 @@ export const SearchFilterValueParent = ({
 
   // Get the current values for the filter definition so we know if any children of this parent
   // filter are active (and we therefore need to get them and unfold the children).
-  const [coursesSearchParams] = useContext(CourseSearchParamsContext);
+  const [coursesSearchParams] = useCourseSearchParams();
   // Default to an array of strings no matter the current value so we can easily check for active values
   const activeFilterValues =
     coursesSearchParams[filter.name] || ([] as string[]);

--- a/src/frontend/js/components/SearchFiltersPane/index.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.tsx
@@ -1,8 +1,8 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { SearchFilterGroup } from 'components/SearchFilterGroup';
-import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { useCourseSearchParams } from 'data/useCourseSearchParams';
 import { API_LIST_DEFAULT_PARAMS } from 'settings';
 import { APICourseSearchResponse } from 'types/api';
 import { Nullable } from 'utils/types';
@@ -36,9 +36,10 @@ export const SearchFiltersPane = ({
   >) => {
   const filterList = filters && Object.values(filters);
 
-  const [courseSearchParams, dispatchCourseSearchParamsUpdate] = useContext(
-    CourseSearchParamsContext,
-  );
+  const [
+    courseSearchParams,
+    dispatchCourseSearchParamsUpdate,
+  ] = useCourseSearchParams();
 
   // Get all the currently active filters to show a count
   const activeFilters = Object.entries(courseSearchParams)

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -110,17 +110,19 @@ export const SearchSuggestField = () => {
   ) => {
     const filter = getRelevantFilter(await getFilters(), suggestion);
 
-    // Dispatch the actual update on the relevant filter
-    dispatchCourseSearchParamsUpdate({
-      filter,
-      payload: String(suggestion.id),
-      type: 'FILTER_ADD',
-    });
-    // Clear the current search query as the selected suggestion was generated from the same user input
-    dispatchCourseSearchParamsUpdate({
-      query: '',
-      type: 'QUERY_UPDATE',
-    });
+    // Dispatch the actual update on the relevant filter and clear the current search query as the
+    // selected suggestion was generated from the same user input
+    dispatchCourseSearchParamsUpdate(
+      {
+        query: '',
+        type: 'QUERY_UPDATE',
+      },
+      {
+        filter,
+        payload: String(suggestion.id),
+        type: 'FILTER_ADD',
+      },
+    );
     // Reset the search field state: the task has been completed
     setValue('');
     setSuggestions([]);

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -1,5 +1,5 @@
 import debounce from 'lodash-es/debounce';
-import React, { useContext, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Autosuggest from 'react-autosuggest';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -9,7 +9,7 @@ import {
   onSuggestionsFetchRequested,
   renderSuggestion,
 } from 'common/searchFields';
-import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { useCourseSearchParams } from 'data/useCourseSearchParams';
 import { useStaticFilters } from 'data/useStaticFilters';
 import {
   SearchAutosuggestProps,
@@ -36,9 +36,10 @@ export const SearchSuggestField = () => {
 
   // Setup our filters updates (for full-text-search and specific filters) directly through the
   // search parameters hook.
-  const [courseSearchParams, dispatchCourseSearchParamsUpdate] = useContext(
-    CourseSearchParamsContext,
-  );
+  const [
+    courseSearchParams,
+    dispatchCourseSearchParamsUpdate,
+  ] = useCourseSearchParams();
 
   // Initialize hooks for the two pieces of state the controlled <Autosuggest> component needs to interact with:
   // the current list of suggestions and the input value.

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -36,7 +36,7 @@ export type CourseSearchParamsReducerAction =
 
 type CourseSearchParamsState = [
   APIListRequestParams,
-  React.Dispatch<CourseSearchParamsReducerAction>,
+  (...Actions: CourseSearchParamsReducerAction[]) => void,
 ];
 
 const courseSearchParamsReducer = (
@@ -96,8 +96,13 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
   // The dispatch + reducer pattern is useful to model changes in the course search params. However, we don't want
   // to duplicate behavior by having to sync the HistoryContext state with a `useReducer` call here.
   // We therefore build our own dispatch function that updates the shared value held by HistoryContext.
-  const dispatch = (action: CourseSearchParamsReducerAction) => {
-    const newParams = courseSearchParamsReducer(courseSearchParams, action);
+  const dispatch = (...actions: CourseSearchParamsReducerAction[]) => {
+    // In some scenarios, we want to dispatch more than one action and only effect one actual history state change.
+    // This is useful to eg. clean up the text query and add a filter the user selected through autosuggest.
+    const newParams = actions.reduce(
+      courseSearchParamsReducer,
+      courseSearchParams,
+    );
     // We should only update the history if the params have actually changed
     // We're using `stringify(parse(location.search))` as a way to reorder location search to the same order
     // `stringify` would output for our courseSearchParams. This allows us to avoid doing a deep comparison on

--- a/src/frontend/js/data/useFilterValue/index.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/index.spec.tsx
@@ -1,11 +1,20 @@
 import { render } from '@testing-library/react';
+import { stringify } from 'query-string';
 import React from 'react';
 
-import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { History, HistoryContext } from 'data/useHistory';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { useFilterValue } from '.';
 
 describe('data/useFilterValue', () => {
+  const historyPushState = jest.fn();
+  const historyReplaceState = jest.fn();
+  const makeHistoryOf: (params: any) => History = params => [
+    { state: params, title: '', url: `/search?${stringify(params)}` },
+    historyPushState,
+    historyReplaceState,
+  ];
+
   // Build a helper component with an out-of-scope function to let us reach our Hook from
   // our test cases.
   let getLatestHookValues: any;
@@ -23,14 +32,10 @@ describe('data/useFilterValue', () => {
 
   beforeEach(jest.resetAllMocks);
 
-  it('returns the active [true] status of the filter value and a function to toggle it', () => {
-    const mockDispatchCourseSearchParamsAction = jest.fn();
+  it('returns the active [false] status of the filter value and a function to toggle it', () => {
     render(
-      <CourseSearchParamsContext.Provider
-        value={[
-          { limit: '999', offset: '0' },
-          mockDispatchCourseSearchParamsAction,
-        ]}
+      <HistoryContext.Provider
+        value={makeHistoryOf({ limit: '999', offset: '0' })}
       >
         <TestComponent
           filter={{
@@ -49,35 +54,26 @@ describe('data/useFilterValue', () => {
             key: '87',
           }}
         />
-      </CourseSearchParamsContext.Provider>,
+      </HistoryContext.Provider>,
     );
     const [isActive, toggle] = getLatestHookValues();
     expect(isActive).toEqual(false);
     toggle();
-    expect(mockDispatchCourseSearchParamsAction).toHaveBeenCalledWith({
-      filter: {
-        base_path: '0003',
-        has_more_values: false,
-        human_name: 'Organizations',
-        is_autocompletable: false,
-        is_searchable: false,
-        name: 'organizations',
-        position: 0,
-        values: [],
-      },
-      payload: '87',
-      type: 'FILTER_ADD',
-    });
+    expect(historyPushState).toHaveBeenCalledWith(
+      { limit: '999', offset: '0', organizations: ['87'] },
+      '',
+      '/?limit=999&offset=0&organizations=87',
+    );
   });
 
-  it('returns the active [false] status of the filter value and a function to toggle it', () => {
-    const mockDispatchCourseSearchParamsAction = jest.fn();
+  it('returns the active [true] status of the filter value and a function to toggle it', () => {
     render(
-      <CourseSearchParamsContext.Provider
-        value={[
-          { limit: '999', offset: '0', organizations: ['87'] },
-          mockDispatchCourseSearchParamsAction,
-        ]}
+      <HistoryContext.Provider
+        value={makeHistoryOf({
+          limit: '999',
+          offset: '0',
+          organizations: ['87'],
+        })}
       >
         <TestComponent
           filter={{
@@ -96,24 +92,15 @@ describe('data/useFilterValue', () => {
             key: '87',
           }}
         />
-      </CourseSearchParamsContext.Provider>,
+      </HistoryContext.Provider>,
     );
     const [isActive, toggle] = getLatestHookValues();
     expect(isActive).toEqual(true);
     toggle();
-    expect(mockDispatchCourseSearchParamsAction).toHaveBeenCalledWith({
-      filter: {
-        base_path: '0003',
-        has_more_values: false,
-        human_name: 'Organizations',
-        is_autocompletable: true,
-        is_searchable: true,
-        name: 'organizations',
-        position: 0,
-        values: [],
-      },
-      payload: '87',
-      type: 'FILTER_REMOVE',
-    });
+    expect(historyPushState).toHaveBeenCalledWith(
+      { limit: '999', offset: '0', organizations: undefined },
+      '',
+      '/?limit=999&offset=0',
+    );
   });
 });

--- a/src/frontend/js/data/useFilterValue/index.ts
+++ b/src/frontend/js/data/useFilterValue/index.ts
@@ -1,6 +1,4 @@
-import { useContext } from 'react';
-
-import { CourseSearchParamsContext } from 'data/useCourseSearchParams';
+import { useCourseSearchParams } from 'data/useCourseSearchParams';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 
 type UseFilterValue = [boolean, () => void];
@@ -9,9 +7,10 @@ export const useFilterValue = (
   filter: FacetedFilterDefinition,
   value: FilterValue,
 ): UseFilterValue => {
-  const [courseSearchParams, dispatchCourseSearchParamsUpdate] = useContext(
-    CourseSearchParamsContext,
-  );
+  const [
+    courseSearchParams,
+    dispatchCourseSearchParamsUpdate,
+  ] = useCourseSearchParams();
 
   const isActive = (courseSearchParams[filter.name] || []).includes(value.key);
 

--- a/src/frontend/js/data/useHistory/index.spec.tsx
+++ b/src/frontend/js/data/useHistory/index.spec.tsx
@@ -1,0 +1,144 @@
+import { act, render } from '@testing-library/react';
+import React from 'react';
+
+import { history, location } from 'utils/indirection/window';
+import { useHistory } from '.';
+
+jest.mock('utils/indirection/window', () => ({
+  history: {
+    pushState: jest.fn(),
+    replaceState: jest.fn(),
+  },
+  location: {
+    pathname: '/to/the/path',
+    search: '?param1=value1&param2=value2',
+  },
+}));
+
+describe('data/useHistory', () => {
+  // Build a helper component with an out-of-scope function to let us reach our Hook from
+  // our test cases.
+  let getLatestHookValues: any;
+  const TestComponent = ({}: {}) => {
+    const hookValues = useHistory();
+    getLatestHookValues = () => hookValues;
+    return <div />;
+  };
+
+  afterEach(() => {
+    location.pathname = '/to/the/path';
+    location.search = '?param1=value1&param2=value2';
+  });
+
+  it('makes the current history entry available at bootstrap', () => {
+    render(<TestComponent />);
+    const [historyEntry] = getLatestHookValues();
+    expect(historyEntry).toEqual({
+      state: { param1: 'value1', param2: 'value2' },
+      title: '',
+      url: '/to/the/path?param1=value1&param2=value2',
+    });
+  });
+
+  it('re-renders with a new value when the popstate event is fired', () => {
+    {
+      // Assert our initial values
+      render(<TestComponent />);
+      const [historyEntry] = getLatestHookValues();
+      expect(historyEntry).toEqual({
+        state: { param1: 'value1', param2: 'value2' },
+        title: '',
+        url: '/to/the/path?param1=value1&param2=value2',
+      });
+    }
+    {
+      // Change location to make sure our history entry is updated
+      location.pathname = '/the/new/path';
+      location.search = '?param3=value3';
+      // Trigger the popstate event (simulates another independent component using pushState)
+      const event: any = new CustomEvent('popstate');
+      event.state = { param3: 'value3' };
+      act(() => {
+        window.dispatchEvent(event);
+      });
+      const [historyEntry] = getLatestHookValues();
+      expect(historyEntry).toEqual({
+        state: { param3: 'value3' },
+        title: '',
+        url: '/the/new/path?param3=value3',
+      });
+    }
+  });
+
+  it('provides a pushState helper that creates a new history entry', () => {
+    {
+      // Assert our initial values
+      render(<TestComponent />);
+      const [historyEntry, pushState] = getLatestHookValues();
+      expect(historyEntry).toEqual({
+        state: { param1: 'value1', param2: 'value2' },
+        title: '',
+        url: '/to/the/path?param1=value1&param2=value2',
+      });
+      // Trigger a pushState ourselves
+      act(() => {
+        pushState(
+          { param4: 'value4', param5: 'value5' },
+          '',
+          '/the/third/path?param4=value4&param5=value5',
+        );
+      });
+    }
+    {
+      // State was changed in the hook
+      const [historyEntry] = getLatestHookValues();
+      expect(historyEntry).toEqual({
+        state: { param4: 'value4', param5: 'value5' },
+        title: '',
+        url: '/the/third/path?param4=value4&param5=value5',
+      });
+      // Actual browser history API was used
+      expect(history.pushState).toHaveBeenCalledWith(
+        { param4: 'value4', param5: 'value5' },
+        '',
+        '/the/third/path?param4=value4&param5=value5',
+      );
+    }
+  });
+
+  it('provides a replaceState helper that replaces the current history entry', () => {
+    {
+      // Assert our initial values
+      render(<TestComponent />);
+      const [historyEntry, , replaceState] = getLatestHookValues();
+      expect(historyEntry).toEqual({
+        state: { param1: 'value1', param2: 'value2' },
+        title: '',
+        url: '/to/the/path?param1=value1&param2=value2',
+      });
+      // Trigger a replaceState ourselves
+      act(() => {
+        replaceState(
+          { param6: 'value6', param7: 'value7' },
+          '',
+          '/the/third/path?param6=value6&param7=value7',
+        );
+      });
+    }
+    {
+      // State was changed in the hook
+      const [historyEntry] = getLatestHookValues();
+      expect(historyEntry).toEqual({
+        state: { param6: 'value6', param7: 'value7' },
+        title: '',
+        url: '/the/third/path?param6=value6&param7=value7',
+      });
+      // Actual browser history API was used
+      expect(history.replaceState).toHaveBeenCalledWith(
+        { param6: 'value6', param7: 'value7' },
+        '',
+        '/the/third/path?param6=value6&param7=value7',
+      );
+    }
+  });
+});

--- a/src/frontend/js/data/useHistory/index.ts
+++ b/src/frontend/js/data/useHistory/index.ts
@@ -1,0 +1,66 @@
+import { parse } from 'query-string';
+import { createContext, useEffect, useState } from 'react';
+
+import { history, location } from 'utils/indirection/window';
+import { Maybe, Nullable } from 'utils/types';
+
+interface HistoryEntry {
+  state: any;
+  title: string;
+  url: Maybe<Nullable<string>>;
+}
+
+type pushStateFn = typeof history.pushState;
+type replaceStateFn = typeof history.replaceState;
+
+type popstateEventListener = (
+  this: Window,
+  ev: WindowEventMap['popstate'],
+) => any;
+
+type History = [HistoryEntry, pushStateFn, replaceStateFn];
+
+export const HistoryContext = createContext<History>([] as any);
+
+export const useHistory: () => History = () => {
+  const [historyEntry, setHistoryEntry] = useState<HistoryEntry>({
+    state: parse(location.search),
+    title: '',
+    url: `${location.pathname}${location.search}`,
+  });
+
+  // Match the signature and function of the browser's pushState.
+  // This is useful when we add history entries after user interaction from our own code.
+  const pushState: pushStateFn = (state, title, url) => {
+    setHistoryEntry({ state, title, url });
+    history.pushState(state, title, url);
+  };
+
+  // Match the signature and function of the browser's replaceState/
+  // This is useful when a component needs to set eg. default query string params to avoid creating broken
+  // history states.
+  const replaceState: replaceStateFn = (state, title, url) => {
+    setHistoryEntry({ state, title, url });
+    history.replaceState(state, title, url);
+  };
+
+  // Listen to external changes to history to make sure we re-render any component(s) that depend on
+  // the contents of the URL and the current history entry
+  useEffect(() => {
+    const handlePopstate: popstateEventListener = event => {
+      setHistoryEntry({
+        state: event.state,
+        title: '',
+        url: `${location.pathname}${location.search}`,
+      });
+    };
+
+    window.addEventListener('popstate', handlePopstate);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopstate);
+    };
+  }, []);
+
+  return [historyEntry, pushState, replaceState];
+};

--- a/src/frontend/js/data/useHistory/index.ts
+++ b/src/frontend/js/data/useHistory/index.ts
@@ -18,7 +18,7 @@ type popstateEventListener = (
   ev: WindowEventMap['popstate'],
 ) => any;
 
-type History = [HistoryEntry, pushStateFn, replaceStateFn];
+export type History = [HistoryEntry, pushStateFn, replaceStateFn];
 
 export const HistoryContext = createContext<History>([] as any);
 

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -15,36 +15,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { IntlProvider } from 'react-intl';
 
-// Import submodules so we don't get the whole of lodash in the bundle
-import get from 'lodash-es/get';
-import includes from 'lodash-es/includes';
-import startCase from 'lodash-es/startCase';
-
-// Import the top-level components that can be directly called from the CMS
-import { RootSearchSuggestField } from 'components/RootSearchSuggestField';
-import { Search } from 'components/Search';
-import { UserLogin } from 'components/UserLogin';
+import { Root } from 'components/Root';
 import { handle } from 'utils/errors/handle';
-// List them in an interface for type-safety when we call them. This will let us use the props for
-// any top-level component in a way TypeScript understand and accepts
-interface ComponentLibrary {
-  Search: typeof Search;
-  RootSearchSuggestField: typeof RootSearchSuggestField;
-  UserLogin: typeof UserLogin;
-}
-// Actually create the component map that we'll use below to access our component classes
-const componentLibrary: ComponentLibrary = {
-  RootSearchSuggestField,
-  Search,
-  UserLogin,
-};
-// Type guard: ensures a given string (candidate) is indeed a proper key of the componentLibrary with a corresponding
-// component. This is a runtime check but it allows TS to check the component prop types at compile time
-function isComponentName(
-  candidate: keyof ComponentLibrary | string,
-): candidate is keyof ComponentLibrary {
-  return includes(Object.keys(componentLibrary), candidate);
-}
 
 // Wait for the DOM to load before we scour it for an element that requires React to be rendered
 document.addEventListener('DOMContentLoaded', async event => {
@@ -106,36 +78,18 @@ document.addEventListener('DOMContentLoaded', async event => {
       }
     }
 
-    richieReactSpots.forEach((element: Element) => {
-      // Generate a component name. It should be a key of the componentLibrary object / ComponentLibrary interface
-      const componentName = startCase(
-        get(element.className.match(/richie-react--([a-zA-Z-]*)/), '[1]') || '',
-      )
-        .split(' ')
-        .join('');
-      // Sanity check: only attempt to access and render components for which we do have a valid name
-      if (isComponentName(componentName)) {
-        // Do get the component dynamically. We know this WILL produce a valid component thanks to the type guard
-        const Component = componentLibrary[componentName];
+    // Create a react root element we'll render into. Note that this is just used to anchor our React tree in an
+    // arbitraty place since all our actual UI components will be rendered into their own containers through portals.
+    const reactRoot = document.createElement('div');
+    reactRoot.setAttribute('class', 'richie-react richie-react--root');
+    document.body.append(reactRoot);
 
-        // Get the incoming props to pass our component from the `data-props` attribute
-        const dataProps = element.getAttribute('data-props');
-        const props = dataProps ? JSON.parse(dataProps) : {};
-
-        // Render the component inside an `IntlProvider` to be able to access translated strings
-        ReactDOM.render(
-          <IntlProvider locale={locale} messages={translatedMessages}>
-            <Component {...props} />
-          </IntlProvider>,
-          element,
-        );
-      } else {
-        // Emit a warning at runtime when we fail to find a matching component for an element that required one
-        console.warn(
-          'Failed to load React component: no such component in Library ' +
-            componentName,
-        );
-      }
-    });
+    // Render the tree inside a shared `IntlProvider` so all components are able to access translated strings.
+    ReactDOM.render(
+      <IntlProvider locale={locale} messages={translatedMessages}>
+        <Root richieReactSpots={richieReactSpots} />
+      </IntlProvider>,
+      reactRoot,
+    );
   }
 });

--- a/src/frontend/scss/templates/search/_search.scss
+++ b/src/frontend/scss/templates/search/_search.scss
@@ -17,14 +17,31 @@ $richie-template-search-padding: 0 !default;
   padding: $richie-template-search-padding;
 
   &__content {
+    position: relative;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+
+    @include media-breakpoint-up(lg) {
+      align-items: center;
+    }
+
+    &__header {
+      display: flex;
+      flex-direction: column;
+      margin: 2rem;
+      text-align: center;
+
+      @include media-breakpoint-up(lg) {
+        width: 50rem;
+      }
+    }
 
     & > .richie-react--search {
       flex-grow: 1;
       display: flex;
       flex-direction: column;
+      width: 100%;
     }
   }
 }

--- a/src/richie/apps/search/templates/search/search.html
+++ b/src/richie/apps/search/templates/search/search.html
@@ -21,9 +21,13 @@
       {% with header_level=2 %}
         {% placeholder "content" %}
       {% endwith %}
+      <div class="search-template__content__header">
+        <h1>{% page_attribute "page_title" %}</h1>
+        <div class="richie-react richie-react--search-suggest-field"></div>
+      </div>
       <div
         class="richie-react richie-react--search"
-        data-props='{"pageTitle": "{% page_attribute "page_title" %}", "context": { "assets": { "icons": "{% static 'richie/icons.svg' %}" } }}'
+        data-props='{"context": { "assets": { "icons": "{% static 'richie/icons.svg' %}" } }}'
       ></div>
     </div>
   </div>

--- a/tests/apps/search/test_templates_search.py
+++ b/tests/apps/search/test_templates_search.py
@@ -32,9 +32,9 @@ class CourseCMSTestCase(CMSTestCase):
             re.search(
                 (
                     r'<html lang="en-US">.*'
+                    r"<h1>search</h1>.*"
                     r"<div[\\n ]*"
                     r'class="richie-react richie-react--search"[\\n ]*'
-                    r'data-props=\\\'{"pageTitle": "search"'
                 ),
                 str(response.content),
             )
@@ -49,9 +49,9 @@ class CourseCMSTestCase(CMSTestCase):
             re.search(
                 (
                     r'<html lang="fr-CA">.*'
+                    r"<h1>recherche</h1>.*"
                     r"<div[\\n ]*"
                     r'class="richie-react richie-react--search"[\\n ]*'
-                    r'data-props=\\\'{"pageTitle": "recherche"'
                 ),
                 str(response.content),
             )


### PR DESCRIPTION
## Purpose

The last step in our modular `<Search />` refactor is to actually unplug the `<SearchSuggestField />` from its dependency on the `CourseSearchParamsContext` and let it be rendered somewhere else in the page.

`<SearchSuggestField />` and `<Search />` still need some global sharing going on because `history.pushState` does not emit any events. Ideally we'd abstract the history in a shared context and use this abstraction to re-render components that need it whenever search is updated.

We can achieve this by grouping all components on any given page under one shared react tree and rendering each component in its intended place through a Portal.

## Proposal

- [x] use Portals to project each component from the root tree (and new `<Root />` component) to its intended location;
- [x] take this opportunity to add a test for this rendering and projecting logic
- [x] build a shared `History` context to abstract away interactions with `pushState` and refresh components that need it
- [x] rework `useCourseSearchParams` to rely on the new `History` context
- [x] actually extract `<SearchSuggestField />` from `<Search />`