### PR TITLE
👌(course) make course glimpse category cartouche less "aggressive"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Include the SVG icons sprite in `base.html` instead of loading it as
   external content so it can support usage with CDNs.
 - Add grid constraint on person 'main_content' placeholder content.
+- Make course glimpse category cartouche less "aggressive".
 
 ## [2.0.0-beta.7] - 2020-06-08
 

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -98,7 +98,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
       $border-width: 0,
       $font-size: 0.8rem,
       $line-height: 1.1,
-      $font-weight: bold
+      $font-weight: $font-weight-normal
     );
     @include r-button-colors(r-theme-val(course-glimpse, icon));
     display: flex;
@@ -110,6 +110,12 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     box-shadow: r-theme-val(course-glimpse, icon-shadow);
+
+    .category-badge {
+      padding: 0;
+      font-size: inherit;
+      font-weight: inherit;
+    }
 
     img {
       @include sv-flex(0, 0, 1.6rem);
@@ -202,7 +208,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     @include sv-flex(1, 0, auto);
     margin: 0;
     padding: 0.75rem 0;
-    font-weight: bold;
+    font-weight: $font-weight-bold;
     line-height: 1.1;
   }
 }


### PR DESCRIPTION
## Purpose

In course glimpses, category cartouche have too much padding and font is in
bold, opposed to mockup which was mocking a less bigger cartouche without
bolded font.

## Proposal

Here we just fix these minor issue in course glimpse Sass.

A screenshot for sample (left for this PR display and right for current invalid layout):

![cartouche](https://user-images.githubusercontent.com/1572165/84786707-61bb5b80-afed-11ea-90f1-3e27c5f3ed2e.png)

