### PR TITLE
⚡️ Limit related courses on other pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Improve ElasticSearch `regenerate_indexes` tests.
-- Limit the number of related courses appearing on the category detail page.
+- Limit the number of related courses appearing on the category and
+  organization detail pages.
 
 ## [1.16.2] - 2019-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Improve ElasticSearch `regenerate_indexes` tests.
+- Limit the number of related courses appearing on the category detail page.
 
 ## [1.16.2] - 2019-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Improve ElasticSearch `regenerate_indexes` tests.
-- Limit the number of related courses appearing on the category and
+- Limit the number of related courses appearing on the category, person and
   organization detail pages.
 
 ## [1.16.2] - 2019-12-18

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -142,6 +142,7 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
                     "cms.context_processors.cms_settings",
                     "richie.apps.core.context_processors.site_metas",
                     "richie.apps.core.context_processors.frontend_context",
+                    "richie.apps.courses.context_processors.page_settings",
                 ],
                 "loaders": [
                     "django.template.loaders.filesystem.Loader",

--- a/src/frontend/scss/templates/courses/cms/_category_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_category_detail.scss
@@ -128,4 +128,10 @@ $richie-category-detail-banner-logo-sizing-xl: 25rem !default;
       @include make-col(12);
     }
   }
+
+  &__see-more {
+    width: 100%;
+    margin: 1rem;
+    text-align: center;
+  }
 }

--- a/src/frontend/scss/templates/courses/cms/_organization_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_organization_detail.scss
@@ -118,4 +118,10 @@ $richie-org-detail-logo-width: 12rem !default;
       @include make-col(12);
     }
   }
+
+  &__see-more {
+    width: 100%;
+    margin: 1rem;
+    text-align: center;
+  }
 }

--- a/src/frontend/scss/templates/courses/cms/_person_detail.scss
+++ b/src/frontend/scss/templates/courses/cms/_person_detail.scss
@@ -69,4 +69,10 @@ $richie-person-detail-media-size: 10rem;
       }
     }
   }
+
+  &__see-more {
+    width: 100%;
+    margin: 1rem;
+    text-align: center;
+  }
 }

--- a/src/richie/apps/courses/context_processors.py
+++ b/src/richie/apps/courses/context_processors.py
@@ -1,0 +1,11 @@
+"""
+Template context processors for the courses app.
+"""
+from .defaults import PAGES_SETTINGS
+
+
+def page_settings(request):
+    """
+    Context processor that makes available general page related settings in templates.
+    """
+    return {"PAGES_SETTINGS": PAGES_SETTINGS}

--- a/src/richie/apps/courses/defaults.py
+++ b/src/richie/apps/courses/defaults.py
@@ -294,6 +294,15 @@ PAGES_INFO.update(getattr(settings, "PAGES_INFO", {}))
 
 ROOT_REVERSE_IDS = PAGES_INFO.keys()
 
+# Common settings for automatically generated pages for Richie
+# objects (eg. category page, courses pages, etc.)
+PAGES_SETTINGS = {
+    # Allow users to limit the number of related objects automatically displayed on details pages
+    "MAX_RELATED_COURSES_ON_DETAILS_PAGES": getattr(
+        settings, "RICHIE_MAX_RELATED_COURSES_ON_DETAILS_PAGES", 20
+    )
+}
+
 # Fields effort and duration
 MINUTE, HOUR, DAY, WEEK, MONTH = "minute", "hour", "day", "week", "month"
 DEFAULT_TIME_UNIT = HOUR

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -47,6 +47,17 @@ class Category(BasePageExtension):
             title=self.extended_object.get_title(),
         )
 
