### PR TITLE
Upgrade testing library practices

### DIFF
--- a/src/frontend/jest.config.js
+++ b/src/frontend/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css)$': '<rootDir>/front/__mocks__/styleMock.js',
   },
+  setupFilesAfterEnv: ['./js/testSetup.ts'],
   testMatch: [`${__dirname}/js/**/*.spec.+(ts|tsx|js)`],
   testURL: 'https://localhost',
   transformIgnorePatterns: ['node_modules/(?!(lodash-es)/)'],

--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { render } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';

--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
@@ -38,7 +38,7 @@ describe('components/CourseGlimpse', () => {
   };
 
   it('renders a course glimpse with its data', () => {
-    const { container, getByText } = render(
+    render(
       <IntlProvider locale="en">
         <CourseGlimpse
           context={commonDataProps}
@@ -52,20 +52,20 @@ describe('components/CourseGlimpse', () => {
     );
 
     // The link that wraps the course glimpse should have no title as its content is explicit enough
-    expect(container.querySelector('a')).not.toHaveAttribute('title');
+    expect(screen.getByRole('link')).not.toHaveAttribute('title');
     // The course glimpse shows the relevant information
-    getByText('Course 42');
-    getByText('Some Organization');
+    screen.getByText('Course 42');
+    screen.getByText('Some Organization');
     // Matches on 'Starts on Mar 14, 2019', date is wrapped with intl <span>
-    getByText('Starts on Mar 14, 2019');
+    screen.getByText('Starts on Mar 14, 2019');
     // The logo is rendered along with alt text "" as it is decorative and included in a link block
-    const img = container.querySelector('img');
+    const img = screen.getByRole('img');
     expect(img).toHaveAttribute('alt', '');
     expect(img).toHaveAttribute('src', '/thumbs/small.png');
   });
 
   it('works when there is no call to action or datetime on the state (eg. an archived course)', () => {
-    const { getByText } = render(
+    render(
       <IntlProvider locale="en">
         <CourseGlimpse
           context={commonDataProps}
@@ -83,11 +83,12 @@ describe('components/CourseGlimpse', () => {
     );
 
     // Make sure the component renders and shows the state
-    getByText('Course 42');
-    getByText('Archived');
+    screen.getByText('Course 42');
+    screen.getByText('Archived');
   });
+
   it('shows the "Cover" placeholder div when the course is missing a cover image', () => {
-    const { getByText } = render(
+    render(
       <IntlProvider locale="en">
         <CourseGlimpse
           context={commonDataProps}
@@ -96,7 +97,7 @@ describe('components/CourseGlimpse', () => {
       </IntlProvider>,
     );
 
-    getByText('Course 42');
-    getByText('Cover');
+    screen.getByText('Course 42');
+    screen.getByText('Cover');
   });
 });

--- a/src/frontend/js/components/CourseGlimpseList/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { render } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';

--- a/src/frontend/js/components/CourseGlimpseList/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/index.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
@@ -28,7 +28,7 @@ describe('components/CourseGlimpseList', () => {
         title: 'Course 45',
       },
     ] as Course[];
-    const { getAllByText, getByText } = render(
+    render(
       <IntlProvider locale="en">
         <CourseGlimpseList
           context={commonDataProps}
@@ -39,10 +39,11 @@ describe('components/CourseGlimpseList', () => {
     );
 
     expect(
-      getAllByText('Showing 1 to 20 of 45 courses matching your search').length,
+      screen.getAllByText('Showing 1 to 20 of 45 courses matching your search')
+        .length,
     ).toEqual(1);
     // Both courses' titles are shown
-    getByText('Course 44');
-    getByText('Course 45');
+    screen.getByText('Course 44');
+    screen.getByText('Course 45');
   });
 });

--- a/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
@@ -22,7 +22,7 @@ describe('<PaginateCourseSearch />', () => {
   beforeEach(jest.resetAllMocks);
 
   it('shows a pagination for course search (when on page 1)', () => {
-    const { getByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -32,21 +32,21 @@ describe('<PaginateCourseSearch />', () => {
       </IntlProvider>,
     );
 
-    getByText('Pagination');
+    screen.getByRole('navigation', { name: 'Pagination' });
     // Accessibility helpers
-    getByText('Currently reading page 1');
-    getByText('Next page 2');
-    getByText('Page 3');
-    getByText('Last page 10');
+    screen.getByText('Currently reading page 1');
+    screen.getByText('Next page 2');
+    screen.getByText('Page 3');
+    screen.getByText('Last page 10');
     // Visual pagination
-    getByText('Page 1');
-    getByText('3');
-    getByText('2');
-    getByText('10');
+    screen.getByText('Page 1');
+    screen.getByText('3');
+    screen.getByText('2');
+    screen.getByText('10');
   });
 
   it('shows a pagination for course search (when on the last page)', () => {
-    const { getAllByText, getByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '200' })}
@@ -56,21 +56,21 @@ describe('<PaginateCourseSearch />', () => {
       </IntlProvider>,
     );
 
-    getByText('Pagination');
+    screen.getByRole('navigation', { name: 'Pagination' });
     // Common text for the first page
-    getAllByText('Page 1');
+    screen.getAllByText('Page 1');
     // Accessibility helpers
-    getByText('Page 9');
-    getByText('Previous page 10');
-    getByText('Currently reading last page 11');
+    screen.getByText('Page 9');
+    screen.getByText('Previous page 10');
+    screen.getByText('Currently reading last page 11');
     // Visual pagination
-    getByText('9');
-    getByText('10');
-    getByText('11');
+    screen.getByText('9');
+    screen.getByText('10');
+    screen.getByText('11');
   });
 
   it('shows a pagination for course search (when on an arbitrary page)', () => {
-    const { getAllByText, getByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '10', offset: '110' })}
@@ -80,27 +80,27 @@ describe('<PaginateCourseSearch />', () => {
       </IntlProvider>,
     );
 
-    getByText('Pagination');
+    screen.getByRole('navigation', { name: 'Pagination' });
     // Common text for the first page
-    getAllByText('Page 1');
+    screen.getAllByText('Page 1');
     // Accessibility helpers
-    getByText('Page 10');
-    getByText('Previous page 11');
-    getByText('Currently reading page 12');
-    getByText('Next page 13');
-    getByText('Page 14');
-    getByText('Last page 35');
+    screen.getByText('Page 10');
+    screen.getByText('Previous page 11');
+    screen.getByText('Currently reading page 12');
+    screen.getByText('Next page 13');
+    screen.getByText('Page 14');
+    screen.getByText('Last page 35');
     // Visual pagination
-    getByText('10');
-    getByText('11');
-    getByText('12');
-    getByText('13');
-    getByText('14');
-    getByText('35');
+    screen.getByText('10');
+    screen.getByText('11');
+    screen.getByText('12');
+    screen.getByText('13');
+    screen.getByText('14');
+    screen.getByText('35');
   });
 
   it('does not render itself when there is only one page', () => {
-    const { queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -110,11 +110,13 @@ describe('<PaginateCourseSearch />', () => {
       </IntlProvider>,
     );
 
-    expect(queryByText('Pagination')).toEqual(null);
+    expect(screen.queryByRole('pagination', { name: 'Pagination' })).toEqual(
+      null,
+    );
   });
 
   it('updates the course search params when the user clicks on a page', () => {
-    const { getByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -124,8 +126,8 @@ describe('<PaginateCourseSearch />', () => {
       </IntlProvider>,
     );
 
-    getByText('Pagination');
-    const page2 = getByText('Next page 2');
+    screen.getByRole('navigation', { name: 'Pagination' });
+    const page2 = screen.getByText('Next page 2');
 
     // Change pages when the user clicks on another page
     fireEvent.click(page2);
@@ -146,7 +148,7 @@ describe('<PaginateCourseSearch />', () => {
   });
 
   it('does not update the course search params when the user clicks on the current page', () => {
-    const { getByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -156,8 +158,8 @@ describe('<PaginateCourseSearch />', () => {
       </IntlProvider>,
     );
 
-    getByText('Pagination');
-    const currentPage1 = getByText('Currently reading page 1');
+    screen.getByRole('navigation', { name: 'Pagination' });
+    const currentPage1 = screen.getByText('Currently reading page 1');
 
     // Don't do anything when the user clicks on the page they're currently on
     historyPushState.mockReset();

--- a/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { fireEvent, render } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
@@ -44,7 +44,7 @@ describe('<RootSearchSuggestField />', () => {
       subjects,
     });
 
-    const { getByPlaceholderText } = render(
+    render(
       <IntlProvider locale="en">
         <RootSearchSuggestField
           courseSearchPageUrl="/en/courses/"
@@ -54,7 +54,7 @@ describe('<RootSearchSuggestField />', () => {
     );
 
     // The placeholder text is shown in the input
-    getByPlaceholderText('Search for courses');
+    screen.getByPlaceholderText('Search for courses');
     // The component should not issue any request "on load", before the user starts interacting
     expect(fetchMock.called()).toEqual(false);
   });
@@ -72,7 +72,7 @@ describe('<RootSearchSuggestField />', () => {
     ]);
     fetchMock.get('/api/v1.0/courses/autocomplete/?query=aut', []);
 
-    const { getByPlaceholderText, getByText, queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <RootSearchSuggestField
           courseSearchPageUrl="/en/courses/"
@@ -81,7 +81,7 @@ describe('<RootSearchSuggestField />', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText('Search for courses');
+    const field = screen.getByPlaceholderText('Search for courses');
 
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
@@ -98,14 +98,14 @@ describe('<RootSearchSuggestField />', () => {
       expect(
         fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
       ).toEqual(true);
-      getByText('Subjects');
-      getByText('Subject #311');
+      screen.getByText('Subjects');
+      screen.getByText('Subject #311');
     });
 
     expect(
       fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
     ).toEqual(true);
-    expect(queryByText('Courses')).toEqual(null);
+    expect(screen.queryByText('Courses')).toEqual(null);
   });
 
   it('goes to the course page when the user selects a course suggestion', async () => {
@@ -123,7 +123,7 @@ describe('<RootSearchSuggestField />', () => {
       },
     ]);
 
-    const { getByPlaceholderText, getByText, queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <RootSearchSuggestField
           courseSearchPageUrl="/en/courses/"
@@ -132,7 +132,7 @@ describe('<RootSearchSuggestField />', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText('Search for courses');
+    const field = screen.getByPlaceholderText('Search for courses');
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'aut' } });
 
@@ -141,13 +141,13 @@ describe('<RootSearchSuggestField />', () => {
         fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
       ).toEqual(true);
     });
-    getByText('Courses');
-    const course = getByText('Course #42');
+    screen.getByText('Courses');
+    const course = screen.getByText('Course #42');
 
     expect(
       fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
     ).toEqual(true);
-    expect(queryByText('Subjects')).toEqual(null);
+    expect(screen.queryByText('Subjects')).toEqual(null);
 
     fireEvent.click(course);
     await waitFor(() => {
@@ -169,7 +169,7 @@ describe('<RootSearchSuggestField />', () => {
     ]);
     fetchMock.get('/api/v1.0/courses/autocomplete/?query=aut', []);
 
-    const { getByPlaceholderText, getByText, queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <RootSearchSuggestField
           courseSearchPageUrl="/en/courses/"
@@ -178,7 +178,7 @@ describe('<RootSearchSuggestField />', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText('Search for courses');
+    const field = screen.getByPlaceholderText('Search for courses');
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'aut' } });
 
@@ -187,13 +187,13 @@ describe('<RootSearchSuggestField />', () => {
         fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
       ).toEqual(true);
     });
-    getByText('Subjects');
-    const subject = getByText('Subject #311');
+    screen.getByText('Subjects');
+    const subject = screen.getByText('Subject #311');
 
     expect(
       fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
     ).toEqual(true);
-    expect(queryByText('Courses')).toEqual(null);
+    expect(screen.queryByText('Courses')).toEqual(null);
 
     fireEvent.click(subject);
     await waitFor(() => {
@@ -212,7 +212,7 @@ describe('<RootSearchSuggestField />', () => {
       fetchMock.get(`/api/v1.0/${kind}/autocomplete/?query=some%20query`, []),
     );
 
-    const { getByPlaceholderText } = render(
+    render(
       <IntlProvider locale="en">
         <RootSearchSuggestField
           courseSearchPageUrl="/en/courses/"
@@ -221,7 +221,7 @@ describe('<RootSearchSuggestField />', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText('Search for courses');
+    const field = screen.getByPlaceholderText('Search for courses');
 
     // Simulate the user typing in some text in the autocomplete field
     fireEvent.focus(field);
@@ -250,7 +250,7 @@ describe('<RootSearchSuggestField />', () => {
       },
     ]);
 
-    const { getByPlaceholderText, getByText, queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <RootSearchSuggestField
           courseSearchPageUrl="/en/courses/"
@@ -259,7 +259,7 @@ describe('<RootSearchSuggestField />', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText('Search for courses');
+    const field = screen.getByPlaceholderText('Search for courses');
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'aut' } });
 
@@ -268,13 +268,13 @@ describe('<RootSearchSuggestField />', () => {
         fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
       ).toEqual(true);
     });
-    getByText('Courses');
-    getByText('Course #42');
+    screen.getByText('Courses');
+    screen.getByText('Course #42');
 
     expect(
       fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
     ).toEqual(true);
-    expect(queryByText('Subjects')).toEqual(null);
+    expect(screen.queryByText('Subjects')).toEqual(null);
 
     fireEvent.keyDown(field, { keyCode: 40 }); // Select the desired suggestion (there is only one)
     fireEvent.keyDown(field, { keyCode: 13 }); // Press enter

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -36,7 +36,7 @@ describe('<RootSearchSuggestField />', () => {
     values: [],
   };
 
-  afterEach(fetchMock.restore);
+  afterEach(() => fetchMock.restore());
   afterEach(jest.resetAllMocks);
 
   it('renders', () => {

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
@@ -88,22 +88,24 @@ describe('<RootSearchSuggestField />', () => {
 
     // No requests are made until the user enters at least 3 characters
     fireEvent.change(field, { target: { value: 'au' } });
-    await wait();
-    expect(fetchMock.called()).toEqual(false);
+    await waitFor(() => {
+      expect(fetchMock.called()).toEqual(false);
+    });
 
     fireEvent.change(field, { target: { value: 'aut' } });
-    await wait();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
+      ).toEqual(true);
+      getByText('Subjects');
+      getByText('Subject #311');
+    });
 
     expect(
       fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
     ).toEqual(true);
     expect(queryByText('Courses')).toEqual(null);
-
-    expect(
-      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
-    ).toEqual(true);
-    getByText('Subjects');
-    getByText('Subject #311');
   });
 
   it('goes to the course page when the user selects a course suggestion', async () => {
@@ -133,22 +135,24 @@ describe('<RootSearchSuggestField />', () => {
     const field = getByPlaceholderText('Search for courses');
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'aut' } });
-    await wait();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
+      ).toEqual(true);
+    });
+    getByText('Courses');
+    const course = getByText('Course #42');
 
     expect(
       fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
     ).toEqual(true);
     expect(queryByText('Subjects')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
-    ).toEqual(true);
-    getByText('Courses');
-    const course = getByText('Course #42');
-
     fireEvent.click(course);
-    await wait();
-    expect(location.assign).toHaveBeenCalledWith('/en/courses/42');
+    await waitFor(() => {
+      expect(location.assign).toHaveBeenCalledWith('/en/courses/42');
+    });
   });
 
   it('goes to course search with the filter value activated when the user clicks on a suggestion', async () => {
@@ -177,24 +181,26 @@ describe('<RootSearchSuggestField />', () => {
     const field = getByPlaceholderText('Search for courses');
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'aut' } });
-    await wait();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
+      ).toEqual(true);
+    });
+    getByText('Subjects');
+    const subject = getByText('Subject #311');
 
     expect(
       fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
     ).toEqual(true);
     expect(queryByText('Courses')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
-    ).toEqual(true);
-    getByText('Subjects');
-    const subject = getByText('Subject #311');
-
     fireEvent.click(subject);
-    await wait();
-    expect(location.assign).toHaveBeenCalledWith(
-      '/en/courses/?limit=13&offset=0&subjects=L-000300010001',
-    );
+    await waitFor(() => {
+      expect(location.assign).toHaveBeenCalledWith(
+        '/en/courses/?limit=13&offset=0&subjects=L-000300010001',
+      );
+    });
   });
 
   it('moves to the search page with a search query when the user types a query and presses ENTER', async () => {
@@ -221,11 +227,12 @@ describe('<RootSearchSuggestField />', () => {
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'some query' } });
     fireEvent.keyDown(field, { keyCode: 13 });
-    await wait();
 
-    expect(location.assign).toHaveBeenCalledWith(
-      '/en/courses/?limit=13&offset=0&query=some%20query',
-    );
+    await waitFor(() => {
+      expect(location.assign).toHaveBeenCalledWith(
+        '/en/courses/?limit=13&offset=0&query=some%20query',
+      );
+    });
   });
 
   it('lets the user select the currently highlighted suggestion by pressing ENTER', async () => {
@@ -255,22 +262,24 @@ describe('<RootSearchSuggestField />', () => {
     const field = getByPlaceholderText('Search for courses');
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'aut' } });
-    await wait();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
+      ).toEqual(true);
+    });
+    getByText('Courses');
+    getByText('Course #42');
 
     expect(
       fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
     ).toEqual(true);
     expect(queryByText('Subjects')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
-    ).toEqual(true);
-    getByText('Courses');
-    getByText('Course #42');
-
     fireEvent.keyDown(field, { keyCode: 40 }); // Select the desired suggestion (there is only one)
     fireEvent.keyDown(field, { keyCode: 13 }); // Press enter
-    await wait();
-    expect(location.assign).toHaveBeenCalledWith('/en/courses/42');
+    await waitFor(() => {
+      expect(location.assign).toHaveBeenCalledWith('/en/courses/42');
+    });
   });
 });

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -40,7 +40,7 @@ describe('<Search />', () => {
     sentry_dsn: null,
   };
 
-  beforeEach(fetchMock.restore);
+  beforeEach(() => fetchMock.restore());
 
   it('shows a spinner while the results are loading', async () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', {

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { stringify } from 'query-string';
 import React from 'react';
@@ -48,7 +48,7 @@ describe('<Search />', () => {
       objects: [],
     });
 
-    const { getByText, queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -59,18 +59,18 @@ describe('<Search />', () => {
     );
 
     expect(
-      getByText('Loading search results...').parentElement,
+      screen.getByText('Loading search results...').parentElement,
     ).toHaveAttribute('role', 'status');
 
     await waitFor(() => {
-      expect(queryByText('Loading search results...')).toBeNull();
+      expect(screen.queryByText('Loading search results...')).toBeNull();
     });
   });
 
   it('shows an error message when it fails to get the results', async () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', 500);
 
-    const { getByText, queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -81,13 +81,13 @@ describe('<Search />', () => {
     );
 
     expect(
-      getByText('Loading search results...').parentElement,
+      screen.getByText('Loading search results...').parentElement,
     ).toHaveAttribute('role', 'status');
 
     await waitFor(() => {
-      expect(queryByText('Loading search results...')).toBeNull();
+      expect(screen.queryByText('Loading search results...')).toBeNull();
     });
-    getByText(`Something's wrong! Courses could not be loaded.`);
+    screen.getByText(`Something's wrong! Courses could not be loaded.`);
   });
 
   it('always shows the filters pane on large screens', async () => {
@@ -128,7 +128,7 @@ describe('<Search />', () => {
     });
 
     mockMatches = false;
-    const { container, getByText, queryByText } = render(
+    const { container } = render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -151,8 +151,8 @@ describe('<Search />', () => {
 
     {
       // We have a "Show" button with the appropriate aria helper
-      expect(queryByText('Hide filters pane')).toEqual(null);
-      const button = getByText('Show filters pane');
+      expect(screen.queryByText('Hide filters pane')).toEqual(null);
+      const button = screen.getByText('Show filters pane');
       expect(
         container.querySelector('.search__filters__toggle'),
       ).toHaveAttribute('aria-expanded', 'false');
@@ -166,8 +166,8 @@ describe('<Search />', () => {
     }
     {
       // We now have a "Hide" button with the appropriate aria helper
-      expect(queryByText('Show filters pane')).toEqual(null);
-      const button = getByText('Hide filters pane');
+      expect(screen.queryByText('Show filters pane')).toEqual(null);
+      const button = screen.getByText('Hide filters pane');
       expect(
         container.querySelector('.search__filters__toggle'),
       ).toHaveAttribute('aria-expanded', 'true');

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -1,6 +1,6 @@
 import 'testSetup';
 
-import { fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { stringify } from 'query-string';
 import React from 'react';
@@ -64,8 +64,9 @@ describe('<Search />', () => {
       getByText('Loading search results...').parentElement,
     ).toHaveAttribute('role', 'status');
 
-    await wait();
-    expect(queryByText('Loading search results...')).toBeNull();
+    await waitFor(() => {
+      expect(queryByText('Loading search results...')).toBeNull();
+    });
   });
 
   it('shows an error message when it fails to get the results', async () => {
@@ -85,8 +86,9 @@ describe('<Search />', () => {
       getByText('Loading search results...').parentElement,
     ).toHaveAttribute('role', 'status');
 
-    await wait();
-    expect(queryByText('Loading search results...')).toBeNull();
+    await waitFor(() => {
+      expect(queryByText('Loading search results...')).toBeNull();
+    });
     getByText(`Something's wrong! Courses could not be loaded.`);
   });
 
@@ -108,13 +110,14 @@ describe('<Search />', () => {
         </HistoryContext.Provider>
       </IntlProvider>,
     );
-    await wait();
 
-    // The search filters pane is not hidden, there is no button to show/hide it
-    expect(container.querySelector('.search-filters-pane')).toHaveAttribute(
-      'aria-hidden',
-      'false',
-    );
+    await waitFor(() => {
+      // The search filters pane is not hidden, there is no button to show/hide it
+      expect(container.querySelector('.search-filters-pane')).toHaveAttribute(
+        'aria-hidden',
+        'false',
+      );
+    });
     expect(container.querySelector('.search__filters__toggle')).toEqual(null);
   });
 
@@ -136,13 +139,14 @@ describe('<Search />', () => {
         </HistoryContext.Provider>
       </IntlProvider>,
     );
-    await wait();
 
-    // The search filters pane is hidden, there is a button to show/hide it
-    expect(container.querySelector('.search-filters-pane')).toHaveAttribute(
-      'aria-hidden',
-      'true',
-    );
+    await waitFor(() => {
+      // The search filters pane is hidden, there is a button to show/hide it
+      expect(container.querySelector('.search-filters-pane')).toHaveAttribute(
+        'aria-hidden',
+        'true',
+      );
+    });
     expect(container.querySelector('.search__filters__toggle')).toEqual(
       jasmine.any(HTMLButtonElement),
     );

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { stringify } from 'query-string';

--- a/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
@@ -56,7 +56,7 @@ describe('components/SearchFilterGroup', () => {
   beforeEach(jest.resetAllMocks);
 
   it('renders the name of the filter with the values as SearchFilters', () => {
-    const { getByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -66,14 +66,14 @@ describe('components/SearchFilterGroup', () => {
       </IntlProvider>,
     );
     // The filter group title and all filters are shown
-    getByText('Organizations');
-    getByText('Received parent: filter - Value One');
-    getByText('Received leaf: filter - Value Two');
-    getByText('More options');
+    screen.getByRole('group', { name: 'Organizations' });
+    screen.getByText('Received parent: filter - Value One');
+    screen.getByText('Received leaf: filter - Value Two');
+    screen.getByRole('button', { name: 'More options' });
   });
 
   it('does not render the "More options" button & modal if the filter is not searchable', () => {
-    const { queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -83,11 +83,13 @@ describe('components/SearchFilterGroup', () => {
       </IntlProvider>,
     );
 
-    expect(queryByText('More options')).toEqual(null);
+    expect(screen.queryByRole('button', { name: 'More options' })).toEqual(
+      null,
+    );
   });
 
   it('does not render the "More options" button & modal if there are no more values to find', () => {
-    const { queryByText } = render(
+    render(
       <IntlProvider locale="en">
         <HistoryContext.Provider
           value={makeHistoryOf({ limit: '20', offset: '0' })}
@@ -97,6 +99,8 @@ describe('components/SearchFilterGroup', () => {
       </IntlProvider>,
     );
 
-    expect(queryByText('More options')).toEqual(null);
+    expect(screen.queryByRole('button', { name: 'More options' })).toEqual(
+      null,
+    );
   });
 });

--- a/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { render } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { stringify } from 'query-string';
 import React from 'react';
@@ -46,7 +46,6 @@ describe('<SearchFilterGroupModal />', () => {
 
   beforeEach(() => fetchMock.restore());
   beforeEach(jest.resetAllMocks);
-  afterEach(cleanup);
 
   it('renders a button with a modal to search values for a given filter', async () => {
     fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, wait } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { stringify } from 'query-string';
 import React from 'react';
@@ -105,8 +105,7 @@ describe('<SearchFilterGroupModal />', () => {
     getByPlaceholderText('Search in Universities');
 
     // Default search results are shown with their facet counts
-    await wait();
-    getByText(
+    await screen.findByText(
       (content) => content.startsWith('Value #42') && content.includes('(7)'),
     );
     getByText(
@@ -161,8 +160,7 @@ describe('<SearchFilterGroupModal />', () => {
     fireEvent.focus(field);
 
     // Default search results are shown with their facet counts
-    await wait();
-    getByText(
+    await screen.findByText(
       (content) => content.startsWith('Value #42') && content.includes('(7)'),
     );
     getByText(
@@ -203,8 +201,7 @@ describe('<SearchFilterGroupModal />', () => {
     fireEvent.change(field, { target: { value: 'user' } });
 
     // New search results are shown with their facet counts
-    await wait();
-    getByText(
+    await screen.findByText(
       (content) => content.startsWith('Value #12') && content.includes('(7)'),
     );
     getByText(
@@ -242,8 +239,7 @@ describe('<SearchFilterGroupModal />', () => {
     fireEvent.change(field, { target: { value: 'user input' } });
 
     // New search results are shown with their facet counts
-    await wait();
-    getByText(
+    await screen.findByText(
       (content) => content.startsWith('Value #03') && content.includes('(12)'),
     );
     getByText(
@@ -297,11 +293,11 @@ describe('<SearchFilterGroupModal />', () => {
     fireEvent.click(closeButton);
 
     // The modal is not rendered any more
-    expect(queryByText('Add filters for Universities')).toEqual(null);
+    await waitFor(() => {
+      expect(queryByText('Add filters for Universities')).toEqual(null);
+    });
     expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
     expect(queryByText('Close')).toEqual(null);
-
-    await wait();
   });
 
   it('adds the value and closes when the user clicks a filter value', async () => {
@@ -356,12 +352,11 @@ describe('<SearchFilterGroupModal />', () => {
     getByPlaceholderText('Search in Universities');
 
     // Default search results are shown with their facet counts
-    await wait();
+    await screen.findByText(
+      (content) => content.startsWith('Value #84') && content.includes('(12)'),
+    );
     const value42 = getByText(
       (content) => content.startsWith('Value #42') && content.includes('(7)'),
-    );
-    getByText(
-      (content) => content.startsWith('Value #84') && content.includes('(12)'),
     );
 
     // User clicks Value #42, it is added to course search params through pushState
@@ -418,8 +413,9 @@ describe('<SearchFilterGroupModal />', () => {
     getByPlaceholderText('Search in Universities');
 
     // The search request failed, the error is logged and a message is displayed
-    await wait();
-    getByText('There was an error while searching for Universities.');
+    await screen.findByText(
+      'There was an error while searching for Universities.',
+    );
   });
 
   it('shows an error message when it fails to get the actual filter', async () => {
@@ -457,7 +453,8 @@ describe('<SearchFilterGroupModal />', () => {
     getByPlaceholderText('Search in Universities');
 
     // The filters request failed, the error is logged and a message is displayed
-    await wait();
-    getByText('There was an error while searching for Universities.');
+    await screen.findByText(
+      'There was an error while searching for Universities.',
+    );
   });
 });

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -44,7 +44,7 @@ describe('<SearchFilterGroupModal />', () => {
     historyReplaceState,
   ];
 
-  beforeEach(fetchMock.restore);
+  beforeEach(() => fetchMock.restore());
   beforeEach(jest.resetAllMocks);
   afterEach(cleanup);
 

--- a/src/frontend/js/components/SearchFilterValueLeaf/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { fireEvent, render } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';

--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { fireEvent, render, screen } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';

--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -1,6 +1,6 @@
 import 'testSetup';
 
-import { fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
@@ -134,10 +134,12 @@ describe('<SearchFilterValueParent />', () => {
     rerender(
       getElement({ limit: '999', offset: '0', subjects: ['L-000400050004'] }),
     );
-    await wait();
+
+    await screen.findByLabelText((content) =>
+      content.startsWith('Classical Literature'),
+    );
 
     // The children filters are now shown along with an icon to hide them
-    getByLabelText((content) => content.startsWith('Classical Literature'));
     getByLabelText((content) => content.startsWith('Modern Literature'));
     const button = getByLabelText('Hide additional filters for Literature');
     expect(button).toHaveAttribute('aria-pressed', 'true');
@@ -199,8 +201,9 @@ describe('<SearchFilterValueParent />', () => {
     expect(
       getByLabelText('Hide additional filters for Literature'),
     ).toHaveAttribute('aria-pressed', 'true');
-    await wait();
-    getByLabelText((content) => content.startsWith('Classical Literature'));
+    await screen.findByLabelText((content) =>
+      content.startsWith('Classical Literature'),
+    );
     getByLabelText((content) => content.startsWith('Modern Literature'));
 
     expect(mockFetchList).toHaveBeenCalledTimes(1);
@@ -241,8 +244,9 @@ describe('<SearchFilterValueParent />', () => {
     expect(
       getByLabelText('Hide additional filters for Literature'),
     ).toHaveAttribute('aria-pressed', 'true');
-    await wait();
-    getByLabelText((content) => content.startsWith('Classical Literature'));
+    await screen.findByLabelText((content) =>
+      content.startsWith('Classical Literature'),
+    );
     getByLabelText((content) => content.startsWith('Modern Literature'));
   });
 

--- a/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { fireEvent, render } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -78,7 +78,7 @@ describe('components/SearchSuggestField', () => {
     position: 3,
   };
 
-  afterEach(fetchMock.restore);
+  afterEach(() => fetchMock.restore());
   beforeEach(jest.resetAllMocks);
   beforeEach(() => (location.search = ''));
 

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -1,6 +1,6 @@
 import 'testSetup';
 
-import { act, fireEvent, render, wait } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
@@ -188,7 +188,14 @@ describe('components/SearchSuggestField', () => {
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'aut' } });
-    await wait();
+
+    await waitFor(() => {
+      expect(
+        fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
+      ).toEqual(true);
+    });
+    getByText('Subjects');
+    getByText('Subject #311');
 
     expect(
       fetchMock.called('/api/v1.0/levels/autocomplete/?query=aut'),
@@ -204,12 +211,6 @@ describe('components/SearchSuggestField', () => {
       fetchMock.called('/api/v1.0/persons/autocomplete/?query=aut'),
     ).toEqual(true);
     expect(queryByText('Persons')).toEqual(null);
-
-    expect(
-      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
-    ).toEqual(true);
-    getByText('Subjects');
-    getByText('Subject #311');
   });
 
   it('does not attempt to get or show any suggestions before the user types 3 characters', async () => {
@@ -239,11 +240,16 @@ describe('components/SearchSuggestField', () => {
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'x' } });
-    await wait();
-    expect(fetchMock.calls().length).toEqual(0);
+    await waitFor(() => {
+      expect(fetchMock.calls().length).toEqual(0);
+    });
 
     fireEvent.change(field, { target: { value: 'xyz' } });
-    await wait();
+    await waitFor(() => {
+      expect(
+        fetchMock.called('/api/v1.0/subjects/autocomplete/?query=xyz'),
+      ).toEqual(true);
+    });
     expect(
       fetchMock.called('/api/v1.0/levels/autocomplete/?query=xyz'),
     ).toEqual(false);
@@ -252,9 +258,6 @@ describe('components/SearchSuggestField', () => {
     ).toEqual(true);
     expect(
       fetchMock.called('/api/v1.0/persons/autocomplete/?query=xyz'),
-    ).toEqual(true);
-    expect(
-      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=xyz'),
     ).toEqual(true);
   });
 
@@ -292,8 +295,10 @@ describe('components/SearchSuggestField', () => {
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'orga' } });
-    await wait();
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(1);
+    });
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -328,9 +333,10 @@ describe('components/SearchSuggestField', () => {
     expect(queryByText('Subjects')).toEqual(null);
 
     fireEvent.click(getByText('Organization #27'));
-    await wait();
 
-    expect(history.pushState).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(2);
+    });
     expect(history.pushState).toHaveBeenCalledWith(
       {
         name: 'courseSearch',
@@ -383,8 +389,10 @@ describe('components/SearchSuggestField', () => {
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'doct' } });
-    await wait();
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(1);
+    });
     expect(history.pushState).toHaveBeenCalledWith(
       {
         name: 'courseSearch',
@@ -419,9 +427,10 @@ describe('components/SearchSuggestField', () => {
     expect(queryByText('Subjects')).toEqual(null);
 
     fireEvent.click(getByText('Doctor Doom'));
-    await wait();
 
-    expect(history.pushState).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(2);
+    });
     expect(history.pushState).toHaveBeenCalledWith(
       {
         name: 'courseSearch',
@@ -470,19 +479,20 @@ describe('components/SearchSuggestField', () => {
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: '' } });
     fireEvent.keyDown(field, { keyCode: 13 });
-    await wait();
 
-    expect(history.pushState).toHaveBeenCalledWith(
-      {
-        name: 'courseSearch',
-        data: {
-          lastDispatchActions: expect.any(Array),
-          params: { limit: '20', offset: '0', query: undefined },
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledWith(
+        {
+          name: 'courseSearch',
+          data: {
+            lastDispatchActions: expect.any(Array),
+            params: { limit: '20', offset: '0', query: undefined },
+          },
         },
-      },
-      '',
-      '/search?limit=20&offset=0',
-    );
+        '',
+        '/search?limit=20&offset=0',
+      );
+    });
   });
 
   it('searches as the user types', async () => {
@@ -513,12 +523,14 @@ describe('components/SearchSuggestField', () => {
     // NB: the tests below rely on the very crude debounce mock for lodash-debounce.
     // TODO: rewrite them when we use mocked timers to test our debouncing strategy.
     fireEvent.change(field, { target: { value: 'ri' } });
-    await wait();
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(history.pushState).not.toHaveBeenCalled();
+    });
 
     fireEvent.change(field, { target: { value: 'ric' } });
-    await wait();
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(1);
+    });
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -532,8 +544,9 @@ describe('components/SearchSuggestField', () => {
     );
 
     fireEvent.change(field, { target: { value: 'rich data driven' } });
-    await wait();
-    expect(history.pushState).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(2);
+    });
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -547,8 +560,9 @@ describe('components/SearchSuggestField', () => {
     );
 
     fireEvent.change(field, { target: { value: '' } });
-    await wait();
-    expect(history.pushState).toHaveBeenCalledTimes(3);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(3);
+    });
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -590,20 +604,24 @@ describe('components/SearchSuggestField', () => {
     // NB: the tests below rely on the very crude debounce mock for lodash-debounce.
     // TODO: rewrite them when we use mocked timers to test our debouncing strategy.
     fireEvent.change(field, { target: { value: 'ri' } });
-    await wait();
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(history.pushState).not.toHaveBeenCalled();
+    });
 
     fireEvent.change(field, { target: { value: 'ri ' } });
-    await wait();
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(history.pushState).not.toHaveBeenCalled();
+    });
 
     fireEvent.change(field, { target: { value: ' ri' } });
-    await wait();
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(history.pushState).not.toHaveBeenCalled();
+    });
 
     fireEvent.change(field, { target: { value: 'ric' } });
-    await wait();
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(1);
+    });
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -653,8 +671,9 @@ describe('components/SearchSuggestField', () => {
 
     // The user is typing an organization name
     fireEvent.change(field, { target: { value: 'orga' } });
-    await wait();
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(1);
+    });
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -668,9 +687,9 @@ describe('components/SearchSuggestField', () => {
     );
     // The user selects an organization from suggestions
     fireEvent.click(getByText('Organization #27'));
-    await wait();
-
-    expect(history.pushState).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(2);
+    });
     expect(history.pushState).toHaveBeenCalledWith(
       {
         name: 'courseSearch',
@@ -690,8 +709,9 @@ describe('components/SearchSuggestField', () => {
 
     // The user starts typing a full-text search, the organization remains selected
     fireEvent.change(field, { target: { value: 'ric' } });
-    await wait();
-    expect(history.pushState).toHaveBeenCalledTimes(3);
+    await waitFor(() => {
+      expect(history.pushState).toHaveBeenCalledTimes(3);
+    });
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',

--- a/src/frontend/js/components/UserLogin/index.spec.tsx
+++ b/src/frontend/js/components/UserLogin/index.spec.tsx
@@ -1,11 +1,12 @@
 import 'testSetup';
 
-import { render, wait } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
 import { handle } from 'utils/errors/handle';
+import { Deferred } from 'utils/tests/Deferred';
 import { UserLogin } from '.';
 
 jest.mock('utils/errors/handle', () => ({
@@ -22,10 +23,8 @@ describe('<UserLogin />', () => {
   beforeEach(() => fetchMock.restore());
 
   it('gets and renders the user name and a log out button', async () => {
-    fetchMock.get('/api/v1.0/users/whoami/', {
-      full_name: 'Decimus Iunius Iuvenalis',
-      username: 'Juvénal',
-    });
+    const deferred = new Deferred();
+    fetchMock.get('/api/v1.0/users/whoami/', deferred.promise);
 
     const { getByText, queryByText } = render(
       <IntlProvider locale="en">
@@ -35,14 +34,20 @@ describe('<UserLogin />', () => {
     expect(fetchMock.calls('/api/v1.0/users/whoami/').length).toEqual(1);
     getByText('Loading login status...');
 
-    await wait();
+    await act(async () =>
+      deferred.resolve({
+        full_name: 'Decimus Iunius Iuvenalis',
+        username: 'Juvénal',
+      }),
+    );
     getByText('Decimus Iunius Iuvenalis');
     getByText('Log out');
     expect(queryByText('Loading login status...')).toBeNull();
   });
 
   it('renders signup/login buttons when the user is not logged in', async () => {
-    fetchMock.get('/api/v1.0/users/whoami/', 401);
+    const deferred = new Deferred();
+    fetchMock.get('/api/v1.0/users/whoami/', deferred.promise);
 
     const { getByText, queryByText } = render(
       <IntlProvider locale="en">
@@ -52,14 +57,15 @@ describe('<UserLogin />', () => {
     expect(fetchMock.calls('/api/v1.0/users/whoami/').length).toEqual(1);
     getByText('Loading login status...');
 
-    await wait();
+    await act(async () => deferred.resolve(401));
     getByText('Log in');
     getByText('Sign up');
     expect(queryByText('Loading login status...')).toBeNull();
   });
 
   it('defaults to the logged off state when it fails to get the user', async () => {
-    fetchMock.get('/api/v1.0/users/whoami/', 500);
+    const deferred = new Deferred();
+    fetchMock.get('/api/v1.0/users/whoami/', deferred.promise);
 
     const { getByText, queryByText } = render(
       <IntlProvider locale="en">
@@ -69,7 +75,7 @@ describe('<UserLogin />', () => {
     expect(fetchMock.calls('/api/v1.0/users/whoami/').length).toEqual(1);
     getByText('Loading login status...');
 
-    await wait();
+    await act(async () => deferred.resolve(500));
     getByText('Log in');
     getByText('Sign up');
     expect(queryByText('Loading login status...')).toBeNull();

--- a/src/frontend/js/components/UserLogin/index.spec.tsx
+++ b/src/frontend/js/components/UserLogin/index.spec.tsx
@@ -19,7 +19,7 @@ describe('<UserLogin />', () => {
     signupUrl: '/signup',
   };
 
-  beforeEach(fetchMock.restore);
+  beforeEach(() => fetchMock.restore());
 
   it('gets and renders the user name and a log out button', async () => {
     fetchMock.get('/api/v1.0/users/whoami/', {

--- a/src/frontend/js/components/UserLogin/index.spec.tsx
+++ b/src/frontend/js/components/UserLogin/index.spec.tsx
@@ -1,5 +1,3 @@
-import 'testSetup';
-
 import { act, render } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';

--- a/src/frontend/js/data/getResourceList/index.spec.ts
+++ b/src/frontend/js/data/getResourceList/index.spec.ts
@@ -36,7 +36,7 @@ describe('data/getResourceList', () => {
   };
 
   describe('fetchList', () => {
-    afterEach(fetchMock.restore);
+    afterEach(() => fetchMock.restore());
 
     it('requests the resource list, parses the JSON response and resolves with the results', async () => {
       fetchMock.mock(

--- a/src/frontend/js/data/useStaticFilters/index.spec.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.spec.tsx
@@ -59,7 +59,7 @@ describe('data/useStaticFilters', () => {
     subjects,
   };
 
-  beforeEach(fetchMock.restore);
+  beforeEach(() => fetchMock.restore());
 
   it('gets and returns the static filter definitions', async () => {
     fetchMock.get('/api/v1.0/filter-definitions/', staticFilterDefinitions);

--- a/src/frontend/js/utils/tests/Deferred.tsx
+++ b/src/frontend/js/utils/tests/Deferred.tsx
@@ -1,0 +1,16 @@
+/*
+ * Test helper: use a deferred object to control promise resolution without mocking
+ * deep inside our code.
+ */
+export class Deferred<T> {
+  promise: Promise<T>;
+  reject!: (reason?: any) => void;
+  resolve!: (value?: T | PromiseLike<T> | undefined) => void;
+
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.reject = reject;
+      this.resolve = resolve;
+    });
+  }
+}


### PR DESCRIPTION
## Purpose

`testing-library` has evolved quite a bit since we started writing our tests using it. Some of our stuff is now triggering deprecation warnings. 

We went through the codebase to remove warnings and keep things up to date.

## Proposal

- [x] move `jest-dom` to jest startup
- [x] stop using deprecated `await wait()`, instead `waitFor()` what we're actually expecting to happen
- [x] change the way we use `fetchMock` helpers to get rid of warnings
- [x] add a `Deferred` helper to facilitate tests
- [x] remove a forgotten `cleanup()` call

Note: we could also replace render destructuring with the use of `screen.getBy*` methods but this is a larger task as it's also an opportunity to add testing based on accessible roles and names, which we'll be doing separately later on.