### PR TITLE
✨(core) add a plugin for django-redis that supports Redis Sentinel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,15 @@ jobs:
       - image: fundocker/openshift-elasticsearch:6.6.2
         environment:
           discovery.type: single-node
+      - image: docker.io/bitnami/redis:6.0-debian-10
+        name: redis-primary
+        environment:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_REPLICATION_MODE: master
+      - image: docker.io/bitnami/redis-sentinel:6.0-debian-10
+        name: redis-sentinel
+        environment:
+          REDIS_MASTER_HOST: redis-primary
     working_directory: ~/fun
     steps:
       - checkout
@@ -262,6 +271,15 @@ jobs:
       - image: fundocker/openshift-elasticsearch:6.6.2
         environment:
           discovery.type: single-node
+      - image: docker.io/bitnami/redis:6.0-debian-10
+        name: redis-primary
+        environment:
+          ALLOW_EMPTY_PASSWORD: yes
+          REDIS_REPLICATION_MODE: master
+      - image: docker.io/bitnami/redis-sentinel:6.0-debian-10
+        name: redis-sentinel
+        environment:
+          REDIS_MASTER_HOST: redis-primary
     working_directory: ~/fun
     steps:
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add Linkedin badge in social networks templates.
 - Add new section "septenary" with a new wave decoration.
+- Add redis sentinel cache backend
 
 ### Fixed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     depends_on:
       - "${DB_HOST:-postgresql}"
       - "elasticsearch"
+      - redis-sentinel
     stdin_open: true
     tty: true
 
@@ -53,3 +54,32 @@ services:
       - env.d/development/crowdin
     user: "${DOCKER_USER:-1000}"
     working_dir: /app
+
+  redis-sentinel:
+    image: docker.io/bitnami/redis-sentinel:6.0-debian-10
+    depends_on:
+      - redis-primary
+      - redis-replica1
+      - redis-replica2
+    environment:
+      - REDIS_MASTER_HOST=redis-primary
+
+  redis-primary:
+    image: docker.io/bitnami/redis:6.0-debian-10
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_REPLICATION_MODE=master
+
+  redis-replica1:
+    image: docker.io/bitnami/redis:6.0-debian-10
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_MASTER_HOST=redis-primary
+
+  redis-replica2:
+    image: docker.io/bitnami/redis:6.0-debian-10
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_REPLICATION_MODE=slave
+      - REDIS_MASTER_HOST=redis-primary

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -438,6 +438,14 @@ class Development(Base):
 class Test(Base):
     """Test environment settings"""
 
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+            "OPTIONS": {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+        }
+    }
+
 
 class ContinuousIntegration(Test):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     elasticsearch>=6.0.0,<7.0.0 # pyup: ignore
     social-auth-core[openidconnect]==3.2.0 # pyup: ignore
     social-auth-app-django==3.1.0 # pyup: ignore
+    django-redis>=4.11.0
 package_dir =
     =src
 packages = find:
@@ -54,6 +55,7 @@ dev =
     ipdb==0.13.3
     ipython==7.16.1
     isort==4.3.21
+    msgpack===1.0.0
     mysqlclient==2.0.1
     pylint==2.5.3
     pylint-django==2.1.0

