### PR TITLE
✨(sandbox) allow to configure cache settings with environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add Linkedin badge in social networks templates.
 - Add new section "septenary" with a new wave decoration.
 - Add redis sentinel cache backend
+- Allow to configure cache and session settings with environment variables
 
 ### Fixed
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -385,6 +385,32 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None
     )
 
+    # Cache
+    CACHES = {
+        "default": {
+            "BACKEND": values.Value(
+                "django.core.cache.backends.locmem.LocMemCache",
+                environ_name="CACHE_DEFAULT_BACKEND",
+                environ_prefix=None,
+            ),
+            "LOCATION": values.Value(
+                "", environ_name="CACHE_DEFAULT_LOCATION", environ_prefix=None,
+            ),
+            "OPTIONS": values.DictValue(
+                {}, environ_name="CACHE_DEFAULT_OPTIONS", environ_prefix=None,
+            ),
+        }
+    }
+
+    # For more details about CMS_CACHE_DURATION, see :
+    # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations
+    CMS_CACHE_DURATIONS = values.DictValue(
+        {"menus": 3600, "content": 60, "permissions": 3600}
+    )
+
+    # Sessions
+    SESSION_ENGINE = values.Value("django.contrib.sessions.backends.db")
+
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 


### PR DESCRIPTION
## Purpose

We want to be able to configure django cache settings with environment variables.

## Proposal

- [x] use django-configurations for cache settings
- [x] set default values that match the previous sandbox settings to prevent introducing a breaking change.

