### PR TITLE
⏪(frontend) revert how SearchSuggestField clears itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   'lg' start.
 - Fix breadcrumb item on small breakpoints when text is too long.
 - Fix nesteditem list variant to act like a basic list.
+- Revert commit 1bfb2d7
 
 ## [2.0.0-beta.8] - 2020-06-17
 

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -147,6 +147,12 @@ describe('components/SearchSuggestField', () => {
 
     // The input does not show a value anymore
     expect(input.value).toEqual('');
+
+    // Simulate the user entering some text in the autocomplete field
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'au' } });
+
+    expect(input.value).toEqual('au');
   });
 
   it('gets suggestions from the API when the user types something in the field', async () => {

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -1,5 +1,5 @@
 import debounce from 'lodash-es/debounce';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Autosuggest from 'react-autosuggest';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -54,18 +54,24 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
   const [value, setValue] = useState(courseSearchParams.query || '');
   const [suggestions, setSuggestions] = useState<SearchSuggestionSection[]>([]);
 
-  // Use current value of courseSearchParams and last dispatched actions to guess if the text query
-  // has been removed by another component in the tree, and clear the field as well
-  // NB: this will do nothing on the first render as there are then no last dispatched actions.
+  // Create a ref too keep around courseSearchParams as they were during render N-1
+  const previousCourseSearchParams = useRef(courseSearchParams);
+
+  // Use the previous & current values of courseSearchParams to guess if the text query had
+  // been removed by another component in the tree, and clear the field as well
+  // NB: this will do nothing on the first render as courseSearchParams and the ref
+  // (previousCourseSearchParams.current) will hold the exact same object at that time.
   if (
     !courseSearchParams.query &&
-    lastDispatchActions
-      ?.map((action) => action.type)
-      .includes(CourseSearchParamsAction.filterReset) &&
+    previousCourseSearchParams.current.query &&
     value
   ) {
     setValue('');
   }
+
+  // Then update the ref to the current courseSearchParams so we can have them to compare
+  // during the next render.
+  previousCourseSearchParams.current = courseSearchParams;
 
   /**
    * Helper to update the course search params when the user types. We needed to take it out of


### PR DESCRIPTION
## Purpose

This commit revert commit 1bfb2d7. This commit introduces a bug explain
in #1067. To be sure to fix it a test was added reproducing the issue
explanation. This commit is temporary, a better fix can be found but we
need a quick fix now.



## Proposal

- [x] revert commit 1bfb2d7
- [x] add a test reproducing #1067
