### PR TITLE
👌(layout) fix glitch with "scaleX" usage on wave decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Improve performance of Search frontend.
 - Refine Large banner plugin layout for hero variant.
 - First course glimpses on three columns on homepage.
+- Fix glitch with "scaleX" usage on wave decoration on category and
+  organization detail banner.
 
 ## [2.0.0-beta.6] - 2020-05-19
 

--- a/src/frontend/scss/components/templates/courses/cms/_category_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_category_detail.scss
@@ -62,7 +62,6 @@ $richie-category-detail-banner-logo-sizing-xl: 25rem !default;
         background-repeat: no-repeat;
         background-position: top left;
         background-size: 100% 100%;
-        transform: scaleX(-1);
         z-index: 2;
       }
     }

--- a/src/frontend/scss/components/templates/courses/cms/_organization_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_organization_detail.scss
@@ -62,7 +62,6 @@
         background-repeat: no-repeat;
         background-position: top left;
         background-size: 100% 100%;
-        transform: scaleX(-1); // horizontally reverse
         z-index: 2;
       }
     }


### PR DESCRIPTION
## Purpose

There is a bug with CSS transform "scaleX(-1)" (to horizontally flip
an element) when browser view is zoomed. This is visible only on
category and organization details banner, the wave decoration is
displaced for one pixel and so does not cover completely the
background image.

## Proposal

Since this is a bug with from every browser we are not able to patch
it directly. So we just removed the scaleX usage and wave go back to
the original direction as everywhere else.
