### PR TITLE
🐛 Empty the search input field when the filters are cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   the first organization by node path.
 - Fix an issue in Course Search that removed existing filters in some cases
   when using full text search.
+- Properly clear the search input when using the "clear fields" button on the
+  course search view.
 
 ### Changed
 

--- a/src/frontend/js/components/SearchFiltersPane/_styles.scss
+++ b/src/frontend/js/components/SearchFiltersPane/_styles.scss
@@ -14,6 +14,7 @@ $richie-search-filters-pane-clear-padding: 0rem 0.5rem 0 !default;
 .search-filters-pane {
   background: $richie-search-filters-pane-background;
   overflow: hidden; // Prevent margin-collapsing as .search-filters-pane has a background
+  color: white;
 
   &__title {
     margin: $richie-search-filters-pane-title-margin;

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -50,6 +50,23 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
   const [value, setValue] = useState(courseSearchParams.query || '');
   const [suggestions, setSuggestions] = useState<SearchSuggestionSection[]>([]);
 
+  // Create a ref too keep around courseSearchParams as they were during render N-1
+  const previousCourseSearchParams = useRef(courseSearchParams);
+  // Use the previous & current values of courseSearchParams to guess if the text query had
+  // been removed by another component in the tree, and clear the field as well
+  // NB: this will do nothing on the first render as courseSearchParams and the ref
+  // (previousCourseSearchParams.current) will hold the exact same object at that time.
+  if (
+    !courseSearchParams.query &&
+    previousCourseSearchParams.current.query &&
+    value
+  ) {
+    setValue('');
+  }
+  // Then update the ref to the current courseSearchParams so we can have them to compare
+  // during the next render.
+  previousCourseSearchParams.current = courseSearchParams;
+
   /**
    * Helper to update the course search params when the user types. We needed to take it out of
    * the `onChange` handler to wrap it in a `debounce` (and therefore a `useRef` to make the


### PR DESCRIPTION
## Purpose

Richie's search engine has a "Clear active filters" link that removes all current filters from the search, including full-text search.

Until now however, it did not clear the actual text in the input field, it only removed the query from the search.

## Proposal

The <SearchSuggestField /> component has no way to know another component did a "FILTER_RESET" or changed the query.

Instead of adding costly plumbing for this, we decided <SearchSuggestField /> can instead just 
clear its own value when it notices the previous courseSearchParams had a query and the incoming ones have not.
We just have to use a ref to keep courseSearchParams N-1 around and do the comparison.

We also added a test to ensure this fixed behavior persists through future changes.

Fixes #978.