### PR TITLE
🐛 Fix the broken course search field after filters are reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   'lg' start.
 - Fix breadcrumb item on small breakpoints when text is too long.
 - Fix nesteditem list variant to act like a basic list.
+- Fix an issue that broke the course search field after the user clicked
+  the "reset filters" helper.
 
 ## [2.0.0-beta.8] - 2020-06-17
 

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -147,6 +147,12 @@ describe('components/SearchSuggestField', () => {
 
     // The input does not show a value anymore
     expect(input.value).toEqual('');
+
+    // Simulate the user entering some text in the autocomplete field
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'au' } });
+
+    expect(input.value).toEqual('au');
   });
 
   it('gets suggestions from the API when the user types something in the field', async () => {

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -1,5 +1,5 @@
 import debounce from 'lodash-es/debounce';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Autosuggest from 'react-autosuggest';
 import { defineMessages, useIntl } from 'react-intl';
 
@@ -57,15 +57,17 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
   // Use current value of courseSearchParams and last dispatched actions to guess if the text query
   // has been removed by another component in the tree, and clear the field as well
   // NB: this will do nothing on the first render as there are then no last dispatched actions.
-  if (
-    !courseSearchParams.query &&
-    lastDispatchActions
-      ?.map((action) => action.type)
-      .includes(CourseSearchParamsAction.filterReset) &&
-    value
-  ) {
-    setValue('');
-  }
+  useEffect(() => {
+    if (
+      !courseSearchParams.query &&
+      lastDispatchActions
+        ?.map((action) => action.type)
+        .includes(CourseSearchParamsAction.filterReset) &&
+      value
+    ) {
+      setValue('');
+    }
+  }, [lastDispatchActions]);
 
   /**
    * Helper to update the course search params when the user types. We needed to take it out of


### PR DESCRIPTION
## Purpose

When we added tracking of the last dispatched action(s) to our state setup, we refactored <SearchSuggestField /> to use that to determine when to empty itself in reaction to "filterReset" actions, instead of the previous approach of guessing based on a comparison between current values and values during the previous render.

However, we did not take into account that leaving the check in the body of the component, it would be executed on each render and prevent any value from being entered after a "filterReset" action was issued.

## Proposal

We can solve it by placing the check & clear in a useEffect that only runs when the last dispatched actions change. This way it will react to incoming action by checking if it needs to empty itself, but not even run the check if there is no new action and the user is just interacting with the field.

Closes #1067 
