### PR TITLE
👌(section) fix basic block element alignment in section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix course detail vertical rhythm and font size.
 - Fix accordion border line.
+- Fix basic block element alignment in section.
 
 ## [2.0.0-beta.7] - 2020-06-08
 

--- a/src/frontend/scss/components/templates/richie/section/_section.scss
+++ b/src/frontend/scss/components/templates/richie/section/_section.scss
@@ -44,10 +44,11 @@ section {
       @include sv-flex(1, 0, 100%);
       margin: 0 auto 0.5rem;
       padding: 0 1rem;
+    }
 
-      @include media-breakpoint-up(lg) {
-        padding: 0 20%;
-      }
+    & > img {
+      display: block;
+      margin: 0 auto 1rem;
     }
 
     // Ensure caesura always takes full width with some space around


### PR DESCRIPTION
## Purpose

Recently Section plugin has been allowed to include simple text and
image in its content items on course_information placeholder. This
new configuration was not correctly integrated and so direct block
element (paragraph, list, images, etc..) was incorrectly
horizontally centered.

## Proposal

This commit fix the behavior for direct block element in section
contents in its Sass component.