+    def get_es_id(self):
+        """
+        An ID built with the node path and the position of this category in the taxonomy:
+            - P: parent, the category has children
+            - L: leaf, the category has no children
+
+        For example: a parent category `P_00010002` and its child `L_000100020001`.
+        """
+        page = self.extended_object
+        return f"{'L' if page.node.is_leaf() else 'P':s}-{page.node.path:s}"
+
     def get_meta_category(self):
         """
         Get the meta category the current category falls under. Meta-categories are a special kind

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -50,6 +50,17 @@ class Organization(BasePageExtension):
             model=self._meta.verbose_name.title(),
         )
 
+    def get_es_id(self):
+        """
+        An ID built with the node path and the position of this organization in the taxonomy:
+            - P: parent, the organization has children
+            - L: leaf, the organization has no children
+
+        For example: a parent organization `P_00010002` and its child `L_000100020001`.
+        """
+        page = self.extended_object
+        return f"{'L' if page.node.is_leaf() else 'P':s}-{page.node.path:s}"
+
     def clean(self):
         """
         We normalize the code with slugify for better uniqueness

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -1,5 +1,5 @@
 {% extends "richie/fullwidth.html" %}
-{% load cms_tags extra_tags i18n thumbnail %}
+{% load cms_tags extra_tags first_n i18n thumbnail %}
 
 {% block meta_opengraph_contextuals %}
     <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
@@ -83,7 +83,7 @@
   {% endif %}
 {% endwith %}
 
-{% with courses=category.get_courses %}
+{% with courses=category.get_courses|first_n:PAGES_SETTINGS.MAX_RELATED_COURSES_ON_DETAILS_PAGES %}
   {% if courses %}
     <section class="course-glimpse-list">
       <h2 class="course-glimpse-list__title">{% trans "Related courses" %}</h2>
@@ -92,6 +92,17 @@
           {% include "courses/cms/fragment_course_glimpse.html" %}
         {% endif %}
       {% endfor %}
