### PR TITLE
👌(layout) customize CMS placeholder menu for more readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Change course detail content titles to neutral dark color;
+- Change course detail content titles to neutral dark color.
+- Customize CMS placeholder menu for more readability.
 
 ### Fixed
 

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -100,5 +100,7 @@
 @import './components/templates/courses/cms/program_list';
 @import './components/templates/courses/cms/program_detail';
 
+// CMS patchs
+@import './trumps/cms';
 // IE11 patchs
 @import './trumps/ie11-fixes';

--- a/src/frontend/scss/trumps/_cms.scss
+++ b/src/frontend/scss/trumps/_cms.scss
@@ -1,8 +1,26 @@
-/*
- * Trick to get a larger cms bar column so long plugin titles are more readable
- */
-@include breakpoint(xlarge) {
-  body div.cms .cms-structure.cms-structure-condensed {
-    width: 30vw;
+div.cms {
+  .cms-structure {
+    //
+    // Trick to get a larger cms bar column so long plugin titles are more
+    // readable
+    //
+    @include media-breakpoint-up(lg) {
+      &.cms-structure-condensed {
+        width: 30vw;
+      }
+    }
+
+    //
+    // Hack page plugins tree menu to push plugin label on two lines,
+    // one for the plugin class title and one for the plugin object title
+    //
+    .cms-dragitem-text {
+      font-size: 0.8rem;
+      line-height: 1.2;
+
+      strong {
+        display: block;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Purpose

CMS page placeholders menu put the plugin name and plugin object
title on the same line to save vertical space at the cost
of readability. It comes quickly to unreadable plugin labels and
leaded to shortenize plugin names that was not intuitive.

## Proposal

This commit hack the CMS placeholder menu CSS to change this
behavior to stacked plugin name and object title on their own line.
With some adjustments to preserve some vertical space it free some
horizontal space so the plugin name can display a long name and
object title can be longer and more accurate.
