### PR TITLE
🐛 Fix invalid alias name bug during `regenerate_indexes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Report frontend errors through Sentry when a sentry DSN is available in
   Django settings.
 
+### Fixed
+
+- Fix an issue that crashed `regenerate_indexes` (and therefore
+  `bootstrap_elasticsearch`) from a broken state in ES.
+
 ### Changed
 
 - Improve ElasticSearch `regenerate_indexes` tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Report frontend errors through Sentry when a sentry DSN is available in
   Django settings.
 
+### Changed
+
+- Improve ElasticSearch `regenerate_indexes` tests.
+
 ## [1.16.2] - 2019-12-18
 
 ### Fixed

--- a/src/richie/apps/search/apps.py
+++ b/src/richie/apps/search/apps.py
@@ -1,4 +1,4 @@
-"""Signals to update the Elasticsearch indexes when page modifications are published."""
+"""Signals to update the Elasticsearch indices when page modifications are published."""
 from django.apps import AppConfig
 
 
@@ -10,7 +10,7 @@ class SearchConfig(AppConfig):
 
     # pylint: disable=import-outside-toplevel
     def ready(self):
-        """Register signals to update the Elasticsearch indexes."""
+        """Register signals to update the Elasticsearch indices."""
         from cms.signals import post_publish
         from .signals import on_page_publish
 

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -1,5 +1,5 @@
 """
-ElasticSearch indexes utilities.
+ElasticSearch indices utilities.
 """
 from functools import reduce
 
@@ -26,12 +26,12 @@ def richie_bulk(actions):
     )
 
 
-def get_indexes_by_alias(existing_indexes, alias):
+def get_indices_by_alias(existing_indices, alias):
     """
     Get existing index(es) for an alias. Support multiple existing aliases so the command
     always 'cleans up' the aliases even if they got messed up somehow.
     """
-    for index, details in existing_indexes.items():
+    for index, details in existing_indices.items():
         if alias in details.get("aliases", {}):
             yield index, alias
 
@@ -65,37 +65,37 @@ def perform_create_index(indexable, logger=None):
     return new_index
 
 
-def regenerate_indexes(logger):
+def regenerate_indices(logger):
     """
-    Create new indexes for our indexables and replace possible existing indexes with
+    Create new indices for our indexables and replace possible existing indices with
     a new one only once it has successfully built it.
     """
-    # Prepare the client we'll be using to handle indexes
+    # Prepare the client we'll be using to handle indices
     indices_client = IndicesClient(client=ES_CLIENT)
 
-    # Get all existing indexes once; we'll look up into this list many times
+    # Get all existing indices once; we'll look up into this list many times
     try:
-        existing_indexes = indices_client.get_alias("*")
+        existing_indices = indices_client.get_alias("*")
     except NotFoundError:
         # Provide a fallback empty list so we don't have to check for its existence later on
-        existing_indexes = []
+        existing_indices = []
 
     # Create a new index for each of those modules
     # NB: we're mapping perform_create_index which produces side-effects
-    indexes_to_create = zip(
+    indices_to_create = zip(
         list(map(lambda ix: perform_create_index(ix, logger), ES_INDICES)), ES_INDICES
     )
 
     # Prepare to alias them so they can be swapped-in for the previous versions
     actions_to_create_aliases = [
         {"add": {"index": index, "alias": ix.index_name}}
-        for index, ix in indexes_to_create
+        for index, ix in indices_to_create
     ]
 
-    # Get the previous indexes for every alias
-    indexes_to_unalias = reduce(
+    # Get the previous indices for every alias
+    indices_to_unalias = reduce(
         lambda acc, ix: acc
-        + list(get_indexes_by_alias(existing_indexes, ix.index_name)),
+        + list(get_indices_by_alias(existing_indices, ix.index_name)),
         ES_INDICES,
         [],
     )
@@ -104,17 +104,17 @@ def regenerate_indexes(logger):
     # NB: use chain to flatten the list of generators
     actions_to_delete_aliases = [
         {"remove": {"index": index, "alias": alias}}
-        for index, alias in indexes_to_unalias
+        for index, alias in indices_to_unalias
     ]
 
-    # Identify orphaned indexes
+    # Identify orphaned indices
     # NB: we *must* do this before the update_aliases call so we don't immediately prune
-    # version n-1 of all our indexes
-    useless_indexes = [
-        index for index, details in existing_indexes.items() if not details["aliases"]
+    # version n-1 of all our indices
+    useless_indices = [
+        index for index, details in existing_indices.items() if not details["aliases"]
     ]
 
-    # Replace the old indexes with the new ones in 1 atomic operation to avoid outage
+    # Replace the old indices with the new ones in 1 atomic operation to avoid outage
     def perform_aliases_update():
         try:
             indices_client.update_aliases(
@@ -139,7 +139,7 @@ def regenerate_indexes(logger):
 
     perform_aliases_update()
 
-    for useless_index in useless_indexes:
+    for useless_index in useless_indices:
         # Disable keyword arguments checking as elasticsearch-py uses a decorator to list
         # valid query parameters and inject them as kwargs. I won't say a word about this
         # anti-pattern.

--- a/src/richie/apps/search/index_manager.py
+++ b/src/richie/apps/search/index_manager.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from elasticsearch.client import IndicesClient
-from elasticsearch.exceptions import NotFoundError
+from elasticsearch.exceptions import NotFoundError, RequestError
 from elasticsearch.helpers import bulk
 
 from . import ES_CLIENT
@@ -115,9 +115,29 @@ def regenerate_indexes(logger):
     ]
 
     # Replace the old indexes with the new ones in 1 atomic operation to avoid outage
-    indices_client.update_aliases(
-        dict(actions=actions_to_create_aliases + actions_to_delete_aliases)
-    )
+    def perform_aliases_update():
+        try:
+            indices_client.update_aliases(
+                dict(actions=actions_to_create_aliases + actions_to_delete_aliases)
+            )
+        except RequestError as exception:
+            # This operation can fail if an index exists with the same name as an alias we're
+            # attempting to create. In Richie, this is not supposed to happen and is usually the
+            # result of a broken ES state.
+            if exception.error == "invalid_alias_name_exception":
+                # Identify the broken index
+                broken_index = exception.info["error"]["index"]
+                # Delete it (it was unusable and we can recreate its data at-will)
+                indices_client.delete(index=broken_index)
+                # Attempt to perform the operation again
+                # We're doing this recursively in case more than one such broken indices existed
+                # (eg. "richie_courses" and "richie_organizations")
+                perform_aliases_update()
+            # Let other kinds of errors be raised
+            else:
+                raise exception
+
+    perform_aliases_update()
 
     for useless_index in useless_indexes:
         # Disable keyword arguments checking as elasticsearch-py uses a decorator to list

--- a/src/richie/apps/search/management/commands/bootstrap_elasticsearch.py
+++ b/src/richie/apps/search/management/commands/bootstrap_elasticsearch.py
@@ -5,7 +5,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from ...index_manager import regenerate_indexes, store_es_scripts
+from ...index_manager import regenerate_indices, store_es_scripts
 
 logger = logging.getLogger("richie.search.bootstrap_elasticsearch")
 
@@ -26,7 +26,7 @@ class Command(BaseCommand):
 
         # Creates new indices each time, populates them, and atomically replaces
         # the old indices once the new ones are ready.
-        regenerate_indexes(logger)
+        regenerate_indices(logger)
 
         # Confirm operation success through a console log
         logger.info("ES indices regenerated.")

--- a/src/richie/apps/search/models.py
+++ b/src/richie/apps/search/models.py
@@ -9,5 +9,5 @@ class SearchAccess(models.Model):
 
         managed = False
         permissions = (
-            ("can_manage_elasticsearch", "Allow managing Elasticsearch indexes"),
+            ("can_manage_elasticsearch", "Allow managing Elasticsearch indices"),
         )

--- a/src/richie/apps/search/signals.py
+++ b/src/richie/apps/search/signals.py
@@ -1,4 +1,4 @@
-"""Update Elasticsearch indexes each time a page is modified."""
+"""Update Elasticsearch indices each time a page is modified."""
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
@@ -10,7 +10,7 @@ from richie.apps.search.indexers import ES_INDICES
 
 def update_course(instance, _language):
     """
-    Update Elasticsearch indexes when a course was modified and published:
+    Update Elasticsearch indices when a course was modified and published:
     - update the course document in the Elasticsearch courses index.
 
     Returns None if the page was related to a course and the Elasticsearch update is done.
@@ -22,7 +22,7 @@ def update_course(instance, _language):
 
 def update_course_run(instance, _language):
     """
-    Update Elasticsearch indexes when a course run was modified and published:
+    Update Elasticsearch indices when a course run was modified and published:
     - update the course document in the Elasticsearch courses index for the parent course
       of this course run.
 
@@ -35,7 +35,7 @@ def update_course_run(instance, _language):
 
 def update_organization(instance, language):
     """
-    Update Elasticsearch indexes when an organization was modified and published:
+    Update Elasticsearch indices when an organization was modified and published:
     - update the organization document in the Elasticsearch organizations index for the
       organization and its direct parent (because the parent ID may change from Parent to Leaf),
     - update the course documents in the Elasticsearch courses index for all courses linked to
@@ -68,7 +68,7 @@ def update_organization(instance, language):
 
 def update_category(instance, language):
     """
-    Update Elasticsearch indexes when a category was modified and published:
+    Update Elasticsearch indices when a category was modified and published:
     - update the category document in the Elasticsearch categories index for the category
       and its direct parent (because the parent ID may change from Parent to Leaf),
     - update the course documents in the Elasticsearch courses index for all courses linked to

--- a/tests/apps/search/test_autocomplete_categories.py
+++ b/tests/apps/search/test_autocomplete_categories.py
@@ -86,7 +86,7 @@ class AutocompleteCategoriesTestCase(TestCase):
         ]
 
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index=CATEGORIES_INDEX)

--- a/tests/apps/search/test_autocomplete_courses.py
+++ b/tests/apps/search/test_autocomplete_courses.py
@@ -87,7 +87,7 @@ class AutocompleteCoursesTestCase(TestCase):
         ]
 
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index=COURSES_INDEX)

--- a/tests/apps/search/test_autocomplete_organizations.py
+++ b/tests/apps/search/test_autocomplete_organizations.py
@@ -71,7 +71,7 @@ class AutocompleteOrganizationsTestCase(TestCase):
         ]
 
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index=ORGANIZATIONS_INDEX)

--- a/tests/apps/search/test_autocomplete_persons.py
+++ b/tests/apps/search/test_autocomplete_persons.py
@@ -55,7 +55,7 @@ class AutocompletePersonsTestCase(TestCase):
         ]
 
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index=PERSONS_INDEX)

--- a/tests/apps/search/test_commands_bootstrap_elasticsearch.py
+++ b/tests/apps/search/test_commands_bootstrap_elasticsearch.py
@@ -14,10 +14,10 @@ logger = logging.getLogger("richie.search.bootstrap_elasticsearch")
 
 class BootstrapElasticsearchCommandsTestCase(TestCase):
     """
-    Test the command that regenerates the Elasticsearch indexes.
+    Test the command that regenerates the Elasticsearch indices.
     """
 
-    @mock.patch.object(index_manager, "regenerate_indexes")
+    @mock.patch.object(index_manager, "regenerate_indices")
     @mock.patch.object(index_manager, "store_es_scripts")
     @mock.patch.object(logger, "info")
     def test_commands_bootstrap_elasticsearch(

--- a/tests/apps/search/test_partial_mappings.py
+++ b/tests/apps/search/test_partial_mappings.py
@@ -16,7 +16,7 @@ class PartialMappingsTestCase(TestCase):
 
     def setUp(self):
         """
-        Instantiate our ES client and make sure all indexes are deleted before each test
+        Instantiate our ES client and make sure all indices are deleted before each test
         """
         super().setUp()
         self.indices_client = IndicesClient(client=ES_CLIENT)

--- a/tests/apps/search/test_query_categories.py
+++ b/tests/apps/search/test_query_categories.py
@@ -39,7 +39,7 @@ class CategoriesQueryTestCase(TestCase):
         """
         # Index these categories in Elasticsearch
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index="test_categories")

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -263,7 +263,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
 
         # Index these 4 courses in Elasticsearch
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index="test_courses")

--- a/tests/apps/search/test_query_courses_edge_cases.py
+++ b/tests/apps/search/test_query_courses_edge_cases.py
@@ -72,7 +72,7 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
         self.create_filter_pages()
         # Index these 4 courses in Elasticsearch
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index="test_courses")

--- a/tests/apps/search/test_query_courses_facets.py
+++ b/tests/apps/search/test_query_courses_facets.py
@@ -153,7 +153,7 @@ class FacetsCoursesQueryTestCase(TestCase):
 
         # Index these 4 courses in Elasticsearch
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index="test_courses")

--- a/tests/apps/search/test_query_organizations.py
+++ b/tests/apps/search/test_query_organizations.py
@@ -38,7 +38,7 @@ class OrganizationsQueryTestCase(TestCase):
         """
         # Index these organizations in Elasticsearch
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index="test_organizations")

--- a/tests/apps/search/test_query_persons.py
+++ b/tests/apps/search/test_query_persons.py
@@ -38,7 +38,7 @@ class PersonsQueryTestCase(TestCase):
         """
         # Index these persons in Elasticsearch
         indices_client = IndicesClient(client=ES_CLIENT)
-        # Delete any existing indexes so we get a clean slate
+        # Delete any existing indices so we get a clean slate
         indices_client.delete(index="_all")
         # Create an index we'll use to test the ES features
         indices_client.create(index="test_persons")

--- a/tests/apps/search/test_signals.py
+++ b/tests/apps/search/test_signals.py
@@ -24,7 +24,7 @@ from richie.apps.search.indexers.courses import CoursesIndexer
 @mock.patch("richie.apps.search.index_manager.bulk")  # Mock call to Elasticsearch
 class CoursesSignalsTestCase(TestCase):
     """
-    Test signals to keep the Elasticsearch indexes up-to-date.
+    Test signals to keep the Elasticsearch indices up-to-date.
     """
 
     @staticmethod


### PR DESCRIPTION
## Purpose

Fixes #939.

In some instances, Richie can end up with an ElasticSearch that contains broken indices, with each index's expected alias as an index name. This can happen for example if the signals that are tasked with updating courses, organizations, etc. are happening in a state where the `bootstrap_elasticsearch` command was not run.

ES then implicitly creates the index for the object we're trying to update.

This caused `bootstrap_elasticsearch` to fail when attempting to create an alias with the same name as an existing index.

## Proposal

We replaced two heavily mocked tests with an entirely non-mocked one that should cover the same code surface with more confidence.

We also touched up on the code in the index_manager module, eg. fixing a small bug we encountered and replacing format calls with f strings.

We then created a test that reproduces the bug in #939. Since the existing index with a problematic name, is broken by nature (it was created with no content, no mappings, no scripts etc.) and a general indices regeneration was triggered, we decided to just delete the broken index and move on with the operation in this case.