### PR TITLE
🐛 Make sure the correct org is highlighted on courses in Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `bootstrap_elasticsearch`) from a broken state in ES.
 - `<Search />` component handles errors in course search requests, displaying
   an error message to end users.
+- Make sure the course search API shows the 1st related organization by
+  placeholder position as highlighted organization for a course instead of
+  the first organization by node path.
 
 ### Changed
 

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -242,6 +242,10 @@ class CoursesIndexersTestCase(TestCase):
                 },
             },
             "is_new": False,
+            "organization_highlighted": {
+                "en": "english main organization title",
+                "fr": "titre organisation principale français",
+            },
             "organizations": ["L-0004", "L-0006"],
             "organizations_names": {
                 "en": [
@@ -268,6 +272,49 @@ class CoursesIndexersTestCase(TestCase):
         )
         self.assertEqual(len(indexed_courses), 1)
         self.assertEqual(indexed_courses[0], expected_course)
+
+    def test_indexers_courses_get_es_document_no_organization(self):
+        """
+        Courses with no linked organizations should get indexed without raising exceptions.
+        """
+        course = CourseFactory(
+            page_title="Enhanced incremental circuit", should_publish=True
+        )
+        indexed_courses = list(
+            CoursesIndexer.get_es_documents(index="some_index", action="some_action")
+        )
+        self.assertEqual(
+            indexed_courses,
+            [
+                {
+                    "_id": str(course.extended_object.publisher_public_id),
+                    "_index": "some_index",
+                    "_op_type": "some_action",
+                    "_type": "course",
+                    "absolute_url": {"en": "/en/enhanced-incremental-circuit/"},
+                    "categories": [],
+                    "categories_names": {},
+                    "complete": {
+                        "en": [
+                            "Enhanced incremental circuit",
+                            "incremental circuit",
+                            "circuit",
+                        ]
+                    },
+                    "course_runs": [],
+                    "cover_image": {},
+                    "description": {},
+                    "icon": {},
+                    "is_new": False,
+                    "organization_highlighted": None,
+                    "organizations": [],
+                    "organizations_names": {},
+                    "persons": [],
+                    "persons_names": {},
+                    "title": {"en": "Enhanced incremental circuit"},
+                }
+            ],
+        )
 
     def test_indexers_courses_get_es_documents_no_start(self):
         """
@@ -438,6 +485,7 @@ class CoursesIndexersTestCase(TestCase):
                 "categories": [43, 86],
                 "cover_image": {"en": "cover_image.jpg"},
                 "icon": {"en": "icon.jpg"},
+                "organization_highlighted": {"en": "Org 84"},
                 "organizations": [42, 84],
                 "organizations_names": {"en": ["Org 42", "Org 84"]},
                 "title": {"en": "Duis eu arcu erat"},
@@ -456,7 +504,7 @@ class CoursesIndexersTestCase(TestCase):
                 "categories": [43, 86],
                 "cover_image": "cover_image.jpg",
                 "icon": "icon.jpg",
-                "organization_highlighted": "Org 42",
+                "organization_highlighted": "Org 84",
                 "organizations": [42, 84],
                 "title": "Duis eu arcu erat",
                 "state": CourseState(
@@ -477,6 +525,7 @@ class CoursesIndexersTestCase(TestCase):
                 "categories": [43, 86],
                 "cover_image": {"en": "cover_image.jpg"},
                 "icon": {"en": "icon.jpg"},
+                "organization_highlighted": None,
                 "organizations": [],
                 "organizations_names": {},
                 "title": {"en": "Duis eu arcu erat"},
@@ -515,6 +564,7 @@ class CoursesIndexersTestCase(TestCase):
                 "categories": [43, 86],
                 "cover_image": {"en": "cover_image.jpg"},
                 "icon": {},
+                "organization_highlighted": {"en": "Org 84"},
                 "organizations": [42, 84],
                 "organizations_names": {"en": ["Org 42", "Org 84"]},
                 "title": {"en": "Duis eu arcu erat"},
@@ -533,7 +583,7 @@ class CoursesIndexersTestCase(TestCase):
                 "categories": [43, 86],
                 "cover_image": "cover_image.jpg",
                 "icon": None,
-                "organization_highlighted": "Org 42",
+                "organization_highlighted": "Org 84",
                 "organizations": [42, 84],
                 "title": "Duis eu arcu erat",
                 "state": CourseState(
@@ -553,6 +603,7 @@ class CoursesIndexersTestCase(TestCase):
                 "categories": [43, 86],
                 "cover_image": {},
                 "icon": {"en": "icon.jpg"},
+                "organization_highlighted": {"en": "Org 42"},
                 "organizations": [42, 84],
                 "organizations_names": {"en": ["Org 42", "Org 84"]},
                 "title": {"en": "Duis eu arcu erat"},

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -30,6 +30,7 @@ COURSES = [
             )
         },
         "is_new": True,
+        "organization_highlighted": {"en": "Org 311"},
         "organizations": ["P-00030001", "P-00030004", "L-000300010001"],
         "organizations_names": {"en": ["Org 31", "Org 34", "Org 311"]},
         "persons": ["2"],
@@ -48,6 +49,7 @@ COURSES = [
             )
         },
         "is_new": True,
+        "organization_highlighted": {"en": "Org 33"},
         "organizations": ["P-00030001", "P-00030003", "L-000300010002"],
         "organizations_names": {"en": ["Org 31", "Org 33", "Org 312"]},
         "persons": [],
@@ -66,6 +68,7 @@ COURSES = [
             )
         },
         "is_new": False,
+        "organization_highlighted": {"en": "Org 321"},
         "organizations": ["P-00030002", "P-00030003", "L-000300020001"],
         "organizations_names": {"en": ["Org 32", "Org 33", "Org 321"]},
         "persons": [],
@@ -83,6 +86,7 @@ COURSES = [
             )
         },
         "is_new": False,
+        "organization_highlighted": {"en": "Org 34"},
         "organizations": ["P-00030002", "P-00030004", "L-000300020002"],
         "organizations_names": {"en": ["Org 32", "Org 34", "Org 322"]},
         "persons": ["2"],
@@ -337,7 +341,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         ],
                         "cover_image": "cover_image.jpg",
                         "icon": "icon.jpg",
-                        "organization_highlighted": "Org 31",
+                        "organization_highlighted": "Org 311",
                         "organizations": ["P-00030001", "P-00030004", "L-000300010001"],
                         "state": {
                             "priority": 0,
@@ -360,7 +364,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         ],
                         "cover_image": "cover_image.jpg",
                         "icon": "icon.jpg",
-                        "organization_highlighted": "Org 32",
+                        "organization_highlighted": "Org 321",
                         "organizations": ["P-00030002", "P-00030003", "L-000300020001"],
                         "state": {
                             "priority": 0,
@@ -383,7 +387,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         ],
                         "cover_image": "cover_image.jpg",
                         "icon": "icon.jpg",
-                        "organization_highlighted": "Org 32",
+                        "organization_highlighted": "Org 34",
                         "organizations": ["P-00030002", "P-00030004", "L-000300020002"],
                         "state": {
                             "priority": 1,
@@ -406,7 +410,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         ],
                         "cover_image": "cover_image.jpg",
                         "icon": "icon.jpg",
-                        "organization_highlighted": "Org 31",
+                        "organization_highlighted": "Org 33",
                         "organizations": ["P-00030001", "P-00030003", "L-000300010002"],
                         "state": {
                             "priority": 4,

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -294,8 +294,8 @@ class CoursesViewsetsTestCase(CMSTestCase):
                 "categories",
                 "cover_image",
                 "icon",
+                "organization_highlighted",
                 "organizations",
-                "organizations_names",
                 "title.*",
             ],
             body={


### PR DESCRIPTION
## Purpose

Fixes #950.

Indexation in ElasticSearch used the order of courses as returned by the `course.get_organizations()` method to get the main organization for the course. This worked with a past implementation of this method but does not work with the current implementation, that does not order the organizations by placeholder position.

The correct method to use to determine the main organization is `course.get_main_organization`. 

## Proposal

Update the courses indexer helpers that put and retrieve objects to and from the index to make sure they get the expected organization as highlighted organization.