### PR TITLE
Update our JS to support IE11 and old browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Rename all occurences of the "form_factor" variable to "variant",
 - Restructure categories glimpse/plugin for modularity and harmonization,
+- Update the frontend build to supported outdated browsers such as IE11.
 - Segment course runs according to status on course detail page,
 - Our course search fields now have a "Search" button with a magnifying
   glass icon.

--- a/src/frontend/babel.config.js
+++ b/src/frontend/babel.config.js
@@ -12,9 +12,10 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        forceAllTransforms: true,
-        useBuiltIns: 'usage',
         corejs: 3,
+        forceAllTransforms: true,
+        targets: 'last 1 version, >0.2%, IE 11',
+        useBuiltIns: 'usage',
       },
     ],
     '@babel/preset-typescript',

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -45,6 +45,11 @@ document.addEventListener('DOMContentLoaded', async event => {
       await import('mdn-polyfills/Node.prototype.append');
     }
 
+    // Polyfill outdated browsers who do not have fetch
+    if (typeof fetch === 'undefined') {
+      await import('whatwg-fetch');
+    }
+
     // Only load Intl polyfills & pre-built locale data for browsers that need it
     try {
       if (!Intl.PluralRules) {

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -36,6 +36,15 @@ document.addEventListener('DOMContentLoaded', async event => {
       );
     }
 
+    // Polyfill outdated browsers who do not have Node.prototype.append
+    if (
+      !Element.prototype.hasOwnProperty('append') &&
+      !Document.prototype.hasOwnProperty('append') &&
+      !DocumentFragment.prototype.hasOwnProperty('append')
+    ) {
+      await import('mdn-polyfills/Node.prototype.append');
+    }
+
     // Only load Intl polyfills & pre-built locale data for browsers that need it
     try {
       if (!Intl.PluralRules) {

--- a/src/frontend/js/types/libs/mdn-polyfills/index.d.ts
+++ b/src/frontend/js/types/libs/mdn-polyfills/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'mdn-polyfills/Node.prototype.append';

--- a/src/frontend/js/types/libs/whatwg-fetch/index.d.ts
+++ b/src/frontend/js/types/libs/whatwg-fetch/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'whatwg-fetch';

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -79,6 +79,7 @@
     "typescript": "3.7.2",
     "webpack": "4.41.2",
     "webpack-cli": "3.3.10",
+    "whatwg-fetch": "3.0.0",
     "xhr-mock": "2.5.1",
     "yargs": "15.0.2"
   },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -62,6 +62,7 @@
     "intl-pluralrules": "1.1.1",
     "jest": "24.9.0",
     "lodash-es": "4.17.15",
+    "mdn-polyfills": "5.19.0",
     "node-fetch": "2.6.0",
     "node-sass": "4.13.0",
     "nodemon": "2.0.1",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@babel/core": "7.7.4",
     "@babel/plugin-syntax-dynamic-import": "7.7.4",
+    "@babel/plugin-transform-modules-commonjs": "7.7.4",
     "@babel/polyfill": "7.7.0",
     "@babel/preset-env": "7.7.4",
     "@babel/preset-typescript": "7.7.4",

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -19,6 +19,14 @@ const overrides = argv.richieSettings
   ? JSON.parse(fs.readFileSync(argv.richieSettings)).overrides
   : {};
 
+const babelCompileDeps = [
+  'query-string',
+  'react-intl',
+  'react-modal',
+  'split-on-first',
+  'strict-uri-encode',
+];
+
 module.exports = {
   // Disable production-specific optimizations by default
   // They can be re-enabled by running the cli with `--mode=production` or making a separate
@@ -55,7 +63,25 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.tsx?$/,
+        test: new RegExp(`(${babelCompileDeps.join('|')}.*)`),
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              plugins: [
+                ...require('./babel.config').plugins,
+                // Some modules (eg. query-string) are not pre-compiled but do not use import/export
+                // We need to give webpack
+                '@babel/plugin-transform-modules-commonjs',
+              ],
+              presets: require('./babel.config').presets,
+            },
+          },
+        ],
+      },
+      {
+        exclude: /node_modules/,
+        test: new RegExp(`\.(tsx?|jsx?)$`),
         use: [
           {
             loader: 'babel-loader',

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -4646,6 +4646,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdn-polyfills@5.19.0:
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/mdn-polyfills/-/mdn-polyfills-5.19.0.tgz#5c2bef9015f53ecab35ec6169d3662a2671d032b"
+  integrity sha512-wtZ6NtGbQFbp8H3ZG+hKIHtFxWgdxYI4hhnb7jG9RR9/SzC1Olf+lAlxEDd5PLlNSbtLaVtYFP2PP9QD5Wvl3Q==
+
 mem@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -475,6 +475,16 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     babel-plugin-dynamic-import-node "^2.3.0"
 
+"@babel/plugin-transform-modules-commonjs@7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.4.tgz#bee4386e550446343dd52a571eda47851ff857a3"
+  integrity sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.7.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.7.4"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
 "@babel/plugin-transform-modules-commonjs@^7.7.4":
   version "7.7.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz#1d27f5eb0bcf7543e774950e5b2fa782e637b345"
@@ -682,9 +692,9 @@
     "@babel/plugin-transform-typescript" "^7.7.4"
 
 "@babel/runtime@^7.5.1", "@babel/runtime@^7.6.0", "@babel/runtime@^7.6.2":
-  version "7.7.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.5.tgz#4b087f183f5d83647744d4157f66199081d17a00"
-  integrity sha512-UXhClKWTL7/vlYX49kETXti6VbpPJK/pdsIOqUMhUUES/lqThpNTsmC/0aU/IW4uozDUx17axjeqel7SCYF6EQ==
+  version "7.7.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.6.tgz#d18c511121aff1b4f2cd1d452f1bac9601dd830f"
+  integrity sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -1881,7 +1891,7 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^4.6.0, browserslist@^4.8.0:
+browserslist@^4.6.0, browserslist@^4.8.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.2.tgz#b45720ad5fbc8713b7253c20766f701c9a694289"
   integrity sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==
@@ -1890,7 +1900,7 @@ browserslist@^4.6.0, browserslist@^4.8.0:
     electron-to-chromium "^1.3.322"
     node-releases "^1.1.42"
 
-bser@^2.0.0:
+bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
@@ -2283,22 +2293,22 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-compat@^3.1.1:
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.4.7.tgz#39f8080b1d92a524d6d90505c42b9c5c1eb90611"
-  integrity sha512-57+mgz/P/xsGdjwQYkwtBZR3LuISaxD1dEwVDtbk8xJMqAmwqaxLOvnNT7kdJ7jYE/NjNptyzXi+IQFMi/2fCw==
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.4.8.tgz#f72e6a4ed76437ea710928f44615f926a81607d5"
+  integrity sha512-l3WTmnXHV2Sfu5VuD7EHE2w7y+K68+kULKt5RJg8ZJk3YhHF1qLD4O8v8AmNq+8vbOwnPFFDvds25/AoEvMqlQ==
   dependencies:
-    browserslist "^4.8.0"
+    browserslist "^4.8.2"
     semver "^6.3.0"
 
 core-js@3, core-js@^3.0.0:
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.7.tgz#57c35937da80fe494fbc3adcf9cf3dc00eb86b34"
-  integrity sha512-qaPVGw30J1wQ0GR3GvoPqlGf9GZfKKF4kFC7kiHlcsPTqH3txrs9crCp3ZiMAXuSenhz89Jnl4GZs/67S5VOSg==
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.8.tgz#e0fc0c61f2ef90cbc10c531dbffaa46dfb7152dd"
+  integrity sha512-b+BBmCZmVgho8KnBUOXpvlqEMguko+0P+kXCwD4vIprsXC6ht1qgPxtb1OK6XgSlrySF71wkwBQ0Hv695bk9gQ==
 
 core-js@^2.4.0, core-js@^2.6.5:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
-  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -2924,11 +2934,11 @@ fast-levenshtein@~2.0.6:
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fb-watchman@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
-  integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
+  integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
-    bser "^2.0.0"
+    bser "2.1.1"
 
 fetch-mock@8.0.0:
   version "8.0.0"
@@ -5072,9 +5082,9 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 npm-bundled@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
-  integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.0.tgz#2e8fdb7e69eff2df963937b696243316537c284b"
+  integrity sha512-ez6dcKBFNo4FvlMqscBEFUum6M2FTLW5grqm3DyBKB5XOyKVCeeWvAuoZtbmW/5Cv8EM2bQUOA6ufxa/TKVN0g==
 
 npm-packlist@^1.1.6:
   version "1.4.6"
@@ -6216,9 +6226,9 @@ semver@~5.3.0:
   integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 serialize-javascript@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.1.tgz#952907a04a3e3a75af7f73d92d15e233862048b2"
-  integrity sha512-MPLPRpD4FNqWq9tTIjYG5LesFouDhdyH0EPY3gVK4DRD5+g4aDqdNSzLIwceulo3Yj+PL1bPh6laE5+H6LTcrQ==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
+  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -6910,9 +6920,9 @@ typescript@3.7.2:
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.1.tgz#35c7de17971a4aa7689cd2eae0a5b39bb838c0c5"
-  integrity sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.2.tgz#cb1a601e67536e9ed094a92dd1e333459643d3f9"
+  integrity sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==
   dependencies:
     commander "~2.20.3"
     source-map "~0.6.1"

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -7229,6 +7229,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -110,26 +110,26 @@
         {% render_block "js" %}
         <script src="{% static 'richie/js/index.js' %}"></script>
         <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            // Get all topbar burger elements
-            const $topbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.topbar__hamburger'), 0);
-
-            // Check if there are any navbar burgers
-            if ($topbarBurgers.length > 0) {
+            document.addEventListener("DOMContentLoaded", function() {
+              // Get all topbar burger elements
+              const topbarBurgers = Array.prototype.slice.call(
+                document.querySelectorAll(".topbar__hamburger"),
+                0
+              );
+              // Check if there are any navbar burgers
+              if (topbarBurgers.length > 0) {
                 // Add a click event on each of them
-                $topbarBurgers.forEach( el => {
-                    el.addEventListener('click', () => {
-                        // Get the target from the "data-target" attribute
-                        const target = el.dataset.target;
-                        const $target = document.getElementById(target);
-
-                        // Toggle the "is-active" class on both the burger and container
-                        el.classList.toggle('is-active');
-                        $target.classList.toggle('is-open');
-                    });
+                topbarBurgers.forEach(function(el) {
+                  el.addEventListener("click", function() {
+                    // Get the target from the "data-target" attribute
+                    const target = document.getElementById(el.dataset.target);
+                    // Toggle the "is-active" class on both the burger and container
+                    el.classList.toggle("is-active");
+                    target.classList.toggle("is-open");
+                  });
                 });
-            }
-        });
+              }
+            });
         </script>
         {% block body_js %}{% endblock body_js %}
     </body>


### PR DESCRIPTION
## Purpose

Richie is not IE11 ready. One of the major parts that did not work with outdated browsers was the JS, which needed to be built specifically to support it.

## Proposal

- [x] add a browserslist with our target browsers
- [x] build dependencies that can't run in IE11
- [x] add required polyfills for IE11
- [x] update `base.html` JS so it runs in IE11
