### PR TITLE
🥅 Improve error handling in <Search /> component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix an issue that crashed `regenerate_indexes` (and therefore
   `bootstrap_elasticsearch`) from a broken state in ES.
+- `<Search />` component handles errors in course search requests, displaying
+  an error message to end users.
 
 ### Changed
 

--- a/src/frontend/js/components/Root/index.spec.tsx
+++ b/src/frontend/js/components/Root/index.spec.tsx
@@ -14,6 +14,8 @@ jest.mock('components/RootSearchSuggestField', () => ({
 }));
 
 describe('<Root />', () => {
+  (window as any).__richie_frontend_context__ = { context: {} };
+
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(() => {});
   });

--- a/src/frontend/js/components/Root/index.tsx
+++ b/src/frontend/js/components/Root/index.tsx
@@ -59,7 +59,7 @@ export const Root = ({ richieReactSpots }: RootProps) => {
 
       // Add context to props if they do not already include it
       if (!props.context) {
-        props.context = (window as any).__richie_frontend_context__;
+        props.context = (window as any).__richie_frontend_context__.context;
       }
 
       return ReactDOM.createPortal(<Component {...props} />, element);

--- a/src/frontend/js/components/Search/_styles.scss
+++ b/src/frontend/js/components/Search/_styles.scss
@@ -78,6 +78,18 @@ $richie-search-results-padding: 0 1rem 0 2rem !default;
       padding: $richie-search-results-padding;
     }
 
+    &__error {
+      display: flex;
+      width: 100%;
+      max-width: 80vw;
+      height: 100%;
+      padding-bottom: 20rem;
+      justify-content: center;
+      align-items: center;
+      margin: auto;
+      text-align: center;
+    }
+
     &__overlay {
       visibility: hidden;
       position: absolute;

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -64,6 +64,28 @@ describe('<Search />', () => {
     expect(queryByText('Loading search results...')).toBeNull();
   });
 
+  it('shows an error message when it fails to get the results', async () => {
+    fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', 500);
+
+    const { getByText, queryByText } = render(
+      <IntlProvider locale="en">
+        <HistoryContext.Provider
+          value={makeHistoryOf({ limit: '20', offset: '0' })}
+        >
+          <Search context={commonDataProps} />
+        </HistoryContext.Provider>
+      </IntlProvider>,
+    );
+
+    expect(
+      getByText('Loading search results...').parentElement,
+    ).toHaveAttribute('role', 'status');
+
+    await wait();
+    expect(queryByText('Loading search results...')).toBeNull();
+    getByText(`Something's wrong! Courses could not be loaded.`);
+  });
+
   it('always shows the filters pane on large screens', async () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', {
       meta: {

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -12,6 +12,12 @@ import { CommonDataProps } from 'types/commonDataProps';
 import { matchMedia } from 'utils/indirection/window';
 
 const messages = defineMessages({
+  errorMessage: {
+    defaultMessage: `Something's wrong! Courses could not be loaded.`,
+    description:
+      'Error message for Search view when the request to load courses fails',
+    id: 'components.Search.errorMessage',
+  },
   hideFiltersPane: {
     defaultMessage: 'Hide filters pane',
     description:
@@ -109,6 +115,11 @@ export const Search = ({ context }: CommonDataProps) => {
               }
             />
           </React.Fragment>
+        ) : courseSearchResponse &&
+          courseSearchResponse.status === requestStatus.FAILURE ? (
+          <div className="search__results__error">
+            <FormattedMessage {...messages.errorMessage} />
+          </div>
         ) : (
           <Spinner size="large">
             <FormattedMessage {...messages.spinnerText} />


### PR DESCRIPTION
## Purpose

Our main `<Search />` component was previously simply ignoring errors, instead just keeping the loading spinner. This is far from ideal as users are left wondering what is happening.

## Proposal

We just added a case in our component to display an error message when the API search request on courses fails.

We also took this opportunity to fix a small mishap with `__richie_frontend_context__` handling.

Closes #938.
