### PR TITLE
🐛Fix an issue with full-text search in course search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Make sure the course search API shows the 1st related organization by
   placeholder position as highlighted organization for a course instead of
   the first organization by node path.
+- Fix an issue in Course Search that removed existing filters in some cases
+  when using full text search.
 
 ### Changed
 

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -70,8 +70,10 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
       });
     }
   };
-  const updateCourseSearchParamsRef = useRef(
-    debounce(searchAsTheUserTypes, 500, { maxWait: 1100 }),
+  const updateCourseSearchParamsDebounced = debounce(
+    searchAsTheUserTypes,
+    500,
+    { maxWait: 1100 },
   );
 
   const inputProps: SearchAutosuggestProps['inputProps'] = {
@@ -85,7 +87,7 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
     onChange: (_, { method, newValue }) => {
       // Always update the state, delegate search-as-the-user-types to debounced function
       setValue(newValue);
-      updateCourseSearchParamsRef.current(_, { method, newValue });
+      updateCourseSearchParamsDebounced(_, { method, newValue });
     },
     onKeyDown: event => {
       if (event.keyCode === 13 /* enter */ && !value) {


### PR DESCRIPTION
## Purpose

Course search had an issue where filters were lost in some cases when the user typed in a full-text search. This was due to the use of a ref in the <SearchSuggestField /> component which resulted in an outdated function with an old closure being used.

## Proposal

Remove the ref which as a premature attempt at optimization.

We had some issues when trying to build tests to show this issue was resolved. We had to refactor the tests to handle history mocking differently and stop mocking our own History providing hook,
mocking only the browser's interface.