### PR TITLE
🔧 Variabilize ES index names through settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Licences (through their "name" and "content" fields) are now translatable.
 - Report frontend errors through Sentry when a sentry DSN is available in
   Django settings.
+- ElasticSearch index name prefix (currently `richie_`) is now customizable
+  through the settings.
 
 ### Fixed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,7 @@ $ make migrate
 
 ## Unreleased
 
+- This release changes names for ElasticSearch indices. Unless they explicitly use `RICHIE_ES_INDICES_PREFIX` setting to replicate the previous behavior (by setting it to `"richie"`), all users will have to regenerate all ElasticSearch indices (can be done by running the `bootstrap_elasticsearch` command).
 - If you override the `courses/cms/blogpost_list.html` template and want to benefit from the
   display of news-related categories on top of the page, you need to add the new markup and css.
 - All occurences of the `form_factor` variable have been renamed to `variant` for clarity.

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -296,6 +296,9 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
     RICHIE_ES_HOST = values.Value(
         "elasticsearch", environ_name="RICHIE_ES_HOST", environ_prefix=None
     )
+    RICHIE_ES_INDICES_PREFIX = values.Value(
+        default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None
+    )
 
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -2,11 +2,15 @@
 Import custom settings and set up defaults for values the Search app needs
 """
 from django.conf import settings
+from django.utils.functional import lazy
 from django.utils.translation import ugettext_lazy as _
 
 # Elasticsearch
 ES_CHUNK_SIZE = 500
 ES_PAGE_SIZE = 10
+
+# Use a lazy to enable easier testing by not defining the value at bootstrap time
+ES_INDICES_PREFIX = lazy(lambda: settings.RICHIE_ES_INDICES_PREFIX)()
 
 # Define the scoring boost (in ElasticSearch) related value names receive when using
 # full-text search.

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -11,7 +11,7 @@ from elasticsearch.exceptions import NotFoundError, RequestError
 from elasticsearch.helpers import bulk
 
 from . import ES_CLIENT
-from .defaults import ES_CHUNK_SIZE
+from .defaults import ES_CHUNK_SIZE, ES_INDICES_PREFIX
 from .indexers import ES_INDICES
 from .text_indexing import ANALYSIS_SETTINGS
 
@@ -107,11 +107,13 @@ def regenerate_indices(logger):
         for index, alias in indices_to_unalias
     ]
 
-    # Identify orphaned indices
+    # Identify orphaned indices that belong to our own app.
     # NB: we *must* do this before the update_aliases call so we don't immediately prune
     # version n-1 of all our indices
     useless_indices = [
-        index for index, details in existing_indices.items() if not details["aliases"]
+        index
+        for index, details in existing_indices.items()
+        if index.startswith(str(ES_INDICES_PREFIX)) and not details["aliases"]
     ]
 
     # Replace the old indices with the new ones in 1 atomic operation to avoid outage

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -13,6 +13,7 @@ from richie.plugins.simple_picture.helpers import get_picture_info
 from richie.plugins.simple_text_ckeditor.models import SimpleText
 
 from ...courses.models import Category
+from ..defaults import ES_INDICES_PREFIX
 from ..forms import ItemSearchForm
 from ..text_indexing import MULTILINGUAL_TEXT
 from ..utils.i18n import get_best_field_language
@@ -26,7 +27,7 @@ class CategoriesIndexer:
     """
 
     document_type = "category"
