### PR TITLE
🔧(courses) allow CKEditor on course format, prerequisite and assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Allow CKEditor with minimal options on course format, prerequisites and
+  assessment sections.
+
 ## [1.16.0] - 2019-12-10
 
 ### Added

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -122,11 +122,11 @@ CMS_PLACEHOLDER_CONF = {
     },
     "courses/cms/course_detail.html course_format": {
         "name": _("Format"),
-        "plugins": ["PlainTextPlugin"],
+        "plugins": ["CKEditorPlugin"],
     },
     "courses/cms/course_detail.html course_prerequisites": {
         "name": _("Prerequisites"),
-        "plugins": ["PlainTextPlugin"],
+        "plugins": ["CKEditorPlugin"],
     },
     "courses/cms/course_detail.html course_team": {
         "name": _("Team"),
@@ -170,7 +170,7 @@ CMS_PLACEHOLDER_CONF = {
     },
     "courses/cms/course_detail.html course_assessment": {
         "name": _("Assessment and Certification"),
-        "plugins": ["PlainTextPlugin"],
+        "plugins": ["CKEditorPlugin"],
     },
     # Organization detail
     "courses/cms/organization_detail.html banner": {
@@ -371,6 +371,10 @@ RICHIE_SIMPLETEXT_CONFIGURATION = [
         "placeholders": ["course_description"],
         "ckeditor": "CKEDITOR_LIMITED_CONFIGURATION",
         "max_length": 1200,
+    },
+    {
+        "placeholders": ["course_assessment", "course_format", "course_prerequisites"],
+        "ckeditor": "CKEDITOR_BASIC_CONFIGURATION",
     },
 ]
 


### PR DESCRIPTION
##  Purpose

We want to allow minimal formatting on these 3 sections. The plain text did not allow line breaks.

## Proposal

- [x] Allow SimpleText plugin on `course_format`, `course_prerequisites` and `course_assesment` placeholders in richie default settings,
- [x] Limit CKEditor options to the minimum for these 3 placeholders.
