### PR TITLE
👌(layout) fix accordion border line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix course detail vertical rhythm and font size.
+- Fix accordion border line.
 
 ## [2.0.0-beta.7] - 2020-06-08
 

--- a/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -201,13 +201,14 @@
 
         li {
           position: relative;
+          margin-top: 0.9rem;
           padding-left: 1.5rem;
 
           &::before {
             content: '';
             display: block;
             position: absolute;
-            top: 0.1rem;
+            top: 0.2rem;
             left: 0;
             width: 0.8rem;
             height: 0.8rem;
@@ -218,10 +219,6 @@
             background-repeat: no-repeat;
             background-position: top left;
             background-size: 100% 100%;
-          }
-
-          & + li {
-            margin-top: 0.9rem;
           }
         }
       }

--- a/src/frontend/scss/components/templates/richie/nesteditem/_nesteditem.scss
+++ b/src/frontend/scss/components/templates/richie/nesteditem/_nesteditem.scss
@@ -48,7 +48,7 @@
   // is always a list
   //
   &--accordion {
-    $accordion-background-color: r-theme-val(accordion-plan, border-color);
+    $accordion-border-color: r-theme-val(accordion-plan, border-color);
     $accordion-border-size: rem-calc(2px);
 
     @include sv-flex(1, 0, 100%);
@@ -101,7 +101,7 @@
         left: 1rem;
         bottom: 1.75rem;
         width: $accordion-border-size;
-        border-left: $accordion-border-size solid $accordion-background-color;
+        border-left: $accordion-border-size solid $accordion-border-color;
       }
 
       & > li {
@@ -109,21 +109,21 @@
         position: relative;
         list-style-type: none;
 
-        @if $accordion-background-color {
-          &:last-child {
-            // Trick to mask border, this would work only with current
-            // accordion background and never with on top of composite
-            // backgrounds like image or gradients
-            &::before {
-              content: '';
-              position: absolute;
-              top: 1.25rem;
-              left: -1.5rem;
-              bottom: 0;
-              width: $accordion-border-size;
-              border-left: $accordion-border-size
-                solid
-                $accordion-background-color;
+        @if $accordion-border-color {
+          &[data-accordion-active] {
+            &:last-child {
+              // Trick to continue border
+              &::before {
+                content: '';
+                position: absolute;
+                top: 1.25rem;
+                left: -1.5rem;
+                bottom: 0;
+                width: $accordion-border-size;
+                border-left: $accordion-border-size
+                  solid
+                  $accordion-border-color;
+              }
             }
           }
         }

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -183,6 +183,7 @@
             if ($accordionItems.length > 0) {
                 $accordionItems.forEach(function(itemObject, itemIndex) {
                     itemObject.addEventListener('click', () => {
+                        itemObject.closest('li').toggleAttribute('data-accordion-active');
                         itemObject.toggleAttribute('data-accordion-open');
                     });
                 });


### PR DESCRIPTION
## Purpose

Accordion left border which make the path between item dots was
ending too far compared to mockup. This was due to CSS techniques
and HTML structure.

## Proposal

This commit just fix this with additional line in accordion
Javascript code to add an attribute on item so we can match
something in CSS and avoid border line to continue after the dot
when not opened. Also this adjust some margin on checkmark list from
previous commit 5d3b383.