--- a/src/richie/apps/core/cache.py
+++ b/src/richie/apps/core/cache.py
@@ -1,0 +1,131 @@
+"""
+Plugin for django-redis that supports redis sentinel.
+Credits :
+ - https://github.com/lamoda/django-sentinel
+ - https://github.com/KabbageInc/django-redis-sentinel
+"""
+
+import logging
+import random
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from django_redis.client import DefaultClient
+from redis.sentinel import Sentinel
+
+DJANGO_REDIS_LOGGER = getattr(settings, "DJANGO_REDIS_LOGGER", __name__)
+
+
+class SentinelClient(DefaultClient):
+    """
+    Sentinel client object extending django-redis DefaultClient
+    """
+
+    def __init__(self, server, params, backend):
+        """
+        Slightly different logic than connection to multiple Redis servers.
+        Reserve only one write and one read descriptor, as they will be closed on exit anyway.
+        """
+        super(SentinelClient, self).__init__(server, params, backend)
+        self._client_write = None
+        self._client_read = None
+        (
+            self._master_name,
+            self._sentinel_hosts,
+            self._database_name,
+        ) = self.parse_connection_string(server)
+        self.log = logging.getLogger(DJANGO_REDIS_LOGGER)
+
+    @staticmethod
+    def parse_connection_string(connection_string):
+        """
+        Parse connection string in format:
+            master_name/sentinel_server:port,sentinel_server:port/db_id
+        Returns master name, list of tuples with pair (host, port) and db_id
+        """
+        try:
+            master_name, servers_string, database_name = connection_string.split("/")
+            servers = [host_port.split(":") for host_port in servers_string.split(",")]
+            sentinel_hosts = [(host, int(port)) for host, port in servers]
+        except (ValueError, TypeError, IndexError):
+            raise ImproperlyConfigured("Incorrect format '%s'" % (connection_string))
+
+        return master_name, sentinel_hosts, database_name
+
+    def get_client(self, write=True, tried=(), show_index=False):
+        """
+        Method used to obtain a raw redis client.
+
+        This function is used by almost all cache backend
+        operations to obtain a native redis client/connection
+        instance.
+        """
+        self.log.debug("get_client called: write=%s", write)
+        if write:
+            if self._client_write is None:
+                self._client_write = self.connect(write)
+
+            if show_index:
+                return self._client_write, 0
+            return self._client_write
+
+        if self._client_read is None:
+            self._client_read = self.connect(write)
+
+        if show_index:
+            return self._client_read, 0
+        return self._client_read
+
+    # pylint: disable=arguments-differ
+    def connect(self, write=True):
+        """
+        Create a redis connection with connection pool.
+        """
+        self.log.debug("connect called: write=%s", write)
+
+        sentinel_timeout = self._options.get("SENTINEL_TIMEOUT", 1)
+        password = self._options.get("PASSWORD", None)
+        sentinel = Sentinel(
+            self._sentinel_hosts, socket_timeout=sentinel_timeout, password=password
+        )
+
+        if write:
+            host, port = sentinel.discover_master(self._master_name)
+        else:
+            try:
+                host, port = random.choice(  # nosec
+                    sentinel.discover_slaves(self._master_name)
+                )
+            except IndexError:
+                self.log.debug("no slaves are available. using master for read.")
+                host, port = sentinel.discover_master(self._master_name)
+
+        if password:
+            connection_url = f"redis://:{password}@{host}:{port}/{self._database_name}"
+        else:
+            connection_url = f"redis://{host}:{port}/{self._database_name}"
+        self.log.debug("Connecting to: %s", connection_url)
+        return self.connection_factory.connect(connection_url)
+
+    def close(self, **kwargs):
+        """
+        Closing old connections, as master may change in time of inactivity.
+        """
+        self.log.debug("close called")
+        if self._client_read:
+            # pylint: disable=protected-access
+            for connection in self._client_read.connection_pool._available_connections:
+                connection.disconnect()
+            self.log.debug("client_read closed")
+
+        if self._client_write:
+            # pylint: disable=protected-access
+            for connection in self._client_write.connection_pool._available_connections:
+                connection.disconnect()
+            self.log.debug("client_write closed")
+
+        del self._client_write
+        del self._client_read
+        self._client_write = None
+        self._client_read = None

