### PR TITLE
🐛(section) remove useless dependency to nesteditem migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Enforce course glimpse footer to be on a single line.
 
+### Fixed
+
+- Fix section migration 0005 that was depending on NestedItem initial
+  migration.
+
 ## [2.0.0-beta.1] - 2020-04-16
 
 ### Fixed

--- a/src/richie/plugins/section/migrations/0005_migrate_sectionlist_to_nesteditem.py
+++ b/src/richie/plugins/section/migrations/0005_migrate_sectionlist_to_nesteditem.py
@@ -20,7 +20,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("section", "0004_remove_section_cadenced"),
-        ("nesteditem", "0001_initial"),
     ]
 
     operations = [migrations.RunPython(forwards_func, migrations.RunPython.noop)]


### PR DESCRIPTION
## Purpose

Migration "0005_migrate_sectionlist_to_nesteditem" has been done
planning to migrate section with deprecated template to a nesteditem
which was finally canceled, but there is still a dependency to
nesteditem initial migration that will cause trouble on migration on 
existing database.

## Proposal

We just remove the dependancy that should fix the issue without any change.
