### PR TITLE
Display publication date on blogpost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Display publication date instead of creation date on blog posts,
 - `<Search />` no longer includes the search bar and page title. Those are
   expected to be included in the Django template. The rationale for this
   change is to give users more freedom with their DOM & page structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Hide unpublished blog posts from the news page,
 - Display publication date instead of creation date on blog posts,
 - `<Search />` no longer includes the search bar and page title. Those are
   expected to be included in the Django template. The rationale for this

--- a/bin/lint-back-diff
+++ b/bin/lint-back-diff
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
+# List modified Python files (excluding migrations that are auto-generated)
 DIFF_FILES="$(git diff --name-only master | grep -e .py$ | grep -v migrations || true)"
 DIFF_WITH_TESTS="$(echo "$DIFF_FILES" | tr "\n" " ")" || true
 DIFF_NO_TESTS="$(echo "$DIFF_FILES" | grep -v tests/ | tr "\n" " ")" || true
 
-if [ -z "$DIFF_FILES" ]; then
+# List new untracked files
+UNTRACKED_FILES="$(git ls-files -o --exclude-standard)"
+UNTRACKED_FILES_WITH_TESTS="$(echo "$UNTRACKED_FILES" | tr "\n" " ")" || true
+UNTRACKED_FILES_NO_TESTS="$(echo "$UNTRACKED_FILES" | grep -v tests/ | tr "\n" " ")" || true
+
+if [ -z "$DIFF_FILES" ] && [ -z "$UNTRACKED_FILES" ]; then
     echo "Nothing new to lint since master"
     exit 0
 fi
 
-_dc_run --no-deps app pylint $DIFF_WITH_TESTS
-_dc_run --no-deps app black $DIFF_WITH_TESTS
-_dc_run --no-deps app flake8 $DIFF_WITH_TESTS
-_dc_run --no-deps app isort --recursive --atomic $DIFF_WITH_TESTS
-_dc_run --no-deps app bandit -qr $DIFF_NO_TESTS
+_dc_run --no-deps app pylint $DIFF_WITH_TESTS $UNTRACKED_FILES_WITH_TESTS
+_dc_run --no-deps app black $DIFF_WITH_TESTS $UNTRACKED_FILES_WITH_TESTS
+_dc_run --no-deps app flake8 $DIFF_WITH_TESTS $UNTRACKED_FILES_WITH_TESTS
+_dc_run --no-deps app isort --recursive --atomic $DIFF_WITH_TESTS $UNTRACKED_FILES_WITH_TESTS
+_dc_run --no-deps app bandit -qr $DIFF_NO_TESTS $UNTRACKED_FILES_NO_TESTS

--- a/src/richie/apps/core/factories.py
+++ b/src/richie/apps/core/factories.py
@@ -121,6 +121,7 @@ class TitleFactory(factory.django.DjangoModelFactory):
 
     language = factory.Iterator([l[0] for l in settings.LANGUAGES])
     page = None
+    path = factory.LazyAttribute(lambda o: o.page.get_path_for_slug(o.slug, o.language))
     slug = factory.LazyAttribute(lambda o: slugify(o.title))
     title = factory.Faker("catch_phrase")
 

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -8,7 +8,7 @@
 {% block meta_opengraph_contextuals %}
     <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
     <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
-    <meta property="article:published_time" content="{{ current_page.creation_date|date:"c" }}">
+    <meta property="article:published_time" content="{{ current_page.publication_date|date:"c" }}">
 {% endblock meta_opengraph_contextuals %}
 
 {% block content %}
@@ -18,7 +18,11 @@
 
   <div class="blogpost-detail__subhead">
     <p class="blogpost-detail__subhead__date">
-      {{ current_page.creation_date|date:"SHORT_DATE_FORMAT" }}
+      {% if current_page.publication_date %}
+        {{ current_page.publication_date|date:"DATE_FORMAT" }}
+      {% else %}
+        {% trans 'Not published yet' %}
+      {% endif %}
     </p>
 
     {% with form_factor="tag" %}

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
@@ -6,8 +6,12 @@
 {% block content %}
 <div class="blogpost-glimpse-list">
   <h1 class="blogpost-glimpse-list__title">{{ current_page.get_title }}</h1>
