### PR TITLE
👌(course) enforce course glimpse to be on single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Enforce course glimpse footer to be on a single line.
+
 ## [2.0.0-beta.1] - 2020-04-16
 
 ### Fixed

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -188,29 +188,21 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
 }
 
 .course-glimpse-footer {
-  display: flex;
-  padding: 0 $course-glimpse-content-padding-sides;
-  border-bottom-left-radius: $border-radius-lg;
-  border-bottom-right-radius: $border-radius-lg;
   @include r-button-colors(
     r-theme-val(course-glimpse, footer),
     $apply-border: true
   );
+  display: flex;
+  padding: 0 $course-glimpse-content-padding-sides;
+  border-bottom-left-radius: $border-radius-lg;
+  border-bottom-right-radius: $border-radius-lg;
+  font-size: 0.8rem;
 
   &__date {
-    display: flex;
-    @include sv-flex-cell-width(50%);
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
+    @include sv-flex(1, 0, auto);
     margin: 0;
-    padding: 0.5rem 0;
-    align-content: center;
+    padding: 0.75rem 0;
     font-weight: bold;
     line-height: 1.1;
-    // Force a line-break between the meaningful text and the actual date information
-    & > span {
-      display: table;
-    }
   }
 }


### PR DESCRIPTION
## Purpose

Since we recently remove course glimpse footer possibility to have a
"call to action" button, it is useless to keep footer date on two lines.

## Proposal

This commit fix the CSS so the footer date always fit on a single line.

![Screenshot_20200416_232020](https://user-images.githubusercontent.com/1572165/79517894-d73b9780-804f-11ea-94ff-aef7e3336768.png)

