### PR TITLE
✨ Improve query analyzer language selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix an issue where analyzing course search queries with irrelevant analyzers
+  caused very low relevance results in course search.
+
 ## [2.0.0-beta.4] - 2020-04-20
 
 ### Fixed

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -12,6 +12,11 @@ ES_PAGE_SIZE = 10
 # Use a lazy to enable easier testing by not defining the value at bootstrap time
 ES_INDICES_PREFIX = lazy(lambda: settings.RICHIE_ES_INDICES_PREFIX)()
 
+# Define which analyzer should be used for each language
+QUERY_ANALYZERS = getattr(
+    settings, "RICHIE_QUERY_ANALYZERS", {"en": "english", "fr": "french"}
+)
+
 # Define the scoring boost (in ElasticSearch) related value names receive when using
 # full-text search.
 # For example, when a user searches for "Science" in full-text, it should match any

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -116,9 +116,19 @@ class CourseSearchFormTestCase(TestCase):
         form = CourseSearchForm(
             data=QueryDict(
                 query_string=(
-                    "availability=coming_soon&levels=1&levels_include=.*&languages=fr&limit=9&"
-                    "offset=3&organizations=10&organizations_include=.*&query=maths&new=new&"
-                    "scope=objects&subjects=1&subjects_include=.*"
+                    "availability=coming_soon"
+                    "&languages=fr"
+                    "&levels=1"
+                    "&levels_include=.*"
+                    "&limit=9"
+                    "&new=new"
+                    "&offset=3"
+                    "&organizations=10"
+                    "&organizations_include=.*"
+                    "&query=maths"
+                    "&scope=objects"
+                    "&subjects=1"
+                    "&subjects_include=.*"
                 )
             )
         )
@@ -152,10 +162,25 @@ class CourseSearchFormTestCase(TestCase):
         form = CourseSearchForm(
             data=QueryDict(
                 query_string=(
-                    "availability=coming_soon&availability=ongoing&levels=1&levels=2&"
-                    "languages=fr&languages=en&limit=9&limit=11&offset=3&offset=17&"
-                    "organizations=10&organizations=11&query=maths&query=physics&new=new&"
-                    "scope=objects&scope=filters&subjects=1&subjects=2"
+                    "availability=coming_soon"
+                    "&availability=ongoing"
+                    "&languages=fr"
+                    "&languages=en"
+                    "&levels=1"
+                    "&levels=2"
+                    "&limit=9"
+                    "&limit=11"
+                    "&new=new"
+                    "&offset=3"
+                    "&offset=17"
+                    "&organizations=10"
+                    "&organizations=11"
+                    "&query=maths"
+                    "&query=physics"
+                    "&scope=objects"
+                    "&scope=filters"
+                    "&subjects=1"
+                    "&subjects=2"
                 )
             )
         )
@@ -187,7 +212,7 @@ class CourseSearchFormTestCase(TestCase):
         Happy path: build a query that filters courses by matching text
         """
         form = CourseSearchForm(
-            data=QueryDict(query_string="query=some%20phrase%20terms&limit=2&offset=20")
+            data=QueryDict(query_string="limit=2&offset=20&query=some%20phrase%20terms")
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(
@@ -196,35 +221,17 @@ class CourseSearchFormTestCase(TestCase):
                 "bool": {
                     "must": [
                         {
-                            "bool": {
-                                "should": [
-                                    {
-                                        "multi_match": {
-                                            "fields": ["description.*", "title.*"],
-                                            "query": "some phrase terms",
-                                            "type": "cross_fields",
-                                        }
-                                    },
-                                    {
-                                        "multi_match": {
-                                            "boost": 0.05,
-                                            "fields": [
-                                                "categories_names.*",
-                                                "organizations_names.*",
-                                            ],
-                                            "query": "some phrase terms",
-                                            "type": "cross_fields",
-                                        }
-                                    },
-                                    {
-                                        "multi_match": {
-                                            "boost": 0.05,
-                                            "fields": ["persons_names.*"],
-                                            "query": "some phrase " "terms",
-                                            "type": "cross_fields",
-                                        }
-                                    },
-                                ]
+                            "multi_match": {
+                                "analyzer": "english",
+                                "fields": [
+                                    "description.*",
+                                    "title.*",
+                                    "categories_names.*^0.05",
+                                    "organizations_names.*^0.05",
+                                    "persons_names.*^0.05",
+                                ],
+                                "query": "some phrase terms",
+                                "type": "cross_fields",
                             }
                         }
                     ]

--- a/tests/apps/search/test_forms_search_items.py
+++ b/tests/apps/search/test_forms_search_items.py
@@ -93,7 +93,7 @@ class ItemSearchFormTestCase(TestCase):
     def test_forms_items_single_values_in_querystring(self, *_):
         """
         The fields from filter definitions should be normalized as lists. The fields defined
