### PR TITLE
🐛(courses) add migrate dependency to update section b4 creating footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing migration dependency to avoid IntegrityError on live databases.
+
 ## [1.14.0] - 2019-11-23
 
 ### Added

--- a/src/richie/apps/courses/migrations/0010_auto_footer_to_static_placeholder.py
+++ b/src/richie/apps/courses/migrations/0010_auto_footer_to_static_placeholder.py
@@ -71,7 +71,10 @@ def migrate_footer_to_static_placeholder(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
-    dependencies = [("courses", "0009_auto_20191014_1801")]
+    dependencies = [
+        ("courses", "0009_auto_20191014_1801"),
+        ("section", "0003_auto_20191119_1650"),
+    ]
 
     operations = [
         migrations.RunPython(


### PR DESCRIPTION

## Purpose

The data migration that moves any existing footer to the new static placeholder was running before the schema migration on the section plugin allowed null titles. This was resulting in IntegrityErrors. We did not see this error in development because the database migrations were run separately. We did not see it in the CI either because migrations run on an empty database.

## Proposal

Add a dependency on the data migration that moves the footer so that it is run after the schema migration on the section plugin.
 