+  {% if current_page.publisher_is_draft %}
+    {% autopaginate current_page.get_child_pages 20 as object_list %}
+  {% else %}
+    {% autopaginate current_page.get_child_pages.published.distinct 20 as object_list %}
+  {% endif %}
 
-  {% autopaginate current_page.get_child_pages 20 as object_list %}
   {% for page in object_list %}
     {% if page.blogpost %}
       {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=page.blogpost %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
@@ -25,11 +25,13 @@
               {% show_placeholder "excerpt" blogpost_page %}
           </p>
       </div>
+      {% if blogpost_page.publication_date %}
       <div class="blogpost-glimpse__footer">
           <p class="blogpost-glimpse__footer__date">
-              {{ blogpost_page.creation_date|date:"DATE_FORMAT" }}
+              {{ blogpost_page.publication_date|date:"DATE_FORMAT" }}
           </p>
       </div>
+      {% endif %}
   </div>
 </a>
 {% endwith %}

--- a/tests/apps/courses/test_templates_blogpost_list.py
+++ b/tests/apps/courses/test_templates_blogpost_list.py
@@ -1,0 +1,57 @@
+"""
+End-to-end tests for the blogpost list view
+"""
+from datetime import timedelta
+from unittest import mock
+
+from django.utils import timezone
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.factories import PageFactory, UserFactory
+from richie.apps.courses.factories import BlogPostFactory
+
+
+class ListBlogPostCMSTestCase(CMSTestCase):
+    """
+    End-to-end test suite to validate the content and Ux of the blogpost list view
+    """
+
+    def test_templates_blogpost_list_cms_content(self):
+        """
+        Validate that the public website only displays blogposts that are currently published,
+        while staff users can see draft and unpublished blogposts.
+        """
+        page = PageFactory(
+            template="courses/cms/blogpost_list.html",
+            title__language="en",
+            should_publish=True,
+        )
+
+        BlogPostFactory(page_parent=page, page_title="First post")
+        BlogPostFactory(page_parent=page, page_title="Second post", should_publish=True)
+
+        # Publish with a publication date in the future
+        future = timezone.now() + timedelta(hours=1)
+        with mock.patch("cms.models.pagemodel.now", return_value=future):
+            BlogPostFactory(
+                page_parent=page, page_title="Third post", should_publish=True
+            )
+
+        # Anonymous users should only see published blogposts
+        response = self.client.get(page.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "First")
+        self.assertContains(response, "Second")
+        self.assertNotContains(response, "Third")
+
+        # Staff users can see draft and unpublished blogposts
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self.client.get(page.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+        for title in ["First", "Second", "Third"]:
+            self.assertContains(response, title)

--- a/tests/plugins/html_sitemap/test_cms_plugins.py
+++ b/tests/plugins/html_sitemap/test_cms_plugins.py
@@ -66,13 +66,13 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">Root</a>
                   <ul>
-                    <li><a href="/en/parent/">Parent</a>
+                    <li><a href="/en/root/parent/">Parent</a>
                       <ul>
-                        <li><a href="/en/page/">Page</a></li>
-                        <li><a href="/en/sibling/">Sibling</a></li>
+                        <li><a href="/en/root/parent/page/">Page</a></li>
+                        <li><a href="/en/root/parent/sibling/">Sibling</a></li>
                       </ul>
                     </li>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
                 <li><a href="/en/sitemap/">Sitemap</a></li>
@@ -110,10 +110,10 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
             """
             <div class="sitemap">
               <ul>
-                <li><a href="/en/parent/">Parent</a>
+                <li><a href="/en/root/parent/">Parent</a>
                   <ul>
-                    <li><a href="/en/page/">Page</a></li>
-                    <li><a href="/en/sibling/">Sibling</a></li>
+                    <li><a href="/en/root/parent/page/">Page</a></li>
+                    <li><a href="/en/root/parent/sibling/">Sibling</a></li>
                   </ul>
                 </li>
               </ul>
@@ -151,8 +151,8 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
             """
             <div class="sitemap">
               <ul>
-                <li><a href="/en/page/">Page</a></li>
-                <li><a href="/en/sibling/">Sibling</a></li>
+                <li><a href="/en/root/parent/page/">Page</a></li>
+                <li><a href="/en/root/parent/sibling/">Sibling</a></li>
               </ul>
             </div>
             """,
@@ -189,8 +189,8 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">Root</a>
                   <ul>
-                    <li><a href="/en/parent/">Parent</a></li>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/parent/">Parent</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
                 <li><a href="/en/sitemap/">Sitemap</a></li>
@@ -231,8 +231,8 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">Root</a>
                   <ul>
-                    <li><a href="/en/parent/">Parent</a></li>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/parent/">Parent</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
               </ul>
@@ -271,8 +271,8 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
             """
             <div class="sitemap">
               <ul>
-                <li><a href="/en/parent/">Parent</a></li>
-                <li><a href="/en/uncle/">Uncle</a></li>
+                <li><a href="/en/root/parent/">Parent</a></li>
+                <li><a href="/en/root/uncle/">Uncle</a></li>
               </ul>
             </div>
             """,
@@ -306,7 +306,7 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">Root</a>
                   <ul>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
                 <li><a href="/en/sitemap/">Sitemap</a></li>
@@ -344,7 +344,7 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">Root</a>
                   <ul>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
                 <li><a href="/en/sitemap/">Sitemap</a></li>
@@ -369,13 +369,13 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">Root</a>
                   <ul>
-                    <li><a href="/en/parent/">Parent</a>
+                    <li><a href="/en/root/parent/">Parent</a>
                       <ul>
-                        <li><a href="/en/page/">Page</a></li>
-                        <li><a href="/en/sibling/">Sibling</a></li>
+                        <li><a href="/en/root/parent/page/">Page</a></li>
+                        <li><a href="/en/root/parent/sibling/">Sibling</a></li>
                       </ul>
                     </li>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
                 <li><a href="/en/sitemap/">Sitemap</a></li>
@@ -442,7 +442,7 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">Root</a>
                   <ul>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
                 <li><a href="/en/sitemap/">Sitemap</a></li>
@@ -463,7 +463,7 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">modified title</a>
                   <ul>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
                 <li><a href="/en/sitemap/">Sitemap</a></li>
@@ -507,13 +507,13 @@ class HTMLSitemapPluginTestCase(CMSPluginTestCase):
               <ul>
                 <li><a href="/en/root/">Root</a>
                   <ul>
-                    <li><a href="/en/parent/">Parent</a>
+                    <li><a href="/en/root/parent/">Parent</a>
                       <ul>
-                        <li><a href="/en/page/">Page</a></li>
-                        <li><a href="/en/sibling/">Sibling</a></li>
+                        <li><a href="/en/root/parent/page/">Page</a></li>
+                        <li><a href="/en/root/parent/sibling/">Sibling</a></li>
                       </ul>
                     </li>
-                    <li><a href="/en/uncle/">Uncle</a></li>
+                    <li><a href="/en/root/uncle/">Uncle</a></li>
                   </ul>
                 </li>
                 <li><a href="/en/sitemap/">Sitemap</a></li>


### PR DESCRIPTION
## Purpose

The date displayed on blog posts was their date of creation. DjangoCMS has a publication date feature that allows setting a date of publication and a date of end of publication for a page.

We would like to display the date of publication instead of the date of creation. 

The publication dates should be respected on the news page by hiding blog posts unless the current date is in the publication window configured for its page. 

## Proposal

- [x] display publication date instead of creation date on blog posts detail and glimpse views,
- [x] on the news page, hide blog posts that are not in the publication window.

While working on this feautre, I bumped into 2 small bugs that I fixed:

- [x] Include new untracked files to lint-back-diff script,
- [x]  Add missing path field to the title factory.
