### PR TITLE
💄(layout) unique breadcrumb layout for course run page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Improve ElasticSearch `regenerate_indexes` tests.
+- Improve breadcrumb on course run page by creating a specific version.
 
 ## [1.16.2] - 2019-12-18
 

--- a/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_run_detail.html
@@ -1,5 +1,5 @@
 {% extends "richie/fullwidth.html" %}
-{% load cms_tags i18n extra_tags %}
+{% load cms_tags i18n extra_tags menu_tags %}
 
 {% block head_title %}{% spaceless %}
   {% page_attribute "page_title" as course_run_title %}
@@ -16,6 +16,14 @@
     <meta property="og:title" content="{{ course_run_title|capfirst }} - {{ course_title|capfirst|truncatechars:53 }}">
     <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">
 {% endblock meta_opengraph_contextuals %}
+
+{% block breadcrumbs %}
+  <ul class="breadcrumbs">
+    {% block breadcrumbs_content %}
+      {% show_breadcrumb 0 "courses/cms/fragment_course_run_breadcrumb.html" %}
+    {% endblock breadcrumbs_content %}
+  </ul>
+{% endblock breadcrumbs %}
 
 {% block content %}{% spaceless %}
 <div class="course-detail">

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_run_breadcrumb.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_run_breadcrumb.html
@@ -1,0 +1,22 @@
+{% if current_page.parent_page.parent_page.course%}
+    {# Course run placed below a snapshot #}
+    {% for ancestor in ancestors %}
+    <li class="breadcrumbs__item">
+        {% if not forloop.last %}
+        <a href="{{ ancestor.get_absolute_url }}">{{ ancestor.get_menu_title }}</a>
+        {% else %}
+        <span class="active">{{ current_page.get_title }}</span>
+        {% endif %}
+    </li>
+    {% endfor %}
+{% else %}
+    {# Course run directly placed below its course #}
+    {% for ancestor in ancestors %}
+    <li class="breadcrumbs__item">
+        <a href="{{ ancestor.get_absolute_url }}">{{ ancestor.get_menu_title }}</a>
+    </li>
+    {% endfor %}
+    <li class="breadcrumbs__item">
+        <span class="active">{{ current_page.get_title }}</span>
+    </li>
+{% endif %}


### PR DESCRIPTION
## Purpose

Is an answer to issue #415 where we need a way to return to the course-run-detail page from the course run page including from snapshoted course run.

## Proposal

create a special breadcrumb layout for course run pages to
take into account snapshots.
