### PR TITLE
📌(backend) pin Django to less than 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Our course search fields now have a "Search" button with a magnifying
   glass icon.
 
+### Fixed
+
+- Pin Django to version less than 3.0.
+
 ## [1.15.0] - 2019-12-02
 
 ### Changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 include_package_data = True
 install_requires =
     arrow # pyup: ignore
+    Django<3.0.0 # pyup: ignore
     dj-pagination # pyup: ignore
     django-cms>=3.6.0 # pyup: ignore
     django-parler # pyup: ignore


### PR DESCRIPTION
## Purpose

Django 3.0 is out but not supported yet by DjangoCMS so we need to make sure we stay on Django 2.x versions.

## Proposal

Add a requirement "Django<3.0" in backend dependencies.
