### PR TITLE
✨(core) allow customizing topbar contact button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Allow overriding the contact us button in the topbar
+
 ## [2.0.0-beta.6] - 2020-05-19
 
 ### Added
@@ -19,7 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Refactor nested items to simplify them
 - Remove the "suggested by" sentence from course detail view
-- Allow removing the contact us button in a theme
+- Allow overriding the contact us button in a theme
 - Center organizations on course detail view
 - Scroll course search to top when the user interacts with the filters pane.
 - Increase default course search results number from 20 to 21.

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -88,9 +88,11 @@
                             <li class="topbar__item topbar__item--login richie-react richie-react--user-login"
                                 data-props='{"loginUrl": "{% url 'admin:index' %}", "logoutUrl": "{% url 'logout' %}", "signupUrl": "{% url 'admin:index' %}"}'></li>
                             {% endblock userlogin %}
+                            {% block topbar_contact %}
                             <li class="topbar__item topbar__item--cta">
                                 <a href="#">{% trans "Contact us" %}</a>
                             </li>
+                            {% endblock topbar_contact %}
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Purpose

We want to make it easier to override the `contact us` button in the topbar.

## Proposal

Wrap the `contact us` button in a template block.
