### PR TITLE
💄(plugins) large_banner hero variant refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Allow glimpse plugin in course information placeholder
 - Allow overriding the contact us button in the topbar
 - Improve performance of Search frontend.
+- Refine Large banner plugin layout for hero variant.
 
 ## [2.0.0-beta.6] - 2020-05-19
 

--- a/src/frontend/scss/components/templates/richie/large_banner/_large_banner.scss
+++ b/src/frontend/scss/components/templates/richie/large_banner/_large_banner.scss
@@ -113,6 +113,8 @@
     }
 
     @include media-breakpoint-up(lg) {
+      display: flex;
+
       @if $r-topbar-height {
         padding: $r-topbar-height 0 calc(5vw + 1rem);
         min-height: ($r-topbar-height + 33.75rem);
@@ -129,7 +131,10 @@
     padding: 1rem;
 
     @include media-breakpoint-up(lg) {
+      display: flex;
       padding: 2rem;
+      flex-direction: column;
+      justify-content: space-between;
     }
   }
 
@@ -140,6 +145,11 @@
     @include media-breakpoint-up(lg) {
       width: 50%;
     }
+
+    strong {
+      color: r-theme-val(hero-intro, title-alt-color);
+      font-weight: inherit;
+    }
   }
 
   &__content {
@@ -148,8 +158,8 @@
   }
 
   &__search {
-    @include responsive-spacer('padding-top', 3, $breakpoints: ('lg': 5));
     display: flex;
+    padding-top: 1rem;
     flex-wrap: wrap;
     align-items: flex-start;
 

--- a/src/frontend/scss/settings/_colors.scss
+++ b/src/frontend/scss/settings/_colors.scss
@@ -297,6 +297,7 @@ $r-theme: (
       url('../../richie/images/components/wave-white.svg'),
     inner-background: $white-mask-gradient,
     title-color: r-color('firebrick6'),
+    title-alt-color: r-color('charcoal'),
     content-color: r-color('black'),
     search-input-background: rgba(r-color('white'), 0.7),
     search-btn-background: r-color('firebrick6'),

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -296,7 +296,10 @@ ICONS_INFO.update(getattr(settings, "RICHIE_DEMO_ICONS_INFO", {}))
 HOMEPAGE_CONTENT = {
     "en": {
         "banner_title": "Welcome to Richie",
-        "banner_content": "It works! This is the default homepage for the Richie CMS.",
+        "banner_content": (
+            """<h1 class="hero-intro__title">Welcome <strong>to Richie</strong></h1>"""
+            """<p>It works! This is the default homepage for the Richie CMS.</p>"""
+        ),
         "banner_template": "richie/large_banner/hero-intro.html",
         "button_template_name": "button-caesura",
         "section_template": "richie/section/section.html",
@@ -315,7 +318,10 @@ HOMEPAGE_CONTENT = {
     },
     "fr": {
         "banner_title": "Bienvenue sur Richie",
-        "banner_content": "Ça marche ! Ceci est la page d'accueil par défaut du CMS Richie.",
+        "banner_content": (
+            """<h1 class="hero-intro__title">Bienvenue <strong>sur Richie</strong></h1>"""
+            """<p>Ça marche ! Ceci est la page d'accueil par défaut du CMS Richie.</p>"""
+        ),
         "banner_template": "richie/large_banner/hero-intro.html",
         "button_template_name": "button-caesura",
         "section_template": "richie/section/section.html",

--- a/src/richie/plugins/large_banner/forms.py
+++ b/src/richie/plugins/large_banner/forms.py
@@ -1,27 +1,13 @@
 """
 Large banner plugin forms
 """
-import warnings
-
 from django import forms
-from django.conf import settings
 
 from djangocms_text_ckeditor.widgets import TextEditorWidget
 
 from .models import LargeBanner
 
-CKEDITOR_CONFIGURATION_NAME = "CKEDITOR_BASIC_CONFIGURATION"
-
-# Fallback to the old setting name for backward compatibility
-if getattr(settings, "CKEDITOR_BASIC_SETTINGS", None) and not getattr(
-    settings, "CKEDITOR_BASIC_CONFIGURATION", None
-):
-    warnings.warn(
-        '"CKEDITOR_BASIC_SETTINGS" is deprecated and renamed to "CKEDITOR_BASIC_CONFIGURATION"',
-        DeprecationWarning,
-        stacklevel=0,
-    )
-    CKEDITOR_CONFIGURATION_NAME = "CKEDITOR_BASIC_SETTINGS"
+CKEDITOR_CONFIGURATION_NAME = "CKEDITOR_SETTINGS"
 
 
 class LargeBannerForm(forms.ModelForm):

--- a/src/richie/plugins/large_banner/templates/richie/large_banner/hero-intro.html
+++ b/src/richie/plugins/large_banner/templates/richie/large_banner/hero-intro.html
@@ -4,28 +4,25 @@
     >
     <div class="hero-intro__inner">
         <div class="hero-intro__body">
-            <h{{ header_level|default:1 }} class="hero-intro__title">
-                {{ instance.title }}
-            </h{{ header_level|default:1 }}>
             <div class="hero-intro__content">
                 {{ instance.content|safe }}
 
                 {% if instance.logo %}
                     <img src="{% thumbnail instance.logo 500x180 %}" class="hero-intro__logo" alt="{{ instance.logo_alt_text }}">
                 {% endif %}
+            </div>
 
-                <div class="hero-intro__search">
-                    <p class="hero-intro__search-title">
-                        {% trans "Search in our courses" %}
-                    </p>
+            <div class="hero-intro__search">
+                <p class="hero-intro__search-title">
+                    {% trans "Search in our courses" %}
+                </p>
 
-                    <div class="richie-react richie-react--root-search-suggest-field"
-                        data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}", "context": { "assets": { "icons": "{% static 'richie/icons.svg' %}" } }}'></div>
+                <div class="richie-react richie-react--root-search-suggest-field"
+                    data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}", "context": { "assets": { "icons": "{% static 'richie/icons.svg' %}" } }}'></div>
 
-                    <a class="hero-intro__cta" href="{% page_url 'courses' %}">
-                        {% trans "Explore our catalog" %}
-                    </a>
-                </div>
+                <a class="hero-intro__cta" href="{% page_url 'courses' %}">
+                    {% trans "Explore our catalog" %}
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Purpose

We need to fit a little bit more closer to the mockups for the hero
variant.

## Proposal

Title field is not used anymore from this variant template. We
expect the title to be add in content and apply a classname
"hero-intro__title" instead. We level up the CKEditor config for
large_banner plugin so now we can add title elements and edit HTML.

Finally, added some CSS changes, added
alternative color for strong element in title and pushed content
near to the top and search bar near to the bottom.
