### PR TITLE
🚸(toolbar) improve plugin description displayed in side toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Improve plugin description displayed in side toolbar.
 - Improve ElasticSearch `regenerate_indexes` tests.
 - Improve breadcrumb on course run page by creating a specific version.
 

--- a/src/richie/apps/core/models.py
+++ b/src/richie/apps/core/models.py
@@ -118,3 +118,7 @@ class PagePluginMixin:
         """
         language = language or translation.get_language()
         return self.page.is_published(language)
+
+    def __str__(self):
+        """Human representation of a page plugin"""
+        return self.page.get_title()

--- a/src/richie/apps/courses/cms_plugins.py
+++ b/src/richie/apps/courses/cms_plugins.py
@@ -32,6 +32,7 @@ class OrganizationPlugin(CMSPluginBase):
     fieldsets = ((None, {"fields": ["page", "variant"]}),)
     model = OrganizationPluginModel
     module = PLUGINS_GROUP
+    name = _("Org")
     render_template = "courses/plugins/organization.html"
 
     def render(self, context, instance, placeholder):
@@ -54,6 +55,7 @@ class OrganizationsByCategoryPlugin(CMSPluginBase):
     cache = True
     model = OrganizationsByCategoryPluginModel
     module = PLUGINS_GROUP
+    name = _("Org by Category")
     render_template = "courses/plugins/organizations_by_category.html"
 
     def render(self, context, instance, placeholder):
@@ -79,6 +81,7 @@ class CategoryPlugin(CMSPluginBase):
     cache = True
     model = CategoryPluginModel
     module = PLUGINS_GROUP
+    name = _("Cat")
     render_template = "courses/plugins/category_plugin.html"
 
     def render(self, context, instance, placeholder):
@@ -102,6 +105,7 @@ class CoursePlugin(CMSPluginBase):
     fieldsets = ((None, {"fields": ["page", "variant"]}),)
     model = CoursePluginModel
     module = PLUGINS_GROUP
+    name = _("Course")
     render_template = "courses/plugins/course_plugin.html"
 
     def render(self, context, instance, placeholder):
@@ -124,6 +128,7 @@ class PersonPlugin(CMSPluginBase):
     cache = True
     model = PersonPluginModel
     module = PLUGINS_GROUP
+    name = _("Person")
     render_template = "courses/plugins/person.html"
 
     def render(self, context, instance, placeholder):
@@ -167,6 +172,7 @@ class BlogPostPlugin(CMSPluginBase):
     cache = True
     model = BlogPostPluginModel
     module = PLUGINS_GROUP
+    name = _("Post")
     render_template = "courses/plugins/blogpost.html"
 
     def render(self, context, instance, placeholder):
@@ -189,6 +195,7 @@ class ProgramPlugin(CMSPluginBase):
     cache = True
     model = ProgramPluginModel
     module = PLUGINS_GROUP
+    name = _("Prog")
     render_template = "courses/plugins/program.html"
 
     def render(self, context, instance, placeholder):

--- a/src/richie/apps/courses/models/blog.py
+++ b/src/richie/apps/courses/models/blog.py
@@ -95,11 +95,5 @@ class BlogPostPluginModel(PagePluginMixin, CMSPlugin):
         db_table = "richie_blog_post_plugin"
         verbose_name = _("blog post plugin")
 
-    def __str__(self):
-        """Human representation of a blogpost plugin"""
-        return "{model:s}: {id:d}".format(
-            model=self._meta.verbose_name.title(), id=self.id
-        )
-
 
 extension_pool.register(BlogPost)

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -204,11 +204,5 @@ class CategoryPluginModel(PagePluginMixin, CMSPlugin):
         db_table = "richie_category_plugin"
         verbose_name = _("category plugin")
 
-    def __str__(self):
-        """Human representation of a page plugin"""
-        return "{model:s}: {id:d}".format(
-            model=self._meta.verbose_name.title(), id=self.id
-        )
-
 
 extension_pool.register(Category)

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -586,12 +586,6 @@ class CoursePluginModel(PagePluginMixin, CMSPlugin):
         db_table = "richie_course_plugin"
         verbose_name = _("course plugin")
 
-    def __str__(self):
-        """Human representation of a page plugin"""
-        return "{model:s}: {id:d}".format(
-            model=self._meta.verbose_name.title(), id=self.id
-        )
-
 
 class Licence(TranslatableModel):
     """

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -234,12 +234,6 @@ class OrganizationPluginModel(PagePluginMixin, CMSPlugin):
         db_table = "richie_organization_plugin"
         verbose_name = _("organization plugin")
 
-    def __str__(self):
-        """Human representation of a organization plugin"""
-        return "{model:s}: {id:d}".format(
-            model=self._meta.verbose_name.title(), id=self.id
-        )
-
 
 class OrganizationsByCategoryPluginModel(PagePluginMixin, CMSPlugin):
     """
@@ -268,12 +262,6 @@ class OrganizationsByCategoryPluginModel(PagePluginMixin, CMSPlugin):
     class Meta:
         db_table = "richie_organizations_by_category_plugin"
         verbose_name = _("organizations by category plugin")
-
-    def __str__(self):
-        """Human representation of a plugin to embed organizations for a category."""
-        return "{model:s}: {id:d}".format(
-            model=self._meta.verbose_name.title(), id=self.id
-        )
 
 
 extension_pool.register(Organization)

--- a/src/richie/apps/courses/models/person.py
+++ b/src/richie/apps/courses/models/person.py
@@ -130,11 +130,5 @@ class PersonPluginModel(PagePluginMixin, CMSPlugin):
         db_table = "richie_person_plugin"
         verbose_name = _("person plugin")
 
-    def __str__(self):
-        """Human representation of a person plugin"""
-        return "{model:s}: {id:d}".format(
-            model=self._meta.verbose_name.title(), id=self.id
-        )
-
 
 extension_pool.register(Person)

--- a/src/richie/apps/courses/models/program.py
+++ b/src/richie/apps/courses/models/program.py
@@ -48,11 +48,5 @@ class ProgramPluginModel(PagePluginMixin, CMSPlugin):
         db_table = "richie_program_plugin"
         verbose_name = _("program plugin")
 
-    def __str__(self):
-        """Human representation of a program plugin"""
-        return "{model:s}: {id:d}".format(
-            model=self._meta.verbose_name.title(), id=self.id
-        )
-
 
 extension_pool.register(Program)


### PR DESCRIPTION
## Purpose

The name and description of plugins below a placeholder in the side toolbar was not helpful. 

## Proposal

We should display the page title preceded by an indication of the type of the plugin that should be as short as possible to leave as much space  as possible for the page title.  Hence the use abbreviations.

