### PR TITLE
💄(nesteditem) fix nesteditem list variant to act like a basic list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix header menus align/position between breakpoint 'md' end and
   'lg' start.
 - Fix breadcrumb item on small breakpoints when text is too long.
+- Fix nesteditem list variant to act like a basic list.
 
 ## [2.0.0-beta.8] - 2020-06-17
 

--- a/src/frontend/scss/components/_footer.scss
+++ b/src/frontend/scss/components/_footer.scss
@@ -128,29 +128,44 @@
       margin-top: 1rem;
     }
 
-    .section-list {
+    //
+    // Default variant acts like a simple horizontal menu
+    //
+    .nested-item--list {
+      $nesteditem-base-selector: '.nested-item';
       @include sv-flex(1, 0, 100%);
-      display: flex;
-      padding: 0;
-      margin-bottom: 0;
-      flex-direction: row;
-      flex-wrap: wrap;
-      list-style-type: none;
 
-      &__item {
-        @include sv-flex(1, 0, 100%);
-        padding: 0.25rem;
+      a {
+        display: block;
+        color: inherit;
+      }
 
-        @include media-breakpoint-up($r-footer-breakpoint) {
-          @include sv-flex(1, 0, 33.3333%);
+      #{$nesteditem-base-selector}__content {
+        margin: 0.1rem;
+        padding: 0.25rem 0.25rem 0.25rem 0;
+        font-weight: bold;
+
+        p {
+          margin: 0;
         }
+      }
 
-        a {
-          color: inherit;
+      #{$nesteditem-base-selector}__items {
+        @include sv-flex(1, 0, 100%);
+        display: flex;
+        padding: 0;
+        margin-bottom: 0;
+        flex-direction: row;
+        flex-wrap: wrap;
+        list-style-type: none;
 
-          &:hover {
-            color: r-theme-val(body-footer, section-hover);
-            text-decoration: none;
+        li {
+          @include sv-flex(1, 0, calc(100% - 0.2rem));
+          margin: 0.1rem;
+          padding: 0.25rem 0.25rem 0.25rem 0;
+
+          @include media-breakpoint-up($r-footer-breakpoint) {
+            @include sv-flex(1, 0, auto);
           }
         }
       }

--- a/src/frontend/scss/components/templates/richie/nesteditem/_nesteditem.scss
+++ b/src/frontend/scss/components/templates/richie/nesteditem/_nesteditem.scss
@@ -2,43 +2,25 @@
   $nesteditem-base-selector: &;
 
   //
-  // Default variant acts like a simple horizontal menu
+  // Default variant acts like a basic bullet list with some minor adjustments
   //
   &--list {
     @include sv-flex(1, 0, 100%);
 
-    a {
-      display: block;
-      color: inherit;
-    }
-
-    #{$nesteditem-base-selector}__content {
-      margin: 0.1rem;
-      padding: 0.25rem 0.25rem 0.25rem 0;
-      font-weight: bold;
-
-      p {
-        margin: 0;
-      }
+    // First level item title have a little bit of distinction for readability
+    &.nested-item--0 > #{$nesteditem-base-selector}__content {
+      @include font-size($h6-font-size);
+      margin-bottom: 0.5rem;
     }
 
     #{$nesteditem-base-selector}__items {
-      @include sv-flex(1, 0, 100%);
-      display: flex;
-      padding: 0;
-      margin-bottom: 0;
-      flex-direction: row;
-      flex-wrap: wrap;
-      list-style-type: none;
+      margin: 0;
+      padding: 0 0 0 0.9rem;
+      list-style-type: disc;
 
       li {
-        @include sv-flex(1, 0, calc(100% - 0.2rem));
         margin: 0.1rem;
-        padding: 0.25rem 0.25rem 0.25rem 0;
-
-        @include media-breakpoint-up($r-footer-breakpoint) {
-          @include sv-flex(1, 0, auto);
-        }
+        padding: initial;
       }
     }
   }


### PR DESCRIPTION
## Purpose

When implemented, nesteditem list variant has been done only to cover
the specific behavior for footer menu which is a horizontal menu. But
finally this variant is expected to act like a common bullet list and
horizontal menu is reserved only for footer.

## Proposal

This commit just fix this behavior without any layout change, just
the horizontal menu keep working in footer and other list variant
usage elsewhere act like a common bullet list like in course plan.