### PR TITLE
🔨 Enable live-debugging in app container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     depends_on:
       - "${DB_HOST:-postgresql}"
       - "elasticsearch"
+    stdin_open: true
+    tty: true
 
   node:
     image: circleci/node:10


### PR DESCRIPTION
## Purpose

During development, it is generally useful to enable live-debugging in the running container. By default, docker/compose prevents us from attaching to the debugger.

## Proposal

Enabling these two settings simply allows `docker attach` to connect to eg. the live python debugger and should not have any side-effects anywhere else as this docker-compose config is only used in development.
