### PR TITLE
👌(layout) lower page detail title and other minor issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Improve search error message layout
 
+### Fixed
+
+- Lowered down global 'h1' and 'h2' font size and added new
+  'extra-font-size' variable with previous h1 value.
+- Adjust title size 'large_banner' variants.
+- Fix accordion button 'nested-item__title' alignment to the left.
+- Another attempt to definitively fix the glitch with wave decoration
+  and Chrome zoom/unzoom.
+- Add a little bit of space between banner and title on organization
+  and category detail.
+- Fix header menus align/position between breakpoint 'md' end and
+  'lg' start.
+- Fix breadcrumb item on small breakpoints when text is too long.
+
 ## [2.0.0-beta.8] - 2020-06-17
 
 ### Added

--- a/src/frontend/scss/components/_content.scss
+++ b/src/frontend/scss/components/_content.scss
@@ -11,7 +11,7 @@
       width: 100%;
       height: 5vw;
       position: absolute;
-      bottom: 0;
+      bottom: -0.05rem;
       left: 0;
       right: 0;
       background-image: r-theme-val(body-content, insert-background-image);

--- a/src/frontend/scss/components/_header.scss
+++ b/src/frontend/scss/components/_header.scss
@@ -66,7 +66,13 @@
       } @else {
         @include sv-flex(0, 0, auto);
       }
-      margin-right: 10%;
+      margin-right: 1vw;
+    }
+    @include media-breakpoint-up(xl) {
+      margin-right: 4vw;
+    }
+    @include media-breakpoint-up(xxl) {
+      margin-right: 6vw;
     }
 
     // Clickable logo
@@ -161,7 +167,10 @@
         margin-top: 0.5rem;
         @include media-breakpoint-up($r-topbar-breakpoint) {
           margin-top: 0;
-          margin-left: 2rem;
+          margin-left: 0.6rem;
+        }
+        @include media-breakpoint-up(xl) {
+          margin-left: 1rem;
         }
       }
     }

--- a/src/frontend/scss/components/templates/courses/cms/_category_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_category_detail.scss
@@ -55,7 +55,7 @@ $richie-category-detail-banner-logo-sizing-xl: 25rem !default;
         width: 100%;
         height: 4rem;
         position: absolute;
-        bottom: 0;
+        bottom: -0.05rem;
         left: 0;
         right: 0;
         background-image: r-theme-val(category-detail, insert-background-image);
@@ -99,6 +99,7 @@ $richie-category-detail-banner-logo-sizing-xl: 25rem !default;
 
   &__intro {
     #{$detail-selector}__title {
+      padding-top: 1rem;
       text-align: left;
       color: r-theme-val(category-detail, intro-title-color);
 

--- a/src/frontend/scss/components/templates/courses/cms/_organization_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_organization_detail.scss
@@ -52,7 +52,7 @@
         width: 100%;
         height: 4rem;
         position: absolute;
-        bottom: 0;
+        bottom: -0.05rem;
         left: 0;
         right: 0;
         background-image: r-theme-val(
@@ -99,6 +99,7 @@
 
   &__intro {
     .organization-detail__title {
+      padding-top: 1rem;
       text-align: left;
       color: r-theme-val(organization-detail, intro-title);
 

--- a/src/frontend/scss/components/templates/richie/large_banner/_large_banner.scss
+++ b/src/frontend/scss/components/templates/richie/large_banner/_large_banner.scss
@@ -42,20 +42,10 @@
     position: relative;
 
     &__title {
+      @include font-size($h1-font-size);
       // Leave some margin between title & logo
       margin: 0 0.5rem 0 0;
-
-      // Adjust text size for smaller screens
-      font-size: 1.5rem;
       text-align: center;
-
-      @include media-breakpoint-up(sm) {
-        font-size: 2rem;
-      }
-
-      @include media-breakpoint-up(md) {
-        font-size: 2.5rem;
-      }
     }
 
     &__logo {
@@ -140,6 +130,7 @@
 
   &__title {
     @include responsive-spacer('margin-bottom', 3, $breakpoints: ('lg': 4));
+    @include font-size($extra-font-size);
     color: r-theme-val(hero-intro, title-color);
 
     @include media-breakpoint-up(lg) {

--- a/src/frontend/scss/components/templates/richie/nesteditem/_nesteditem.scss
+++ b/src/frontend/scss/components/templates/richie/nesteditem/_nesteditem.scss
@@ -158,6 +158,7 @@
           color: r-theme-val(accordion-plan, title-color);
           font-weight: bold;
           line-height: 1.1;
+          text-align: left;
           cursor: pointer;
           background: transparent;
           border: 0;

--- a/src/frontend/scss/objects/_breadcrumbs.scss
+++ b/src/frontend/scss/objects/_breadcrumbs.scss
@@ -13,7 +13,7 @@ $r-breadcrumbs-separator: '›';
   }
 
   &__item {
-    @include sv-flex(0, 0, auto);
+    @include sv-flex(0, 1, auto);
     font-size: inherit;
     font-family: $r-font-family-montserrat;
     font-weight: $font-weight-boldest;

--- a/src/frontend/scss/settings/_variables.scss
+++ b/src/frontend/scss/settings/_variables.scss
@@ -65,8 +65,9 @@ $font-weight-boldest: 700; // Montserrat only
 $font-weight-extrabold: 800; // Montserrat only
 
 // Adjust heading sizes
-$h1-font-size: 3rem;
-$h2-font-size: 2rem;
+$extra-font-size: 3rem;
+$h1-font-size: 2.2rem;
+$h2-font-size: 1.8rem;
 $h3-font-size: 1.5rem;
 $h4-font-size: 1.125rem;
 $h5-font-size: 1rem;


### PR DESCRIPTION
## Purpose

Page detail main title is too big, this especially obvious when text
is longer than four words. 

Also since working on recent refinements and fixes, some minor issues have been found with some responsive behaviors.

## Proposal

This commit fix these issues (only Sass sources have been changed
without changes on theme):

- Lowered down global 'h1' and 'h2' font size and added new
  'extra-font-size' variable with previous h1 value.
- Adjust title size 'large_banner' variants.
- Fix accordion button 'nested-item__title' alignment to the left.
- Another attempt to definitively fix the glitch with wave decoration
  and Chrome zoom/unzoom.
- Add a little bit of space between banner and title on organization
  and category detail.
- Fix header menus align/position between breakpoint 'md' end and
  'lg' start.
- Fix breadcrumb item on small breakpoints when text is too long.
