### PR TITLE
🐛(dependencies) fix typo in python dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0-beta.11] - 2020-08-17
+
 ### Fixed
 
 - Fix typo in python dev dependencies
@@ -941,7 +943,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v2.0.0-beta.10...master
+[unreleased]: https://github.com/openfun/richie/compare/v2.0.0-beta.11...master
+[2.0.0-beta.11]: https://github.com/openfun/richie/compare/v2.0.0-beta.10...v2.0.0-beta.11
 [2.0.0-beta.10]: https://github.com/openfun/richie/compare/v2.0.0-beta.9...v2.0.0-beta.10
 [2.0.0-beta.9]: https://github.com/openfun/richie/compare/v2.0.0-beta.8...v2.0.0-beta.9
 [2.0.0-beta.8]: https://github.com/openfun/richie/compare/v2.0.0-beta.7...v2.0.0-beta.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix typo in python dev dependencies
+
 ## [2.0.0-beta.10] - 2020-08-17
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ dev =
     ipdb==0.13.3
     ipython==7.17.0
     isort==4.3.21
-    msgpack===1.0.0
+    msgpack==1.0.0
     mysqlclient==2.0.1
     pylint==2.5.3
     pylint-django==2.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 2.0.0-beta.10
+version = 2.0.0-beta.11
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {

--- a/tests_e2e/package.json
+++ b/tests_e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-tests-e2e",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "End-to-end tests for the Richie project",
   "repository": "https://github.com/openfun/richie",
   "author": "Open FUN (France Université Numérique)",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education-docs",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "Documentation website for the Richie project",
   "scripts": {
     "build": "docusaurus-build",


### PR DESCRIPTION
## Purpose

There is a typo in python dev dependencies. As a result, we were
unable to upload the release 2.0.0-beta.10 to PyPI.

## Proposal

- [x] fix typo