-        on the form should be single values (limit, offset and query)
+        on the form should be single values (limit, offset and query).
         """
         form = ItemSearchForm(
             data=QueryDict(query_string=("limit=9&offset=3&query=maths"))
@@ -108,7 +108,7 @@ class ItemSearchFormTestCase(TestCase):
         Happy path: build a query that filters items by matching text
         """
         form = ItemSearchForm(
-            data=QueryDict(query_string="query=some%20phrase%20terms&limit=20&offset=2")
+            data=QueryDict(query_string="limit=20&offset=2&query=some%20phrase%20terms")
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(
@@ -122,6 +122,7 @@ class ItemSearchFormTestCase(TestCase):
                             "must": [
                                 {
                                     "multi_match": {
+                                        "analyzer": "english",
                                         "fields": ["title.*"],
                                         "query": "some phrase " "terms",
                                     }
@@ -139,7 +140,7 @@ class ItemSearchFormTestCase(TestCase):
         as argument.
         """
         form = ItemSearchForm(
-            data=QueryDict(query_string="query=some%20phrase%20terms&limit=20&offset=2")
+            data=QueryDict(query_string="limit=20&offset=2&query=some%20phrase%20terms")
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(
@@ -154,6 +155,7 @@ class ItemSearchFormTestCase(TestCase):
                                 {"term": {"kind": "subjects"}},
                                 {
                                     "multi_match": {
+                                        "analyzer": "english",
                                         "fields": ["title.*"],
                                         "query": "some phrase " "terms",
                                     }

--- a/tests/apps/search/test_viewsets_categories.py
+++ b/tests/apps/search/test_viewsets_categories.py
@@ -148,8 +148,9 @@ class CategoriesViewsetsTestCase(TestCase):
                             {"term": {"kind": "subjects"}},
                             {
                                 "multi_match": {
-                                    "query": "Science",
+                                    "analyzer": "english",
                                     "fields": ["title.*"],
+                                    "query": "Science",
                                 }
                             },
                         ]

--- a/tests/apps/search/test_viewsets_organizations.py
+++ b/tests/apps/search/test_viewsets_organizations.py
@@ -53,10 +53,6 @@ class OrganizationsViewsetsTestCase(TestCase):
         self.assertEqual(response.status_code, 404)
 
     @override_settings(RICHIE_ES_INDICES_PREFIX="richie")
-    @mock.patch(
-        "richie.apps.search.forms.ItemSearchForm.build_es_query",
-        lambda x: (2, 0, {"query": "something"}),
-    )
     @mock.patch.object(ES_CLIENT, "search")
     def test_viewsets_organizations_search(self, mock_search):
         """
@@ -101,7 +97,21 @@ class OrganizationsViewsetsTestCase(TestCase):
         # The ES connector was called with a query that matches the client's request
         mock_search.assert_called_with(
             _source=["absolute_url", "logo", "title.*"],
-            body={"query": "something"},
+            body={
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "multi_match": {
+                                    "analyzer": "english",
+                                    "fields": ["title.*"],
+                                    "query": "Université",
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
             doc_type="organization",
             from_=0,
             index="richie_organizations",


### PR DESCRIPTION
## Purpose

Each field defines its own default search analyzer in its mapping (or defaults to the content analyzer if a specific search query analyzer is not defined). This is appropriate in principle but it
breaks down when we attempt to do multilingual searches: search queries are then analyzed using the field's analyzer or search analyzer, which might be in the wrong language, and give terrible results for the search query.

To prevent this from happening, we decided to enforce an analyzer at query time. If we can find an appropriate analyzer, it can then be used before searching even in indices in other languages.

## Proposal

To best find this appropriate analyzer, we let the frontend client pass us a preferred query language, which it can determine by guessing and offering guesses to the user to help them, or other UI elements.

What we suggest:
- do not change the base UI at all;
- guess query language in the frontend (using the same Java `langdetect` lib as ported to javascript instead of python);
- when our confident guess differs from the current language **and** we can offer a better analyzer (eg. the language we guessed is supported by the current Richie instance), show a toast to the user offering this: _It seems like your search query is in Spanish, would you like to search in Spanish?_;
- if the user does change the query language, we then display a language selector next to the search input.

This way we can be helpful wrt. query language and irrelevant results, without breaking search behavior due to the inherent unreliability of attempting to guess the language of a very small text sample. We also don't pollute the UI for something that 95-99% of users will never need.

In the absence of a cue by the frontend (which would only be there for less than 5% of queries), we then default to the current UI language.

In any case, we can keep searching in all languages' versions of the fields and be sure we have the best analyzer we could offer.

## Alternatives considered

We started out trying to just automatically detect the query language and using that guess to choose the most correct analyzer without any user input besides their text query. We wanted to use `langdetect` for this.

`langdetect` is a great library, but it cannot provide reliable guesses in the absence of enough data. The author of the original library (in Java) notes [here](http://www.slideshare.net/shuyo/language-detection-library-for-java) that it is not reliable for tweets which are too short (at 100-500 characters), and that for automatic detection to be worthwhile, it needs to be very reliable.

They echo [this note](https://www.elastic.co/fr/blog/multilingual-search-using-language-identification-in-elasticsearch) from Elastic that notes ElasticSearch's own language detection should not be used for search queries as it's unreliable for text shorter than 50 characters.

Additionally, we observed as we attempted it that it fails for common queries attempted in Richie. More importantly, it produced unexpected behavior as the guesses changed when using search-as-the-user-types: if the analyzer changes through different languages as the user types their query, the search results will also flicker between vastly different result sets instead of progressively narrowing to our best results.

## TODO

- [x] set an analyzer for full-text queries in the backend;
- [x] ~accept a new query string parameter on search API endpoints so the frontend can let us use the user's preferred language (as opposed to the current UI language);~
- [ ] ~help the user select an appropriate query language in the frontend;~

Fixes #997.
