### PR TITLE
♻️(courses) change CTA button for anonymous users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change CTA enrollment button for anonymous users
+
 ## [2.0.0-beta.13] - 2020-08-27
 
 ### Added

--- a/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
@@ -38,7 +38,11 @@ describe('<CourseRunEnrollment />', () => {
 
     render(
       <IntlProvider locale="en">
-        <CourseRunEnrollment context={context} courseRunId={courseRun.id} />
+        <CourseRunEnrollment
+          context={context}
+          courseRunId={courseRun.id}
+          loginUrl={'/oauth/login/edx-oauth2/?next=/en/courses/'}
+        />
       </IntlProvider>,
     );
     screen.getByRole('status', { name: 'Loading enrollment information...' });
@@ -84,7 +88,11 @@ describe('<CourseRunEnrollment />', () => {
 
     render(
       <IntlProvider locale="en">
-        <CourseRunEnrollment context={context} courseRunId={courseRun.id} />
+        <CourseRunEnrollment
+          context={context}
+          courseRunId={courseRun.id}
+          loginUrl={'/oauth/login/edx-oauth2/?next=/en/courses/'}
+        />
       </IntlProvider>,
     );
     screen.getByRole('status', { name: 'Loading enrollment information...' });
@@ -128,7 +136,11 @@ describe('<CourseRunEnrollment />', () => {
 
     render(
       <IntlProvider locale="en">
-        <CourseRunEnrollment context={context} courseRunId={courseRun.id} />
+        <CourseRunEnrollment
+          context={context}
+          courseRunId={courseRun.id}
+          loginUrl={'/oauth/login/edx-oauth2/?next=/en/courses/'}
+        />
       </IntlProvider>,
     );
     screen.getByRole('status', { name: 'Loading enrollment information...' });
@@ -164,7 +176,11 @@ describe('<CourseRunEnrollment />', () => {
 
     render(
       <IntlProvider locale="en">
-        <CourseRunEnrollment context={context} courseRunId={courseRun.id} />
+        <CourseRunEnrollment
+          context={context}
+          courseRunId={courseRun.id}
+          loginUrl={'/oauth/login/edx-oauth2/?next=/en/courses/'}
+        />
       </IntlProvider>,
     );
     screen.getByRole('status', { name: 'Loading enrollment information...' });
@@ -197,7 +213,11 @@ describe('<CourseRunEnrollment />', () => {
 
     render(
       <IntlProvider locale="en">
-        <CourseRunEnrollment context={context} courseRunId={courseRun.id} />
+        <CourseRunEnrollment
+          context={context}
+          courseRunId={courseRun.id}
+          loginUrl={'/oauth/login/edx-oauth2/?next=/en/courses/'}
+        />
       </IntlProvider>,
     );
     screen.getByRole('status', { name: 'Loading enrollment information...' });
@@ -207,8 +227,6 @@ describe('<CourseRunEnrollment />', () => {
       enrollmentsDeferred.resolve([]);
     });
 
-    const button = screen.getByRole('button', { name: 'Enroll now' });
-    expect(button).toHaveAttribute('aria-disabled', 'true');
-    screen.getByText('Sign up or log in to enroll');
+    screen.getByRole('link', { name: 'Log in to enroll' });
   });
 });

--- a/src/frontend/js/components/CourseRunEnrollment/index.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.tsx
@@ -48,9 +48,8 @@ const messages = defineMessages({
     id: 'components.CourseRunEnrollment.loadingInitial',
   },
   loginToEnroll: {
-    defaultMessage: 'Sign up or log in to enroll',
-    description:
-      'Helper text below the disabled enrolle button for non logged in users',
+    defaultMessage: 'Log in to enroll',
+    description: 'Helper text in the enroll button for non logged in users',
     id: 'components.CourseRunEnrollment.loginToEnroll',
   },
 });
@@ -171,11 +170,12 @@ const headers = {
 
 interface CourseRunEnrollmentProps {
   courseRunId: number;
+  loginUrl: string;
 }
 
 export const CourseRunEnrollment: React.FC<
   CourseRunEnrollmentProps & CommonDataProps
-> = ({ context, courseRunId }) => {
+> = ({ context, courseRunId, loginUrl }) => {
   const [state, send] = useMachine(machine, {
     guards: {
       isCourseRunClosed: (ctx) =>
@@ -259,17 +259,9 @@ export const CourseRunEnrollment: React.FC<
 
     case state.matches('anonymous'):
       return (
-        <React.Fragment>
-          <button
-            className="course-run-enrollment__cta disabled"
-            aria-disabled="true"
-          >
-            <FormattedMessage {...messages.enroll} />
-          </button>
-          <div className="course-run-enrollment__helptext">
-            <FormattedMessage {...messages.loginToEnroll} />
-          </div>
-        </React.Fragment>
+        <a href={loginUrl} className="course-run-enrollment__cta">
+          <FormattedMessage {...messages.loginToEnroll} />
+        </a>
       );
 
     case state.matches('closed'):

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -87,7 +87,7 @@
                         <ul class="topbar__list topbar__list--controls">
                             {% block userlogin %}
                             <li class="topbar__item topbar__item--login richie-react richie-react--user-login"
-                                data-props='{"loginUrl": "{% url 'social:begin' 'edx-oauth2' %}", "logoutUrl": "{% url 'logout' %}", "signupUrl": "{% url 'admin:index' %}"}'></li>
+                                data-props='{"loginUrl": "{% url 'social:begin' 'edx-oauth2' %}?next={{ request.path }}", "logoutUrl": "{% url 'logout' %}", "signupUrl": "{% url 'admin:index' %}"}'></li>
                             {% endblock userlogin %}
                             {% block topbar_contact %}
                             <li class="topbar__item topbar__item--cta">

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_run.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_run.html
@@ -15,7 +15,7 @@
     {% if run|has_connected_lms %}
         <div
             class="richie-react richie-react--course-run-enrollment"
-            data-props='{"courseRunId": {{ run.id }}}'
+            data-props='{"courseRunId": {{ run.id }}, "loginUrl": "{% url 'social:begin' 'edx-oauth2' %}?next={{ request.path }}"}'
         ></div>
     {% else %}
         <a href="{{ run.extended_object.get_absolute_url }}" class="course-detail__run-cta">

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -492,8 +492,10 @@ class RunsCourseCMSTestCase(CMSTestCase):
             re.search(
                 (
                     r'.*class="richie-react richie-react--course-run-enrollment".*'
-                    r"data-props=\\\'{{\"courseRunId\": {}}}\\\'".format(
-                        course_run.public_extension_id
+                    r"data-props=\\\'{{\"courseRunId\": {}, \"loginUrl\": "
+                    r"\"/oauth/login/edx-oauth2/\?next={}\"}}\\\'".format(
+                        course_run.public_extension_id,
+                        course.extended_object.get_absolute_url(),
                     )
                 ),
                 str(response.content),
@@ -555,8 +557,10 @@ class RunsCourseCMSTestCase(CMSTestCase):
             re.search(
                 (
                     r'.*class="richie-react richie-react--course-run-enrollment".*'
-                    r"data-props=\\\'{{\"courseRunId\": {}}}\\\'".format(
-                        course_run.public_extension_id
+                    r"data-props=\\\'{{\"courseRunId\": {}, \"loginUrl\": "
+                    r"\"/oauth/login/edx-oauth2/\?next={}\"}}\\\'".format(
+                        course_run.public_extension_id,
+                        course.extended_object.get_absolute_url(),
                     )
                 ),
                 str(response.content),


### PR DESCRIPTION
## Purpose

For anynomous users, the enroll button was disabled and a help text
displayed to inform the user to sign up or log in first. We change with
an active button which send the user to the log in page. The user is
redirected to the course page once connected.


## Proposal

- [x] change CTA button for anonymous users
