### PR TITLE
✨(blogposts) add method on blogpost model to retrieve related blogposts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a method to retrieve the list of blogposts related to (ie that
+  share at least one category with) another blogpost.
 - Licences (through their "name" and "content" fields) are now translatable.
 - Report frontend errors through Sentry when a sentry DSN is available in
   Django settings.

--- a/src/richie/apps/courses/models/blog.py
+++ b/src/richie/apps/courses/models/blog.py
@@ -2,6 +2,7 @@
 Declare and configure the models for the blog part
 """
 from django.db import models
+from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
 
 from cms.api import Page
@@ -28,6 +29,52 @@ class BlogPost(BasePageExtension):
         """Human representation of a blogpost"""
         return "{model}: {name}".format(
             name=self.extended_object.get_title(), model=self._meta.verbose_name.title()
+        )
+
+    def _get_category_pages(self, language=None):
+        """
+        Return the category pages linked to the blogpost via a category plugin in the "categories"
+        placeholder on the blogpost detail page, ranked by their `path` to respect the
+        order in the categories tree.
+        """
+        language = language or translation.get_language()
+
+        selector = "category_plugins__cmsplugin_ptr"
+        # pylint: disable=no-member
+        filter_dict = {
+            f"{selector:s}__language": language,
+            f"{selector:s}__placeholder__page": self.extended_object,
+        }
+        # For a public blogpost, we must filter out categories that are not published in
+        # any language
+        if self.extended_object.publisher_is_draft is False:
+            filter_dict["title_set__published"] = True
+
+        return Page.objects.filter(**filter_dict).order_by("node__path").distinct()
+
+    def get_related_blogposts(self, language=None):
+        """
+        Return the blogposts related to the current blogpost ie that share common categories.
+        the blogposts returned are sorted by their `path` to respect the order in the page
+        tree.
+        """
+        is_draft = self.extended_object.publisher_is_draft
+        language = language or translation.get_language()
+
+        bfs = "extended_object__placeholders__cmsplugin__courses_categorypluginmodel__page__in"
+        selector = {bfs: self._get_category_pages()}
+
+        # pylint: disable=no-member
+        return (
+            BlogPost.objects.filter(
+                extended_object__publisher_is_draft=is_draft,
+                extended_object__placeholders__cmsplugin__language=language,
+                **selector,
+            )
+            .exclude(id=self.id)
+            .select_related("extended_object")
+            .distinct()
+            .order_by("extended_object__node__path")
         )
 
 

--- a/tests/apps/courses/test_models_blogpost.py
+++ b/tests/apps/courses/test_models_blogpost.py
@@ -3,8 +3,9 @@ Unit tests for the BlogPost model
 """
 from django.test import TestCase
 
-from cms.api import create_page
+from cms.api import add_plugin, create_page
 
+from richie.apps.courses.factories import BlogPostFactory, CategoryFactory
 from richie.apps.courses.models import BlogPost
 
 
@@ -22,3 +23,57 @@ class BlogPostModelsTestCase(TestCase):
         blogpost = BlogPost(extended_object=page)
         with self.assertNumQueries(1):
             self.assertEqual(str(blogpost), "Blog Post: My first article")
+
+    @staticmethod
+    def _attach_category(blogpost, category):
+        """Not a test. Utility method to easily attach a category to a blogpost."""
+        placeholder = blogpost.extended_object.placeholders.get(slot="categories")
+        add_plugin(placeholder, "CategoryPlugin", "en", page=category.extended_object)
+
+    def test_models_blogpost_get_related_blogposts(self):
+        """
+        Blogposts related via a plugin on the draft page should appear in
+        their draft version on the draft page.
+        Blogposts related via a plugin on the public page should appear in
+        their public version on the public page.
+        """
+        blogpost1, blogpost2, blogpost3 = BlogPostFactory.create_batch(
+            3, should_publish=True
+        )
+        category = CategoryFactory(should_publish=True)
+
+        # Attach categories
+        self._attach_category(blogpost1, category)
+        self._attach_category(blogpost2, category)
+        self._attach_category(blogpost1.public_extension, category)
+        self._attach_category(blogpost3.public_extension, category)
+
+        # Draft blogposts
+        with self.assertNumQueries(1):
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [blogpost2])
+        with self.assertNumQueries(1):
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [blogpost1])
+        # 2 queries because blogpost3 page fields were not retrieved when attaching categories
+        with self.assertNumQueries(2):
+            self.assertFalse(blogpost3.get_related_blogposts().exists())
+
+        blogpost1_public = blogpost1.public_extension
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                list(blogpost1_public.get_related_blogposts()),
+                [blogpost3.public_extension],
+            )
+
+        # Public blogposts
+        blogpost2_public = blogpost2.public_extension
+        # 2 queries because blogpost2.public_extension page fields were not retrieved when
+        # attaching categories
+        with self.assertNumQueries(2):
+            self.assertFalse(blogpost2_public.get_related_blogposts().exists())
+
+        blogpost3_public = blogpost3.public_extension
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                list(blogpost3_public.get_related_blogposts()),
+                [blogpost1.public_extension],
+            )


### PR DESCRIPTION
## Purpose

We want to display, in the side column of the blogpost detail page, a list of related blogposts. 

## Proposal

I propose to add a method to retrieve the list of blogposts that share at least one category with the current blogpost.