-    index_name = "richie_categories"
+    index_name = f"{ES_INDICES_PREFIX}_categories"
     form = ItemSearchForm
     mapping = {
         "dynamic_templates": MULTILINGUAL_TEXT,

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -16,6 +16,7 @@ from richie.plugins.simple_picture.helpers import get_picture_info
 from richie.plugins.simple_text_ckeditor.models import SimpleText
 
 from ...courses.models import MAX_DATE, CategoryPluginModel, Course, CourseState
+from ..defaults import ES_INDICES_PREFIX
 from ..forms import CourseSearchForm
 from ..text_indexing import MULTILINGUAL_TEXT
 from ..utils.i18n import get_best_field_language
@@ -30,7 +31,7 @@ class CoursesIndexer:
     """
 
     document_type = "course"
-    index_name = "richie_courses"
+    index_name = f"{ES_INDICES_PREFIX}_courses"
     mapping = {
         "dynamic_templates": MULTILINGUAL_TEXT,
         "properties": {

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -13,6 +13,7 @@ from richie.plugins.simple_picture.helpers import get_picture_info
 from richie.plugins.simple_text_ckeditor.models import SimpleText
 
 from ...courses.models import Organization
+from ..defaults import ES_INDICES_PREFIX
 from ..forms import ItemSearchForm
 from ..text_indexing import MULTILINGUAL_TEXT
 from ..utils.i18n import get_best_field_language
@@ -26,7 +27,7 @@ class OrganizationsIndexer:
     """
 
     document_type = "organization"
-    index_name = "richie_organizations"
+    index_name = f"{ES_INDICES_PREFIX}_organizations"
     form = ItemSearchForm
     mapping = {
         "dynamic_templates": MULTILINGUAL_TEXT,

--- a/src/richie/apps/search/indexers/persons.py
+++ b/src/richie/apps/search/indexers/persons.py
@@ -13,6 +13,7 @@ from richie.plugins.simple_picture.helpers import get_picture_info
 from richie.plugins.simple_text_ckeditor.models import SimpleText
 
 from ...courses.models import Person
+from ..defaults import ES_INDICES_PREFIX
 from ..forms import ItemSearchForm
 from ..text_indexing import MULTILINGUAL_TEXT
 from ..utils.i18n import get_best_field_language
@@ -26,7 +27,7 @@ class PersonsIndexer:
     """
 
     document_type = "person"
-    index_name = "richie_persons"
+    index_name = f"{ES_INDICES_PREFIX}_persons"
     form = ItemSearchForm
     mapping = {
         "dynamic_templates": MULTILINGUAL_TEXT,

--- a/tests/apps/search/test_viewsets_categories.py
+++ b/tests/apps/search/test_viewsets_categories.py
@@ -4,6 +4,7 @@ Tests for the category viewset
 from unittest import mock
 
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from elasticsearch.exceptions import NotFoundError
 
@@ -63,6 +64,7 @@ class CategoriesViewsetsTestCase(TestCase):
         # The client received a standard NotFound response
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(RICHIE_ES_INDICES_PREFIX="richie")
     @mock.patch.object(ES_CLIENT, "search")
     def test_viewsets_categories_search(self, mock_search):
         """

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -3,6 +3,7 @@ Tests for the course viewset
 """
 from unittest import mock
 
+from django.test.utils import override_settings
 from django.utils import timezone
 
 import pytz
@@ -56,6 +57,7 @@ class CoursesViewsetsTestCase(CMSTestCase):
         # The client received a standard NotFound response
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(RICHIE_ES_INDICES_PREFIX="richie")
     @mock.patch(
         "richie.apps.search.forms.CourseSearchForm.build_es_query",
         lambda *args: (2, 77, {"some": "query"}, {"some": "aggs"}),

--- a/tests/apps/search/test_viewsets_organizations.py
+++ b/tests/apps/search/test_viewsets_organizations.py
@@ -4,6 +4,7 @@ Tests for the organization viewset
 from unittest import mock
 
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from elasticsearch.exceptions import NotFoundError
 
@@ -51,6 +52,7 @@ class OrganizationsViewsetsTestCase(TestCase):
         # The client received a standard NotFound response
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(RICHIE_ES_INDICES_PREFIX="richie")
     @mock.patch(
         "richie.apps.search.forms.ItemSearchForm.build_es_query",
         lambda x: (2, 0, {"query": "something"}),

--- a/tests/apps/search/test_viewsets_persons.py
+++ b/tests/apps/search/test_viewsets_persons.py
@@ -4,6 +4,7 @@ Tests for the person viewset
 from unittest import mock
 
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from elasticsearch.exceptions import NotFoundError
 
@@ -51,6 +52,7 @@ class PersonsViewSetTestCase(TestCase):
         # The client received a standard NotFound response
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(RICHIE_ES_INDICES_PREFIX="richie")
     @mock.patch(
         "richie.apps.search.forms.ItemSearchForm.build_es_query",
         lambda x: (2, 0, {"query": "something"}),


### PR DESCRIPTION
## Purpose

ElasticSearch index names are hardcoded in their respective indexers.

There is a `richie_` prefix that should prevent conflicts with other applications running on the same ElasticSearch instance, but that still prevents more than one instance of Richie to run on the same ElasticSearch, as indices would share names.

## Proposal

We can make this changeable through the settings and an environment variable, using `richie_`as a default so it's not a breaking change for existing users.

Closes #940.

Note: rebased on #941 to avoid pointless conflicts as it affects the same files.