### PR TITLE
🐛 Fix spinner styles & improve a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add Linkedin badge in social networks templates.
 - Add new section "septenary" with a new wave decoration.
 
+### Fixed
+
+- Spinner component was broken due to missing styles.
+
 ## [2.0.0-beta.9] - 2020-07-01
 
 ### Added

--- a/src/frontend/js/components/Spinner/_styles.scss
+++ b/src/frontend/js/components/Spinner/_styles.scss
@@ -7,8 +7,8 @@
 
 .spinner {
   border: 0.125rem solid transparent;
-  border-left-color: $dodgerblue5;
-  border-top-color: $dodgerblue5;
+  border-left-color: r-color('denim');
+  border-top-color: r-color('denim');
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
   display: inline-block;

--- a/src/frontend/js/components/Spinner/index.tsx
+++ b/src/frontend/js/components/Spinner/index.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 
 interface SpinnerProps {
+  'aria-labelledby'?: string;
   size?: 'small' | 'large';
-  children: React.ReactNode;
 }
 
 /** Component. Displays a rotating CSS loader. */
-export const Spinner = ({ children, size }: SpinnerProps) => {
+export const Spinner: React.FC<SpinnerProps> = (props) => {
+  const { children, size } = props;
+  const spinnerProps = props['aria-labelledby']
+    ? { ['aria-labelledby']: props['aria-labelledby'] }
+    : {};
+
   return (
-    <div className="spinner-container" role="status">
+    <div className="spinner-container" role="status" {...spinnerProps}>
       <div className={`spinner spinner--${size || 'small'}`} />
       <div className="offscreen">{children}</div>
     </div>

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -71,6 +71,7 @@
 @import '../js/components/SearchFilterGroupModal/styles';
 @import '../js/components/SearchFiltersPane/styles';
 @import '../js/components/SearchInput/styles';
+@import '../js/components/Spinner/styles';
 @import '../js/components/UserLogin/styles';
 @import './components/templates/courses/plugins/category_plugin';
 @import './components/templates/courses/plugins/licence_plugin';


### PR DESCRIPTION
## Purpose

Merge spinner related fixes from #1034.

## Proposal

As we worked on course run enrollments, we fixed `<Spinner />` and made some improvements. We're proposing to merge them here as #1034 is now not intended to be merged (or at least not for a while).

- [x] add back missing styles for `<Spinner />` removed in Richie v2
- [x] improve `<Spinner />` accessibility by having it accept `aria-labelledby`
