### PR TITLE
🐛(docker) fix inconsistent sentinel state when running tests

### DIFF
--- a/bin/pytest
+++ b/bin/pytest
@@ -2,9 +2,14 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
+# Recreate the redis sentinel service to avoid inconsistent state
+_docker_compose up -d -V redis-sentinel
+
 _dc_run \
     -e DJANGO_CONFIGURATION=Test \
     -e PYTHONPATH=/app/sandbox \
     app \
-    dockerize -wait "tcp://${DB_HOST:-postgresql}:${DB_PORT:-5432}" -timeout 60s \
-        pytest "$@"
+    dockerize -wait "tcp://${DB_HOST:-postgresql}:${DB_PORT:-5432}" \
+        -wait "tcp://redis-primary:6379" \
+        -wait "tcp://redis-sentinel:26379" \
+        -timeout 60s pytest "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     depends_on:
       - "${DB_HOST:-postgresql}"
       - "elasticsearch"
-      - redis-sentinel
+
     stdin_open: true
     tty: true
 
@@ -76,6 +76,8 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
       - REDIS_REPLICATION_MODE=slave
       - REDIS_MASTER_HOST=redis-primary
+    depends_on:
+      - redis-primary
 
   redis-replica2:
     image: docker.io/bitnami/redis:6.0-debian-10
@@ -83,3 +85,5 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
       - REDIS_REPLICATION_MODE=slave
       - REDIS_MASTER_HOST=redis-primary
+    depends_on:
+      - redis-primary


### PR DESCRIPTION
## Purpose

The `make test-back` command fails randomly with the following errors : 

  - `No master found for mymaster`
 - `Error 111 connecting to x.x.x.x:6379. Connection refused.`

This happens for the following reasons:
 - when containers are restarted by `docker-compose`, their IP change 
 - the `redis-sentinel` container is persisting the redis master IP across restarts

As a result, sentinel sometimes try to monitor the wrong container (i.e. postgresql) as the redis master and constantly fail.

## Proposal

- [x] Recreate the `redis-sentinel` container before running the tests to ensure it has a consistent state.
