### PR TITLE
🌐(frontend) do not report errors related to en-US l10n files

### DIFF
--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -91,7 +91,19 @@ document.addEventListener('DOMContentLoaded', async event => {
     try {
       translatedMessages = await import(`./translations/${locale}.json`);
     } catch (e) {
-      handle(e);
+      // Richie implicitly uses 'en-US' as its default locales: it does not provide localization files and strings
+      // for this locale but instead relies on them being the default messages throughout the code.
+      // We therefore do not want to report errors for a missing locale file that is not expected to exist in stock
+      // Richie. We still want errors if another locale is expected but missing, and we still want to log something
+      // to the console so Richie users who provide their own 'en-US' strings are warned if they are not loaded.
+      if (locale === 'en-US') {
+        // tslint:disable:no-console
+        console.log(
+          'No localization file found for default en-US locale, using default messages.',
+        );
+      } else {
+        handle(e);
+      }
     }
 
     richieReactSpots.forEach((element: Element) => {


### PR DESCRIPTION
## Purpose

Richie's frontend operates on the assumption that en-US is the default language and is contained in the default messages as opposed to localization files that are lazily loaded for other languages.

We don't want to add a special case that does not import() an l10n file for en-US because we don't want to prevent Richie users from creating their own and loading it.

## Proposal

Therefore, we decided to load it if it's there, but not report an error that is in the default and most common case, just the app working as intended.

Closes #913 
