### PR TITLE
♻️(core) remove context processor that was added since latest release

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -39,7 +39,6 @@ $ make migrate
 - Users who make use of `<SearchSuggestField />` or `<RootSearchSuggestField />` in their own
   templates through `richie-react` need to update all the call sites: the `context` prop is now
   required for both of them. See the documentation for more details on `context`.
-- Users who are handling their own settings need to add the new frontend context processor (`"richie.apps.core.context_processors.frontend_context"`) in their own settings
 
 ## 1.14.x to 1.15.x
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -141,7 +141,6 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
                     "django.template.context_processors.static",
                     "cms.context_processors.cms_settings",
                     "richie.apps.core.context_processors.site_metas",
-                    "richie.apps.core.context_processors.frontend_context",
                 ],
                 "loaders": [
                     "django.template.loaders.filesystem.Loader",


### PR DESCRIPTION
## Purpose

Since the latest release the frontend context processor was added.  It constitutes a breaking change because this context processor is required.

## Proposal

I propose to group all context variables under one single existing context processor so that projects using richie don't need to add multiple context processors to their project just for richie when they are in fact all required.
