### PR TITLE
👌(layout) change course detail content titles to neutral dark color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change course detail content titles to neutral dark color;
+
 ## [2.0.0-beta.7] - 2020-06-08
 
 ### Changed

--- a/src/frontend/scss/settings/_colors.scss
+++ b/src/frontend/scss/settings/_colors.scss
@@ -486,8 +486,8 @@ $r-theme: (
   ),
   course-detail: (
     organizations-title-color: r-color('slate-grey'),
-    aside-title-border: r-color('black'),
-    primary-group-title-color: r-color('firebrick6'),
+    aside-title-border: r-color('charcoal'),
+    primary-group-title-color: r-color('charcoal'),
     primary-group-background: null,
     primary-group-arc: null,
     run-cta: $indianred3-scheme,


### PR DESCRIPTION
## Purpose

From mockup, content titles in course detail should be a neutral dark
color except for the "plan" accordion which still in primary color.

## Proposal

This commit just change the color from theme, other richie projects
will have to update it also in their own theme if needed.
