### PR TITLE
👌(layout) add checkmark icon to course skills bullet lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add checkmark icon to course skills bullet lists.
+
 ### Changed
 
 - Change course detail content titles to neutral dark color;

--- a/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -193,6 +193,41 @@
     }
   }
 
+  &__skills {
+    @if r-theme-val(course-detail, checkmark-list-decoration) {
+      ul {
+        padding-left: 0.3rem;
+        list-style-type: none;
+
+        li {
+          position: relative;
+          padding-left: 1.5rem;
+
+          &::before {
+            content: '';
+            display: block;
+            position: absolute;
+            top: 0.1rem;
+            left: 0;
+            width: 0.8rem;
+            height: 0.8rem;
+            background-image: r-theme-val(
+              course-detail,
+              checkmark-list-decoration
+            );
+            background-repeat: no-repeat;
+            background-position: top left;
+            background-size: 100% 100%;
+          }
+
+          & + li {
+            margin-top: 0.9rem;
+          }
+        }
+      }
+    }
+  }
+
   &__license {
     #{$detail-selector}__title {
       @include font-size($h3-font-size);

--- a/src/frontend/scss/settings/_colors.scss
+++ b/src/frontend/scss/settings/_colors.scss
@@ -494,6 +494,8 @@ $r-theme: (
     run-descriptions-divider: r-color('light-grey'),
     plan-title-color: r-color('firebrick6'),
     license-label-color: r-color('denim'),
+    checkmark-list-decoration:
+      url('../../richie/images/components/checkmark.svg'),
   ),
   organization-detail: (
     banner-empty-background: r-color('smoke'),

--- a/src/richie/apps/core/static/richie/images/components/checkmark.svg
+++ b/src/richie/apps/core/static/richie/images/components/checkmark.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M432 64L192 304 80 192 0 272l192 192 320-320z" fill="#f72c3f"/></svg>


### PR DESCRIPTION
## Purpose

From mockups, bullet lists in "course_skills" placeholder from course
details have a specific layout with colored checkmark instead of
disc. This was missing from integration.

## Proposal

This commit add a checkmark image file, some CSS specific to course
skills content and a new property "checkmark-list-decoration" in
theme group "course-detail".
