### PR TITLE
Scroll to top in course search on most user actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Scroll course search to top when the user interacts with the filters pane.
+
 ## [2.0.0-beta.5] - 2020-05-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Scroll course search to top when the user interacts with the filters pane.
+- Increase default course search results number from 20 to 21.
 
 ## [2.0.0-beta.5] - 2020-05-04
 

--- a/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
@@ -12,7 +12,11 @@ describe('<PaginateCourseSearch />', () => {
   const historyPushState = jest.fn();
   const historyReplaceState = jest.fn();
   const makeHistoryOf: (params: any) => History = (params) => [
-    { state: params, title: '', url: `/search?${stringify(params)}` },
+    {
+      state: { name: 'courseSearch', data: { params } },
+      title: '',
+      url: `/search?${stringify(params)}`,
+    },
     historyPushState,
     historyReplaceState,
   ];
@@ -129,8 +133,14 @@ describe('<PaginateCourseSearch />', () => {
     fireEvent.click(page2);
     expect(historyPushState).toHaveBeenCalledWith(
       {
-        limit: '20',
-        offset: '20',
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: {
+            limit: '20',
+            offset: '20',
+          },
+        },
       },
       '',
       '/?limit=20&offset=20',

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { useCourseSearchParams } from 'data/useCourseSearchParams';
+import {
+  CourseSearchParamsAction,
+  useCourseSearchParams,
+} from 'data/useCourseSearchParams';
 
 const messages = defineMessages({
   currentlyReadingLastPageN: {
@@ -146,7 +149,7 @@ export const PaginateCourseSearch = ({
                       dispatchCourseSearchParamsUpdate({
                         // Pages are 1-indexed, we need to 0-index them to calculate the correct offset
                         offset: String((page - 1) * limit),
-                        type: 'PAGE_CHANGE',
+                        type: CourseSearchParamsAction.pageChange,
                       })
                     }
                   >

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -58,10 +58,10 @@ export const PaginateCourseSearch = ({
   // Generate a unique ID per instance to ensure our aria-labelledby do not break if there are two
   // or more instances of <PaginateCourseSearch /> on the page
   const [componentId] = useState(Math.random());
-  const [
+  const {
     courseSearchParams,
     dispatchCourseSearchParamsUpdate,
-  ] = useCourseSearchParams();
+  } = useCourseSearchParams();
 
   // Extract pagination information from params and search results meta
   const limit = Number(courseSearchParams.limit);

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -6,6 +6,10 @@ import { IntlProvider } from 'react-intl';
 import { location } from 'utils/indirection/window';
 import { RootSearchSuggestField } from '.';
 
+jest.mock('settings', () => ({
+  API_LIST_DEFAULT_PARAMS: { limit: '13', offset: '0' },
+}));
+
 jest.mock('utils/indirection/window', () => ({
   location: {
     assign: jest.fn(),
@@ -189,7 +193,7 @@ describe('<RootSearchSuggestField />', () => {
     fireEvent.click(subject);
     await wait();
     expect(location.assign).toHaveBeenCalledWith(
-      '/en/courses/?limit=20&offset=0&subjects=L-000300010001',
+      '/en/courses/?limit=13&offset=0&subjects=L-000300010001',
     );
   });
 
@@ -220,7 +224,7 @@ describe('<RootSearchSuggestField />', () => {
     await wait();
 
     expect(location.assign).toHaveBeenCalledWith(
-      '/en/courses/?limit=20&offset=0&query=some%20query',
+      '/en/courses/?limit=13&offset=0&query=some%20query',
     );
   });
 

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -22,7 +22,11 @@ describe('<Search />', () => {
   const historyPushState = jest.fn();
   const historyReplaceState = jest.fn();
   const makeHistoryOf: (params: any) => History = (params) => [
-    { state: params, title: '', url: `/search?${stringify(params)}` },
+    {
+      state: { name: 'courseSearch', data: { params } },
+      title: '',
+      url: `/search?${stringify(params)}`,
+    },
     historyPushState,
     historyReplaceState,
   ];

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -39,7 +39,7 @@ const messages = defineMessages({
 });
 
 export const Search = ({ context }: CommonDataProps) => {
-  const [courseSearchParams] = useCourseSearchParams();
+  const { courseSearchParams } = useCourseSearchParams();
   const courseSearchResponse = useCourseSearch(courseSearchParams);
 
   const alwaysShowFilters = matchMedia('(min-width: 992px)').matches;

--- a/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
@@ -24,7 +24,11 @@ describe('components/SearchFilterGroup', () => {
   const historyPushState = jest.fn();
   const historyReplaceState = jest.fn();
   const makeHistoryOf: (params: any) => History = (params) => [
-    { state: params, title: '', url: `/search?${stringify(params)}` },
+    {
+      state: { name: 'courseSearch', data: { params } },
+      title: '',
+      url: `/search?${stringify(params)}`,
+    },
     historyPushState,
     historyReplaceState,
   ];

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -35,7 +35,11 @@ describe('<SearchFilterGroupModal />', () => {
   const historyPushState = jest.fn();
   const historyReplaceState = jest.fn();
   const makeHistoryOf: (params: any) => History = (params) => [
-    { state: params, title: '', url: `/search?${stringify(params)}` },
+    {
+      state: { name: 'courseSearch', data: { params } },
+      title: '',
+      url: `/search?${stringify(params)}`,
+    },
     historyPushState,
     historyReplaceState,
   ];
@@ -364,9 +368,15 @@ describe('<SearchFilterGroupModal />', () => {
     fireEvent.click(value42);
     expect(historyPushState).toHaveBeenLastCalledWith(
       {
-        limit: '20',
-        offset: '0',
-        universities: ['42'],
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: {
+            limit: '20',
+            offset: '0',
+            universities: ['42'],
+          },
+        },
       },
       '',
       '/?limit=20&offset=0&universities=42',

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -7,7 +7,10 @@ import {
 import ReactModal from 'react-modal';
 
 import { fetchList } from 'data/getResourceList';
-import { useCourseSearchParams } from 'data/useCourseSearchParams';
+import {
+  CourseSearchParamsAction,
+  useCourseSearchParams,
+} from 'data/useCourseSearchParams';
 import { requestStatus } from 'types/api';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { Nullable } from 'utils/types';
@@ -171,7 +174,7 @@ export const SearchFilterGroupModal = ({
                       dispatchCourseSearchParamsUpdate({
                         filter,
                         payload: value.key,
-                        type: 'FILTER_ADD',
+                        type: CourseSearchParamsAction.filterAdd,
                       });
                       setModalIsOpen(false);
                     }}

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -67,10 +67,10 @@ export const SearchFilterGroupModal = ({
   const [error, setError] = useState(null as Nullable<MessageDescriptor>);
 
   // We need the current course search params to get the facet counts
-  const [
-    coursesSearchParams,
+  const {
+    courseSearchParams,
     dispatchCourseSearchParamsUpdate,
-  ] = useCourseSearchParams();
+  } = useCourseSearchParams();
 
   // When the modal is closed, reset state so the user gets a brand-new one if they come back
   useEffect(() => {
@@ -99,7 +99,7 @@ export const SearchFilterGroupModal = ({
     }
 
     const facetResponse = await fetchList('courses', {
-      ...coursesSearchParams,
+      ...courseSearchParams,
       [`${filter.name}_include`]: `(${searchResponse.content.objects
         .map((resource) => resource.id)
         .join('|')})`,

--- a/src/frontend/js/components/SearchFilterValueLeaf/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/index.spec.tsx
@@ -12,7 +12,11 @@ describe('components/SearchFilterValueLeaf', () => {
   const historyPushState = jest.fn();
   const historyReplaceState = jest.fn();
   const makeHistoryOf: (params: any) => History = (params) => [
-    { state: params, title: '', url: `/search?${stringify(params)}` },
+    {
+      state: { name: 'courseSearch', data: { params } },
+      title: '',
+      url: `/search?${stringify(params)}`,
+    },
     historyPushState,
     historyReplaceState,
   ];
@@ -164,7 +168,13 @@ describe('components/SearchFilterValueLeaf', () => {
       getByLabelText((content, _) => content.includes('Human name')),
     );
     expect(historyPushState).toHaveBeenCalledWith(
-      { filter_name: ['43'], limit: '999', offset: '0' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { filter_name: ['43'], limit: '999', offset: '0' },
+        },
+      },
       '',
       '/?filter_name=43&limit=999&offset=0',
     );
@@ -205,7 +215,13 @@ describe('components/SearchFilterValueLeaf', () => {
       getByLabelText((content, _) => content.includes('Human name')),
     );
     expect(historyPushState).toHaveBeenCalledWith(
-      { filter_name: undefined, limit: '999', offset: '0' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { filter_name: undefined, limit: '999', offset: '0' },
+        },
+      },
       '',
       '/?limit=999&offset=0',
     );

--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -21,7 +21,11 @@ describe('<SearchFilterValueParent />', () => {
   const historyPushState = jest.fn();
   const historyReplaceState = jest.fn();
   const makeHistoryOf: (params: any) => History = (params) => [
-    { state: params, title: '', url: `/search?${stringify(params)}` },
+    {
+      state: { name: 'courseSearch', data: { params } },
+      title: '',
+      url: `/search?${stringify(params)}`,
+    },
     historyPushState,
     historyReplaceState,
   ];
@@ -386,7 +390,13 @@ describe('<SearchFilterValueParent />', () => {
       getByLabelText((content) => content.startsWith('Human name')),
     );
     expect(historyPushState).toHaveBeenCalledWith(
-      { filter_name: ['P-00040005'], limit: '999', offset: '0' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { filter_name: ['P-00040005'], limit: '999', offset: '0' },
+        },
+      },
       '',
       '/?filter_name=P-00040005&limit=999&offset=0',
     );
@@ -427,7 +437,13 @@ describe('<SearchFilterValueParent />', () => {
       getByLabelText((content) => content.startsWith('Human name')),
     );
     expect(historyPushState).toHaveBeenCalledWith(
-      { filter_name: undefined, limit: '999', offset: '0' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { filter_name: undefined, limit: '999', offset: '0' },
+        },
+      },
       '',
       '/?limit=999&offset=0',
     );

--- a/src/frontend/js/components/SearchFilterValueParent/index.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.tsx
@@ -39,10 +39,10 @@ export const SearchFilterValueParent = ({
 
   // Get the current values for the filter definition so we know if any children of this parent
   // filter are active (and we therefore need to get them and unfold the children).
-  const [coursesSearchParams] = useCourseSearchParams();
+  const { courseSearchParams } = useCourseSearchParams();
   // Default to an array of strings no matter the current value so we can easily check for active values
   const activeFilterValues =
-    coursesSearchParams[filter.name] || ([] as string[]);
+    courseSearchParams[filter.name] || ([] as string[]);
   const activeValuesList =
     typeof activeFilterValues === 'string'
       ? [activeFilterValues]
@@ -69,7 +69,7 @@ export const SearchFilterValueParent = ({
     if (showChildren) {
       // Get only the filters & facet counts for the children of the current parent
       const childrenResponse = await fetchList('courses', {
-        ...coursesSearchParams,
+        ...courseSearchParams,
         [`${filter.name}_include`]: childrenPathMatch,
         scope: 'filters',
       });
@@ -84,7 +84,7 @@ export const SearchFilterValueParent = ({
     }
     // Be sure to include courseSearchParams in the dependencies so the children counts are re-fetched whenever
     // the user applies new filters or queries
-  }, [showChildren, value, coursesSearchParams]);
+  }, [showChildren, value, courseSearchParams]);
 
   // We also need to know if the current filter is active itself and let the user toggle it directly
   const [isActive, toggle] = useFilterValue(filter, value);

--- a/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
@@ -18,7 +18,11 @@ describe('components/SearchFiltersPane', () => {
   const historyPushState = jest.fn();
   const historyReplaceState = jest.fn();
   const makeHistoryOf: (params: any) => History = (params) => [
-    { state: params, title: '', url: `/search?${stringify(params)}` },
+    {
+      state: { name: 'courseSearch', data: { params } },
+      title: '',
+      url: `/search?${stringify(params)}`,
+    },
     historyPushState,
     historyReplaceState,
   ];
@@ -125,7 +129,13 @@ describe('components/SearchFiltersPane', () => {
 
     fireEvent.click(clearButton);
     expect(historyPushState).toHaveBeenCalledWith(
-      { limit: '14', offset: '0' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '14', offset: '0' },
+        },
+      },
       '',
       '/?limit=14&offset=0',
     );

--- a/src/frontend/js/components/SearchFiltersPane/index.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { SearchFilterGroup } from 'components/SearchFilterGroup';
-import { useCourseSearchParams } from 'data/useCourseSearchParams';
+import {
+  CourseSearchParamsAction,
+  useCourseSearchParams,
+} from 'data/useCourseSearchParams';
 import { API_LIST_DEFAULT_PARAMS } from 'settings';
 import { APICourseSearchResponse } from 'types/api';
 import { Nullable } from 'utils/types';
@@ -65,7 +68,9 @@ export const SearchFiltersPane = ({
         }`}
         tabIndex={0}
         onClick={() =>
-          dispatchCourseSearchParamsUpdate({ type: 'FILTER_RESET' })
+          dispatchCourseSearchParamsUpdate({
+            type: CourseSearchParamsAction.filterReset,
+          })
         }
       >
         <FormattedMessage

--- a/src/frontend/js/components/SearchFiltersPane/index.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.tsx
@@ -36,10 +36,10 @@ export const SearchFiltersPane = ({
   >) => {
   const filterList = filters && Object.values(filters);
 
-  const [
+  const {
     courseSearchParams,
     dispatchCourseSearchParamsUpdate,
-  ] = useCourseSearchParams();
+  } = useCourseSearchParams();
 
   // Get all the currently active filters to show a count
   const activeFilters = Object.entries(courseSearchParams)

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -5,7 +5,10 @@ import fetchMock from 'fetch-mock';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
-import { useCourseSearchParams } from 'data/useCourseSearchParams';
+import {
+  useCourseSearchParams,
+  CourseSearchParamsAction,
+} from 'data/useCourseSearchParams';
 import { HistoryContext, useHistory } from 'data/useHistory';
 import { FilterDefinition } from 'types/filters';
 import { history, location } from 'utils/indirection/window';
@@ -135,7 +138,11 @@ describe('components/SearchSuggestField', () => {
     const input: any = getByDisplayValue('social sciences');
 
     // Some other component resets the filter, in effect clearing the query
-    act(() => doDispatchCourseSearchParamsUpdate({ type: 'FILTER_RESET' }));
+    act(() =>
+      doDispatchCourseSearchParamsUpdate({
+        type: CourseSearchParamsAction.filterReset,
+      }),
+    );
     rerender(
       <IntlProvider locale="en">
         <HistoryWrapper>

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -288,7 +288,13 @@ describe('components/SearchSuggestField', () => {
     await wait();
     expect(history.pushState).toHaveBeenCalledTimes(1);
     expect(history.pushState).toHaveBeenLastCalledWith(
-      { limit: '20', offset: '0', query: 'orga' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '20', offset: '0', query: 'orga' },
+        },
+      },
       '',
       '/search?limit=20&offset=0&query=orga',
     );
@@ -320,10 +326,16 @@ describe('components/SearchSuggestField', () => {
     expect(history.pushState).toHaveBeenCalledTimes(2);
     expect(history.pushState).toHaveBeenCalledWith(
       {
-        limit: '20',
-        offset: '0',
-        organizations: ['L-00020007'],
-        query: undefined,
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: {
+            limit: '20',
+            offset: '0',
+            organizations: ['L-00020007'],
+            query: undefined,
+          },
+        },
       },
       '',
       '/search?limit=20&offset=0&organizations=L-00020007',
@@ -367,7 +379,13 @@ describe('components/SearchSuggestField', () => {
     await wait();
     expect(history.pushState).toHaveBeenCalledTimes(1);
     expect(history.pushState).toHaveBeenCalledWith(
-      { limit: '20', offset: '0', query: 'doct' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '20', offset: '0', query: 'doct' },
+        },
+      },
       '',
       '/search?limit=20&offset=0&query=doct',
     );
@@ -398,7 +416,18 @@ describe('components/SearchSuggestField', () => {
 
     expect(history.pushState).toHaveBeenCalledTimes(2);
     expect(history.pushState).toHaveBeenCalledWith(
-      { limit: '20', offset: '0', persons: ['73'], query: undefined },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: {
+            limit: '20',
+            offset: '0',
+            persons: ['73'],
+            query: undefined,
+          },
+        },
+      },
       '',
       '/search?limit=20&offset=0&persons=73',
     );
@@ -437,7 +466,13 @@ describe('components/SearchSuggestField', () => {
     await wait();
 
     expect(history.pushState).toHaveBeenCalledWith(
-      { limit: '20', offset: '0', query: undefined },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '20', offset: '0', query: undefined },
+        },
+      },
       '',
       '/search?limit=20&offset=0',
     );
@@ -478,7 +513,13 @@ describe('components/SearchSuggestField', () => {
     await wait();
     expect(history.pushState).toHaveBeenCalledTimes(1);
     expect(history.pushState).toHaveBeenLastCalledWith(
-      { limit: '20', offset: '0', query: 'ric' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '20', offset: '0', query: 'ric' },
+        },
+      },
       '',
       '/search?limit=20&offset=0&query=ric',
     );
@@ -487,7 +528,13 @@ describe('components/SearchSuggestField', () => {
     await wait();
     expect(history.pushState).toHaveBeenCalledTimes(2);
     expect(history.pushState).toHaveBeenLastCalledWith(
-      { limit: '20', offset: '0', query: 'rich data driven' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '20', offset: '0', query: 'rich data driven' },
+        },
+      },
       '',
       '/search?limit=20&offset=0&query=rich%20data%20driven',
     );
@@ -496,7 +543,13 @@ describe('components/SearchSuggestField', () => {
     await wait();
     expect(history.pushState).toHaveBeenCalledTimes(3);
     expect(history.pushState).toHaveBeenLastCalledWith(
-      { limit: '20', offset: '0', query: undefined },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '20', offset: '0', query: undefined },
+        },
+      },
       '',
       '/search?limit=20&offset=0',
     );
@@ -545,7 +598,13 @@ describe('components/SearchSuggestField', () => {
     await wait();
     expect(history.pushState).toHaveBeenCalledTimes(1);
     expect(history.pushState).toHaveBeenLastCalledWith(
-      { limit: '20', offset: '0', query: 'ric' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '20', offset: '0', query: 'ric' },
+        },
+      },
       '',
       '/search?limit=20&offset=0&query=ric',
     );
@@ -590,7 +649,13 @@ describe('components/SearchSuggestField', () => {
     await wait();
     expect(history.pushState).toHaveBeenCalledTimes(1);
     expect(history.pushState).toHaveBeenLastCalledWith(
-      { limit: '20', offset: '0', query: 'orga' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: { limit: '20', offset: '0', query: 'orga' },
+        },
+      },
       '',
       '/search?limit=20&offset=0&query=orga',
     );
@@ -601,10 +666,16 @@ describe('components/SearchSuggestField', () => {
     expect(history.pushState).toHaveBeenCalledTimes(2);
     expect(history.pushState).toHaveBeenCalledWith(
       {
-        limit: '20',
-        offset: '0',
-        organizations: ['L-00020007'],
-        query: undefined,
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: {
+            limit: '20',
+            offset: '0',
+            organizations: ['L-00020007'],
+            query: undefined,
+          },
+        },
       },
       '',
       '/search?limit=20&offset=0&organizations=L-00020007',
@@ -616,10 +687,16 @@ describe('components/SearchSuggestField', () => {
     expect(history.pushState).toHaveBeenCalledTimes(3);
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
-        limit: '20',
-        offset: '0',
-        organizations: ['L-00020007'],
-        query: 'ric',
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: expect.any(Array),
+          params: {
+            limit: '20',
+            offset: '0',
+            organizations: ['L-00020007'],
+            query: 'ric',
+          },
+        },
       },
       '',
       '/search?limit=20&offset=0&organizations=L-00020007&query=ric',

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -14,6 +14,16 @@ import { FilterDefinition } from 'types/filters';
 import { history, location } from 'utils/indirection/window';
 import { SearchSuggestField } from '.';
 
+// Unexplained difficulties with fake timers were encountered in these tests.
+// We decided to mock the debounce function instead.
+jest.mock('lodash-es/debounce', () => (fn: any) => (...args: any[]) =>
+  fn(...args),
+);
+
+jest.mock('settings', () => ({
+  API_LIST_DEFAULT_PARAMS: { limit: '13', offset: '0' },
+}));
+
 jest.mock('utils/indirection/window', () => ({
   history: {
     pushState: jest.fn(),
@@ -22,12 +32,6 @@ jest.mock('utils/indirection/window', () => ({
   location: { pathname: '/search' },
   scroll: jest.fn(),
 }));
-
-// Unexplained difficulties with fake timers were encountered in these tests.
-// We decided to mock the debounce function instead.
-jest.mock('lodash-es/debounce', () => (fn: any) => (...args: any[]) =>
-  fn(...args),
-);
 
 describe('components/SearchSuggestField', () => {
   const HistoryWrapper = ({ children }: { children: React.ReactNode }) => {
@@ -300,11 +304,11 @@ describe('components/SearchSuggestField', () => {
         name: 'courseSearch',
         data: {
           lastDispatchActions: expect.any(Array),
-          params: { limit: '20', offset: '0', query: 'orga' },
+          params: { limit: '13', offset: '0', query: 'orga' },
         },
       },
       '',
-      '/search?limit=20&offset=0&query=orga',
+      '/search?limit=13&offset=0&query=orga',
     );
 
     expect(
@@ -338,7 +342,7 @@ describe('components/SearchSuggestField', () => {
         data: {
           lastDispatchActions: expect.any(Array),
           params: {
-            limit: '20',
+            limit: '13',
             offset: '0',
             organizations: ['L-00020007'],
             query: undefined,
@@ -346,7 +350,7 @@ describe('components/SearchSuggestField', () => {
         },
       },
       '',
-      '/search?limit=20&offset=0&organizations=L-00020007',
+      '/search?limit=13&offset=0&organizations=L-00020007',
     );
   });
 
@@ -391,11 +395,11 @@ describe('components/SearchSuggestField', () => {
         name: 'courseSearch',
         data: {
           lastDispatchActions: expect.any(Array),
-          params: { limit: '20', offset: '0', query: 'doct' },
+          params: { limit: '13', offset: '0', query: 'doct' },
         },
       },
       '',
-      '/search?limit=20&offset=0&query=doct',
+      '/search?limit=13&offset=0&query=doct',
     );
 
     expect(
@@ -429,7 +433,7 @@ describe('components/SearchSuggestField', () => {
         data: {
           lastDispatchActions: expect.any(Array),
           params: {
-            limit: '20',
+            limit: '13',
             offset: '0',
             persons: ['73'],
             query: undefined,
@@ -437,7 +441,7 @@ describe('components/SearchSuggestField', () => {
         },
       },
       '',
-      '/search?limit=20&offset=0&persons=73',
+      '/search?limit=13&offset=0&persons=73',
     );
   });
 
@@ -525,11 +529,11 @@ describe('components/SearchSuggestField', () => {
         name: 'courseSearch',
         data: {
           lastDispatchActions: expect.any(Array),
-          params: { limit: '20', offset: '0', query: 'ric' },
+          params: { limit: '13', offset: '0', query: 'ric' },
         },
       },
       '',
-      '/search?limit=20&offset=0&query=ric',
+      '/search?limit=13&offset=0&query=ric',
     );
 
     fireEvent.change(field, { target: { value: 'rich data driven' } });
@@ -540,11 +544,11 @@ describe('components/SearchSuggestField', () => {
         name: 'courseSearch',
         data: {
           lastDispatchActions: expect.any(Array),
-          params: { limit: '20', offset: '0', query: 'rich data driven' },
+          params: { limit: '13', offset: '0', query: 'rich data driven' },
         },
       },
       '',
-      '/search?limit=20&offset=0&query=rich%20data%20driven',
+      '/search?limit=13&offset=0&query=rich%20data%20driven',
     );
 
     fireEvent.change(field, { target: { value: '' } });
@@ -555,11 +559,11 @@ describe('components/SearchSuggestField', () => {
         name: 'courseSearch',
         data: {
           lastDispatchActions: expect.any(Array),
-          params: { limit: '20', offset: '0', query: undefined },
+          params: { limit: '13', offset: '0', query: undefined },
         },
       },
       '',
-      '/search?limit=20&offset=0',
+      '/search?limit=13&offset=0',
     );
   });
 
@@ -610,11 +614,11 @@ describe('components/SearchSuggestField', () => {
         name: 'courseSearch',
         data: {
           lastDispatchActions: expect.any(Array),
-          params: { limit: '20', offset: '0', query: 'ric' },
+          params: { limit: '13', offset: '0', query: 'ric' },
         },
       },
       '',
-      '/search?limit=20&offset=0&query=ric',
+      '/search?limit=13&offset=0&query=ric',
     );
   });
 
@@ -661,11 +665,11 @@ describe('components/SearchSuggestField', () => {
         name: 'courseSearch',
         data: {
           lastDispatchActions: expect.any(Array),
-          params: { limit: '20', offset: '0', query: 'orga' },
+          params: { limit: '13', offset: '0', query: 'orga' },
         },
       },
       '',
-      '/search?limit=20&offset=0&query=orga',
+      '/search?limit=13&offset=0&query=orga',
     );
     // The user selects an organization from suggestions
     fireEvent.click(getByText('Organization #27'));
@@ -678,7 +682,7 @@ describe('components/SearchSuggestField', () => {
         data: {
           lastDispatchActions: expect.any(Array),
           params: {
-            limit: '20',
+            limit: '13',
             offset: '0',
             organizations: ['L-00020007'],
             query: undefined,
@@ -686,7 +690,7 @@ describe('components/SearchSuggestField', () => {
         },
       },
       '',
-      '/search?limit=20&offset=0&organizations=L-00020007',
+      '/search?limit=13&offset=0&organizations=L-00020007',
     );
 
     // The user starts typing a full-text search, the organization remains selected
@@ -699,7 +703,7 @@ describe('components/SearchSuggestField', () => {
         data: {
           lastDispatchActions: expect.any(Array),
           params: {
-            limit: '20',
+            limit: '13',
             offset: '0',
             organizations: ['L-00020007'],
             query: 'ric',
@@ -707,7 +711,7 @@ describe('components/SearchSuggestField', () => {
         },
       },
       '',
-      '/search?limit=20&offset=0&organizations=L-00020007&query=ric',
+      '/search?limit=13&offset=0&organizations=L-00020007&query=ric',
     );
   });
 });

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -17,6 +17,7 @@ jest.mock('utils/indirection/window', () => ({
     replaceState: jest.fn(),
   },
   location: { pathname: '/search' },
+  scroll: jest.fn(),
 }));
 
 // Unexplained difficulties with fake timers were encountered in these tests.

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -115,7 +115,7 @@ describe('components/SearchSuggestField', () => {
   it('clears the input field when the query is removed by another component elsewhere in the tree', () => {
     let doDispatchCourseSearchParamsUpdate: any;
     const OtherComponent = () => {
-      const [, dispatchCourseSearchParamsUpdate] = useCourseSearchParams();
+      const { dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
       doDispatchCourseSearchParamsUpdate = dispatchCourseSearchParamsUpdate;
       return <div></div>;
     };

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -10,7 +10,10 @@ import {
   renderSuggestion,
 } from 'common/searchFields';
 import { SearchInput } from 'components/SearchInput';
-import { useCourseSearchParams } from 'data/useCourseSearchParams';
+import {
+  CourseSearchParamsAction,
+  useCourseSearchParams,
+} from 'data/useCourseSearchParams';
 import { useStaticFilters } from 'data/useStaticFilters';
 import { CommonDataProps } from 'types/commonDataProps';
 import {
@@ -58,7 +61,7 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
     !courseSearchParams.query &&
     lastDispatchActions
       ?.map((action) => action.type)
-      .includes('FILTER_RESET') &&
+      .includes(CourseSearchParamsAction.filterReset) &&
     value
   ) {
     setValue('');
@@ -85,7 +88,7 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
     ) {
       dispatchCourseSearchParamsUpdate({
         query: newValue,
-        type: 'QUERY_UPDATE',
+        type: CourseSearchParamsAction.queryUpdate,
       });
     }
   };
@@ -112,7 +115,7 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
       if (event.keyCode === 13 /* enter */ && !value) {
         dispatchCourseSearchParamsUpdate({
           query: '',
-          type: 'QUERY_UPDATE',
+          type: CourseSearchParamsAction.queryUpdate,
         });
       }
     },
@@ -140,12 +143,12 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
     dispatchCourseSearchParamsUpdate(
       {
         query: '',
-        type: 'QUERY_UPDATE',
+        type: CourseSearchParamsAction.queryUpdate,
       },
       {
         filter,
         payload: String(suggestion.id),
-        type: 'FILTER_ADD',
+        type: CourseSearchParamsAction.filterAdd,
       },
     );
     // Reset the search field state: the task has been completed

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -1,5 +1,5 @@
 import debounce from 'lodash-es/debounce';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import Autosuggest from 'react-autosuggest';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -42,6 +42,7 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
   const {
     courseSearchParams,
     dispatchCourseSearchParamsUpdate,
+    lastDispatchActions,
   } = useCourseSearchParams();
 
   // Initialize hooks for the two pieces of state the controlled <Autosuggest> component needs to interact with:
@@ -50,22 +51,18 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
   const [value, setValue] = useState(courseSearchParams.query || '');
   const [suggestions, setSuggestions] = useState<SearchSuggestionSection[]>([]);
 
-  // Create a ref too keep around courseSearchParams as they were during render N-1
-  const previousCourseSearchParams = useRef(courseSearchParams);
-  // Use the previous & current values of courseSearchParams to guess if the text query had
-  // been removed by another component in the tree, and clear the field as well
-  // NB: this will do nothing on the first render as courseSearchParams and the ref
-  // (previousCourseSearchParams.current) will hold the exact same object at that time.
+  // Use current value of courseSearchParams and last dispatched actions to guess if the text query
+  // has been removed by another component in the tree, and clear the field as well
+  // NB: this will do nothing on the first render as there are then no last dispatched actions.
   if (
     !courseSearchParams.query &&
-    previousCourseSearchParams.current.query &&
+    lastDispatchActions
+      ?.map((action) => action.type)
+      .includes('FILTER_RESET') &&
     value
   ) {
     setValue('');
   }
-  // Then update the ref to the current courseSearchParams so we can have them to compare
-  // during the next render.
-  previousCourseSearchParams.current = courseSearchParams;
 
   /**
    * Helper to update the course search params when the user types. We needed to take it out of

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -39,10 +39,10 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
 
   // Setup our filters updates (for full-text-search and specific filters) directly through the
   // search parameters hook.
-  const [
+  const {
     courseSearchParams,
     dispatchCourseSearchParamsUpdate,
-  ] = useCourseSearchParams();
+  } = useCourseSearchParams();
 
   // Initialize hooks for the two pieces of state the controlled <Autosuggest> component needs to interact with:
   // the current list of suggestions and the input value.

--- a/src/frontend/js/data/useCourseSearchParams/computeNewFilterValue.ts
+++ b/src/frontend/js/data/useCourseSearchParams/computeNewFilterValue.ts
@@ -1,12 +1,15 @@
 import { isMPTTChildOf, isMPTTParentOf } from 'utils/mptt';
 import { Maybe } from 'utils/types';
+import { CourseSearchParamsAction } from '.';
 
 // Compute a new value for a filter to apply to course search, reacting to a user interaction by
 // either adding a new filter or removing one
 export const computeNewFilterValue = (
   existingValue: Maybe<string | string[]>,
   update: {
-    action: 'FILTER_ADD' | 'FILTER_REMOVE';
+    action:
+      | CourseSearchParamsAction.filterAdd
+      | CourseSearchParamsAction.filterRemove;
     isDrilldown: boolean;
     payload: string;
   },
@@ -14,11 +17,11 @@ export const computeNewFilterValue = (
   if (update.isDrilldown) {
     return {
       // ADD: Drilldown filters only support one value at a time
-      FILTER_ADD: () => update.payload,
+      [CourseSearchParamsAction.filterAdd]: () => update.payload,
       // REMOVE:
       // - Drop the existing value if it matches the payload
       // - Keep it otherwise
-      FILTER_REMOVE: () =>
+      [CourseSearchParamsAction.filterRemove]: () =>
         // Drilldown filters only support one value at a time
         existingValue === update.payload
           ? undefined
@@ -30,9 +33,9 @@ export const computeNewFilterValue = (
   if (!existingValue) {
     return {
       // ADD: Make an array with the existing value
-      FILTER_ADD: () => [update.payload],
+      [CourseSearchParamsAction.filterAdd]: () => [update.payload],
       // REMOVE: There's nothing that could possibly removed, return undefined
-      FILTER_REMOVE: () => undefined,
+      [CourseSearchParamsAction.filterRemove]: () => undefined,
     }[update.action]();
   }
 
@@ -43,7 +46,7 @@ export const computeNewFilterValue = (
       // - Make an array with the existing value and the new one if they're different and unrelated
       // - Only keep the new value if the existing value is either its parent or its child
       // - Don't duplicate the value if the new value and existing one are the same
-      FILTER_ADD: () =>
+      [CourseSearchParamsAction.filterAdd]: () =>
         existingValue === update.payload
           ? [existingValue]
           : isMPTTParentOf(existingValue, update.payload) ||
@@ -53,7 +56,7 @@ export const computeNewFilterValue = (
       // REMOVE:
       // - Return nothing if we had to drop the existing value we had
       // - Keep the existing value if it's not the one we needed to drop
-      FILTER_REMOVE: () =>
+      [CourseSearchParamsAction.filterRemove]: () =>
         existingValue === update.payload ? undefined : existingValue,
     }[update.action]();
   }
@@ -61,7 +64,7 @@ export const computeNewFilterValue = (
   // The existing value is an array of strings or numbers (see function signature)
   return {
     // ADD: Just push the new value into our existing array of values
-    FILTER_ADD: () => [
+    [CourseSearchParamsAction.filterAdd]: () => [
       ...existingValue.filter(
         (value) =>
           value !== update.payload &&
@@ -71,7 +74,7 @@ export const computeNewFilterValue = (
       update.payload,
     ],
     // REMOVE: Return the existing array of values without the one we needed to remove
-    FILTER_REMOVE: () =>
+    [CourseSearchParamsAction.filterRemove]: () =>
       dropEmptyArray(existingValue.filter((v) => v !== update.payload)),
   }[update.action]();
 

--- a/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { HistoryContext, useHistory } from 'data/useHistory';
 import * as mockWindow from 'utils/indirection/window';
-import { useCourseSearchParams } from '.';
+import { CourseSearchParamsAction, useCourseSearchParams } from '.';
 
 jest.mock('utils/indirection/window', () => ({
   history: { pushState: jest.fn(), replaceState: jest.fn() },
@@ -91,7 +91,7 @@ describe('data/useCourseSearchParams', () => {
         act(() =>
           dispatchCourseSearchParamsUpdate({
             offset: '39',
-            type: 'PAGE_CHANGE',
+            type: CourseSearchParamsAction.pageChange,
           }),
         );
       }
@@ -110,7 +110,7 @@ describe('data/useCourseSearchParams', () => {
               lastDispatchActions: [
                 {
                   offset: '39',
-                  type: 'PAGE_CHANGE',
+                  type: CourseSearchParamsAction.pageChange,
                 },
               ],
               params: { languages: 'fr', limit: '13', offset: '39' },
@@ -144,7 +144,7 @@ describe('data/useCourseSearchParams', () => {
         act(() =>
           dispatchCourseSearchParamsUpdate({
             query: 'some text query',
-            type: 'QUERY_UPDATE',
+            type: CourseSearchParamsAction.queryUpdate,
           }),
         );
       }
@@ -164,7 +164,7 @@ describe('data/useCourseSearchParams', () => {
               lastDispatchActions: [
                 {
                   query: 'some text query',
-                  type: 'QUERY_UPDATE',
+                  type: CourseSearchParamsAction.queryUpdate,
                 },
               ],
               params: {
@@ -200,7 +200,7 @@ describe('data/useCourseSearchParams', () => {
         act(() =>
           dispatchCourseSearchParamsUpdate({
             query: 'some new query',
-            type: 'QUERY_UPDATE',
+            type: CourseSearchParamsAction.queryUpdate,
           }),
         );
       }
@@ -220,7 +220,7 @@ describe('data/useCourseSearchParams', () => {
               lastDispatchActions: [
                 {
                   query: 'some new query',
-                  type: 'QUERY_UPDATE',
+                  type: CourseSearchParamsAction.queryUpdate,
                 },
               ],
               params: {
@@ -256,7 +256,7 @@ describe('data/useCourseSearchParams', () => {
         act(() =>
           dispatchCourseSearchParamsUpdate({
             query: undefined,
-            type: 'QUERY_UPDATE',
+            type: CourseSearchParamsAction.queryUpdate,
           }),
         );
       }
@@ -276,7 +276,7 @@ describe('data/useCourseSearchParams', () => {
               lastDispatchActions: [
                 {
                   query: undefined,
-                  type: 'QUERY_UPDATE',
+                  type: CourseSearchParamsAction.queryUpdate,
                 },
               ],
               params: {
@@ -318,7 +318,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: 'L-00010017',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -341,7 +341,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'organizations',
                   },
                   payload: 'L-00010017',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -380,7 +380,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'languages',
             },
             payload: 'it',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -403,7 +403,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'languages',
                   },
                   payload: 'it',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -442,7 +442,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: 'L-00010017',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -465,7 +465,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'organizations',
                   },
                   payload: 'L-00010017',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -503,7 +503,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'languages',
             },
             payload: 'zh',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -526,7 +526,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'languages',
                   },
                   payload: 'zh',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -564,7 +564,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: 'L-00010014',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -588,7 +588,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'organizations',
                   },
                   payload: 'L-00010014',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -629,7 +629,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: 'L-00010009',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -680,7 +680,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'subjects',
             },
             payload: 'L-000200030005',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -705,7 +705,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'subjects',
                   },
                   payload: 'L-000200030005',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -752,7 +752,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'subjects',
             },
             payload: 'L-000200030005',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -777,7 +777,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'subjects',
                   },
                   payload: 'L-000200030005',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -826,7 +826,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'subjects',
             },
             payload: 'L-0002000300050013',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -851,7 +851,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'subjects',
                   },
                   payload: 'L-0002000300050013',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -899,7 +899,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'subjects',
             },
             payload: 'L-0002000300050013',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -924,7 +924,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'subjects',
                   },
                   payload: 'L-0002000300050013',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -966,7 +966,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'level',
             },
             payload: 'L-000200010003',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -989,7 +989,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'level',
                   },
                   payload: 'L-000200010003',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -1015,7 +1015,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'level',
             },
             payload: 'L-000200010002',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -1038,7 +1038,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'level',
                   },
                   payload: 'L-000200010002',
-                  type: 'FILTER_ADD',
+                  type: CourseSearchParamsAction.filterAdd,
                 },
               ],
               params: {
@@ -1076,7 +1076,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'level',
             },
             payload: 'L-000200010001',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           }),
         );
       }
@@ -1118,7 +1118,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: 'L-00010009',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1142,7 +1142,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'organizations',
                   },
                   payload: 'L-00010009',
-                  type: 'FILTER_REMOVE',
+                  type: CourseSearchParamsAction.filterRemove,
                 },
               ],
               params: {
@@ -1167,7 +1167,7 @@ describe('data/useCourseSearchParams', () => {
           dispatchCourseSearchParamsUpdate({
             filter: { is_drilldown: false, name: 'organizations' },
             payload: 'L00010011',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1190,7 +1190,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'organizations',
                   },
                   payload: 'L00010011',
-                  type: 'FILTER_REMOVE',
+                  type: CourseSearchParamsAction.filterRemove,
                 },
               ],
               params: {
@@ -1232,7 +1232,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: 'L-00010013',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1255,7 +1255,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'organizations',
                   },
                   payload: 'L-00010013',
-                  type: 'FILTER_REMOVE',
+                  type: CourseSearchParamsAction.filterRemove,
                 },
               ],
               params: {
@@ -1293,7 +1293,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'subjects',
             },
             payload: 'L-00010076',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1331,7 +1331,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: '121',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1371,7 +1371,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: '121',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1412,7 +1412,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'level',
             },
             payload: 'L-000200010001',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1435,7 +1435,7 @@ describe('data/useCourseSearchParams', () => {
                     name: 'level',
                   },
                   payload: 'L-000200010001',
-                  type: 'FILTER_REMOVE',
+                  type: CourseSearchParamsAction.filterRemove,
                 },
               ],
               params: {
@@ -1475,7 +1475,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'level',
             },
             payload: 'L-000200010003',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1515,7 +1515,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'level',
             },
             payload: 'L-000200010002',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           }),
         );
       }
@@ -1551,7 +1551,11 @@ describe('data/useCourseSearchParams', () => {
           subjects: ['P-00030004', 'P-00030007'],
         });
 
-        act(() => dispatchCourseSearchParamsUpdate({ type: 'FILTER_RESET' }));
+        act(() =>
+          dispatchCourseSearchParamsUpdate({
+            type: CourseSearchParamsAction.filterReset,
+          }),
+        );
       }
       {
         const { courseSearchParams } = getLatestHookValues();
@@ -1562,7 +1566,7 @@ describe('data/useCourseSearchParams', () => {
             data: {
               lastDispatchActions: [
                 {
-                  type: 'FILTER_RESET',
+                  type: CourseSearchParamsAction.filterReset,
                 },
               ],
               params: { limit: '27', offset: '0' },
@@ -1600,7 +1604,7 @@ describe('data/useCourseSearchParams', () => {
               name: 'organizations',
             },
             payload: 'L-00010009',
-            type: 'FILTER_REMOVE',
+            type: CourseSearchParamsAction.filterRemove,
           },
           {
             filter: {
@@ -1608,9 +1612,12 @@ describe('data/useCourseSearchParams', () => {
               name: 'languages',
             },
             payload: 'it',
-            type: 'FILTER_ADD',
+            type: CourseSearchParamsAction.filterAdd,
           },
-          { query: 'some new query', type: 'QUERY_UPDATE' },
+          {
+            query: 'some new query',
+            type: CourseSearchParamsAction.queryUpdate,
+          },
         ),
       );
     }
@@ -1635,7 +1642,7 @@ describe('data/useCourseSearchParams', () => {
                   name: 'organizations',
                 },
                 payload: 'L-00010009',
-                type: 'FILTER_REMOVE',
+                type: CourseSearchParamsAction.filterRemove,
               },
               {
                 filter: {
@@ -1643,11 +1650,11 @@ describe('data/useCourseSearchParams', () => {
                   name: 'languages',
                 },
                 payload: 'it',
-                type: 'FILTER_ADD',
+                type: CourseSearchParamsAction.filterAdd,
               },
               {
                 query: 'some new query',
-                type: 'QUERY_UPDATE',
+                type: CourseSearchParamsAction.queryUpdate,
               },
             ],
             params: {

--- a/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
@@ -5,6 +5,10 @@ import { HistoryContext, useHistory } from 'data/useHistory';
 import * as mockWindow from 'utils/indirection/window';
 import { CourseSearchParamsAction, useCourseSearchParams } from '.';
 
+jest.mock('settings', () => ({
+  API_LIST_DEFAULT_PARAMS: { limit: '13', offset: '0' },
+}));
+
 jest.mock('utils/indirection/window', () => ({
   history: { pushState: jest.fn(), replaceState: jest.fn() },
   location: {},
@@ -58,7 +62,7 @@ describe('data/useCourseSearchParams', () => {
     mockWindow.location.search = '';
     render(<WrappedTestComponent />);
     const { courseSearchParams } = getLatestHookValues();
-    expect(courseSearchParams).toEqual({ limit: '20', offset: '0' });
+    expect(courseSearchParams).toEqual({ limit: '13', offset: '0' });
     // We need an update so the URL reflects the actual query params
     expect(mockWindow.history.replaceState).toHaveBeenCalledTimes(1);
     expect(mockWindow.history.replaceState).toHaveBeenCalledWith(
@@ -66,11 +70,11 @@ describe('data/useCourseSearchParams', () => {
         name: 'courseSearch',
         data: {
           lastDispatchActions: null,
-          params: { limit: '20', offset: '0' },
+          params: { limit: '13', offset: '0' },
         },
       },
       '',
-      '/search?limit=20&offset=0',
+      '/search?limit=13&offset=0',
     );
   });
 

--- a/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
@@ -354,7 +354,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=10&offset=0&organizations=L-00010003&organizations=L-00010009&organizations=L-00010017',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -416,7 +416,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?languages=en&languages=fr&languages=it&limit=10&offset=0',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -478,7 +478,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=10&offset=0&organizations=L-00010003&organizations=L-00010017',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -539,7 +539,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?languages=de&languages=zh&limit=10&offset=0',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -602,7 +602,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&organizations=L-00010014&query=some%20query',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -720,7 +720,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=a%20query&subjects=P-000200030012&subjects=L-000200030005',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -792,7 +792,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query&subjects=L-000200030005',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -867,7 +867,7 @@ describe('data/useCourseSearchParams', () => {
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query' +
             '&subjects=P-000200030012&subjects=L-0002000300050013',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -939,7 +939,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query&subjects=L-0002000300050013',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
   });
@@ -1002,7 +1002,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?level=L-000200010003&limit=999&offset=0',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
       {
         // Replace an existing value
@@ -1051,7 +1051,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?level=L-000200010002&limit=999&offset=0',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -1156,7 +1156,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&organizations=L00010011&query=some%20query',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
       {
         // Remove from a list of just one value
@@ -1203,7 +1203,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&query=some%20query',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -1268,7 +1268,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&query=some%20query',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -1448,7 +1448,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&query=some%20query',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -1571,7 +1571,7 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=27&offset=0',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
+        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
   });

--- a/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
@@ -43,7 +43,7 @@ describe('data/useCourseSearchParams', () => {
     mockWindow.location.search =
       '?organizations=L-00010003&organizations=L-00010009&query=some%20query&limit=8&offset=3';
     render(<WrappedTestComponent />);
-    const [courseSearchParams] = getLatestHookValues();
+    const { courseSearchParams } = getLatestHookValues();
     expect(courseSearchParams).toEqual({
       limit: '8',
       offset: '3',
@@ -57,7 +57,7 @@ describe('data/useCourseSearchParams', () => {
   it('initializes with defaults if there is no query string param', () => {
     mockWindow.location.search = '';
     render(<WrappedTestComponent />);
-    const [courseSearchParams] = getLatestHookValues();
+    const { courseSearchParams } = getLatestHookValues();
     expect(courseSearchParams).toEqual({ limit: '20', offset: '0' });
     // We need an update so the URL reflects the actual query params
     expect(mockWindow.history.replaceState).toHaveBeenCalledTimes(1);
@@ -73,16 +73,24 @@ describe('data/useCourseSearchParams', () => {
       mockWindow.location.search = '?languages=fr&limit=13&offset=26';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'fr',
           limit: '13',
           offset: '26',
         });
-        act(() => dispatch({ offset: '39', type: 'PAGE_CHANGE' }));
+        act(() =>
+          dispatchCourseSearchParamsUpdate({
+            offset: '39',
+            type: 'PAGE_CHANGE',
+          }),
+        );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'fr',
           limit: '13',
@@ -107,16 +115,24 @@ describe('data/useCourseSearchParams', () => {
       mockWindow.location.search = '?languages=en&limit=17&offset=5';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'en',
           limit: '17',
           offset: '5',
         });
-        act(() => dispatch({ query: 'some text query', type: 'QUERY_UPDATE' }));
+        act(() =>
+          dispatchCourseSearchParamsUpdate({
+            query: 'some text query',
+            type: 'QUERY_UPDATE',
+          }),
+        );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'en',
           limit: '17',
@@ -143,17 +159,25 @@ describe('data/useCourseSearchParams', () => {
         '?languages=fr&limit=999&offset=0&query=some%20previous%20query';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'fr',
           limit: '999',
           offset: '0',
           query: 'some previous query',
         });
-        act(() => dispatch({ query: 'some new query', type: 'QUERY_UPDATE' }));
+        act(() =>
+          dispatchCourseSearchParamsUpdate({
+            query: 'some new query',
+            type: 'QUERY_UPDATE',
+          }),
+        );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'fr',
           limit: '999',
@@ -180,17 +204,25 @@ describe('data/useCourseSearchParams', () => {
         '?languages=es&limit=999&offset=0&query=some%20existing%20query';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'es',
           limit: '999',
           offset: '0',
           query: 'some existing query',
         });
-        act(() => dispatch({ query: undefined, type: 'QUERY_UPDATE' }));
+        act(() =>
+          dispatchCourseSearchParamsUpdate({
+            query: undefined,
+            type: 'QUERY_UPDATE',
+          }),
+        );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'es',
           limit: '999',
@@ -214,7 +246,10 @@ describe('data/useCourseSearchParams', () => {
         '?organizations=L-00010003&organizations=L-00010009&offset=999&limit=10';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '10',
           offset: '999',
@@ -222,7 +257,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'organizations',
@@ -233,7 +268,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '10',
           offset: '0',
@@ -258,7 +293,10 @@ describe('data/useCourseSearchParams', () => {
         '?languages=en&languages=fr&offset=999&limit=10';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: ['en', 'fr'],
           limit: '10',
@@ -266,7 +304,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'languages',
@@ -277,7 +315,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: ['en', 'fr', 'it'],
           limit: '10',
@@ -298,7 +336,10 @@ describe('data/useCourseSearchParams', () => {
         '?organizations=L-00010003&offset=999&limit=10';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '10',
           offset: '999',
@@ -306,7 +347,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'organizations',
@@ -317,7 +358,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '10',
           offset: '0',
@@ -341,7 +382,10 @@ describe('data/useCourseSearchParams', () => {
       mockWindow.location.search = '?languages=de&offset=999&limit=10';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'de',
           limit: '10',
@@ -349,7 +393,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'languages',
@@ -360,7 +404,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: ['de', 'zh'],
           limit: '10',
@@ -384,7 +428,10 @@ describe('data/useCourseSearchParams', () => {
       mockWindow.location.search = '?limit=999&offset=0&query=some%20query';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -392,7 +439,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'organizations',
@@ -403,7 +450,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -430,7 +477,10 @@ describe('data/useCourseSearchParams', () => {
         '?limit=999&offset=0&query=some%20query&organizations=L-00010009';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -439,7 +489,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'organizations',
@@ -450,7 +500,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -473,7 +523,10 @@ describe('data/useCourseSearchParams', () => {
         '&levels=L-000200020005';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -487,7 +540,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'subjects',
@@ -498,7 +551,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -531,7 +584,10 @@ describe('data/useCourseSearchParams', () => {
         '&levels=L-000200020005';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -541,7 +597,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'subjects',
@@ -552,7 +608,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -587,7 +643,10 @@ describe('data/useCourseSearchParams', () => {
         '&levels=L-000200020005';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -597,7 +656,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'subjects',
@@ -608,7 +667,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -642,7 +701,10 @@ describe('data/useCourseSearchParams', () => {
         '&levels=L-000200020005';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -652,7 +714,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'subjects',
@@ -663,7 +725,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -694,14 +756,17 @@ describe('data/useCourseSearchParams', () => {
       render(<WrappedTestComponent />);
       {
         // Set a value where there was no value
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: true,
               name: 'level',
@@ -712,7 +777,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010003',
           limit: '999',
@@ -733,9 +798,9 @@ describe('data/useCourseSearchParams', () => {
       {
         // Replace an existing value
         jest.resetAllMocks();
-        const [, dispatch] = getLatestHookValues();
+        const { dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: true,
               name: 'level',
@@ -746,7 +811,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010002',
           limit: '999',
@@ -770,7 +835,10 @@ describe('data/useCourseSearchParams', () => {
       mockWindow.location.search = '?level=L-000200010001&limit=999&offset=0';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010001',
           limit: '999',
@@ -778,7 +846,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: true,
               name: 'level',
@@ -789,7 +857,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010001',
           limit: '999',
@@ -808,7 +876,10 @@ describe('data/useCourseSearchParams', () => {
       render(<WrappedTestComponent />);
       {
         // Remove from a list of more than one value
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -817,7 +888,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'organizations',
@@ -828,7 +899,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -851,10 +922,10 @@ describe('data/useCourseSearchParams', () => {
       {
         // Remove from a list of just one value
         jest.resetAllMocks();
-        const [, dispatch] = getLatestHookValues();
+        const { dispatchCourseSearchParamsUpdate } = getLatestHookValues();
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: { is_drilldown: false, name: 'organizations' },
             payload: 'L00010011',
             type: 'FILTER_REMOVE',
@@ -862,7 +933,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -889,7 +960,10 @@ describe('data/useCourseSearchParams', () => {
         '?limit=999&offset=0&query=some%20query&organizations=L-00010013';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -898,7 +972,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'organizations',
@@ -909,7 +983,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -933,7 +1007,10 @@ describe('data/useCourseSearchParams', () => {
       mockWindow.location.search = '?limit=999&offset=0&query=some%20query';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -941,7 +1018,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'subjects',
@@ -952,7 +1029,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -968,7 +1045,10 @@ describe('data/useCourseSearchParams', () => {
         '?limit=999&offset=0&organizations=L-00010003&organizations=L-00010009';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -976,7 +1056,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'organizations',
@@ -987,7 +1067,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1005,7 +1085,10 @@ describe('data/useCourseSearchParams', () => {
         '?limit=999&offset=0&organizations=L-00010011';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1013,7 +1096,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: false,
               name: 'organizations',
@@ -1024,7 +1107,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1042,7 +1125,10 @@ describe('data/useCourseSearchParams', () => {
         '?level=L-000200010001&limit=999&offset=0&query=some%20query';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010001',
           limit: '999',
@@ -1051,7 +1137,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: true,
               name: 'level',
@@ -1062,7 +1148,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1087,7 +1173,10 @@ describe('data/useCourseSearchParams', () => {
         '?level=L-000200010001&limit=999&offset=0&query=some%20query';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010001',
           limit: '999',
@@ -1096,7 +1185,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: true,
               name: 'level',
@@ -1107,7 +1196,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010001',
           limit: '999',
@@ -1124,7 +1213,10 @@ describe('data/useCourseSearchParams', () => {
         '?organizations=L-00010009&limit=999&offset=0&query=some%20query';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1133,7 +1225,7 @@ describe('data/useCourseSearchParams', () => {
         });
 
         act(() =>
-          dispatch({
+          dispatchCourseSearchParamsUpdate({
             filter: {
               is_drilldown: true,
               name: 'level',
@@ -1144,7 +1236,7 @@ describe('data/useCourseSearchParams', () => {
         );
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1163,7 +1255,10 @@ describe('data/useCourseSearchParams', () => {
         '?organizations=L-00010004&subjects=P-00030004&subjects=P-00030007&limit=27&offset=54&query=some%20query';
       render(<WrappedTestComponent />);
       {
-        const [courseSearchParams, dispatch] = getLatestHookValues();
+        const {
+          courseSearchParams,
+          dispatchCourseSearchParamsUpdate,
+        } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '27',
           offset: '54',
@@ -1172,10 +1267,10 @@ describe('data/useCourseSearchParams', () => {
           subjects: ['P-00030004', 'P-00030007'],
         });
 
-        act(() => dispatch({ type: 'FILTER_RESET' }));
+        act(() => dispatchCourseSearchParamsUpdate({ type: 'FILTER_RESET' }));
       }
       {
-        const [courseSearchParams] = getLatestHookValues();
+        const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({ limit: '27', offset: '0' });
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           { limit: '27', offset: '0' },
@@ -1192,7 +1287,10 @@ describe('data/useCourseSearchParams', () => {
       '?limit=20&offset=0&query=some%20query&organizations=L-00010009&organizations=L00010011';
     render(<WrappedTestComponent />);
     {
-      const [courseSearchParams, dispatch] = getLatestHookValues();
+      const {
+        courseSearchParams,
+        dispatchCourseSearchParamsUpdate,
+      } = getLatestHookValues();
       expect(courseSearchParams).toEqual({
         limit: '20',
         offset: '0',
@@ -1201,7 +1299,7 @@ describe('data/useCourseSearchParams', () => {
       });
       // Dispatch three actions at once to make sure everything is handled cleanly
       act(() =>
-        dispatch(
+        dispatchCourseSearchParamsUpdate(
           {
             filter: {
               is_drilldown: false,
@@ -1223,7 +1321,7 @@ describe('data/useCourseSearchParams', () => {
       );
     }
     {
-      const [courseSearchParams] = getLatestHookValues();
+      const { courseSearchParams } = getLatestHookValues();
       expect(courseSearchParams).toEqual({
         languages: ['it'],
         limit: '20',

--- a/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
@@ -62,7 +62,13 @@ describe('data/useCourseSearchParams', () => {
     // We need an update so the URL reflects the actual query params
     expect(mockWindow.history.replaceState).toHaveBeenCalledTimes(1);
     expect(mockWindow.history.replaceState).toHaveBeenCalledWith(
-      { limit: '20', offset: '0' },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: null,
+          params: { limit: '20', offset: '0' },
+        },
+      },
       '',
       '/search?limit=20&offset=0',
     );
@@ -98,7 +104,18 @@ describe('data/useCourseSearchParams', () => {
         });
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
-          { languages: 'fr', limit: '13', offset: '39' },
+          {
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  offset: '39',
+                  type: 'PAGE_CHANGE',
+                },
+              ],
+              params: { languages: 'fr', limit: '13', offset: '39' },
+            },
+          },
           '',
           '/search?languages=fr&limit=13&offset=39',
         );
@@ -142,10 +159,21 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            languages: 'en',
-            limit: '17',
-            offset: '0',
-            query: 'some text query',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  query: 'some text query',
+                  type: 'QUERY_UPDATE',
+                },
+              ],
+              params: {
+                languages: 'en',
+                limit: '17',
+                offset: '0',
+                query: 'some text query',
+              },
+            },
           },
           '',
           '/search?languages=en&limit=17&offset=0&query=some%20text%20query',
@@ -187,10 +215,21 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            languages: 'fr',
-            limit: '999',
-            offset: '0',
-            query: 'some new query',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  query: 'some new query',
+                  type: 'QUERY_UPDATE',
+                },
+              ],
+              params: {
+                languages: 'fr',
+                limit: '999',
+                offset: '0',
+                query: 'some new query',
+              },
+            },
           },
           '',
           '/search?languages=fr&limit=999&offset=0&query=some%20new%20query',
@@ -231,7 +270,23 @@ describe('data/useCourseSearchParams', () => {
         });
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
-          { languages: 'es', limit: '999', offset: '0', query: undefined },
+          {
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  query: undefined,
+                  type: 'QUERY_UPDATE',
+                },
+              ],
+              params: {
+                languages: 'es',
+                limit: '999',
+                offset: '0',
+                query: undefined,
+              },
+            },
+          },
           '',
           '/search?languages=es&limit=999&offset=0',
         );
@@ -277,9 +332,24 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            limit: '10',
-            offset: '0',
-            organizations: ['L-00010003', 'L-00010009', 'L-00010017'],
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'organizations',
+                  },
+                  payload: 'L-00010017',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                limit: '10',
+                offset: '0',
+                organizations: ['L-00010003', 'L-00010009', 'L-00010017'],
+              },
+            },
           },
           '',
           '/search?limit=10&offset=0&organizations=L-00010003&organizations=L-00010009&organizations=L-00010017',
@@ -323,7 +393,26 @@ describe('data/useCourseSearchParams', () => {
         });
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
-          { languages: ['en', 'fr', 'it'], limit: '10', offset: '0' },
+          {
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'languages',
+                  },
+                  payload: 'it',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                languages: ['en', 'fr', 'it'],
+                limit: '10',
+                offset: '0',
+              },
+            },
+          },
           '',
           '/search?languages=en&languages=fr&languages=it&limit=10&offset=0',
         );
@@ -367,9 +456,24 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            limit: '10',
-            offset: '0',
-            organizations: ['L-00010003', 'L-00010017'],
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'organizations',
+                  },
+                  payload: 'L-00010017',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                limit: '10',
+                offset: '0',
+                organizations: ['L-00010003', 'L-00010017'],
+              },
+            },
           },
           '',
           '/search?limit=10&offset=0&organizations=L-00010003&organizations=L-00010017',
@@ -413,9 +517,24 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            languages: ['de', 'zh'],
-            limit: '10',
-            offset: '0',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'languages',
+                  },
+                  payload: 'zh',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                languages: ['de', 'zh'],
+                limit: '10',
+                offset: '0',
+              },
+            },
           },
           '',
           '/search?languages=de&languages=zh&limit=10&offset=0',
@@ -460,10 +579,25 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            limit: '999',
-            offset: '0',
-            organizations: ['L-00010014'],
-            query: 'some query',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'organizations',
+                  },
+                  payload: 'L-00010014',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                limit: '999',
+                offset: '0',
+                organizations: ['L-00010014'],
+                query: 'some query',
+              },
+            },
           },
           '',
           '/search?limit=999&offset=0&organizations=L-00010014&query=some%20query',
@@ -562,11 +696,26 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            levels: 'L-000200020005',
-            limit: '999',
-            offset: '0',
-            query: 'a query',
-            subjects: ['P-000200030012', 'L-000200030005'],
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'subjects',
+                  },
+                  payload: 'L-000200030005',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                levels: 'L-000200020005',
+                limit: '999',
+                offset: '0',
+                query: 'a query',
+                subjects: ['P-000200030012', 'L-000200030005'],
+              },
+            },
           },
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=a%20query&subjects=P-000200030012&subjects=L-000200030005',
@@ -619,11 +768,26 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            levels: 'L-000200020005',
-            limit: '999',
-            offset: '0',
-            query: 'some query',
-            subjects: ['L-000200030005'],
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'subjects',
+                  },
+                  payload: 'L-000200030005',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                levels: 'L-000200020005',
+                limit: '999',
+                offset: '0',
+                query: 'some query',
+                subjects: ['L-000200030005'],
+              },
+            },
           },
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query&subjects=L-000200030005',
@@ -678,11 +842,26 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            levels: 'L-000200020005',
-            limit: '999',
-            offset: '0',
-            query: 'some query',
-            subjects: ['P-000200030012', 'L-0002000300050013'],
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'subjects',
+                  },
+                  payload: 'L-0002000300050013',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                levels: 'L-000200020005',
+                limit: '999',
+                offset: '0',
+                query: 'some query',
+                subjects: ['P-000200030012', 'L-0002000300050013'],
+              },
+            },
           },
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query' +
@@ -736,11 +915,26 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            levels: 'L-000200020005',
-            limit: '999',
-            offset: '0',
-            query: 'some query',
-            subjects: ['L-0002000300050013'],
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'subjects',
+                  },
+                  payload: 'L-0002000300050013',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                levels: 'L-000200020005',
+                limit: '999',
+                offset: '0',
+                query: 'some query',
+                subjects: ['L-0002000300050013'],
+              },
+            },
           },
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query&subjects=L-0002000300050013',
@@ -786,9 +980,24 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            level: 'L-000200010003',
-            limit: '999',
-            offset: '0',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: true,
+                    name: 'level',
+                  },
+                  payload: 'L-000200010003',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                level: 'L-000200010003',
+                limit: '999',
+                offset: '0',
+              },
+            },
           },
           '',
           '/search?level=L-000200010003&limit=999&offset=0',
@@ -820,9 +1029,24 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            level: 'L-000200010002',
-            limit: '999',
-            offset: '0',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: true,
+                    name: 'level',
+                  },
+                  payload: 'L-000200010002',
+                  type: 'FILTER_ADD',
+                },
+              ],
+              params: {
+                level: 'L-000200010002',
+                limit: '999',
+                offset: '0',
+              },
+            },
           },
           '',
           '/search?level=L-000200010002&limit=999&offset=0',
@@ -909,10 +1133,25 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            limit: '999',
-            offset: '0',
-            organizations: ['L00010011'],
-            query: 'some query',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'organizations',
+                  },
+                  payload: 'L-00010009',
+                  type: 'FILTER_REMOVE',
+                },
+              ],
+              params: {
+                limit: '999',
+                offset: '0',
+                organizations: ['L00010011'],
+                query: 'some query',
+              },
+            },
           },
           '',
           '/search?limit=999&offset=0&organizations=L00010011&query=some%20query',
@@ -942,9 +1181,24 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            limit: '999',
-            offset: '0',
-            query: 'some query',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'organizations',
+                  },
+                  payload: 'L00010011',
+                  type: 'FILTER_REMOVE',
+                },
+              ],
+              params: {
+                limit: '999',
+                offset: '0',
+                query: 'some query',
+              },
+            },
           },
           '',
           '/search?limit=999&offset=0&query=some%20query',
@@ -992,9 +1246,24 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            limit: '999',
-            offset: '0',
-            query: 'some query',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: false,
+                    name: 'organizations',
+                  },
+                  payload: 'L-00010013',
+                  type: 'FILTER_REMOVE',
+                },
+              ],
+              params: {
+                limit: '999',
+                offset: '0',
+                query: 'some query',
+              },
+            },
           },
           '',
           '/search?limit=999&offset=0&query=some%20query',
@@ -1157,9 +1426,24 @@ describe('data/useCourseSearchParams', () => {
         expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
           {
-            limit: '999',
-            offset: '0',
-            query: 'some query',
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  filter: {
+                    is_drilldown: true,
+                    name: 'level',
+                  },
+                  payload: 'L-000200010001',
+                  type: 'FILTER_REMOVE',
+                },
+              ],
+              params: {
+                limit: '999',
+                offset: '0',
+                query: 'some query',
+              },
+            },
           },
           '',
           '/search?limit=999&offset=0&query=some%20query',
@@ -1273,7 +1557,17 @@ describe('data/useCourseSearchParams', () => {
         const { courseSearchParams } = getLatestHookValues();
         expect(courseSearchParams).toEqual({ limit: '27', offset: '0' });
         expect(mockWindow.history.pushState).toHaveBeenCalledWith(
-          { limit: '27', offset: '0' },
+          {
+            name: 'courseSearch',
+            data: {
+              lastDispatchActions: [
+                {
+                  type: 'FILTER_RESET',
+                },
+              ],
+              params: { limit: '27', offset: '0' },
+            },
+          },
           '',
           '/search?limit=27&offset=0',
         );
@@ -1332,11 +1626,38 @@ describe('data/useCourseSearchParams', () => {
       expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
       expect(mockWindow.history.pushState).toHaveBeenCalledWith(
         {
-          languages: ['it'],
-          limit: '20',
-          offset: '0',
-          organizations: ['L00010011'],
-          query: 'some new query',
+          name: 'courseSearch',
+          data: {
+            lastDispatchActions: [
+              {
+                filter: {
+                  is_drilldown: false,
+                  name: 'organizations',
+                },
+                payload: 'L-00010009',
+                type: 'FILTER_REMOVE',
+              },
+              {
+                filter: {
+                  is_drilldown: false,
+                  name: 'languages',
+                },
+                payload: 'it',
+                type: 'FILTER_ADD',
+              },
+              {
+                query: 'some new query',
+                type: 'QUERY_UPDATE',
+              },
+            ],
+            params: {
+              languages: ['it'],
+              limit: '20',
+              offset: '0',
+              organizations: ['L00010011'],
+              query: 'some new query',
+            },
+          },
         },
         '',
         '/search?languages=it&limit=20&offset=0&organizations=L00010011&query=some%20new%20query',

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -93,7 +93,7 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
   const [historyEntry, pushState, replaceState] = useContext(HistoryContext);
 
   // HistoryEntry.state includes parse query strings, which if we're on a search page should be course search params
-  const courseSearchParams: APIListRequestParams = historyEntry.state;
+  const courseSearchParams: APIListRequestParams = historyEntry.state.data.params;
 
   // The dispatch + reducer pattern is useful to model changes in the course search params. However, we don't want
   // to duplicate behavior by having to sync the HistoryContext state with a `useReducer` call here.
@@ -111,12 +111,22 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
     // `courseSearchParams` and the result of `parse(location.search)`.
     // It also neatly treats eg. `organizations: '43'` and `organizations: ['43']` as the same.
     if (stringify(newParams) !== stringify(parse(location.search))) {
-      pushState(newParams, '', `${location.pathname}?${stringify(newParams)}`);
+      pushState(
+        {
+          name: 'courseSearch',
+          data: { params: newParams, lastDispatchActions: actions },
+        },
+        '',
+        `${location.pathname}?${stringify(newParams)}`,
+      );
     } else {
       // Just issue a replaceState call. This is useful as it means we'll push normalized params from
       // our reducer function.
       replaceState(
-        newParams,
+        {
+          name: 'courseSearch',
+          data: { params: newParams, lastDispatchActions: actions },
+        },
         '',
         `${location.pathname}?${stringify(newParams)}`,
       );
@@ -152,7 +162,10 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
     if (!courseSearchParams.limit || !courseSearchParams.offset) {
       const newParams = { ...API_LIST_DEFAULT_PARAMS, ...courseSearchParams };
       replaceState(
-        newParams,
+        {
+          name: 'courseSearch',
+          data: { params: newParams, lastDispatchActions: null },
+        },
         '',
         `${location.pathname}?${stringify(newParams)}`,
       );

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -34,10 +34,12 @@ export type CourseSearchParamsReducerAction =
   | PageChangeAction
   | QueryAction;
 
-type CourseSearchParamsState = [
-  APIListRequestParams,
-  (...Actions: CourseSearchParamsReducerAction[]) => void,
-];
+type CourseSearchParamsState = {
+  courseSearchParams: APIListRequestParams;
+  dispatchCourseSearchParamsUpdate: (
+    ...Actions: CourseSearchParamsReducerAction[]
+  ) => void;
+};
 
 const courseSearchParamsReducer = (
   courseSearchParams: APIListRequestParams,
@@ -157,5 +159,8 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
     }
   }, [courseSearchParams]);
 
-  return [courseSearchParams, dispatch];
+  return {
+    courseSearchParams,
+    dispatchCourseSearchParamsUpdate: dispatch,
+  };
 };

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -6,6 +6,7 @@ import { API_LIST_DEFAULT_PARAMS } from 'settings';
 import { APIListRequestParams } from 'types/api';
 import { FilterDefinition } from 'types/filters';
 import { location, scroll } from 'utils/indirection/window';
+import { Maybe } from 'utils/types';
 import { computeNewFilterValue } from './computeNewFilterValue';
 
 interface FilterResetAction {
@@ -39,6 +40,7 @@ type CourseSearchParamsState = {
   dispatchCourseSearchParamsUpdate: (
     ...Actions: CourseSearchParamsReducerAction[]
   ) => void;
+  lastDispatchActions: Maybe<CourseSearchParamsReducerAction[]>;
 };
 
 const courseSearchParamsReducer = (
@@ -171,5 +173,6 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
   return {
     courseSearchParams,
     dispatchCourseSearchParamsUpdate: dispatch,
+    lastDispatchActions: historyEntry.state.data?.lastDispatchActions,
   };
 };

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -93,7 +93,8 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
   const [historyEntry, pushState, replaceState] = useContext(HistoryContext);
 
   // HistoryEntry.state includes parse query strings, which if we're on a search page should be course search params
-  const courseSearchParams: APIListRequestParams = historyEntry.state.data.params;
+  const courseSearchParams: APIListRequestParams =
+    historyEntry.state.data.params;
 
   // The dispatch + reducer pattern is useful to model changes in the course search params. However, we don't want
   // to duplicate behavior by having to sync the HistoryContext state with a `useReducer` call here.
@@ -134,19 +135,14 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
   };
 
   useEffect(() => {
-    // We want to scroll back to the top only when pagination is updated. When the user clicks on a page number,
-    // we can safely assume they are done interacting and want to move up top to see the new page.
-    // When they're adding filters, we don't want to jankily force them to scroll again to where they were in
-    // the page if they wanted to add more than one filter.
-    // We're using `stringify(parse(location.search))` as a way to reorder location search to the same order
-    // `stringify` would output for our courseSearchParams. This allows us to avoid doing a deep comparison on
-    // `courseSearchParams` and the result of `parse(location.search)`.
+    // We want to scroll back to the top when course search params have changed, unless the last action resulted
+    // from a user interaction with the SuggestField, eg. changed the query
     if (
-      parse(location.search).offset !== courseSearchParams.offset &&
-      stringify({
-        ...courseSearchParams,
-        offset: parse(location.search).offset,
-      }) === stringify(parse(location.search))
+      historyEntry.state.data &&
+      historyEntry.state.data.lastDispatchActions &&
+      !historyEntry.state.data?.lastDispatchActions
+        ?.map((action: CourseSearchParamsReducerAction) => action.type)
+        .includes('QUERY_UPDATE')
     ) {
       scroll({
         behavior: 'smooth',
@@ -170,7 +166,7 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
         `${location.pathname}?${stringify(newParams)}`,
       );
     }
-  }, [courseSearchParams]);
+  }, [stringify(courseSearchParams)]);
 
   return {
     courseSearchParams,

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -9,27 +9,37 @@ import { location, scroll } from 'utils/indirection/window';
 import { Maybe } from 'utils/types';
 import { computeNewFilterValue } from './computeNewFilterValue';
 
+export enum CourseSearchParamsAction {
+  filterReset = 'FILTER_RESET',
+  filterAdd = 'FILTER_ADD',
+  filterRemove = 'FILTER_REMOVE',
+  pageChange = 'PAGE_CHANGE',
+  queryUpdate = 'QUERY_UPDATE',
+}
+
 interface FilterResetAction {
-  type: 'FILTER_RESET';
+  type: CourseSearchParamsAction.filterReset;
 }
 
 interface FilterSingleAction {
   filter: FilterDefinition;
   payload: string;
-  type: 'FILTER_ADD' | 'FILTER_REMOVE';
+  type:
+    | CourseSearchParamsAction.filterAdd
+    | CourseSearchParamsAction.filterRemove;
 }
 
 interface PageChangeAction {
   offset: string;
-  type: 'PAGE_CHANGE';
+  type: CourseSearchParamsAction.pageChange;
 }
 
 interface QueryAction {
   query: string;
-  type: 'QUERY_UPDATE';
+  type: CourseSearchParamsAction.queryUpdate;
 }
 
-export type CourseSearchParamsReducerAction =
+type CourseSearchParamsReducerAction =
   | FilterResetAction
   | FilterSingleAction
   | PageChangeAction
@@ -48,13 +58,13 @@ const courseSearchParamsReducer = (
   action: CourseSearchParamsReducerAction,
 ) => {
   switch (action.type) {
-    case 'PAGE_CHANGE':
+    case CourseSearchParamsAction.pageChange:
       return {
         ...courseSearchParams,
         offset: action.offset,
       };
 
-    case 'QUERY_UPDATE':
+    case CourseSearchParamsAction.queryUpdate:
       return {
         ...courseSearchParams,
         // Go back to page 1 when the query changes
@@ -64,8 +74,8 @@ const courseSearchParamsReducer = (
         query: action.query || undefined,
       };
 
-    case 'FILTER_ADD':
-    case 'FILTER_REMOVE':
+    case CourseSearchParamsAction.filterAdd:
+    case CourseSearchParamsAction.filterRemove:
       return {
         ...courseSearchParams,
         // Go back to page 1 when the query changes
@@ -80,7 +90,7 @@ const courseSearchParamsReducer = (
         ),
       };
 
-    case 'FILTER_RESET':
+    case CourseSearchParamsAction.filterReset:
       // Remove all parameters and reset pagination
       return {
         ...API_LIST_DEFAULT_PARAMS,
@@ -144,7 +154,7 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
       historyEntry.state.data.lastDispatchActions &&
       !historyEntry.state.data?.lastDispatchActions
         ?.map((action: CourseSearchParamsReducerAction) => action.type)
-        .includes('QUERY_UPDATE')
+        .includes(CourseSearchParamsAction.queryUpdate)
     ) {
       scroll({
         behavior: 'smooth',

--- a/src/frontend/js/data/useFilterValue/index.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/index.spec.tsx
@@ -10,7 +10,11 @@ describe('data/useFilterValue', () => {
   const historyPushState = jest.fn();
   const historyReplaceState = jest.fn();
   const makeHistoryOf: (params: any) => History = (params) => [
-    { state: params, title: '', url: `/search?${stringify(params)}` },
+    {
+      state: { name: 'courseSearch', data: { params } },
+      title: '',
+      url: `/search?${stringify(params)}`,
+    },
     historyPushState,
     historyReplaceState,
   ];
@@ -60,7 +64,28 @@ describe('data/useFilterValue', () => {
     expect(isActive).toEqual(false);
     toggle();
     expect(historyPushState).toHaveBeenCalledWith(
-      { limit: '999', offset: '0', organizations: ['87'] },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: [
+            {
+              filter: {
+                base_path: '0003',
+                has_more_values: false,
+                human_name: 'Organizations',
+                is_autocompletable: false,
+                is_searchable: false,
+                name: 'organizations',
+                position: 0,
+                values: [],
+              },
+              payload: '87',
+              type: 'FILTER_ADD',
+            },
+          ],
+          params: { limit: '999', offset: '0', organizations: ['87'] },
+        },
+      },
       '',
       '/?limit=999&offset=0&organizations=87',
     );
@@ -98,7 +123,28 @@ describe('data/useFilterValue', () => {
     expect(isActive).toEqual(true);
     toggle();
     expect(historyPushState).toHaveBeenCalledWith(
-      { limit: '999', offset: '0', organizations: undefined },
+      {
+        name: 'courseSearch',
+        data: {
+          lastDispatchActions: [
+            {
+              filter: {
+                base_path: '0003',
+                has_more_values: false,
+                human_name: 'Organizations',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'organizations',
+                position: 0,
+                values: [],
+              },
+              payload: '87',
+              type: 'FILTER_REMOVE',
+            },
+          ],
+          params: { limit: '999', offset: '0', organizations: undefined },
+        },
+      },
       '',
       '/?limit=999&offset=0',
     );

--- a/src/frontend/js/data/useFilterValue/index.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/index.spec.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';
 
+import { CourseSearchParamsAction } from 'data/useCourseSearchParams';
 import { History, HistoryContext } from 'data/useHistory';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { useFilterValue } from '.';
@@ -80,7 +81,7 @@ describe('data/useFilterValue', () => {
                 values: [],
               },
               payload: '87',
-              type: 'FILTER_ADD',
+              type: CourseSearchParamsAction.filterAdd,
             },
           ],
           params: { limit: '999', offset: '0', organizations: ['87'] },
@@ -139,7 +140,7 @@ describe('data/useFilterValue', () => {
                 values: [],
               },
               payload: '87',
-              type: 'FILTER_REMOVE',
+              type: CourseSearchParamsAction.filterRemove,
             },
           ],
           params: { limit: '999', offset: '0', organizations: undefined },

--- a/src/frontend/js/data/useFilterValue/index.ts
+++ b/src/frontend/js/data/useFilterValue/index.ts
@@ -1,4 +1,7 @@
-import { useCourseSearchParams } from 'data/useCourseSearchParams';
+import {
+  CourseSearchParamsAction,
+  useCourseSearchParams,
+} from 'data/useCourseSearchParams';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 
 type UseFilterValue = [boolean, () => void];
@@ -18,7 +21,9 @@ export const useFilterValue = (
     dispatchCourseSearchParamsUpdate({
       filter,
       payload: value.key,
-      type: isActive ? 'FILTER_REMOVE' : 'FILTER_ADD',
+      type: isActive
+        ? CourseSearchParamsAction.filterRemove
+        : CourseSearchParamsAction.filterAdd,
     });
 
   return [isActive, toggle];

--- a/src/frontend/js/data/useFilterValue/index.ts
+++ b/src/frontend/js/data/useFilterValue/index.ts
@@ -7,10 +7,10 @@ export const useFilterValue = (
   filter: FacetedFilterDefinition,
   value: FilterValue,
 ): UseFilterValue => {
-  const [
+  const {
     courseSearchParams,
     dispatchCourseSearchParamsUpdate,
-  ] = useCourseSearchParams();
+  } = useCourseSearchParams();
 
   const isActive = (courseSearchParams[filter.name] || []).includes(value.key);
 

--- a/src/frontend/js/data/useHistory/index.spec.tsx
+++ b/src/frontend/js/data/useHistory/index.spec.tsx
@@ -34,7 +34,10 @@ describe('data/useHistory', () => {
     render(<TestComponent />);
     const [historyEntry] = getLatestHookValues();
     expect(historyEntry).toEqual({
-      state: { param1: 'value1', param2: 'value2' },
+      state: {
+        name: '',
+        data: { params: { param1: 'value1', param2: 'value2' } },
+      },
       title: '',
       url: '/to/the/path?param1=value1&param2=value2',
     });
@@ -46,7 +49,10 @@ describe('data/useHistory', () => {
       render(<TestComponent />);
       const [historyEntry] = getLatestHookValues();
       expect(historyEntry).toEqual({
-        state: { param1: 'value1', param2: 'value2' },
+        state: {
+          name: '',
+          data: { params: { param1: 'value1', param2: 'value2' } },
+        },
         title: '',
         url: '/to/the/path?param1=value1&param2=value2',
       });
@@ -76,7 +82,10 @@ describe('data/useHistory', () => {
       render(<TestComponent />);
       const [historyEntry, pushState] = getLatestHookValues();
       expect(historyEntry).toEqual({
-        state: { param1: 'value1', param2: 'value2' },
+        state: {
+          name: '',
+          data: { params: { param1: 'value1', param2: 'value2' } },
+        },
         title: '',
         url: '/to/the/path?param1=value1&param2=value2',
       });
@@ -112,7 +121,10 @@ describe('data/useHistory', () => {
       render(<TestComponent />);
       const [historyEntry, , replaceState] = getLatestHookValues();
       expect(historyEntry).toEqual({
-        state: { param1: 'value1', param2: 'value2' },
+        state: {
+          name: '',
+          data: { params: { param1: 'value1', param2: 'value2' } },
+        },
         title: '',
         url: '/to/the/path?param1=value1&param2=value2',
       });

--- a/src/frontend/js/data/useHistory/index.ts
+++ b/src/frontend/js/data/useHistory/index.ts
@@ -24,7 +24,7 @@ export const HistoryContext = createContext<History>([] as any);
 
 export const useHistory: () => History = () => {
   const [historyEntry, setHistoryEntry] = useState<HistoryEntry>({
-    state: parse(location.search),
+    state: { name: '', data: { params: parse(location.search) } },
     title: '',
     url: `${location.pathname}${location.search}`,
   });

--- a/src/frontend/js/settings.ts
+++ b/src/frontend/js/settings.ts
@@ -1,4 +1,4 @@
 export const API_LIST_DEFAULT_PARAMS = {
-  limit: '20',
+  limit: '21',
   offset: '0',
 };


### PR DESCRIPTION
## Purpose

Fixes #998.

A bug was introduced that prevented course search from scrolling to the top on page change in course search.

In addition to fixing that bug, we decided to experiment (as mentioned in #998) with scrolling to the top when the user interacts with filters in the filters pane.

## Proposal

To make all of that work smoothly, we made some changes around course search params & actions:

- [x] make `useCourseSearchParams` return an object instead of a tuple (so we can more easily add a new entry in the return value)
- [x] store actions from the last dispatch call as part of History state (the only layer of state we're sharing between different React locations on the page)
- [x] add these actions to the `useCourseSearchParams` return value
- [x] use the last dispatch actions to determine when to scroll to top of course search (and do it on every action that does not use the `<SearchSuggestField />`
- [x] refactor `<SearchSuggestField />` to use last dispatch actions to replace an internal mechanism
- [x] change default number of results per page from 20 to 21