### PR TITLE
⚡️Improve <Search> performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Allow overriding the contact us button in the topbar
+- Improve performance of Search frontend.
 
 ## [2.0.0-beta.6] - 2020-05-19
 

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -18,7 +18,7 @@ const messages = defineMessages({
   },
 });
 
-export const CourseGlimpse = ({
+const CourseGlimpseBase = ({
   context,
   course,
 }: CourseGlimpseProps & CommonDataProps) => (
@@ -64,3 +64,12 @@ export const CourseGlimpse = ({
     </div>
   </a>
 );
+
+const areEqual: (
+  prevProps: Readonly<CourseGlimpseProps & CommonDataProps>,
+  newProps: Readonly<CourseGlimpseProps & CommonDataProps>,
+) => boolean = (prevProps, newProps) =>
+  prevProps.context === newProps.context &&
+  prevProps.course.id === newProps.course.id;
+
+export const CourseGlimpse = React.memo(CourseGlimpseBase, areEqual);

--- a/src/frontend/js/components/Root/index.tsx
+++ b/src/frontend/js/components/Root/index.tsx
@@ -8,7 +8,7 @@ import { RootSearchSuggestField } from 'components/RootSearchSuggestField';
 import { Search } from 'components/Search';
 import { SearchSuggestField } from 'components/SearchSuggestField';
 import { UserLogin } from 'components/UserLogin';
-import { HistoryContext, useHistory } from 'data/useHistory';
+import { HistoryProvider } from 'data/useHistory';
 
 // List the top-level components that can be directly called from the Django templates in an interface
 // for type-safety when we call them. This will let us use the props for any top-level component in a
@@ -39,8 +39,6 @@ interface RootProps {
 }
 
 export const Root = ({ richieReactSpots }: RootProps) => {
-  const history = useHistory();
-
   const portals = richieReactSpots.map((element: Element) => {
     // Generate a component name. It should be a key of the componentLibrary object / ComponentLibrary interface
     const componentName = startCase(
@@ -73,7 +71,5 @@ export const Root = ({ richieReactSpots }: RootProps) => {
     }
   });
 
-  return (
-    <HistoryContext.Provider value={history}>{portals}</HistoryContext.Provider>
-  );
+  return <HistoryProvider>{portals}</HistoryProvider>;
 };

--- a/src/frontend/js/components/SearchFilterValueLeaf/index.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/index.tsx
@@ -8,7 +8,7 @@ export interface SearchFilterValueLeafProps {
   value: FilterValue;
 }
 
-export const SearchFilterValueLeaf = ({
+const SearchFilterValueLeafBase = ({
   filter,
   value,
 }: SearchFilterValueLeafProps) => {
@@ -34,3 +34,14 @@ export const SearchFilterValueLeaf = ({
     </label>
   );
 };
+
+const areEqual: (
+  prevProps: Readonly<SearchFilterValueLeafProps>,
+  newProps: Readonly<SearchFilterValueLeafProps>,
+) => boolean = (prevProps, newProps) =>
+  prevProps.value.count === newProps.value.count;
+
+export const SearchFilterValueLeaf = React.memo(
+  SearchFilterValueLeafBase,
+  areEqual,
+);

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -9,7 +9,7 @@ import {
   useCourseSearchParams,
   CourseSearchParamsAction,
 } from 'data/useCourseSearchParams';
-import { HistoryContext, useHistory } from 'data/useHistory';
+import { HistoryProvider } from 'data/useHistory';
 import { FilterDefinition } from 'types/filters';
 import { history, location } from 'utils/indirection/window';
 import { SearchSuggestField } from '.';
@@ -34,15 +34,6 @@ jest.mock('utils/indirection/window', () => ({
 }));
 
 describe('components/SearchSuggestField', () => {
-  const HistoryWrapper = ({ children }: { children: React.ReactNode }) => {
-    const localHistory = useHistory();
-    return (
-      <HistoryContext.Provider value={localHistory}>
-        {children}
-      </HistoryContext.Provider>
-    );
-  };
-
   const context = {
     assets: {
       icons: '/icons.svg',
@@ -96,9 +87,9 @@ describe('components/SearchSuggestField', () => {
   it('renders', () => {
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -110,9 +101,9 @@ describe('components/SearchSuggestField', () => {
     location.search = '?limit=20&offset=0&query=machine%20learning';
     const { getByDisplayValue } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -131,10 +122,10 @@ describe('components/SearchSuggestField', () => {
     location.search = '?limit=20&offset=0&query=social%20sciences';
     const { getByDisplayValue, rerender } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
           <OtherComponent />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -149,10 +140,10 @@ describe('components/SearchSuggestField', () => {
     );
     rerender(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
           <OtherComponent />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -180,9 +171,9 @@ describe('components/SearchSuggestField', () => {
 
     const { getByPlaceholderText, getByText, queryByText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -231,9 +222,9 @@ describe('components/SearchSuggestField', () => {
 
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -284,9 +275,9 @@ describe('components/SearchSuggestField', () => {
 
     const { getByPlaceholderText, getByText, queryByText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -375,9 +366,9 @@ describe('components/SearchSuggestField', () => {
 
     const { getByPlaceholderText, getByText, queryByText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -461,9 +452,9 @@ describe('components/SearchSuggestField', () => {
 
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -504,9 +495,9 @@ describe('components/SearchSuggestField', () => {
 
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -581,9 +572,9 @@ describe('components/SearchSuggestField', () => {
 
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 
@@ -645,9 +636,9 @@ describe('components/SearchSuggestField', () => {
 
     const { getByPlaceholderText, getByText } = render(
       <IntlProvider locale="en">
-        <HistoryWrapper>
+        <HistoryProvider>
           <SearchSuggestField context={context} />
-        </HistoryWrapper>
+        </HistoryProvider>
       </IntlProvider>,
     );
 

--- a/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
@@ -1,7 +1,7 @@
 import { act, render } from '@testing-library/react';
 import React from 'react';
 
-import { HistoryContext, useHistory } from 'data/useHistory';
+import { HistoryProvider } from 'data/useHistory';
 import * as mockWindow from 'utils/indirection/window';
 import { CourseSearchParamsAction, useCourseSearchParams } from '.';
 
@@ -25,15 +25,6 @@ describe('data/useCourseSearchParams', () => {
     return <div />;
   };
 
-  const WrappedTestComponent = () => {
-    const history = useHistory();
-    return (
-      <HistoryContext.Provider value={history}>
-        <TestComponent />
-      </HistoryContext.Provider>
-    );
-  };
-
   beforeEach(() => {
     // Remove any keys added to the mockWindow location object, reset pathname to /search
     Object.keys(mockWindow.location).forEach(
@@ -46,7 +37,11 @@ describe('data/useCourseSearchParams', () => {
   it('initializes with the URL query string', () => {
     mockWindow.location.search =
       '?organizations=L-00010003&organizations=L-00010009&query=some%20query&limit=8&offset=3';
-    render(<WrappedTestComponent />);
+    render(
+      <HistoryProvider>
+        <TestComponent />
+      </HistoryProvider>,
+    );
     const { courseSearchParams } = getLatestHookValues();
     expect(courseSearchParams).toEqual({
       limit: '8',
@@ -60,7 +55,11 @@ describe('data/useCourseSearchParams', () => {
 
   it('initializes with defaults if there is no query string param', () => {
     mockWindow.location.search = '';
-    render(<WrappedTestComponent />);
+    render(
+      <HistoryProvider>
+        <TestComponent />
+      </HistoryProvider>,
+    );
     const { courseSearchParams } = getLatestHookValues();
     expect(courseSearchParams).toEqual({ limit: '13', offset: '0' });
     // We need an update so the URL reflects the actual query params
@@ -81,7 +80,11 @@ describe('data/useCourseSearchParams', () => {
   describe('PAGE_CHANGE', () => {
     it('updates the offset on the courseSearchParams & updates history', () => {
       mockWindow.location.search = '?languages=fr&limit=13&offset=26';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -134,7 +137,11 @@ describe('data/useCourseSearchParams', () => {
   describe('QUERY_UPDATE', () => {
     it('sets the query on courseSearchParams, resets pagination & updates history', () => {
       mockWindow.location.search = '?languages=en&limit=17&offset=5';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -189,7 +196,11 @@ describe('data/useCourseSearchParams', () => {
     it('replaces the query on courseSearchParams & updates history', () => {
       mockWindow.location.search =
         '?languages=fr&limit=999&offset=0&query=some%20previous%20query';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -245,7 +256,11 @@ describe('data/useCourseSearchParams', () => {
     it('clears the query on courseSearchParams & updates query history', () => {
       mockWindow.location.search =
         '?languages=es&limit=999&offset=0&query=some%20existing%20query';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -303,7 +318,11 @@ describe('data/useCourseSearchParams', () => {
     it('adds the value to the existing list for this filter, resets pagination & updates history', () => {
       mockWindow.location.search =
         '?organizations=L-00010003&organizations=L-00010009&offset=999&limit=10';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -365,7 +384,11 @@ describe('data/useCourseSearchParams', () => {
     it('adds to the existing list for non-MPTT-formatted filter value keys and resets pagination', () => {
       mockWindow.location.search =
         '?languages=en&languages=fr&offset=999&limit=10';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -427,7 +450,11 @@ describe('data/useCourseSearchParams', () => {
     it('creates a list with the existing single value and the new value, resets pagination & updates history', () => {
       mockWindow.location.search =
         '?organizations=L-00010003&offset=999&limit=10';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -488,7 +515,11 @@ describe('data/useCourseSearchParams', () => {
 
     it('creates the new list for non-MPTT-formatted filter value keys and resets pagination', () => {
       mockWindow.location.search = '?languages=de&offset=999&limit=10';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -549,7 +580,11 @@ describe('data/useCourseSearchParams', () => {
 
     it('creates a new list with the value & updates history', () => {
       mockWindow.location.search = '?limit=999&offset=0&query=some%20query';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -613,7 +648,11 @@ describe('data/useCourseSearchParams', () => {
     it('does nothing if the value is already in the list for this filter', () => {
       mockWindow.location.search =
         '?limit=999&offset=0&query=some%20query&organizations=L-00010009';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -659,7 +698,11 @@ describe('data/useCourseSearchParams', () => {
         '&subjects=P-000200030012' +
         // some unrelated category from another meta-category
         '&levels=L-000200020005';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -735,7 +778,11 @@ describe('data/useCourseSearchParams', () => {
         '&subjects=L-0002000300050001' +
         // some unrelated category from another meta-category
         '&levels=L-000200020005';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -809,7 +856,11 @@ describe('data/useCourseSearchParams', () => {
         '&subjects=P-000200030012' +
         // some unrelated category from another meta-category
         '&levels=L-000200020005';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -882,7 +933,11 @@ describe('data/useCourseSearchParams', () => {
         '&subjects=P-000200030005' +
         // some unrelated category from another meta-category
         '&levels=L-000200020005';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -951,7 +1006,11 @@ describe('data/useCourseSearchParams', () => {
   describe('FILTER_ADD [drilldown]', () => {
     it('sets the value for the filter', () => {
       mockWindow.location.search = '?limit=999&offset=0';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         // Set a value where there was no value
         const {
@@ -1061,7 +1120,11 @@ describe('data/useCourseSearchParams', () => {
 
     it('does nothing if the value was already on the filter', () => {
       mockWindow.location.search = '?level=L-000200010001&limit=999&offset=0';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1101,7 +1164,11 @@ describe('data/useCourseSearchParams', () => {
     it('removes the value from the existing list for this filter & updates history', () => {
       mockWindow.location.search =
         '?limit=999&offset=0&query=some%20query&organizations=L-00010009&organizations=L00010011';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         // Remove from a list of more than one value
         const {
@@ -1216,7 +1283,11 @@ describe('data/useCourseSearchParams', () => {
       // just parsed and not interacted with yet.
       mockWindow.location.search =
         '?limit=999&offset=0&query=some%20query&organizations=L-00010013';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1278,7 +1349,11 @@ describe('data/useCourseSearchParams', () => {
 
     it('does nothing if there was no value for this filter', () => {
       mockWindow.location.search = '?limit=999&offset=0&query=some%20query';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1316,7 +1391,11 @@ describe('data/useCourseSearchParams', () => {
     it('does nothing if the value was not in the list for this filter', () => {
       mockWindow.location.search =
         '?limit=999&offset=0&organizations=L-00010003&organizations=L-00010009';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1356,7 +1435,11 @@ describe('data/useCourseSearchParams', () => {
       // just parsed and not interacted with yet.
       mockWindow.location.search =
         '?limit=999&offset=0&organizations=L-00010011';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1396,7 +1479,11 @@ describe('data/useCourseSearchParams', () => {
     it('removes the value from the filter', () => {
       mockWindow.location.search =
         '?level=L-000200010001&limit=999&offset=0&query=some%20query';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1459,7 +1546,11 @@ describe('data/useCourseSearchParams', () => {
     it('does nothing if the value to remove was not the existing value', () => {
       mockWindow.location.search =
         '?level=L-000200010001&limit=999&offset=0&query=some%20query';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1499,7 +1590,11 @@ describe('data/useCourseSearchParams', () => {
     it('does nothing if there was already no value for this filter', () => {
       mockWindow.location.search =
         '?organizations=L-00010009&limit=999&offset=0&query=some%20query';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1541,7 +1636,11 @@ describe('data/useCourseSearchParams', () => {
     it('resets all the query parameters except limit', () => {
       mockWindow.location.search =
         '?organizations=L-00010004&subjects=P-00030004&subjects=P-00030007&limit=27&offset=54&query=some%20query';
-      render(<WrappedTestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       {
         const {
           courseSearchParams,
@@ -1587,7 +1686,11 @@ describe('data/useCourseSearchParams', () => {
   it('can handle more than one action passed at the same time', () => {
     mockWindow.location.search =
       '?limit=20&offset=0&query=some%20query&organizations=L-00010009&organizations=L00010011';
-    render(<WrappedTestComponent />);
+    render(
+      <HistoryProvider>
+        <TestComponent />
+      </HistoryProvider>,
+    );
     {
       const {
         courseSearchParams,

--- a/src/frontend/js/data/useHistory/index.spec.tsx
+++ b/src/frontend/js/data/useHistory/index.spec.tsx
@@ -2,7 +2,7 @@ import { act, render } from '@testing-library/react';
 import React from 'react';
 
 import { history, location } from 'utils/indirection/window';
-import { useHistory } from '.';
+import { HistoryProvider, useHistory } from '.';
 
 jest.mock('utils/indirection/window', () => ({
   history: {
@@ -31,7 +31,11 @@ describe('data/useHistory', () => {
   });
 
   it('makes the current history entry available at bootstrap', () => {
-    render(<TestComponent />);
+    render(
+      <HistoryProvider>
+        <TestComponent />
+      </HistoryProvider>,
+    );
     const [historyEntry] = getLatestHookValues();
     expect(historyEntry).toEqual({
       state: {
@@ -46,7 +50,11 @@ describe('data/useHistory', () => {
   it('re-renders with a new value when the popstate event is fired', () => {
     {
       // Assert our initial values
-      render(<TestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       const [historyEntry] = getLatestHookValues();
       expect(historyEntry).toEqual({
         state: {
@@ -79,7 +87,11 @@ describe('data/useHistory', () => {
   it('provides a pushState helper that creates a new history entry', () => {
     {
       // Assert our initial values
-      render(<TestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       const [historyEntry, pushState] = getLatestHookValues();
       expect(historyEntry).toEqual({
         state: {
@@ -118,7 +130,11 @@ describe('data/useHistory', () => {
   it('provides a replaceState helper that replaces the current history entry', () => {
     {
       // Assert our initial values
-      render(<TestComponent />);
+      render(
+        <HistoryProvider>
+          <TestComponent />
+        </HistoryProvider>,
+      );
       const [historyEntry, , replaceState] = getLatestHookValues();
       expect(historyEntry).toEqual({
         state: {

--- a/src/frontend/js/data/useHistory/index.tsx
+++ b/src/frontend/js/data/useHistory/index.tsx
@@ -1,5 +1,11 @@
 import { parse } from 'query-string';
-import { createContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  PropsWithChildren,
+  useEffect,
+  useState,
+  useContext,
+} from 'react';
 
 import { history, location } from 'utils/indirection/window';
 import { Maybe, Nullable } from 'utils/types';
@@ -22,7 +28,20 @@ export type History = [HistoryEntry, pushStateFn, replaceStateFn];
 
 export const HistoryContext = createContext<History>([] as any);
 
-export const useHistory: () => History = () => {
+export const useHistory = () => {
+  return useContext(HistoryContext);
+};
+
+export const HistoryProvider = ({ children }: PropsWithChildren<{}>) => {
+  const historyValue = useProvideHistory();
+  return (
+    <HistoryContext.Provider value={historyValue}>
+      {children}
+    </HistoryContext.Provider>
+  );
+};
+
+const useProvideHistory: () => History = () => {
   const [historyEntry, setHistoryEntry] = useState<HistoryEntry>({
     state: { name: '', data: { params: parse(location.search) } },
     title: '',


### PR DESCRIPTION
## Purpose

We were noticing some performance issues with Richie's Search. We were able to find a lot of pointless renders by using the React profiler.

## Proposal

We went through the lowest hanging fruits:

- memoize `<CourseGlimpse />` and `<SearchFilterValueLeaf />`, which are the two most common components in our app and are easy to skip
- stop re-rendering `<Root />`, which is very expensive and we never really need to re-render anyway