+      {% if courses.count == PAGES_SETTINGS.MAX_RELATED_COURSES_ON_DETAILS_PAGES %}
+        {% if category.get_meta_category %}
+          <a href="{% page_url 'courses' %}?{{ category.get_meta_category.extended_object.reverse_id }}={{ category.get_es_id }}" class="category-detail__see-more">
+            {% blocktrans with category_title=category.extended_object.get_title %}See all courses related to {{ category_title }}{% endblocktrans %}
+          </a>
+        {% else %}
+          <a href="{% page_url 'courses' %}" class="category-detail__see-more">
+            {% trans "See all courses" %}
+          </a>
+        {% endif %}
+      {% endif %}
     </section>
   {% endif %}
 {% endwith %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -1,5 +1,5 @@
 {% extends "richie/fullwidth.html" %}
-{% load cms_tags extra_tags i18n static thumbnail %}
+{% load cms_tags extra_tags first_n i18n static thumbnail %}
 
 {% block meta_opengraph_contextuals %}
     <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
@@ -69,7 +69,7 @@
   </div>
 </div>
 
-{% with courses=organization.get_courses %}
+{% with courses=organization.get_courses|first_n:PAGES_SETTINGS.MAX_RELATED_COURSES_ON_DETAILS_PAGES %}
   {% if courses %}
     <section class="course-glimpse-list">
       <h2 class="course-glimpse-list__title">{% trans "Related courses" %}</h2>
@@ -78,6 +78,11 @@
           {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
         {% endif %}
       {% endfor %}
+      {% if courses.count == PAGES_SETTINGS.MAX_RELATED_COURSES_ON_DETAILS_PAGES %}
+        <a href="{% page_url 'courses' %}?organizations={{ organization.get_es_id }}" class="organization-detail__see-more">
+          {% blocktrans with organization_title=organization.extended_object.get_title %}See all courses related to {{ organization_title }}{% endblocktrans %}
+        </a>
+      {% endif %}
     </section>
   {% endif %}
 {% endwith %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -1,5 +1,5 @@
 {% extends "richie/fullwidth.html" %}
-{% load cms_tags extra_tags i18n thumbnail %}
+{% load cms_tags extra_tags first_n i18n thumbnail %}
 
 {% block meta_opengraph_contextuals %}
     <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
@@ -61,7 +61,7 @@
     </section>
   {% endif %}
 
-  {% with courses=person.get_courses %}
+  {% with courses=person.get_courses|first_n:PAGES_SETTINGS.MAX_RELATED_COURSES_ON_DETAILS_PAGES %}
     {% if courses %}
       <section class="course-glimpse-list">
         <h2 class="course-glimpse-list__title">{% trans "Courses" %}</h2>
@@ -70,6 +70,11 @@
               {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
           {% endif %}
         {% endfor %}
+        {% if courses.count == PAGES_SETTINGS.MAX_RELATED_COURSES_ON_DETAILS_PAGES %}
+          <a href="{% page_url 'courses' %}?persons={{ person.extended_object_id }}" class="person-detail__see-more">
+            {% blocktrans with person_title=person.extended_object.get_title %}See all courses related to {{ person_title }}{% endblocktrans %}
+          </a>
+        {% endif %}
       </section>
     {% endif %}
   {% endwith %}

--- a/src/richie/apps/courses/templatetags/first_n.py
+++ b/src/richie/apps/courses/templatetags/first_n.py
@@ -1,0 +1,15 @@
+"""Templatetags module for the first_n filter."""
+from django import template
+
+# pylint: disable=invalid-name
+register = template.Library()
+
+
+@register.filter("first_n")
+def first_n_filter(value, arg):
+    """
+    Picks the first N items in a list.
+    The reason this exists over stock "slice" is to allow using a variable to define
+    the number of items to pick.
+    """
+    return value[slice(0, arg)]

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -65,20 +65,6 @@ class CategoriesIndexer:
         "title.*",
     ]
 
-    @staticmethod
-    def get_es_id(page):
-        """
-        An ID built with the node path and the position of this category in the taxonomy:
-            - P: parent, the category has children
-            - L: leaf, the category has no children
-
-        For example: a parent category `P_00010002` and its child `L_000100020001`.
-        """
-        return "{type:s}-{path:s}".format(
-            type="L" if page.node.is_leaf() else "P",  # Leaf or Parent?
-            path=page.node.path,
-        )
-
     @classmethod
     def get_es_document_for_category(cls, category, index=None, action="index"):
         """Build an Elasticsearch document from the category instance."""
@@ -129,7 +115,7 @@ class CategoriesIndexer:
             kind = None
 
         return {
-            "_id": cls.get_es_id(category.extended_object),
+            "_id": category.get_es_id(),
             "_index": index,
             "_op_type": action,
             "_type": cls.document_type,

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -21,7 +21,6 @@ from ..forms import CourseSearchForm
 from ..text_indexing import MULTILINGUAL_TEXT
 from ..utils.i18n import get_best_field_language
 from ..utils.indexers import slice_string_for_completion
-from . import ES_INDICES
 
 
 class CoursesIndexer:
@@ -518,8 +517,7 @@ class CoursesIndexer:
             if organization_highlighted
             else None,
             "organizations": [
-                ES_INDICES.organizations.get_es_id(o.extended_object)
-                for o in organizations
+                organization.get_es_id() for organization in organizations
             ],
             # Index the names of organizations to surface them in full text searches
             "organizations_names": reduce(

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -488,9 +488,7 @@ class CoursesIndexer:
                 language: course.extended_object.get_absolute_url(language)
                 for language in titles.keys()
             },
-            "categories": [
-                ES_INDICES.categories.get_es_id(page) for page in category_pages
-            ],
+            "categories": [page.category.get_es_id() for page in category_pages],
             # Index the names of categories to surface them in full text searches
             "categories_names": reduce(
                 lambda acc, title: {

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -49,20 +49,6 @@ class OrganizationsIndexer:
     scripts = {}
     display_fields = ["absolute_url", "logo", "title.*"]
 
-    @staticmethod
-    def get_es_id(page):
-        """
-        An ID built with the node path and the position of this organization in the taxonomy:
-            - P: parent, the organization has children
-            - L: leaf, the organization has no children
-
-        For example: a parent organization `P_00010002` and its child `L_000100020001`.
-        """
-        return "{type:s}-{path:s}".format(
-            type="L" if page.node.is_leaf() else "P",  # Leaf or Parent?
-            path=page.node.path,
-        )
-
     @classmethod
     def get_es_document_for_organization(cls, organization, index=None, action="index"):
         """Build an Elasticsearch document from the category instance."""
@@ -95,7 +81,7 @@ class OrganizationsIndexer:
             description[simple_text.cmsplugin_ptr.language].append(simple_text.body)
 
         return {
-            "_id": cls.get_es_id(organization.extended_object),
+            "_id": organization.get_es_id(),
             "_index": index,
             "_op_type": action,
             "_type": cls.document_type,

--- a/tests/apps/courses/test_templates_category_detail.py
+++ b/tests/apps/courses/test_templates_category_detail.py
@@ -1,11 +1,15 @@
 """
 End-to-end tests for the category detail view
 """
+from unittest import mock
+
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
+from richie.apps.core.helpers import create_i18n_page
 from richie.apps.courses.cms_plugins import CategoryPlugin
+from richie.apps.courses.context_processors import PAGES_SETTINGS
 from richie.apps.courses.factories import (
     BlogPostFactory,
     CategoryFactory,
@@ -120,6 +124,110 @@ class CategoryCMSTestCase(CMSTestCase):
             "course_categories",
             '<p class="course-glimpse__content__title">{:s}</p>',
         )
+
+    @mock.patch(
+        "cms.templatetags.cms_tags.PageUrl.get_value", return_value="/the/courses/"
+    )
+    @mock.patch.dict(PAGES_SETTINGS, {"MAX_RELATED_COURSES_ON_DETAILS_PAGES": 2})
+    def test_templates_category_detail_cms_published_content_max_courses(
+        self, _mock_page_url
+    ):
+        """
+        Make sure the category detail page does not display too many courses, even when a large
+        number are related to the current category, as this can cause the page to load very slowly
+        and is not a great experience for the user anyway.
+        """
+        # Create our dummy category and the 3 courses we'll attach to it
+        meta = CategoryFactory(
+            page_parent=create_i18n_page(
+                {"en": "Categories", "fr": "Catégories"}, published=True
+            ),
+            page_reverse_id="subjects",
+            page_title={"en": "Subjects", "fr": "Sujets"},
+            should_publish=True,
+        )
+        category = CategoryFactory(
+            page_parent=meta.extended_object, should_publish=True
+        )
+        courses = CourseFactory.create_batch(
+            3, fill_categories=[category], should_publish=True
+        )
+        # Link the 3 courses with our category through the relevant placeholder
+        for course in courses:
+            add_plugin(
+                course.extended_object.placeholders.get(slot="course_categories"),
+                CategoryPlugin,
+                "en",
+                page=category.extended_object,
+            )
+        # Make sure we do have 3 courses on the category
+        self.assertEqual(category.get_courses().count(), 3)
+
+        # Only the first two are rendered in the template
+        response = self.client.get(category.extended_object.get_absolute_url())
+        self.assertContains(response, courses[0].extended_object.get_title())
+        self.assertContains(response, courses[1].extended_object.get_title())
+        self.assertNotContains(response, courses[2].extended_object.get_title())
+
+        # There is a link to view more related courses directly in the Search view
+        self.assertContains(
+            response, f'href="/the/courses/?subjects={category.get_es_id():s}"'
+        )
+        self.assertContains(
+            response,
+            f"See all courses related to {category.extended_object.get_title():s}",
+        )
+
+    @mock.patch(
+        "cms.templatetags.cms_tags.PageUrl.get_value", return_value="/the/courses/"
+    )
+    @mock.patch.dict(PAGES_SETTINGS, {"MAX_RELATED_COURSES_ON_DETAILS_PAGES": 2})
+    def test_templates_category_detail_cms_published_content_max_courses_on_meta(
+        self, _mock_page_url
+    ):
+        """
+        Meta categories are a special case: technically, any page linked to one of their children
+        is linked to the meta-category too. This means in a lot of cases we just want a link to
+        *all* courses not just their related courses.
+        The Search view is also not equipped to filter on a meta-category. In this case, we just
+        link to it with a different link text.
+        """
+        # Create our dummy category and the 3 courses we'll attach to it
+        meta = CategoryFactory(
+            page_parent=create_i18n_page(
+                {"en": "Categories", "fr": "Catégories"}, published=True
+            ),
+            page_reverse_id="subjects",
+            page_title={"en": "Subjects", "fr": "Sujets"},
+            should_publish=True,
+        )
+        category = CategoryFactory(
+            page_parent=meta.extended_object, should_publish=True
+        )
+        courses = CourseFactory.create_batch(
+            3, fill_categories=[category], should_publish=True
+        )
+        # Link the 3 courses with our category through the relevant placeholder
+        for course in courses:
+            add_plugin(
+                course.extended_object.placeholders.get(slot="course_categories"),
+                CategoryPlugin,
+                "en",
+                page=category.extended_object,
+            )
+        # Make sure we do have 3 courses on the category
+        self.assertEqual(category.get_courses().count(), 3)
+
+        # NB: here we are requesting the meta category's page, not the child category
+        # Only the first two are rendered in the template
+        response = self.client.get(meta.extended_object.get_absolute_url())
+        self.assertContains(response, courses[0].extended_object.get_title())
+        self.assertContains(response, courses[1].extended_object.get_title())
+        self.assertNotContains(response, courses[2].extended_object.get_title())
+
+        # There is a link to view all courses
+        self.assertContains(response, 'href="/the/courses/')
+        self.assertContains(response, "See all courses")
 
     def test_templates_category_detail_cms_published_content_blogposts(self):
         """

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -2,12 +2,14 @@
 End-to-end tests for the organization detail view
 """
 import re
+from unittest import mock
 
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.cms_plugins import CategoryPlugin, OrganizationPlugin
+from richie.apps.courses.context_processors import PAGES_SETTINGS
 from richie.apps.courses.factories import (
     CategoryFactory,
     CourseFactory,
@@ -152,6 +154,49 @@ class OrganizationCMSTestCase(CMSTestCase):
 
         # Modified draft category and course should not be leaked
         self.assertNotContains(response, "modified")
+
+    @mock.patch(
+        "cms.templatetags.cms_tags.PageUrl.get_value", return_value="/the/courses/"
+    )
+    @mock.patch.dict(PAGES_SETTINGS, {"MAX_RELATED_COURSES_ON_DETAILS_PAGES": 2})
+    def test_templates_organization_detail_cms_published_content_max_courses(
+        self, _mock_page_url
+    ):
+        """
+        Make sure the organization detail page does not display too many courses, even when a large
+        number are related to the current organization, as this can cause the page to load very
+        slowly and is not a great experience for the user anyway.
+        """
+        # Create our dummy organization and the 3 courses we'll attach to it
+        organization = OrganizationFactory(should_publish=True)
+        courses = CourseFactory.create_batch(
+            3, fill_organizations=[organization], should_publish=True
+        )
+        # Link the 3 courses with our organization through the relevant placeholder
+        for course in courses:
+            add_plugin(
+                course.extended_object.placeholders.get(slot="course_organizations"),
+                OrganizationPlugin,
+                "en",
+                page=organization.extended_object,
+            )
+        # Make sure we do have 3 courses on the organization
+        self.assertEqual(organization.get_courses().count(), 3)
+
+        # Only the first two are rendered in the template
+        response = self.client.get(organization.extended_object.get_absolute_url())
+        self.assertContains(response, courses[0].extended_object.get_title())
+        self.assertContains(response, courses[1].extended_object.get_title())
+        self.assertNotContains(response, courses[2].extended_object.get_title())
+
+        # There is a link to view more related courses directly in the Search view
+        self.assertContains(
+            response, f'href="/the/courses/?organizations={organization.get_es_id():s}"'
+        )
+        self.assertContains(
+            response,
+            f"See all courses related to {organization.extended_object.get_title():s}",
+        )
 
     def test_templates_organization_detail_cms_draft_content(self):
         """

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -2,12 +2,18 @@
 End-to-end tests for the person detail view
 """
 import re
+from unittest import mock
 
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
-from richie.apps.courses.cms_plugins import CategoryPlugin, OrganizationPlugin
+from richie.apps.courses.cms_plugins import (
+    CategoryPlugin,
+    OrganizationPlugin,
+    PersonPlugin,
+)
+from richie.apps.courses.context_processors import PAGES_SETTINGS
 from richie.apps.courses.factories import (
     BlogPostFactory,
     CategoryFactory,
@@ -296,6 +302,46 @@ class PersonCMSTestCase(CMSTestCase):
                 course.extended_object.get_title()
             ),
             html=True,
+        )
+
+    @mock.patch(
+        "cms.templatetags.cms_tags.PageUrl.get_value", return_value="/the/courses/"
+    )
+    @mock.patch.dict(PAGES_SETTINGS, {"MAX_RELATED_COURSES_ON_DETAILS_PAGES": 2})
+    def test_templates_person_detail_related_max_courses(self, _mock_page_url):
+        """
+        Make sure the person detail page does not display too many courses, even when a large
+        number are related to the current person, as this can cause the page to load very slowly
+        and is not a great experience for the user anyway.
+        """
+        # Create our dummy person and the 3 courses we'll attach to it
+        person = PersonFactory(should_publish=True)
+        courses = CourseFactory.create_batch(3, fill_team=[person], should_publish=True)
+        # Link the 3 courses with our person through the relevant placeholder
+        for course in courses:
+            add_plugin(
+                course.extended_object.placeholders.get(slot="course_team"),
+                PersonPlugin,
+                "en",
+                page=person.extended_object,
+            )
+        # Make sure we do have 3 courses on the person
+        self.assertEqual(person.get_courses().count(), 3)
+
+        # Only the first two are rendered in the template
+        response = self.client.get(person.extended_object.get_absolute_url())
+        self.assertContains(response, courses[0].extended_object.get_title())
+        self.assertContains(response, courses[1].extended_object.get_title())
+        self.assertNotContains(response, courses[2].extended_object.get_title())
+
+        # There is a link to view more related courses directly in the Search view
+        self.assertContains(
+            response,
+            f'href="/the/courses/?persons={person.public_extension.extended_object_id}"',
+        )
+        self.assertContains(
+            response,
+            f"See all courses related to {person.extended_object.get_title():s}",
         )
 
     def test_templates_person_detail_related_blog_posts(self):

--- a/tests/apps/courses/test_templatetags_first_n.py
+++ b/tests/apps/courses/test_templatetags_first_n.py
@@ -1,0 +1,19 @@
+"""
+Unit tests for templatetags in the courses app.
+"""
+from django.test import TestCase
+
+from richie.apps.courses.templatetags.first_n import first_n_filter
+
+
+class FirstNTemplateTagsTestCase(TestCase):
+    """
+    Unit test suite to validate the behavior of the `first_n` template filter.
+    """
+
+    def test_first_n(self):
+        """
+        Make sure the first_n filter picks the first N elements in a list or a string.
+        """
+        self.assertEqual(first_n_filter(["a", "b", "c"], 2), ["a", "b"])
+        self.assertEqual(first_n_filter("DEFG", 3), "DEF")


### PR DESCRIPTION
## Purpose

Per #946.

Richie currently has scaling problems where large numbers of related items automatically loaded on some pages can cause them to be very slow. Eg. a category page on a Richie instance with ~500 courses can take up to 30 seconds to load.

This is unacceptable. Users probably don't even want to see hundred-items-long lists of courses or other objects on a related page.

## Proposal

- [x] Add settings/defaults/a context manager to limit the lengths of automatic lists of related objects
- [x] Create a filter to slice queries for related items through this new setting+context manager
- [x] Move `get_es_id` from categories indexer to category model so we can more easily build search URLs that filter by category
- [x] Ditto for organizations `get_es_id`
- [x] Limit the number of related courses on category pages
- [x] ... on organization pages
- [x] ... on person pages
