### PR TITLE
🐛 Fix an issue with get_picture_info when there is no image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue with Picture instances that did not contain an image.
+
 ## [1.16.1] - 2019-12-13
 
 ### Changed

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -376,7 +376,9 @@ class CoursesIndexer:
         ):
             language = cover.cmsplugin_ptr.language
             with translation.override(language):
-                cover_images[language] = get_picture_info(cover, "cover")
+                picture_info = get_picture_info(cover, "cover")
+                if picture_info:
+                    cover_images[language] = picture_info
 
         # Prepare the related category icon
         icon_images = {}
@@ -393,8 +395,9 @@ class CoursesIndexer:
                 cmsplugin_ptr__position=0,
             ):
                 with translation.override(language):
+                    picture_info = get_picture_info(icon, "icon") or {}
                     icon_images[language] = {
-                        **get_picture_info(icon, "icon"),
+                        **picture_info,
                         "color": plugin_model.page.category.color,
                         "title": plugin_model.page.get_title(),
                     }

--- a/src/richie/plugins/simple_picture/helpers.py
+++ b/src/richie/plugins/simple_picture/helpers.py
@@ -24,6 +24,11 @@ def get_picture_info(instance, preset_name):
     }
 
     """
+    # Bail out if the picture does not have an image as that's the object we use to get
+    # all the information we need to return any picture info.
+    if not instance.picture:
+        return None
+
     thumbnailer = instance.picture.easy_thumbnails_thumbnailer
 
     # Look for the preset in settings and fallback to "default"

--- a/tests/plugins/simple_picture/test_helpers.py
+++ b/tests/plugins/simple_picture/test_helpers.py
@@ -98,3 +98,12 @@ class SimplePictureHelpersTestCase(TestCase):
             mock_thumbnail.call_args_list,
             [mock.call({"size": (500, 500), "subject_location": location})],
         )
+
+    def test_helpers_simplepicture_get_picture_info_no_picture(self):
+        """
+        The `get_picture_info` method should not fail and raise an error if it encounters
+        a picture without an image.
+        """
+        simple_picture = PictureFactory(picture=None)
+        info = get_picture_info(simple_picture, "my-preset")
+        self.assertEqual(info, None)


### PR DESCRIPTION
## Purpose

Our simple plugin's `get_picture_info()` helper operated on the assumption that an Picture has a picture attribute, with a FileImage.

Depending on how actual users use the back-office, it is possible to create Picture instances that are missing this. This caused the helper to raise an error and crash the ES index generation.


## Proposal

We added a test to reproduce this issue and solved it by simply bailing out at the top if there is no image as `get_picture_info()` has pretty much nothing to return then.
