### PR TITLE
🐛(permissions) prevent creating duplicate permissions programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Refactor our template tags related to placeholders to fix ghost placeholders
+- Prevent unintentionally creating duplicate permissions programmatically
 - Fix an issue that crashed `regenerate_indexes` (and therefore
   `bootstrap_elasticsearch`) from a broken state in ES.
 - `<Search />` component handles errors in course search requests, displaying

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -208,17 +208,21 @@ class Course(BasePageExtension):
             return
 
         # - Create DjangoCMS page permissions
-        PagePermission.objects.create(
+        PagePermission.objects.get_or_create(
             group_id=organization_page_role.group_id,
             page_id=self.extended_object_id,
-            **defaults.ORGANIZATION_ADMIN_ROLE.get("courses_page_permissions", {}),
+            defaults=defaults.ORGANIZATION_ADMIN_ROLE.get(
+                "courses_page_permissions", {}
+            ),
         )
 
         # - Create the Django Filer folder permissions
-        FolderPermission.objects.create(
-            folder_id=course_page_role.folder_id,
+        FolderPermission.objects.get_or_create(
             group_id=organization_page_role.group_id,
-            **defaults.ORGANIZATION_ADMIN_ROLE.get("courses_folder_permissions", {}),
+            folder_id=course_page_role.folder_id,
+            defaults=defaults.ORGANIZATION_ADMIN_ROLE.get(
+                "courses_folder_permissions", {}
+            ),
         )
 
     def get_persons(self, language=None):


### PR DESCRIPTION
## Purpose

When manipulating organizations and courses programmatically, it was possible to unintentionally generate duplicate permissions. We should prevent that.

This issue does not affect creating organizations and courses via the DjangoCMS wizards.

## Proposal

- [x] Replace `create` by `get_or_create` when creating page and folder permissions
- [x] Add tests to make sure that permissions and neither duplicated, nor updated (we create them once and then respect the modifications that admin users may make on permissions via the web interface).
