### PR TITLE
💄(homepage) first course glimpses on three columns on homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Allow overriding the contact us button in the topbar
 - Improve performance of Search frontend.
 - Refine Large banner plugin layout for hero variant.
+- First course glimpses on three columns on homepage.
 
 ## [2.0.0-beta.6] - 2020-05-19
 

--- a/src/frontend/scss/components/templates/courses/cms/_homepage.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_homepage.scss
@@ -23,4 +23,18 @@
       @include content-padding-fix;
     }
   }
+
+  .section {
+    .course-glimpse {
+      &:nth-child(-n + 3) {
+        @include media-breakpoint-up(lg) {
+          @include sv-flex(
+            1,
+            0,
+            calc(33.3333% - #{$r-course-glimpse-gutter * 2})
+          );
+        }
+      }
+    }
+  }
 }

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -23,7 +23,7 @@ NB_OBJECTS = {
     "programs": 6,
     "programs_courses": 4,
     "home_blogposts": 5,
-    "home_courses": 8,
+    "home_courses": 7,
     "home_organizations": 4,
     "home_subjects": 6,
     "home_persons": 4,


### PR DESCRIPTION
## Purpose

According to homepage mockup, the first three course glimpses should
be on three columns, then following glimpses should return to the
basic 4 columns behavior.

## Proposal

This commit update the "home_courses" number from demo to 7 objects
and added special homepage modifier for first three course glimpses
to be on three columns.