--- a/tests/apps/core/test_cache.py
+++ b/tests/apps/core/test_cache.py
@@ -1,0 +1,409 @@
+"""
+Test suite for the cache module in the `core` application
+
+Credits :
+ - https://github.com/lamoda/django-sentinel
+ - https://github.com/KabbageInc/django-redis-sentinel
+"""
+
+import time
+from datetime import datetime
+
+from django.core.cache import cache, caches
+from django.test import TestCase
+
+from django_redis.serializers import json as json_serializer
+from django_redis.serializers import msgpack as msgpack_serializer
+
+
+# pylint: disable=too-many-public-methods
+class TestSentinelClient(TestCase):
+    """Test case for the SentinelClient"""
+
+    def setUp(self) -> None:
+        """Clears the cache before each test"""
+        cache.clear()
+
+    @staticmethod
+    def test_close():
+        """Calling close on the cache backend should not raise any error"""
+        default_cache = caches["default"]
+        default_cache.set("f", "1")
+        default_cache.close()
+
+    def test_decr(self):
+        """Test the decr cache operation"""
+        cache.set("num", 20)
+
+        cache.decr("num")
+        res = cache.get("num")
+        self.assertEqual(res, 19)
+
+        cache.decr("num", 20)
+        res = cache.get("num")
+        self.assertEqual(res, -1)
+
+        cache.decr("num", 2)
+        res = cache.get("num")
+        self.assertEqual(res, -3)
+
+        cache.set("num", 20)
+
+        cache.decr("num")
+        res = cache.get("num")
+        self.assertEqual(res, 19)
+
+        # max 64 bit signed int + 1
+        cache.set("num", 9223372036854775808)
+
+        cache.decr("num")
+        res = cache.get("num")
+        self.assertEqual(res, 9223372036854775807)
+
+        cache.decr("num", 2)
+        res = cache.get("num")
+        self.assertEqual(res, 9223372036854775805)
+
+    def test_delete(self):
+        """Test the delete cache operation """
+        cache.set_many({"a": 1, "b": 2, "c": 3})
+        res = cache.delete("a")
+        self.assertTrue(bool(res))
+
+        res = cache.get_many(["a", "b", "c"])
+        assert res == {"b": 2, "c": 3}
+
+        res = cache.delete("a")
+        self.assertFalse(bool(res))
+
+    def test_delete_many(self):
+        """Test the delete_many cache operation"""
+        cache.set_many({"a": 1, "b": 2, "c": 3})
+        res = cache.delete_many(["a", "b"])
+        self.assertTrue(bool(res))
+
+        res = cache.get_many(["a", "b", "c"])
+        self.assertEqual(res, {"c": 3})
+
+        res = cache.delete_many(["a", "b"])
+        self.assertFalse(bool(res))
+
+    def test_delete_many_generator(self):
+        """Test the delete_many cache operation with a generator"""
+        cache.set_many({"a": 1, "b": 2, "c": 3})
+        res = cache.delete_many(key for key in ["a", "b"])
+        self.assertTrue(bool(res))
+
+        res = cache.get_many(["a", "b", "c"])
+        self.assertEqual(res, {"c": 3})
+
+        res = cache.delete_many(["a", "b"])
+        self.assertFalse(bool(res))
+
+    def test_delete_many_empty_generator(self):
+        """Test the delete_many cache operation with an empty generator"""
+        res = cache.delete_many(key for key in [])
+        self.assertFalse(bool(res))
+
+    def test_delete_pattern(self):
+        """Test the delete_pattern cache operation"""
+        for key in ["foo-aa", "foo-ab", "foo-bb", "foo-bc"]:
+            cache.set(key, "foo")
+
+        res = cache.delete_pattern("*foo-a*")
+        self.assertTrue(bool(res))
+
+        keys = cache.keys("foo*")
+        self.assertEqual(set(keys), {"foo-bb", "foo-bc"})
+
+        res = cache.delete_pattern("*foo-a*")
+        self.assertFalse(bool(res))
+
+    def test_expire(self):
+        """Test the expire cache operation"""
+        cache.set("foo", "bar", timeout=None)
+        cache.expire("foo", 20)
+        ttl = cache.ttl("foo")
+        self.assertGreater(ttl + 0.5, 20)
+
+    def test_get_default(self):
+        """Test get cache operation with a default value """
+        res = cache.get("test_key")
+        self.assertIsNone(res)
+
+        res = cache.get("test_key", "default_value")
+        self.assertEqual(res, "default_value")
+
+    def test_get_many(self):
+        """Test the get_many cache operation"""
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.set("c", 3)
+
+        res = cache.get_many(["a", "b", "c"])
+        self.assertEqual(res, {"a": 1, "b": 2, "c": 3})
+
+    def test_get_many_unicode(self):
+        """Test the get_many cache operation with unicode values"""
+        cache.set("a", "àầä")
+        cache.set("b", "bèéë")
+        cache.set("c", "çééé")
+
+        res = cache.get_many(["a", "b", "c"])
+        self.assertEqual(res, {"a": "àầä", "b": "bèéë", "c": "çééé"})
+
+    def test_get_set_bool(self):
+        """Test the get and set cache operations with boolean values"""
+        cache.set("bool", True)
+        res = cache.get("bool")
+
+        self.assertIsInstance(res, bool)
+        self.assertTrue(res)
+
+        cache.set("bool", False)
+        res = cache.get("bool")
+
+        self.assertIsInstance(res, bool)
+        self.assertFalse(res)
+
+    def test_get_set_dict(self):
+        """Test the get and set cache operations with dict values"""
+        # pylint: disable=protected-access
+        if isinstance(cache.client._serializer, json_serializer.JSONSerializer):
+            self.skipTest("Datetimes are not JSON serializable")
+
+        # pylint: disable=protected-access
+        if isinstance(cache.client._serializer, msgpack_serializer.MSGPackSerializer):
+            # MSGPackSerializer serializers use the isoformat for datetimes
+            # https://github.com/msgpack/msgpack-python/issues/12
+            now_dt = datetime.now().isoformat()
+        else:
+            now_dt = datetime.now()
+
+        test_dict = {"id": 1, "date": now_dt, "name": "Foo"}
+
+        cache.set("test_key", test_dict)
+        res = cache.get("test_key")
+
+        self.assertIsInstance(res, dict)
+        self.assertEqual(res["id"], 1)
+        self.assertEqual(res["name"], "Foo")
+        self.assertEqual(res["date"], now_dt)
+
+    def test_save_float(self):
+        """Test the get and set cache operations with float values"""
+        float_val = 1.345620002
+
+        cache.set("test_key", float_val)
+        res = cache.get("test_key")
+
+        self.assertIsInstance(res, float)
+        self.assertEqual(res, float_val)
+
+    def test_get_set_integer(self):
+        """Test the get and set cache operations on int values"""
+        cache.set("test_key", 2)
+        res = cache.get("test_key", "Foo")
+
+        self.assertIsInstance(res, int)
+        self.assertEqual(res, 2)
+
+    def test_get_set_string(self):
+        """Test the get and set cache operations on string values"""
+        cache.set("test_key", "hello" * 1000)
+        res = cache.get("test_key")
+
+        self.assertIsInstance(res, str)
+        self.assertEqual(res, "hello" * 1000)
+
+        cache.set("test_key", "2")
+        res = cache.get("test_key")
+
+        self.assertIsInstance(res, str)
+        self.assertEqual(res, "2")
+
+    def test_save_unicode(self):
+        """Test the get and set cache operations on unicode string values"""
+        cache.set("test_key", "heló")
+        res = cache.get("test_key")
+
+        self.assertIsInstance(res, str)
+        self.assertEqual(res, "heló")
+
+    def test_incr(self):
+        """"Test the incr cache operation"""
+        cache.set("num", 1)
+
+        cache.incr("num")
+        res = cache.get("num")
+        self.assertEqual(res, 2)
+
+        cache.incr("num", 10)
+        res = cache.get("num")
+        self.assertEqual(res, 12)
+
+        # max 64 bit signed int
+        cache.set("num", 9223372036854775807)
+
+        cache.incr("num")
+        res = cache.get("num")
+        self.assertEqual(res, 9223372036854775808)
+
+        cache.incr("num", 2)
+        res = cache.get("num")
+        self.assertEqual(res, 9223372036854775810)
+
+        cache.set("num", 3)
+
+        cache.incr("num", 2)
+        res = cache.get("num")
+        self.assertEqual(res, 5)
+
+    def test_incr_error(self):
+        """Calling incr cachi operation on an non-existing key should raise an error"""
+        with self.assertRaises(ValueError):
+            # key not exists
+            cache.incr("numnum")
+
+    def test_incr_version(self):
+        """Test the incr_version cache operation"""
+        cache.set("keytest", 2)
+        cache.incr_version("keytest")
+
+        res = cache.get("keytest")
+        self.assertIsNone(res)
+
+        res = cache.get("keytest", version=2)
+        self.assertEqual(res, 2)
+
+    def test_iter_keys(self):
+        """Test the iter_keys cache operation"""
+        cache.set("foo1", 1)
+        cache.set("foo2", 1)
+        cache.set("foo3", 1)
+
+        # Test simple result
+        result = set(cache.iter_keys("foo*"))
+        self.assertEqual(result, {"foo1", "foo2", "foo3"})
+
+        # Test limited result
+        result = list(cache.iter_keys("foo*", itersize=2))
+        self.assertEqual(len(result), 3)
+
+        # Test generator object
+        result = cache.iter_keys("foo*")
+        self.assertIsNotNone(next(result))
+
+    def test_lock(self):
+        """Test the lock cache operation"""
+        lock = cache.lock("foobar")
+        lock.acquire(blocking=True)
+
+        self.assertTrue("foobar" in cache)
+        lock.release()
+        self.assertFalse("foobar" in cache)
+
+    def test_persist(self):
+        """Test the persist cache operation"""
+        cache.set("foo", "bar", timeout=20)
+        cache.persist("foo")
+
+        ttl = cache.ttl("foo")
+        self.assertIsNone(ttl)
+
+    def test_set_add(self):
+        """Test the add cache operation"""
+        cache.set("add_key", "Initial value")
+        cache.add("add_key", "New value")
+        res = cache.get("add_key")
+        self.assertEqual(res, "Initial value")
+
+    def test_set_many(self):
+        """Test the set_many cache operation"""
+        cache.set_many({"a": 1, "b": 2, "c": 3})
+        res = cache.get_many(["a", "b", "c"])
+        self.assertEqual(res, {"a": 1, "b": 2, "c": 3})
+
+    def test_setnx(self):
+        """Test the SETNX (set if not exist) cache operation"""
+        # we should ensure there is no test_key_nx in redis
+        cache.delete("test_key_nx")
+        res = cache.get("test_key_nx", None)
+        self.assertIsNone(res)
+
+        res = cache.set("test_key_nx", 1, nx=True)
+        self.assertTrue(res)
+        # test that second set will have
+        res = cache.set("test_key_nx", 2, nx=True)
+        self.assertFalse(res)
+        res = cache.get("test_key_nx")
+        self.assertEqual(res, 1)
+
+        cache.delete("test_key_nx")
+        res = cache.get("test_key_nx", None)
+        self.assertIsNone(res)
+
+    def test_setnx_timeout(self):
+        """Test the timeout option on the SETNX cache operation"""
+        # test that timeout still works for nx=True
+        res = cache.set("test_key_nx", 1, timeout=2, nx=True)
+        self.assertTrue(res)
+        time.sleep(3)
+        res = cache.get("test_key_nx", None)
+        self.assertIsNone(res)
+
+        # test that timeout will not affect key, if it was there
+        cache.set("test_key_nx", 1)
+        res = cache.set("test_key_nx", 2, timeout=2, nx=True)
+        self.assertFalse(res)
+        time.sleep(3)
+        res = cache.get("test_key_nx", None)
+        self.assertEqual(res, 1)
+
+        cache.delete("test_key_nx")
+        res = cache.get("test_key_nx", None)
+        self.assertIsNone(res)
+
+    def test_timeout(self):
+        """Test the expiration of cache entries"""
+        cache.set("test_key", 222, timeout=3)
+        time.sleep(4)
+
+        res = cache.get("test_key", None)
+        self.assertIsNone(res)
+
+    def test_timeout_0(self):
+        """Ensure that cache entries expire immediately if the specified timeout is 0"""
+        cache.set("test_key", 222, timeout=0)
+        res = cache.get("test_key", None)
+        self.assertIsNone(res)
+
+    def test_ttl(self):
+        """Test the ttl cache operation"""
+        # Test ttl
+        cache.set("foo", "bar", 10)
+        ttl = cache.ttl("foo")
+        self.assertGreater(ttl + 0.5, 10)
+
+        # Test ttl None
+        cache.set("foo", "foo", timeout=None)
+        ttl = cache.ttl("foo")
+        self.assertIsNone(ttl)
+
+        # Test ttl with expired key
+        cache.set("foo", "foo", timeout=-1)
+        ttl = cache.ttl("foo")
+        self.assertEqual(ttl, 0)
+
+        # Test ttl with not existent key
+        ttl = cache.ttl("not-existent-key")
+        self.assertEqual(ttl, 0)
+
+    def test_version(self):
+        """Test the version option of the get/set cache operations"""
+        cache.set("keytest", 2, version=2)
+        res = cache.get("keytest")
+        self.assertIsNone(res)
+
+        res = cache.get("keytest", version=2)
+        self.assertEqual(res, 2)


### PR DESCRIPTION
## Purpose

We want to enable Django caching features in production and use Redis (with Sentinel support) as a cache backend.

## Proposal

Use [django-redis](https://github.com/jazzband/django-redis) library and add support for Redis Sentinel with a [custom client class](https://github.com/lamoda/django-sentinel).

- [x] Add `django-redis` dependency
- [x] Create a `richie.apps.core.cache.SentinelClient` client class based on [lamoda/django-sentinel](https://github.com/lamoda/django-sentinel) work
- [x] Configure a redis-sentinel cluster in `docker-compose.yml`
- [x] Import tests from [lamoda/django-sentinel](https://github.com/lamoda/django-sentinel) and update them to pass `make lint-back`
