### PR TITLE
👌(section) fix alignment for category glimpses in section tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - First course glimpses on three columns on homepage.
 - Fix glitch with "scaleX" usage on wave decoration on category and
   organization detail banner.
+- Fix content vertical alignment for category glimpses in section
+  tiles.
 
 ## [2.0.0-beta.6] - 2020-05-19
 

--- a/src/frontend/scss/components/templates/richie/section/_section.scss
+++ b/src/frontend/scss/components/templates/richie/section/_section.scss
@@ -135,6 +135,9 @@ section {
     border: 0;
 
     &__logo {
+      flex-grow: 0;
+      justify-content: flex-start;
+
       img {
         max-width: 3.75rem;
         margin: 0 auto;


### PR DESCRIPTION
## Purpose

Vertical alignment was not really correct for content in category
glimpses in section tiles.

## Proposal

This commit just fix this behavior in Section Sass source so content
is aligned to the top.
