### PR TITLE
♻️ Improve ES index management command and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Report frontend errors through Sentry when a sentry DSN is available in
   Django settings.
 
+### Changed
+
+- Improve ElasticSearch `regenerate_indexes` tests.
+
 ## [1.16.2] - 2019-12-18
 
 ### Fixed

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -36,18 +36,19 @@ def get_indexes_by_alias(existing_indexes, alias):
             yield index, alias
 
 
-def perform_create_index(indexable, logger):
+def perform_create_index(indexable, logger=None):
     """
     Create a new index in ElasticSearch from an indexable instance
     """
     indices_client = IndicesClient(client=ES_CLIENT)
     # Create a new index name, suffixing its name with a timestamp
-    new_index = "{:s}_{:s}".format(
-        indexable.index_name, timezone.now().strftime("%Y-%m-%d-%Hh%Mm%S.%fs")
+    new_index = (
+        f"{indexable.index_name:s}_{timezone.now().strftime('%Y-%m-%d-%Hh%Mm%S.%fs'):s}"
     )
 
     # Create the new index
-    logger.info('Creating a new Elasticsearch index "{:s}"...'.format(new_index))
+    if logger:
+        logger.info(f'Creating a new Elasticsearch index "{new_index:s}"...')
     indices_client.create(index=new_index)
 
     # The index needs to be closed before we set an analyzer
@@ -112,7 +113,7 @@ def regenerate_indexes(logger):
     # NB: we *must* do this before the update_aliases call so we don't immediately prune
     # version n-1 of all our indexes
     useless_indexes = [
-        index for index, details in existing_indexes.items() if "aliases" not in details
+        index for index, details in existing_indexes.items() if details["aliases"] == {}
     ]
 
     # Replace the old indexes with the new ones in 1 atomic operation to avoid outage
@@ -120,7 +121,6 @@ def regenerate_indexes(logger):
         dict(actions=actions_to_create_aliases + actions_to_delete_aliases)
     )
 
-    # Cleanup step: do prune older indexes that are now useless
     for useless_index in useless_indexes:
         # Disable keyword arguments checking as elasticsearch-py uses a decorator to list
         # valid query parameters and inject them as kwargs. I won't say a word about this
@@ -130,7 +130,7 @@ def regenerate_indexes(logger):
         indices_client.delete(index=useless_index, ignore=[400, 404])
 
 
-def store_es_scripts(logger):
+def store_es_scripts(logger=None):
     """
     Iterate over the indexers listed in the settings, import them, and store the scripts
     they define on their "scripts" key in ElasticSearch
@@ -138,5 +138,5 @@ def store_es_scripts(logger):
     for indexer in ES_INDICES:
         for script_id, script_body in indexer.scripts.items():
             if logger:
-                logger.info('Storing script "{:s}"...'.format(script_id))
+                logger.info(f'Storing script "{script_id:s}"...')
             ES_CLIENT.put_script(id=script_id, body=script_body)

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -12,6 +12,7 @@ import pytz
 from elasticsearch.client import IndicesClient
 from elasticsearch.exceptions import NotFoundError
 
+from richie.apps.courses.factories import CourseFactory
 from richie.apps.search import ES_CLIENT
 from richie.apps.search.index_manager import (
     get_indexes_by_alias,
@@ -19,6 +20,7 @@ from richie.apps.search.index_manager import (
     regenerate_indexes,
     store_es_scripts,
 )
+from richie.apps.search.signals import update_course
 
 
 class IndexManagerTestCase(TestCase):
@@ -246,6 +248,37 @@ class IndexManagerTestCase(TestCase):
             # Version n-2 of the index does not exist any more
             with self.assertRaises(NotFoundError):
                 indices_client.get(f"{index_name}_{creation1_string}")
+
+    def test_index_manager_regenerate_indexes_from_broken_state(self):
+        """
+        `regenerate_indexes` should succeed and give us a working ElasticSearch
+        when it runs and finds a broken state (eg. with an existing, incorrect
+        index with the name of an alias).
+
+        This can occur when ES restarts and an update signal is triggered before
+        Richie had a chance to bootstrap ES.
+        """
+        # The indices client will be used to test the actual indices in ElasticSearch
+        indices_client = IndicesClient(client=ES_CLIENT)
+
+        # Create a course and trigger a signal to index it. This will create a
+        # broken "richie_courses" index
+        course = CourseFactory(should_publish=True)
+        update_course(course.extended_object, "en")
+
+        # Call our `regenerate_indexes command`
+        creation_datetime = datetime(2010, 1, 1, tzinfo=timezone.utc)
+        creation_string = creation_datetime.strftime("%Y-%m-%d-%Hh%Mm%S.%fs")
+        with mock.patch.object(timezone, "now", return_value=creation_datetime):
+            regenerate_indexes(None)
+
+        # No error was thrown, the courses index (like all others) was bootstrapped
+        self.assertIsNotNone(indices_client.get(f"richie_courses_{creation_string}"))
+        # The expected alias is associated with the index
+        self.assertEqual(
+            list(indices_client.get_alias("richie_courses").keys())[0],
+            f"richie_courses_{creation_string}",
+        )
 
     # pylint: disable=unused-argument
     @mock.patch(


### PR DESCRIPTION
## Purpose

While trying to solve #939, we looked at the `index_manager` tests.

We noticed they were using a lot of mocks such that they provided very little confidence in the code actually working as intended.

## Proposal

We replaced two heavily mocked tests with an entirely non-mocked one that should cover the same code surface with more confidence.

We also touched up on the code in the index_manager module, eg. fixing a small bug we encountered and replacing format calls with f strings.


This did not find us the bug as we had hoped it might, but it's an improvement nonetheless.
