### PR TITLE
🐛 Fix an issue with whitespace in short search strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   when using full text search.
 - Properly clear the search input when using the "clear fields" button on the
   course search view.
+- Prevent search view errors when the search query is 3 or more characters
+  long, but 2 or less when whitespace is trimmed from both ends.
 
 ### Changed
 

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -80,7 +80,12 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
     _,
     { method, newValue },
   ) => {
-    if (method === 'type' && (newValue.length === 0 || newValue.length >= 3)) {
+    if (
+      method === 'type' &&
+      // Check length against trimmed version as our backend API needs 3 non-space characters to
+      // do a full-text search.
+      (newValue.length === 0 || newValue.trim().length >= 3)
+    ) {
       dispatchCourseSearchParamsUpdate({
         query: newValue,
         type: 'QUERY_UPDATE',


### PR DESCRIPTION
## Purpose

Our full-text search API endpoint only accepts strings of 3 characters or more. This does not include white space. For instance, "ric" is a valid search query, but "ri " is not.

This was not reflected in our frontend check, which just looked at the string length.

## Proposal

We just have to trim the string before doing this check to ensure the query is valid. Also add a test for this behavior.
