### PR TITLE
🔧(courses) allow glimpse plugin in course information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Allow glimpse plugin in course information placeholder
 - Allow overriding the contact us button in the topbar
 - Improve performance of Search frontend.
 

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -157,6 +157,7 @@ CMS_PLACEHOLDER_CONF = {
         "parent_classes": {
             "CKEditorPlugin": ["SectionPlugin"],
             "SimplePicturePlugin": ["SectionPlugin"],
+            "GlimpsePlugin": ["SectionPlugin"],
         },
         "child_classes": {"SectionPlugin": ["CKEditorPlugin", "SimplePicturePlugin"]},
     },


### PR DESCRIPTION

## Purpose

Glimpse plugins were added for use in the course information placeholder
they should be allowed by default in this placeholder.


## Proposal

Add `GlimpsePlugin` in `course_information` placeholder in default Richie settings.