### PR TITLE
🔧(prettier) add default rules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Because django templates requires syntax which can't contain line break
+# Prettier must ignore all Django templates files
+src/richie/**/*.html

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,2 +1,5 @@
+printWidth: 100
 singleQuote: true
+tabWidth: 2
 trailingComma: all
+useTabs: false

--- a/src/frontend/js/common/searchFields/getSuggestionsSection.spec.ts
+++ b/src/frontend/js/common/searchFields/getSuggestionsSection.spec.ts
@@ -19,11 +19,7 @@ describe('common/searchFields/getSuggestionsSection', () => {
 
     let suggestionsSection;
     try {
-      suggestionsSection = await getSuggestionsSection(
-        'courses',
-        'Courses',
-        'some search',
-      );
+      suggestionsSection = await getSuggestionsSection('courses', 'Courses', 'some search');
     } catch (error) {
       fail('Did not expect getSuggestionsSection to fail');
     }
@@ -43,9 +39,7 @@ describe('common/searchFields/getSuggestionsSection', () => {
       throws: new Error('Failed to send API request'),
     });
     await getSuggestionsSection('courses', 'Courses', 'some search');
-    expect(mockHandle).toHaveBeenCalledWith(
-      new Error('Failed to send API request'),
-    );
+    expect(mockHandle).toHaveBeenCalledWith(new Error('Failed to send API request'));
   });
 
   it('reports the error when the server returns an error code', async () => {
@@ -60,10 +54,7 @@ describe('common/searchFields/getSuggestionsSection', () => {
   });
 
   it('reports the error when it receives broken json', async () => {
-    fetchMock.get(
-      '/api/v1.0/courses/autocomplete/?query=some%20search',
-      'not json',
-    );
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=some%20search', 'not json');
     await getSuggestionsSection('courses', 'Courses', 'some search');
     expect(mockHandle).toHaveBeenCalledWith(
       new Error(

--- a/src/frontend/js/common/searchFields/getSuggestionsSection.ts
+++ b/src/frontend/js/common/searchFields/getSuggestionsSection.ts
@@ -12,22 +12,15 @@ import { handle } from 'utils/errors/handle';
  * @param sectionTitleMessage MessageDescriptor for the title of the section that displays the suggestions.
  * @param query The actual payload to run the completion search with.
  */
-export const getSuggestionsSection = async (
-  kind: string,
-  title: string,
-  query: string,
-) => {
+export const getSuggestionsSection = async (kind: string, title: string, query: string) => {
   // Run the search for the section on the API
   let response: Response;
   try {
-    response = await fetch(
-      `/api/v1.0/${kind}/autocomplete/?${stringify({ query })}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
+    response = await fetch(`/api/v1.0/${kind}/autocomplete/?${stringify({ query })}`, {
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+    });
   } catch (error) {
     return handle(error);
   }
@@ -35,20 +28,14 @@ export const getSuggestionsSection = async (
   // Fetch treats remote errors (400, 404, 503...) as successes
   // The ok flag is the way to discriminate
   if (!response.ok) {
-    return handle(
-      new Error(
-        `Failed to get list from ${kind} autocomplete : ${response.status}`,
-      ),
-    );
+    return handle(new Error(`Failed to get list from ${kind} autocomplete : ${response.status}`));
   }
 
   let responseData: Suggestion<string>[];
   try {
     responseData = await response.json();
   } catch (error) {
-    return handle(
-      new Error('Failed to decode JSON in getSuggestionSection ' + error),
-    );
+    return handle(new Error('Failed to decode JSON in getSuggestionSection ' + error));
   }
 
   return {

--- a/src/frontend/js/common/searchFields/index.tsx
+++ b/src/frontend/js/common/searchFields/index.tsx
@@ -14,18 +14,17 @@ import { getSuggestionsSection } from './getSuggestionsSection';
  * `react-autosuggest` callback to get a human string value from a Suggestion object.
  * @param suggestion The relevant suggestion object.
  */
-export const getSuggestionValue: SearchAutosuggestProps['getSuggestionValue'] = (
-  suggestion,
-) => suggestion.title;
+export const getSuggestionValue: SearchAutosuggestProps['getSuggestionValue'] = (suggestion) =>
+  suggestion.title;
 
 /**
  * `react-autosuggest` callback to render one suggestion.
  * @param suggestion Either a resource suggestion with a model name & a machine name, or the default
  * suggestion with some text to render.
  */
-export const renderSuggestion: SearchAutosuggestProps['renderSuggestion'] = (
-  suggestion,
-) => <span>{suggestion.title}</span>;
+export const renderSuggestion: SearchAutosuggestProps['renderSuggestion'] = (suggestion) => (
+  <span>{suggestion.title}</span>
+);
 
 /**
  * `react-autosuggest` callback to build up the list of suggestions and sections whenever user
@@ -50,11 +49,7 @@ export const onSuggestionsFetchRequested = async (
       Object.values(await filters)
         .filter((filterdef) => filterdef.is_autocompletable)
         .map((filterdef) =>
-          getSuggestionsSection(
-            filterdef.name,
-            filterdef.human_name,
-            incomingValue,
-          ),
+          getSuggestionsSection(filterdef.name, filterdef.human_name, incomingValue),
         ),
       // We can assert this because of the catch below
     )) as SearchSuggestionSection[];
@@ -78,9 +73,7 @@ export const getRelevantFilter = (
   suggestion: SearchSuggestion,
 ) => {
   // Use the `kind` field on the suggestion to pick the relevant filter to update.
-  let filter = Object.values(filters).find(
-    (fltr) => fltr.name === suggestion.kind,
-  )!;
+  let filter = Object.values(filters).find((fltr) => fltr.name === suggestion.kind)!;
 
   // We need a special-case to handle categories until we refactor the API to separate endpoints between
   // kinds of categories
@@ -88,9 +81,7 @@ export const getRelevantFilter = (
     // Pick the filter to update based on the payload's path: it contains the relevant filter's page path
     // (for eg. a meta-category or the "organizations" root page)
     filter = Object.values(filters).find(
-      (fltr) =>
-        !!fltr.base_path &&
-        String(suggestion.id).substr(2).startsWith(fltr.base_path),
+      (fltr) => !!fltr.base_path && String(suggestion.id).substr(2).startsWith(fltr.base_path),
     )!;
   }
 

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpseFooter.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpseFooter.tsx
@@ -8,9 +8,7 @@ import { Course } from 'types/Course';
  * <CourseGlimpseFooter />.
  * This is spun off from <CourseGlimpse /> to allow easier override through webpack.
  */
-export const CourseGlimpseFooter: React.FC<
-  { course: Course } & CommonDataProps
-> = ({ course }) => {
+export const CourseGlimpseFooter: React.FC<{ course: Course } & CommonDataProps> = ({ course }) => {
   const intl = useIntl();
   return (
     <div className="course-glimpse-footer">

--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -91,10 +91,7 @@ describe('components/CourseGlimpse', () => {
   it('shows the "Cover" placeholder div when the course is missing a cover image', () => {
     render(
       <IntlProvider locale="en">
-        <CourseGlimpse
-          context={commonDataProps}
-          course={{ ...course, cover_image: null }}
-        />
+        <CourseGlimpse context={commonDataProps} course={{ ...course, cover_image: null }} />
       </IntlProvider>,
     );
 

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -12,16 +12,12 @@ export interface CourseGlimpseProps {
 const messages = defineMessages({
   cover: {
     defaultMessage: 'Cover',
-    description:
-      'Placeholder text when the course we are glimpsing at is missing a cover image',
+    description: 'Placeholder text when the course we are glimpsing at is missing a cover image',
     id: 'components.CourseGlimpse.cover',
   },
 });
 
-const CourseGlimpseBase = ({
-  context,
-  course,
-}: CourseGlimpseProps & CommonDataProps) => (
+const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataProps) => (
   <a className="course-glimpse course-glimpse--link" href={course.absolute_url}>
     <div className="course-glimpse__media">
       {course.cover_image ? (
@@ -40,18 +36,10 @@ const CourseGlimpseBase = ({
     <div className="course-glimpse__content">
       {course.icon ? (
         <div className="course-glimpse__icon">
-          <div
-            className="course-glimpse__band"
-            style={{ background: course.icon.color }}
-          >
+          <div className="course-glimpse__band" style={{ background: course.icon.color }}>
             {course.icon.title}
           </div>
-          <img
-            src={course.icon.src}
-            srcSet={course.icon.srcset}
-            sizes={course.icon.sizes}
-            alt=""
-          />
+          <img src={course.icon.src} srcSet={course.icon.srcset} sizes={course.icon.sizes} alt="" />
         </div>
       ) : null}
       <div className="course-glimpse__wrapper">
@@ -72,7 +60,6 @@ const areEqual: (
   prevProps: Readonly<CourseGlimpseProps & CommonDataProps>,
   newProps: Readonly<CourseGlimpseProps & CommonDataProps>,
 ) => boolean = (prevProps, newProps) =>
-  prevProps.context === newProps.context &&
-  prevProps.course.id === newProps.course.id;
+  prevProps.context === newProps.context && prevProps.course.id === newProps.course.id;
 
 export const CourseGlimpse = React.memo(CourseGlimpseBase, areEqual);

--- a/src/frontend/js/components/CourseGlimpseList/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/index.spec.tsx
@@ -40,8 +40,7 @@ describe('components/CourseGlimpseList', () => {
     );
 
     expect(
-      screen.getAllByText('Showing 1 to 20 of 45 courses matching your search')
-        .length,
+      screen.getAllByText('Showing 1 to 20 of 45 courses matching your search').length,
     ).toEqual(1);
     // Both courses' titles are shown
     screen.getByText('Course 44');

--- a/src/frontend/js/components/CourseGlimpseList/index.tsx
+++ b/src/frontend/js/components/CourseGlimpseList/index.tsx
@@ -40,10 +40,7 @@ export const CourseGlimpseList = ({
         />
       </div>
       {courses.map(
-        (course) =>
-          course && (
-            <CourseGlimpse context={context} course={course} key={course.id} />
-          ),
+        (course) => course && <CourseGlimpse context={context} course={course} key={course.id} />,
       )}
     </div>
   );

--- a/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
@@ -24,17 +24,11 @@ describe('<CourseRunEnrollment />', () => {
     courseRun.state.priority = 0;
 
     const courseRunDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/course-runs/${courseRun.id}/`,
-      courseRunDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const userDeferred = new Deferred();
     fetchMock.get('/api/v1.0/users/whoami/', userDeferred.promise);
     const enrollmentsDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/enrollments/?course_run=${courseRun.id}`,
-      enrollmentsDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/enrollments/?course_run=${courseRun.id}`, enrollmentsDeferred.promise);
 
     render(
       <IntlProvider locale="en">
@@ -74,17 +68,11 @@ describe('<CourseRunEnrollment />', () => {
     courseRun.state.priority = 0;
 
     const courseRunDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/course-runs/${courseRun.id}/`,
-      courseRunDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const userDeferred = new Deferred();
     fetchMock.get('/api/v1.0/users/whoami/', userDeferred.promise);
     const enrollmentsDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/enrollments/?course_run=${courseRun.id}`,
-      enrollmentsDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/enrollments/?course_run=${courseRun.id}`, enrollmentsDeferred.promise);
 
     render(
       <IntlProvider locale="en">
@@ -122,17 +110,11 @@ describe('<CourseRunEnrollment />', () => {
     courseRun.state.priority = 0;
 
     const courseRunDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/course-runs/${courseRun.id}/`,
-      courseRunDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const userDeferred = new Deferred();
     fetchMock.get('/api/v1.0/users/whoami/', userDeferred.promise);
     const enrollmentsDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/enrollments/?course_run=${courseRun.id}`,
-      enrollmentsDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/enrollments/?course_run=${courseRun.id}`, enrollmentsDeferred.promise);
 
     render(
       <IntlProvider locale="en">
@@ -162,17 +144,11 @@ describe('<CourseRunEnrollment />', () => {
     courseRun.state.priority = 4;
 
     const courseRunDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/course-runs/${courseRun.id}/`,
-      courseRunDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const userDeferred = new Deferred();
     fetchMock.get('/api/v1.0/users/whoami/', userDeferred.promise);
     const enrollmentsDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/enrollments/?course_run=${courseRun.id}`,
-      enrollmentsDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/enrollments/?course_run=${courseRun.id}`, enrollmentsDeferred.promise);
 
     render(
       <IntlProvider locale="en">
@@ -200,15 +176,9 @@ describe('<CourseRunEnrollment />', () => {
     courseRun.state.priority = 0;
 
     const courseRunDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/course-runs/${courseRun.id}/`,
-      courseRunDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const enrollmentsDeferred = new Deferred();
-    fetchMock.get(
-      `/api/v1.0/enrollments/?course_run=${courseRun.id}`,
-      enrollmentsDeferred.promise,
-    );
+    fetchMock.get(`/api/v1.0/enrollments/?course_run=${courseRun.id}`, enrollmentsDeferred.promise);
     fetchMock.get('/api/v1.0/users/whoami/', 401);
 
     render(

--- a/src/frontend/js/components/CourseRunEnrollment/index.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.tsx
@@ -20,14 +20,12 @@ const messages = defineMessages({
   },
   enrolled: {
     defaultMessage: 'You are enrolled in this course run',
-    description:
-      'Help text for users who see the "Go to course" CTA on course run enrollment',
+    description: 'Help text for users who see the "Go to course" CTA on course run enrollment',
     id: 'components.CourseRunEnrollment.enrolled',
   },
   enrollmentClosed: {
     defaultMessage: 'Enrollment in this course run is closed at the moment',
-    description:
-      'Help text replacing the CTA on a course run when enrollment is closed.',
+    description: 'Help text replacing the CTA on a course run when enrollment is closed.',
     id: 'components.CourseRunEnrollment.enrollmentClosed',
   },
   enrollmentFailed: {
@@ -173,16 +171,16 @@ interface CourseRunEnrollmentProps {
   loginUrl: string;
 }
 
-export const CourseRunEnrollment: React.FC<
-  CourseRunEnrollmentProps & CommonDataProps
-> = ({ context, courseRunId, loginUrl }) => {
+export const CourseRunEnrollment: React.FC<CourseRunEnrollmentProps & CommonDataProps> = ({
+  context,
+  courseRunId,
+  loginUrl,
+}) => {
   const [state, send] = useMachine(machine, {
     guards: {
-      isCourseRunClosed: (ctx) =>
-        !!ctx.courseRun && ctx.courseRun.state.priority > 1,
+      isCourseRunClosed: (ctx) => !!ctx.courseRun && ctx.courseRun.state.priority > 1,
       isEnrolled: (ctx) => !!ctx.enrollment,
-      isInitialReady: (ctx) =>
-        !!ctx.courseRun && !!ctx.currentUser && !!ctx.enrollment,
+      isInitialReady: (ctx) => !!ctx.courseRun && !!ctx.currentUser && !!ctx.enrollment,
       isLoggedInUser: (ctx) => !!ctx.currentUser,
     },
     services: {
@@ -195,9 +193,7 @@ export const CourseRunEnrollment: React.FC<
         if (response.ok) {
           return true; // There is no content in the enrollment success response
         }
-        throw new Error(
-          `Failed to enroll in ${courseRunId}, ${response.status}`,
-        );
+        throw new Error(`Failed to enroll in ${courseRunId}, ${response.status}`);
       },
       getCourseRun: async () => {
         const response = await fetch(`/api/v1.0/course-runs/${courseRunId}/`, {
@@ -206,9 +202,7 @@ export const CourseRunEnrollment: React.FC<
         if (response.ok) {
           return await response.json();
         }
-        throw new Error(
-          `Failed to get course run ${courseRunId}, ${response.status}.`,
-        );
+        throw new Error(`Failed to get course run ${courseRunId}, ${response.status}.`);
       },
       getCurrentUser: async () => {
         const response = await fetch('/api/v1.0/users/whoami/', { headers });
@@ -223,10 +217,7 @@ export const CourseRunEnrollment: React.FC<
       },
       getEnrollment: async () => {
         const params = { course_run: courseRunId };
-        const response = await fetch(
-          `/api/v1.0/enrollments/?${stringify(params)}`,
-          { headers },
-        );
+        const response = await fetch(`/api/v1.0/enrollments/?${stringify(params)}`, { headers });
         if (response.ok) {
           const enrollments = await response.json();
           return enrollments.length > 0 ? enrollments[0] : null;
@@ -236,9 +227,7 @@ export const CourseRunEnrollment: React.FC<
         if (response.status === 401 || response.status === 403) {
           return null;
         }
-        throw new Error(
-          `Failed to get enrollments for user, ${response.status}`,
-        );
+        throw new Error(`Failed to get enrollments for user, ${response.status}`);
       },
     },
   });
@@ -247,10 +236,7 @@ export const CourseRunEnrollment: React.FC<
   switch (true) {
     case state.matches('loadingInitial'):
       return (
-        <Spinner
-          size="small"
-          aria-labelledby={`loading-course-run-${courseRunId}`}
-        >
+        <Spinner size="small" aria-labelledby={`loading-course-run-${courseRunId}`}>
           <span id={`loading-course-run-${courseRunId}`}>
             <FormattedMessage {...messages.loadingInitial} />
           </span>
@@ -279,9 +265,7 @@ export const CourseRunEnrollment: React.FC<
           <button
             onClick={() => send('ENROLL')}
             className={`course-run-enrollment__cta ${
-              state.matches('enrollmentLoading')
-                ? 'course-run-enrollment__cta--loading'
-                : ''
+              state.matches('enrollmentLoading') ? 'course-run-enrollment__cta--loading' : ''
             }`}
             aria-busy={state.matches('enrollmentLoading')}
           >
@@ -306,10 +290,7 @@ export const CourseRunEnrollment: React.FC<
     case state.matches('enrolled'):
       return (
         <React.Fragment>
-          <a
-            href={courseRun?.resource_link}
-            className="course-run-enrollment__cta"
-          >
+          <a href={courseRun?.resource_link} className="course-run-enrollment__cta">
             <FormattedMessage {...messages.goToCourse} />
           </a>
           <div className="course-run-enrollment__helptext">
@@ -320,8 +301,6 @@ export const CourseRunEnrollment: React.FC<
   }
 
   // Switch should cover all our cases. Report the error and do not render anything if we end up here.
-  handle(
-    new Error(`<CourseRunEnrollment /> in an impossible state, ${state.value}`),
-  );
+  handle(new Error(`<CourseRunEnrollment /> in an impossible state, ${state.value}`));
   return null;
 };

--- a/src/frontend/js/components/LanguageSelector/index.tsx
+++ b/src/frontend/js/components/LanguageSelector/index.tsx
@@ -7,8 +7,7 @@ import { location } from 'utils/indirection/window';
 const messages = defineMessages({
   currentlySelected: {
     defaultMessage: '(currently selected)',
-    description:
-      'Accessible hint to mark the currently selected language in the language selector',
+    description: 'Accessible hint to mark the currently selected language in the language selector',
     id: 'components.LanguageSelector.currentlySelected',
   },
   languages: {
@@ -24,8 +23,7 @@ const messages = defineMessages({
   },
   switchToLanguage: {
     defaultMessage: 'Switch to {language}',
-    description:
-      'Accessible link title for the language switching links in language selector',
+    description: 'Accessible link title for the language switching links in language selector',
     id: 'components.LanguageSelector.switchToLanguage',
   },
 });
@@ -67,31 +65,20 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
       </label>
       <button {...getToggleButtonProps()} className="language-selector__button">
         {selectedItem?.name || intl.formatMessage(messages.languages)}
-        <svg
-          role="img"
-          className="language-selector__button__icon"
-          aria-hidden="true"
-        >
+        <svg role="img" className="language-selector__button__icon" aria-hidden="true">
           <use xlinkHref="#icon-chevron-down" />
         </svg>
       </button>
       <ul
         {...getMenuProps()}
-        className={`language-selector__list ${
-          isOpen ? '' : 'language-selector__list--is-closed'
-        }`}
+        className={`language-selector__list ${isOpen ? '' : 'language-selector__list--is-closed'}`}
       >
         {isOpen &&
           languagesList.map((language, index) => (
-            <li
-              key={`${language.code}${index}`}
-              {...getItemProps({ item: language, index })}
-            >
+            <li key={`${language.code}${index}`} {...getItemProps({ item: language, index })}>
               <a
                 className={`language-selector__list__link ${
-                  highlightedIndex === index
-                    ? 'language-selector__list__link--highlighted'
-                    : ''
+                  highlightedIndex === index ? 'language-selector__list__link--highlighted' : ''
                 }`}
                 href={language.url}
                 title={`${intl.formatMessage(messages.switchToLanguage, {

--- a/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
@@ -24,9 +24,7 @@ describe('<PaginateCourseSearch />', () => {
   it('shows a pagination for course search (when on page 1)', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <PaginateCourseSearch courseSearchTotalCount={200} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -48,9 +46,7 @@ describe('<PaginateCourseSearch />', () => {
   it('shows a pagination for course search (when on the last page)', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '200' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '200' })}>
           <PaginateCourseSearch courseSearchTotalCount={211} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -72,9 +68,7 @@ describe('<PaginateCourseSearch />', () => {
   it('shows a pagination for course search (when on an arbitrary page)', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '10', offset: '110' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '10', offset: '110' })}>
           <PaginateCourseSearch courseSearchTotalCount={345} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -102,25 +96,19 @@ describe('<PaginateCourseSearch />', () => {
   it('does not render itself when there is only one page', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <PaginateCourseSearch courseSearchTotalCount={14} />
         </HistoryContext.Provider>
       </IntlProvider>,
     );
 
-    expect(screen.queryByRole('pagination', { name: 'Pagination' })).toEqual(
-      null,
-    );
+    expect(screen.queryByRole('pagination', { name: 'Pagination' })).toEqual(null);
   });
 
   it('updates the course search params when the user clicks on a page', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <PaginateCourseSearch courseSearchTotalCount={200} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -150,9 +138,7 @@ describe('<PaginateCourseSearch />', () => {
   it('does not update the course search params when the user clicks on the current page', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <PaginateCourseSearch courseSearchTotalCount={200} />
         </HistoryContext.Provider>
       </IntlProvider>,

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import {
-  CourseSearchParamsAction,
-  useCourseSearchParams,
-} from 'data/useCourseSearchParams';
+import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
 
 const messages = defineMessages({
   currentlyReadingLastPageN: {
@@ -21,14 +18,12 @@ const messages = defineMessages({
   },
   lastPageN: {
     defaultMessage: 'Last page {page}',
-    description:
-      'Accessibility helper for pagination, added on the last page link.',
+    description: 'Accessibility helper for pagination, added on the last page link.',
     id: 'components.PaginateCourseSearch.lastPageN',
   },
   nextPageN: {
     defaultMessage: 'Next page {page}',
-    description:
-      'Accessibility helper for pagination, added on the next page link.',
+    description: 'Accessibility helper for pagination, added on the next page link.',
     id: 'components.PaginateCourseSearch.nextPageN',
   },
   pageN: {
@@ -39,14 +34,12 @@ const messages = defineMessages({
   },
   pagination: {
     defaultMessage: 'Pagination',
-    description:
-      'Label for the pagination navigation in course search results.',
+    description: 'Label for the pagination navigation in course search results.',
     id: 'components.PaginateCourseSearch.pagination',
   },
   previousPageN: {
     defaultMessage: 'Previous page {page}',
-    description:
-      'Accessibility helper for pagination, added on the previous page link.',
+    description: 'Accessibility helper for pagination, added on the previous page link.',
     id: 'components.PaginateCourseSearch.previousPageN',
   },
 });
@@ -55,16 +48,11 @@ interface PaginateCourseSearchProps {
   courseSearchTotalCount: number;
 }
 
-export const PaginateCourseSearch = ({
-  courseSearchTotalCount,
-}: PaginateCourseSearchProps) => {
+export const PaginateCourseSearch = ({ courseSearchTotalCount }: PaginateCourseSearchProps) => {
   // Generate a unique ID per instance to ensure our aria-labelledby do not break if there are two
   // or more instances of <PaginateCourseSearch /> on the page
   const [componentId] = useState(Math.random());
-  const {
-    courseSearchParams,
-    dispatchCourseSearchParamsUpdate,
-  } = useCourseSearchParams();
+  const { courseSearchParams, dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
 
   // Extract pagination information from params and search results meta
   const limit = Number(courseSearchParams.limit);
@@ -105,9 +93,7 @@ export const PaginateCourseSearch = ({
             <React.Fragment key={page}>
               {/* Prepend a cell with "..." when the page number we're rendering does not follow the previous one */}
               {page > (pageList[index - 1] || 0) + 1 && (
-                <li className="pagination__list__item pagination__list__item--placeholder">
-                  ...
-                </li>
+                <li className="pagination__list__item pagination__list__item--placeholder">...</li>
               )}
 
               {page === currentPage ? (
@@ -122,19 +108,13 @@ export const PaginateCourseSearch = ({
                           values={{ page }}
                         />
                       ) : (
-                        <FormattedMessage
-                          {...messages.currentlyReadingPageN}
-                          values={{ page }}
-                        />
+                        <FormattedMessage {...messages.currentlyReadingPageN} values={{ page }} />
                       )}
                     </span>
                     <span aria-hidden={true}>
                       {/* Show context "Page 1" on the first item to make it obvious this is pagination */}
                       {page === 1 ? (
-                        <FormattedMessage
-                          {...messages.pageN}
-                          values={{ page }}
-                        />
+                        <FormattedMessage {...messages.pageN} values={{ page }} />
                       ) : (
                         page
                       )}
@@ -156,34 +136,19 @@ export const PaginateCourseSearch = ({
                     {/*  Help assistive technology users with some context */}
                     <span className="offscreen">
                       {page === maxPage ? (
-                        <FormattedMessage
-                          {...messages.lastPageN}
-                          values={{ page }}
-                        />
+                        <FormattedMessage {...messages.lastPageN} values={{ page }} />
                       ) : page === currentPage - 1 ? (
-                        <FormattedMessage
-                          {...messages.previousPageN}
-                          values={{ page }}
-                        />
+                        <FormattedMessage {...messages.previousPageN} values={{ page }} />
                       ) : page === currentPage + 1 ? (
-                        <FormattedMessage
-                          {...messages.nextPageN}
-                          values={{ page }}
-                        />
+                        <FormattedMessage {...messages.nextPageN} values={{ page }} />
                       ) : (
-                        <FormattedMessage
-                          {...messages.pageN}
-                          values={{ page }}
-                        />
+                        <FormattedMessage {...messages.pageN} values={{ page }} />
                       )}
                     </span>
                     <span aria-hidden={true}>
                       {/* Show context "Page 1" on the first item to make it obvious this is pagination */}
                       {page === 1 ? (
-                        <FormattedMessage
-                          {...messages.pageN}
-                          values={{ page }}
-                        />
+                        <FormattedMessage {...messages.pageN} values={{ page }} />
                       ) : (
                         page
                       )}

--- a/src/frontend/js/components/Root/index.spec.tsx
+++ b/src/frontend/js/components/Root/index.spec.tsx
@@ -25,10 +25,7 @@ describe('<Root />', () => {
   it('finds all richie-react containers and renders the relevant components into them with their passed props', () => {
     // Create the containers for the two components we're about to render
     const userLoginContainer = document.createElement('div');
-    userLoginContainer.setAttribute(
-      'class',
-      'richie-react richie-react--user-login',
-    );
+    userLoginContainer.setAttribute('class', 'richie-react richie-react--user-login');
     document.body.append(userLoginContainer);
     const rootSearchSuggestFieldContainer = document.createElement('div');
     rootSearchSuggestFieldContainer.setAttribute(
@@ -44,12 +41,7 @@ describe('<Root />', () => {
     // Render the root component, passing the elements in need of frontend rendering
     render(
       <IntlProvider locale="en">
-        <Root
-          richieReactSpots={[
-            userLoginContainer,
-            rootSearchSuggestFieldContainer,
-          ]}
-        />
+        <Root richieReactSpots={[userLoginContainer, rootSearchSuggestFieldContainer]} />
       </IntlProvider>,
     );
 
@@ -63,17 +55,11 @@ describe('<Root />', () => {
   it('prints a console warning and still renders everything else when it fails to find a component', () => {
     // Create the containers for the component we're about to render
     const userLoginContainer = document.createElement('div');
-    userLoginContainer.setAttribute(
-      'class',
-      'richie-react richie-react--user-login',
-    );
+    userLoginContainer.setAttribute('class', 'richie-react richie-react--user-login');
     document.body.append(userLoginContainer);
     // On the other hand, <UserFeedback /> is not a component that exists in Richie
     const userFeedbackContainer = document.createElement('div');
-    userFeedbackContainer.setAttribute(
-      'class',
-      'richie-react richie-react--user-feedback',
-    );
+    userFeedbackContainer.setAttribute('class', 'richie-react richie-react--user-feedback');
     document.body.append(userFeedbackContainer);
 
     // Render the root component, passing our real element and our bogus one

--- a/src/frontend/js/components/Root/index.tsx
+++ b/src/frontend/js/components/Root/index.tsx
@@ -62,9 +62,7 @@ export const Root = ({ richieReactSpots }: RootProps) => {
       // Get the props to pass our components from the `data-props-source` if
       const dataPropsSource = element.getAttribute('data-props-source');
       if (dataPropsSource) {
-        props = JSON.parse(
-          document.querySelector(dataPropsSource)!.textContent!,
-        );
+        props = JSON.parse(document.querySelector(dataPropsSource)!.textContent!);
       }
 
       // Get the incoming props to pass our component from `data-props` if applicable
@@ -81,10 +79,7 @@ export const Root = ({ richieReactSpots }: RootProps) => {
       return ReactDOM.createPortal(<Component {...props} />, element);
     } else {
       // Emit a warning at runtime when we fail to find a matching component for an element that required one
-      console.warn(
-        'Failed to load React component: no such component in Library ' +
-          componentName,
-      );
+      console.warn('Failed to load React component: no such component in Library ' + componentName);
       return null;
     }
   });

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -47,10 +47,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField
-          courseSearchPageUrl="/en/courses/"
-          context={commonDataProps}
-        />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={commonDataProps} />
       </IntlProvider>,
     );
 
@@ -75,10 +72,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField
-          courseSearchPageUrl="/en/courses/"
-          context={commonDataProps}
-        />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={commonDataProps} />
       </IntlProvider>,
     );
 
@@ -96,16 +90,12 @@ describe('<RootSearchSuggestField />', () => {
     fireEvent.change(field, { target: { value: 'aut' } });
 
     await waitFor(() => {
-      expect(
-        fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
-      ).toEqual(true);
+      expect(fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut')).toEqual(true);
       screen.getByText('Subjects');
       screen.getByText('Subject #311');
     });
 
-    expect(
-      fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut')).toEqual(true);
     expect(screen.queryByText('Courses')).toEqual(null);
   });
 
@@ -126,10 +116,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField
-          courseSearchPageUrl="/en/courses/"
-          context={commonDataProps}
-        />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={commonDataProps} />
       </IntlProvider>,
     );
 
@@ -138,16 +125,12 @@ describe('<RootSearchSuggestField />', () => {
     fireEvent.change(field, { target: { value: 'aut' } });
 
     await waitFor(() => {
-      expect(
-        fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
-      ).toEqual(true);
+      expect(fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut')).toEqual(true);
     });
     screen.getByText('Courses');
     const course = screen.getByText('Course #42');
 
-    expect(
-      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut')).toEqual(true);
     expect(screen.queryByText('Subjects')).toEqual(null);
 
     fireEvent.click(course);
@@ -172,10 +155,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField
-          courseSearchPageUrl="/en/courses/"
-          context={commonDataProps}
-        />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={commonDataProps} />
       </IntlProvider>,
     );
 
@@ -184,16 +164,12 @@ describe('<RootSearchSuggestField />', () => {
     fireEvent.change(field, { target: { value: 'aut' } });
 
     await waitFor(() => {
-      expect(
-        fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
-      ).toEqual(true);
+      expect(fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut')).toEqual(true);
     });
     screen.getByText('Subjects');
     const subject = screen.getByText('Subject #311');
 
-    expect(
-      fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut')).toEqual(true);
     expect(screen.queryByText('Courses')).toEqual(null);
 
     fireEvent.click(subject);
@@ -215,10 +191,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField
-          courseSearchPageUrl="/en/courses/"
-          context={commonDataProps}
-        />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={commonDataProps} />
       </IntlProvider>,
     );
 
@@ -253,10 +226,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField
-          courseSearchPageUrl="/en/courses/"
-          context={commonDataProps}
-        />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={commonDataProps} />
       </IntlProvider>,
     );
 
@@ -265,16 +235,12 @@ describe('<RootSearchSuggestField />', () => {
     fireEvent.change(field, { target: { value: 'aut' } });
 
     await waitFor(() => {
-      expect(
-        fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut'),
-      ).toEqual(true);
+      expect(fetchMock.called('/api/v1.0/courses/autocomplete/?query=aut')).toEqual(true);
     });
     screen.getByText('Courses');
     screen.getByText('Course #42');
 
-    expect(
-      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut')).toEqual(true);
     expect(screen.queryByText('Subjects')).toEqual(null);
 
     fireEvent.keyDown(field, { keyCode: 40 }); // Select the desired suggestion (there is only one)

--- a/src/frontend/js/components/RootSearchSuggestField/index.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.tsx
@@ -23,8 +23,7 @@ import { location } from 'utils/indirection/window';
 const messages = defineMessages({
   searchFieldPlaceholder: {
     defaultMessage: 'Search for courses',
-    description:
-      'Placeholder text displayed in the search field when it is empty.',
+    description: 'Placeholder text displayed in the search field when it is empty.',
     id: 'components.SearchSuggestField.searchFieldPlaceholder',
   },
 });
@@ -55,9 +54,7 @@ export const RootSearchSuggestField = ({
 
   // Helper to know if the user is currently highlighting a suggestion. This is necessary to make sure we do not
   // override default `Autosuggest` behavior when we receive the ENTER keycode that triggers text search.
-  const [hasHighlightedSuggestion, setHasHighlightedSuggestion] = useState(
-    false,
-  );
+  const [hasHighlightedSuggestion, setHasHighlightedSuggestion] = useState(false);
 
   /**
    * Helper function; sends the user to the Search view with the current input value as full text search.
@@ -133,15 +130,9 @@ export const RootSearchSuggestField = ({
       multiSection={true}
       onSuggestionsClearRequested={() => setSuggestions([])}
       onSuggestionsFetchRequested={async ({ value: incomingValue }) =>
-        onSuggestionsFetchRequested(
-          await getFilters(),
-          setSuggestions,
-          incomingValue,
-        )
+        onSuggestionsFetchRequested(await getFilters(), setSuggestions, incomingValue)
       }
-      onSuggestionHighlighted={({ suggestion }) =>
-        setHasHighlightedSuggestion(!suggestion)
-      }
+      onSuggestionHighlighted={({ suggestion }) => setHasHighlightedSuggestion(!suggestion)}
       onSuggestionSelected={onSuggestionSelected}
       renderInputComponent={(passthroughInputProps) => (
         <SearchInput

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -51,17 +51,16 @@ describe('<Search />', () => {
 
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <Search context={commonDataProps} />
         </HistoryContext.Provider>
       </IntlProvider>,
     );
 
-    expect(
-      screen.getByText('Loading search results...').parentElement,
-    ).toHaveAttribute('role', 'status');
+    expect(screen.getByText('Loading search results...').parentElement).toHaveAttribute(
+      'role',
+      'status',
+    );
 
     await waitFor(() => {
       expect(screen.queryByText('Loading search results...')).toBeNull();
@@ -73,17 +72,16 @@ describe('<Search />', () => {
 
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <Search context={commonDataProps} />
         </HistoryContext.Provider>
       </IntlProvider>,
     );
 
-    expect(
-      screen.getByText('Loading search results...').parentElement,
-    ).toHaveAttribute('role', 'status');
+    expect(screen.getByText('Loading search results...').parentElement).toHaveAttribute(
+      'role',
+      'status',
+    );
 
     await waitFor(() => {
       expect(screen.queryByText('Loading search results...')).toBeNull();
@@ -102,9 +100,7 @@ describe('<Search />', () => {
     mockMatches = true;
     const { container } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <Search context={commonDataProps} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -131,9 +127,7 @@ describe('<Search />', () => {
     mockMatches = false;
     const { container } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <Search context={commonDataProps} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -154,9 +148,10 @@ describe('<Search />', () => {
       // We have a "Show" button with the appropriate aria helper
       expect(screen.queryByText('Hide filters pane')).toEqual(null);
       const button = screen.getByText('Show filters pane');
-      expect(
-        container.querySelector('.search__filters__toggle'),
-      ).toHaveAttribute('aria-expanded', 'false');
+      expect(container.querySelector('.search__filters__toggle')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      );
 
       // After a click the filters pane is now shown
       fireEvent.click(button);
@@ -169,9 +164,10 @@ describe('<Search />', () => {
       // We now have a "Hide" button with the appropriate aria helper
       expect(screen.queryByText('Show filters pane')).toEqual(null);
       const button = screen.getByText('Hide filters pane');
-      expect(
-        container.querySelector('.search__filters__toggle'),
-      ).toHaveAttribute('aria-expanded', 'true');
+      expect(container.querySelector('.search__filters__toggle')).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      );
 
       // After another click the filters pane is hidden again
       fireEvent.click(button);

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -14,8 +14,7 @@ import { matchMedia } from 'utils/indirection/window';
 const messages = defineMessages({
   errorMessage: {
     defaultMessage: `Something's wrong! Courses could not be loaded.`,
-    description:
-      'Error message for Search view when the request to load courses fails',
+    description: 'Error message for Search view when the request to load courses fails',
     id: 'components.Search.errorMessage',
   },
   hideFiltersPane: {
@@ -32,8 +31,7 @@ const messages = defineMessages({
   },
   spinnerText: {
     defaultMessage: 'Loading search results...',
-    description:
-      'Accessibility text for the spinner while search results are being loaded',
+    description: 'Accessibility text for the spinner while search results are being loaded',
     id: 'components.Search.spinnerText',
   },
 });
@@ -57,8 +55,7 @@ export const Search = ({ context }: CommonDataProps) => {
         <SearchFiltersPane
           aria-hidden={alwaysShowFilters ? false : !showFilters}
           filters={
-            courseSearchResponse &&
-            courseSearchResponse.status === requestStatus.SUCCESS
+            courseSearchResponse && courseSearchResponse.status === requestStatus.SUCCESS
               ? courseSearchResponse.content.filters
               : null
           }
@@ -73,11 +70,7 @@ export const Search = ({ context }: CommonDataProps) => {
           >
             {showFilters ? (
               <React.Fragment>
-                <svg
-                  aria-hidden={true}
-                  role="img"
-                  className="icon search__filters__toggle__icon"
-                >
+                <svg aria-hidden={true} role="img" className="icon search__filters__toggle__icon">
                   <use xlinkHref="#icon-cross" />
                 </svg>{' '}
                 <span className="offscreen">
@@ -86,11 +79,7 @@ export const Search = ({ context }: CommonDataProps) => {
               </React.Fragment>
             ) : (
               <React.Fragment>
-                <svg
-                  aria-hidden={true}
-                  role="img"
-                  className="icon search__filters__toggle__icon"
-                >
+                <svg aria-hidden={true} role="img" className="icon search__filters__toggle__icon">
                   <use xlinkHref="#icon-filter" />
                 </svg>
                 <span className="offscreen">
@@ -102,8 +91,7 @@ export const Search = ({ context }: CommonDataProps) => {
         )}
       </div>
       <div className="search__results">
-        {courseSearchResponse &&
-        courseSearchResponse.status === requestStatus.SUCCESS ? (
+        {courseSearchResponse && courseSearchResponse.status === requestStatus.SUCCESS ? (
           <React.Fragment>
             <CourseGlimpseList
               context={context}
@@ -111,13 +99,10 @@ export const Search = ({ context }: CommonDataProps) => {
               meta={courseSearchResponse.content.meta}
             />
             <PaginateCourseSearch
-              courseSearchTotalCount={
-                courseSearchResponse.content.meta.total_count
-              }
+              courseSearchTotalCount={courseSearchResponse.content.meta.total_count}
             />
           </React.Fragment>
-        ) : courseSearchResponse &&
-          courseSearchResponse.status === requestStatus.FAILURE ? (
+        ) : courseSearchResponse && courseSearchResponse.status === requestStatus.FAILURE ? (
           <div className="search__results__error">
             <svg aria-hidden={true} role="img">
               <use xlinkHref="#icon-search-fail" />

--- a/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
@@ -58,9 +58,7 @@ describe('components/SearchFilterGroup', () => {
   it('renders the name of the filter with the values as SearchFilters', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroup filter={filter} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -75,32 +73,24 @@ describe('components/SearchFilterGroup', () => {
   it('does not render the "More options" button & modal if the filter is not searchable', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroup filter={{ ...filter, is_searchable: false }} />
         </HistoryContext.Provider>
       </IntlProvider>,
     );
 
-    expect(screen.queryByRole('button', { name: 'More options' })).toEqual(
-      null,
-    );
+    expect(screen.queryByRole('button', { name: 'More options' })).toEqual(null);
   });
 
   it('does not render the "More options" button & modal if there are no more values to find', () => {
     render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroup filter={{ ...filter, has_more_values: false }} />
         </HistoryContext.Provider>
       </IntlProvider>,
     );
 
-    expect(screen.queryByRole('button', { name: 'More options' })).toEqual(
-      null,
-    );
+    expect(screen.queryByRole('button', { name: 'More options' })).toEqual(null);
   });
 });

--- a/src/frontend/js/components/SearchFilterGroup/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.tsx
@@ -17,11 +17,7 @@ export const SearchFilterGroup = ({ filter }: SearchFilterGroupProps) => (
         value.key.startsWith(
           'P-',
         ) /* Values with children have a key that starts with `P-` by convention */ ? (
-          <SearchFilterValueParent
-            filter={filter}
-            value={value}
-            key={value.key}
-          />
+          <SearchFilterValueParent filter={filter} value={value} key={value.key} />
         ) : (
           /* Other values' keys start with `L-` */ <SearchFilterValueLeaf
             filter={filter}

--- a/src/frontend/js/components/SearchFilterGroupModal/_styles.scss
+++ b/src/frontend/js/components/SearchFilterGroupModal/_styles.scss
@@ -55,8 +55,7 @@
           text-align: left;
           background: inherit;
           border: none;
-          border-bottom: 1px solid
-            r-theme-val(search-filters-group-modal, item-border);
+          border-bottom: 1px solid r-theme-val(search-filters-group-modal, item-border);
           color: inherit;
         }
       }

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -78,16 +78,9 @@ describe('<SearchFilterGroupModal />', () => {
       },
     );
 
-    const {
-      getByPlaceholderText,
-      getByText,
-      queryByPlaceholderText,
-      queryByText,
-    } = render(
+    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroupModal filter={filter} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -107,12 +100,8 @@ describe('<SearchFilterGroupModal />', () => {
     await screen.findByText(
       (content) => content.startsWith('Value #42') && content.includes('(7)'),
     );
-    getByText(
-      (content) => content.startsWith('Value #84') && content.includes('(12)'),
-    );
-    getByText(
-      (content) => content.startsWith('Value #99') && content.includes('(21)'),
-    );
+    getByText((content) => content.startsWith('Value #84') && content.includes('(12)'));
+    getByText((content) => content.startsWith('Value #99') && content.includes('(21)'));
   });
 
   it('searches as the user types', async () => {
@@ -143,9 +132,7 @@ describe('<SearchFilterGroupModal />', () => {
 
     const { getByPlaceholderText, getByText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroupModal filter={filter} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -162,9 +149,7 @@ describe('<SearchFilterGroupModal />', () => {
     await screen.findByText(
       (content) => content.startsWith('Value #42') && content.includes('(7)'),
     );
-    getByText(
-      (content) => content.startsWith('Value #84') && content.includes('(12)'),
-    );
+    getByText((content) => content.startsWith('Value #84') && content.includes('(12)'));
 
     // User starts typing, less than 3 characters
     fetchMock.resetHistory();
@@ -203,17 +188,12 @@ describe('<SearchFilterGroupModal />', () => {
     await screen.findByText(
       (content) => content.startsWith('Value #12') && content.includes('(7)'),
     );
-    getByText(
-      (content) => content.startsWith('Value #17') && content.includes('(12)'),
-    );
+    getByText((content) => content.startsWith('Value #17') && content.includes('(12)'));
 
     // User further refines their search query
-    fetchMock.get(
-      '/api/v1.0/universities/?limit=20&offset=0&query=user%20input',
-      {
-        objects: [{ id: 'L-03' }, { id: 'L-66' }],
-      },
-    );
+    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=user%20input', {
+      objects: [{ id: 'L-03' }, { id: 'L-66' }],
+    });
     fetchMock.get(
       '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_include=%28L-03%7CL-66%29',
       {
@@ -241,9 +221,7 @@ describe('<SearchFilterGroupModal />', () => {
     await screen.findByText(
       (content) => content.startsWith('Value #03') && content.includes('(12)'),
     );
-    getByText(
-      (content) => content.startsWith('Value #17') && content.includes('(2)'),
-    );
+    getByText((content) => content.startsWith('Value #17') && content.includes('(2)'));
   });
 
   it('closes when the user clicks the close button', async () => {
@@ -261,16 +239,9 @@ describe('<SearchFilterGroupModal />', () => {
       },
     );
 
-    const {
-      getByPlaceholderText,
-      getByText,
-      queryByPlaceholderText,
-      queryByText,
-    } = render(
+    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroupModal filter={filter} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -325,16 +296,9 @@ describe('<SearchFilterGroupModal />', () => {
       },
     );
 
-    const {
-      getByPlaceholderText,
-      getByText,
-      queryByPlaceholderText,
-      queryByText,
-    } = render(
+    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroupModal filter={filter} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -386,16 +350,9 @@ describe('<SearchFilterGroupModal />', () => {
       throws: new Error('Failed to search for universities'),
     });
 
-    const {
-      getByPlaceholderText,
-      getByText,
-      queryByPlaceholderText,
-      queryByText,
-    } = render(
+    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroupModal filter={filter} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -412,9 +369,7 @@ describe('<SearchFilterGroupModal />', () => {
     getByPlaceholderText('Search in Universities');
 
     // The search request failed, the error is logged and a message is displayed
-    await screen.findByText(
-      'There was an error while searching for Universities.',
-    );
+    await screen.findByText('There was an error while searching for Universities.');
   });
 
   it('shows an error message when it fails to get the actual filter', async () => {
@@ -426,16 +381,9 @@ describe('<SearchFilterGroupModal />', () => {
       { throws: new Error('Failed to search for universities') },
     );
 
-    const {
-      getByPlaceholderText,
-      getByText,
-      queryByPlaceholderText,
-      queryByText,
-    } = render(
+    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '20', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
           <SearchFilterGroupModal filter={filter} />
         </HistoryContext.Provider>
       </IntlProvider>,
@@ -452,8 +400,6 @@ describe('<SearchFilterGroupModal />', () => {
     getByPlaceholderText('Search in Universities');
 
     // The filters request failed, the error is logged and a message is displayed
-    await screen.findByText(
-      'There was an error while searching for Universities.',
-    );
+    await screen.findByText('There was an error while searching for Universities.');
   });
 });

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -1,16 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import {
-  defineMessages,
-  FormattedMessage,
-  MessageDescriptor,
-} from 'react-intl';
+import { defineMessages, FormattedMessage, MessageDescriptor } from 'react-intl';
 import ReactModal from 'react-modal';
 
 import { fetchList } from 'data/getResourceList';
-import {
-  CourseSearchParamsAction,
-  useCourseSearchParams,
-} from 'data/useCourseSearchParams';
+import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
 import { requestStatus } from 'types/api';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { Nullable } from 'utils/types';
@@ -34,8 +27,7 @@ const messages = defineMessages({
   },
   modalTitle: {
     defaultMessage: 'Add filters for {filterName}',
-    description:
-      'Title for the modal to add more filter values in the search filters modal.',
+    description: 'Title for the modal to add more filter values in the search filters modal.',
     id: 'components.SearchFilterGroupModal.modalTitle',
   },
   moreOptionsButton: {
@@ -61,19 +53,14 @@ if (!isTestEnv) {
   ReactModal.setAppElement('#modal-exclude');
 }
 
-export const SearchFilterGroupModal = ({
-  filter,
-}: SearchFilterGroupModalProps) => {
+export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [values, setValues] = useState([] as FilterValue[]);
   const [query, setQuery] = useState('');
   const [error, setError] = useState(null as Nullable<MessageDescriptor>);
 
   // We need the current course search params to get the facet counts
-  const {
-    courseSearchParams,
-    dispatchCourseSearchParamsUpdate,
-  } = useCourseSearchParams();
+  const { courseSearchParams, dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
 
   // When the modal is closed, reset state so the user gets a brand-new one if they come back
   useEffect(() => {
@@ -122,10 +109,7 @@ export const SearchFilterGroupModal = ({
 
   return (
     <React.Fragment>
-      <button
-        className="search-filter-group-modal-button"
-        onClick={() => setModalIsOpen(true)}
-      >
+      <button className="search-filter-group-modal-button" onClick={() => setModalIsOpen(true)}>
         <FormattedMessage {...messages.moreOptionsButton} />
       </button>
       <ReactModal
@@ -138,10 +122,7 @@ export const SearchFilterGroupModal = ({
       >
         <fieldset className="search-filter-group-modal__form">
           <legend className="search-filter-group-modal__form__title">
-            <FormattedMessage
-              {...messages.modalTitle}
-              values={{ filterName: filter.human_name }}
-            />
+            <FormattedMessage {...messages.modalTitle} values={{ filterName: filter.human_name }} />
           </legend>
           <input
             aria-label="Search for filters to add"
@@ -153,10 +134,7 @@ export const SearchFilterGroupModal = ({
           />
           {error ? (
             <div className="search-filter-group-modal__form__error">
-              <FormattedMessage
-                {...messages.error}
-                values={{ filterName: filter.human_name }}
-              />
+              <FormattedMessage {...messages.error} values={{ filterName: filter.human_name }} />
             </div>
           ) : query.length > 0 && query.length < 3 ? (
             <div className="search-filter-group-modal__form__error">
@@ -165,10 +143,7 @@ export const SearchFilterGroupModal = ({
           ) : (
             <ul className="search-filter-group-modal__form__values">
               {values.map((value) => (
-                <li
-                  className="search-filter-group-modal__form__values__item"
-                  key={value.key}
-                >
+                <li className="search-filter-group-modal__form__values__item" key={value.key}>
                   <button
                     onClick={() => {
                       dispatchCourseSearchParamsUpdate({
@@ -187,10 +162,7 @@ export const SearchFilterGroupModal = ({
             </ul>
           )}
         </fieldset>
-        <button
-          className="search-filter-group-modal__close"
-          onClick={() => setModalIsOpen(false)}
-        >
+        <button className="search-filter-group-modal__close" onClick={() => setModalIsOpen(false)}>
           <FormattedMessage {...messages.closeButton} />
         </button>
       </ReactModal>

--- a/src/frontend/js/components/SearchFilterValueLeaf/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/index.spec.tsx
@@ -24,9 +24,7 @@ describe('components/SearchFilterValueLeaf', () => {
   it('renders the name of the filter value', () => {
     const { getByLabelText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFilterValueLeaf
             filter={{
               base_path: null,
@@ -49,9 +47,7 @@ describe('components/SearchFilterValueLeaf', () => {
     );
 
     // The filter value is displayed with its facet count
-    const checkbox = getByLabelText((content, _) =>
-      content.includes('Human name'),
-    );
+    const checkbox = getByLabelText((content, _) => content.includes('Human name'));
     expect(checkbox.parentElement).toHaveTextContent('(217)');
     // The filter is not currently active
     expect(checkbox).not.toHaveAttribute('checked');
@@ -90,9 +86,7 @@ describe('components/SearchFilterValueLeaf', () => {
     );
 
     // The filter shows its active state
-    const checkbox = getByLabelText((content, _) =>
-      content.includes('Human name'),
-    );
+    const checkbox = getByLabelText((content, _) => content.includes('Human name'));
     expect(checkbox).toHaveAttribute('checked');
     expect(checkbox.parentElement).toHaveClass('active'); // label that contains checkbox
   });
@@ -100,9 +94,7 @@ describe('components/SearchFilterValueLeaf', () => {
   it('disables the value when its count is 0', () => {
     const { getByLabelText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFilterValueLeaf
             filter={{
               base_path: null,
@@ -125,22 +117,16 @@ describe('components/SearchFilterValueLeaf', () => {
     );
 
     // The filter shows its active state
-    const checkbox = getByLabelText((content, _) =>
-      content.includes('Human name'),
-    );
+    const checkbox = getByLabelText((content, _) => content.includes('Human name'));
     expect(checkbox).not.toHaveAttribute('checked');
     expect(checkbox).toHaveAttribute('disabled');
-    expect(checkbox.parentElement).toHaveClass(
-      'search-filter-value-leaf--disabled',
-    );
+    expect(checkbox.parentElement).toHaveClass('search-filter-value-leaf--disabled');
   });
 
   it('dispatches a FILTER_ADD action on filter click if it was not active', () => {
     const { getByLabelText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFilterValueLeaf
             filter={{
               base_path: null,
@@ -162,9 +148,7 @@ describe('components/SearchFilterValueLeaf', () => {
       </IntlProvider>,
     );
 
-    fireEvent.click(
-      getByLabelText((content, _) => content.includes('Human name')),
-    );
+    fireEvent.click(getByLabelText((content, _) => content.includes('Human name')));
     expect(historyPushState).toHaveBeenCalledWith(
       {
         name: 'courseSearch',
@@ -209,9 +193,7 @@ describe('components/SearchFilterValueLeaf', () => {
       </IntlProvider>,
     );
 
-    fireEvent.click(
-      getByLabelText((content, _) => content.includes('Human name')),
-    );
+    fireEvent.click(getByLabelText((content, _) => content.includes('Human name')));
     expect(historyPushState).toHaveBeenCalledWith(
       {
         name: 'courseSearch',

--- a/src/frontend/js/components/SearchFilterValueLeaf/index.tsx
+++ b/src/frontend/js/components/SearchFilterValueLeaf/index.tsx
@@ -8,10 +8,7 @@ export interface SearchFilterValueLeafProps {
   value: FilterValue;
 }
 
-const SearchFilterValueLeafBase = ({
-  filter,
-  value,
-}: SearchFilterValueLeafProps) => {
+const SearchFilterValueLeafBase = ({ filter, value }: SearchFilterValueLeafProps) => {
   const [isActive, toggle] = useFilterValue(filter, value);
 
   return (
@@ -38,10 +35,6 @@ const SearchFilterValueLeafBase = ({
 const areEqual: (
   prevProps: Readonly<SearchFilterValueLeafProps>,
   newProps: Readonly<SearchFilterValueLeafProps>,
-) => boolean = (prevProps, newProps) =>
-  prevProps.value.count === newProps.value.count;
+) => boolean = (prevProps, newProps) => prevProps.value.count === newProps.value.count;
 
-export const SearchFilterValueLeaf = React.memo(
-  SearchFilterValueLeafBase,
-  areEqual,
-);
+export const SearchFilterValueLeaf = React.memo(SearchFilterValueLeafBase, areEqual);

--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -33,9 +33,7 @@ describe('<SearchFilterValueParent />', () => {
   it('renders the parent filter value and a button to show the children', () => {
     const { getByLabelText, queryByLabelText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFilterValueParent
             filter={{
               base_path: '00010002',
@@ -62,12 +60,8 @@ describe('<SearchFilterValueParent />', () => {
       'aria-pressed',
       'false',
     );
-    expect(
-      queryByLabelText((content) => content.startsWith('Classical Literature')),
-    ).toEqual(null);
-    expect(
-      queryByLabelText((content) => content.startsWith('Modern Literature')),
-    ).toEqual(null);
+    expect(queryByLabelText((content) => content.startsWith('Classical Literature'))).toEqual(null);
+    expect(queryByLabelText((content) => content.startsWith('Modern Literature'))).toEqual(null);
   });
 
   it('shows the children when one of them is active', async () => {
@@ -122,20 +116,14 @@ describe('<SearchFilterValueParent />', () => {
 
     // Children filters are not shown
     getByLabelText((content) => content.startsWith('Literature'));
-    expect(queryByLabelText('Hide additional filters for Literature')).toEqual(
-      null,
-    );
+    expect(queryByLabelText('Hide additional filters for Literature')).toEqual(null);
     queryByLabelText((content) => content.startsWith('Classical Literature'));
     queryByLabelText((content) => content.startsWith('Modern Literature'));
 
     // The params are updated, now include a child filter of Literature
-    rerender(
-      getElement({ limit: '999', offset: '0', subjects: ['L-000400050004'] }),
-    );
+    rerender(getElement({ limit: '999', offset: '0', subjects: ['L-000400050004'] }));
 
-    await screen.findByLabelText((content) =>
-      content.startsWith('Classical Literature'),
-    );
+    await screen.findByLabelText((content) => content.startsWith('Classical Literature'));
 
     // The children filters are now shown along with an icon to hide them
     getByLabelText((content) => content.startsWith('Modern Literature'));
@@ -196,12 +184,11 @@ describe('<SearchFilterValueParent />', () => {
     );
 
     getByLabelText((content) => content.startsWith('Literature'));
-    expect(
-      getByLabelText('Hide additional filters for Literature'),
-    ).toHaveAttribute('aria-pressed', 'true');
-    await screen.findByLabelText((content) =>
-      content.startsWith('Classical Literature'),
+    expect(getByLabelText('Hide additional filters for Literature')).toHaveAttribute(
+      'aria-pressed',
+      'true',
     );
+    await screen.findByLabelText((content) => content.startsWith('Classical Literature'));
     getByLabelText((content) => content.startsWith('Modern Literature'));
 
     expect(mockFetchList).toHaveBeenCalledTimes(1);
@@ -220,12 +207,8 @@ describe('<SearchFilterValueParent />', () => {
       'aria-pressed',
       'false',
     );
-    expect(
-      queryByLabelText((content) => content.startsWith('Classical Literature')),
-    ).toEqual(null);
-    expect(
-      queryByLabelText((content) => content.startsWith('Modern Literature')),
-    ).toEqual(null);
+    expect(queryByLabelText((content) => content.startsWith('Classical Literature'))).toEqual(null);
+    expect(queryByLabelText((content) => content.startsWith('Modern Literature'))).toEqual(null);
     expect(mockFetchList).toHaveBeenCalledTimes(1);
 
     fireEvent.click(getByLabelText('Show more filters for Literature'));
@@ -239,21 +222,18 @@ describe('<SearchFilterValueParent />', () => {
       subjects: ['L-000400050004'],
       subjects_include: '.-00040005.{4,}',
     });
-    expect(
-      getByLabelText('Hide additional filters for Literature'),
-    ).toHaveAttribute('aria-pressed', 'true');
-    await screen.findByLabelText((content) =>
-      content.startsWith('Classical Literature'),
+    expect(getByLabelText('Hide additional filters for Literature')).toHaveAttribute(
+      'aria-pressed',
+      'true',
     );
+    await screen.findByLabelText((content) => content.startsWith('Classical Literature'));
     getByLabelText((content) => content.startsWith('Modern Literature'));
   });
 
   it('shows the parent filter value itself as inactive when it is not in the search params', () => {
     const { getByLabelText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFilterValueParent
             filter={{
               base_path: '0009',
@@ -276,9 +256,7 @@ describe('<SearchFilterValueParent />', () => {
     );
 
     // The filter value is displayed with its facet count
-    const checkbox = getByLabelText((content) =>
-      content.startsWith('Human name'),
-    );
+    const checkbox = getByLabelText((content) => content.startsWith('Human name'));
     expect(checkbox!.parentElement).toHaveTextContent('(217)'); // label that contains checkbox
     // The filter is not currently active
     expect(checkbox).not.toHaveAttribute('checked');
@@ -288,9 +266,7 @@ describe('<SearchFilterValueParent />', () => {
   it('disables the parent value when its count is 0', () => {
     const { getByLabelText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFilterValueParent
             filter={{
               base_path: '0009',
@@ -313,14 +289,10 @@ describe('<SearchFilterValueParent />', () => {
     );
 
     // The filter shows its active state
-    const checkbox = getByLabelText((content) =>
-      content.startsWith('Human name'),
-    );
+    const checkbox = getByLabelText((content) => content.startsWith('Human name'));
     expect(checkbox).not.toHaveAttribute('checked');
     expect(checkbox).toHaveAttribute('disabled');
-    expect(checkbox.parentElement).toHaveClass(
-      'search-filter-value-parent__self__label--disabled',
-    );
+    expect(checkbox.parentElement).toHaveClass('search-filter-value-parent__self__label--disabled');
   });
   it('shows the parent filter value itself as active when it is in the search params', () => {
     const { getByLabelText } = render(
@@ -353,9 +325,7 @@ describe('<SearchFilterValueParent />', () => {
       </IntlProvider>,
     );
 
-    const checkbox = getByLabelText((content) =>
-      content.startsWith('Human name'),
-    );
+    const checkbox = getByLabelText((content) => content.startsWith('Human name'));
     expect(checkbox!.parentElement).toHaveTextContent('(218)'); // label that contains checkbox
     expect(checkbox).toHaveAttribute('checked');
     expect(checkbox!.parentElement!.parentElement).toHaveClass('active'); // parent self filter
@@ -364,9 +334,7 @@ describe('<SearchFilterValueParent />', () => {
   it('dispatches a FILTER_ADD action on filter click if it was not active', () => {
     const { getByLabelText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFilterValueParent
             filter={{
               base_path: '0009',
@@ -388,9 +356,7 @@ describe('<SearchFilterValueParent />', () => {
       </IntlProvider>,
     );
 
-    fireEvent.click(
-      getByLabelText((content) => content.startsWith('Human name')),
-    );
+    fireEvent.click(getByLabelText((content) => content.startsWith('Human name')));
     expect(historyPushState).toHaveBeenCalledWith(
       {
         name: 'courseSearch',
@@ -435,9 +401,7 @@ describe('<SearchFilterValueParent />', () => {
       </IntlProvider>,
     );
 
-    fireEvent.click(
-      getByLabelText((content) => content.startsWith('Human name')),
-    );
+    fireEvent.click(getByLabelText((content) => content.startsWith('Human name')));
     expect(historyPushState).toHaveBeenCalledWith(
       {
         name: 'courseSearch',

--- a/src/frontend/js/components/SearchFilterValueParent/index.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.tsx
@@ -14,14 +14,12 @@ import { useAsyncEffect } from 'utils/useAsyncEffect';
 const messages = defineMessages({
   ariaHideChildren: {
     defaultMessage: 'Hide additional filters for {filterValueName}',
-    description:
-      'Accessibility message for the button to hide children of the current filter',
+    description: 'Accessibility message for the button to hide children of the current filter',
     id: 'components.SearchFilterValueParent.ariaHideChildren',
   },
   ariaShowChildren: {
     defaultMessage: 'Show more filters for {filterValueName}',
-    description:
-      'Accessibility message for the button to show children of the current filter',
+    description: 'Accessibility message for the button to show children of the current filter',
     id: 'components.SearchFilterValueParent.ariaShowChildren',
   },
 });
@@ -31,22 +29,16 @@ interface SearchFilterValueParentProps {
   value: FilterValue;
 }
 
-export const SearchFilterValueParent = ({
-  filter,
-  value,
-}: SearchFilterValueParentProps) => {
+export const SearchFilterValueParent = ({ filter, value }: SearchFilterValueParentProps) => {
   const intl = useIntl();
 
   // Get the current values for the filter definition so we know if any children of this parent
   // filter are active (and we therefore need to get them and unfold the children).
   const { courseSearchParams } = useCourseSearchParams();
   // Default to an array of strings no matter the current value so we can easily check for active values
-  const activeFilterValues =
-    courseSearchParams[filter.name] || ([] as string[]);
+  const activeFilterValues = courseSearchParams[filter.name] || ([] as string[]);
   const activeValuesList =
-    typeof activeFilterValues === 'string'
-      ? [activeFilterValues]
-      : activeFilterValues;
+    typeof activeFilterValues === 'string' ? [activeFilterValues] : activeFilterValues;
 
   // We can easily determine if any children are active without having to GET them first through our
   // path key convention.
@@ -58,11 +50,8 @@ export const SearchFilterValueParent = ({
   const hasActiveChildren = activeValuesList.some((activeValueKey) =>
     childrenPathMatchRegexp.test(activeValueKey),
   );
-  const [userShowChildren, setUserShowChildren] = useState(
-    null as Nullable<boolean>,
-  );
-  const showChildren =
-    userShowChildren !== null ? !!userShowChildren : hasActiveChildren;
+  const [userShowChildren, setUserShowChildren] = useState(null as Nullable<boolean>);
+  const showChildren = userShowChildren !== null ? !!userShowChildren : hasActiveChildren;
 
   const [children, setChildren] = useState([] as FilterValue[]);
   useAsyncEffect(async () => {
@@ -75,9 +64,7 @@ export const SearchFilterValueParent = ({
       });
 
       if (childrenResponse.status === requestStatus.FAILURE) {
-        throw new Error(
-          `Failed to get children filters for ${filter.name}/${childrenPathMatch}`,
-        );
+        throw new Error(`Failed to get children filters for ${filter.name}/${childrenPathMatch}`);
       }
 
       setChildren(childrenResponse.content.filters[filter.name].values);
@@ -90,16 +77,10 @@ export const SearchFilterValueParent = ({
   const [isActive, toggle] = useFilterValue(filter, value);
   return (
     <div className="search-filter-value-parent">
-      <div
-        className={`search-filter-value-parent__self ${
-          isActive ? 'active' : ''
-        }`}
-      >
+      <div className={`search-filter-value-parent__self ${isActive ? 'active' : ''}`}>
         <label
           className={`search-filter-value-parent__self__label ${
-            value.count === 0
-              ? 'search-filter-value-parent__self__label--disabled'
-              : ''
+            value.count === 0 ? 'search-filter-value-parent__self__label--disabled' : ''
           }`}
         >
           <input
@@ -116,9 +97,7 @@ export const SearchFilterValueParent = ({
         </label>
         <button
           aria-label={intl.formatMessage(
-            showChildren
-              ? messages.ariaHideChildren
-              : messages.ariaShowChildren,
+            showChildren ? messages.ariaHideChildren : messages.ariaShowChildren,
             {
               filterValueName: value.human_name,
             },
@@ -135,11 +114,7 @@ export const SearchFilterValueParent = ({
       {showChildren && (
         <div className="search-filter-value-parent__children">
           {children.map((childValue) => (
-            <SearchFilterValueLeaf
-              filter={filter}
-              key={childValue.key}
-              value={childValue}
-            />
+            <SearchFilterValueLeaf filter={filter} key={childValue.key} value={childValue} />
           ))}
         </div>
       )}

--- a/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
@@ -28,9 +28,7 @@ describe('components/SearchFiltersPane', () => {
   it('renders all our search filter groups', () => {
     const { getByText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFiltersPane
             filters={{
               categories: {
@@ -63,17 +61,13 @@ describe('components/SearchFiltersPane', () => {
     getByText('Filter courses');
     getByText('Received filter title: Categories');
     getByText('Received filter title: Organizations');
-    expect(getByText('Clear 0 active filters')).toHaveClass(
-      'search-filters-pane__clear--hidden',
-    );
+    expect(getByText('Clear 0 active filters')).toHaveClass('search-filters-pane__clear--hidden');
   });
 
   it('still renders with its title when it is not passed anything', () => {
     const { getByText } = render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({ limit: '999', offset: '0' })}
-        >
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFiltersPane filters={null} />
         </HistoryContext.Provider>
       </IntlProvider>,

--- a/src/frontend/js/components/SearchFiltersPane/index.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { SearchFilterGroup } from 'components/SearchFilterGroup';
-import {
-  CourseSearchParamsAction,
-  useCourseSearchParams,
-} from 'data/useCourseSearchParams';
+import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
 import { API_LIST_DEFAULT_PARAMS } from 'settings';
 import { APICourseSearchResponse } from 'types/api';
 import { Nullable } from 'utils/types';
@@ -18,8 +15,7 @@ const messages = defineMessages({
   clearFilters: {
     defaultMessage:
       'Clear {activeFilterCount, number} active {activeFilterCount, plural, one {filter} other {filters}}',
-    description:
-      'Helper button in search filters pane in search page to remove all active filters',
+    description: 'Helper button in search filters pane in search page to remove all active filters',
     id: 'components.SearchFiltersPane.clearFilters',
   },
   filter: {
@@ -33,16 +29,10 @@ export const SearchFiltersPane = ({
   filters,
   ...passThroughProps
 }: SearchFiltersPaneProps &
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLDivElement>,
-    HTMLDivElement
-  >) => {
+  React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>) => {
   const filterList = filters && Object.values(filters);
 
-  const {
-    courseSearchParams,
-    dispatchCourseSearchParamsUpdate,
-  } = useCourseSearchParams();
+  const { courseSearchParams, dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
 
   // Get all the currently active filters to show a count
   const activeFilters = Object.entries(courseSearchParams)
@@ -73,15 +63,10 @@ export const SearchFiltersPane = ({
           })
         }
       >
-        <FormattedMessage
-          {...messages.clearFilters}
-          values={{ activeFilterCount }}
-        />
+        <FormattedMessage {...messages.clearFilters} values={{ activeFilterCount }} />
       </a>
       {filterList &&
-        filterList.map((filter) => (
-          <SearchFilterGroup filter={filter} key={filter.name} />
-        ))}
+        filterList.map((filter) => <SearchFilterGroup filter={filter} key={filter.name} />)}
     </div>
   );
 };

--- a/src/frontend/js/components/SearchInput/index.spec.tsx
+++ b/src/frontend/js/components/SearchInput/index.spec.tsx
@@ -33,11 +33,7 @@ describe('<SearchInput />', () => {
 
     const { getByText } = render(
       <IntlProvider locale="en">
-        <SearchInput
-          context={context}
-          inputProps={inputProps}
-          onClick={callback}
-        />
+        <SearchInput context={context} inputProps={inputProps} onClick={callback} />
       </IntlProvider>,
     );
 

--- a/src/frontend/js/components/SearchInput/index.tsx
+++ b/src/frontend/js/components/SearchInput/index.tsx
@@ -6,8 +6,7 @@ import { CommonDataProps } from 'types/commonDataProps';
 const messages = defineMessages({
   button: {
     defaultMessage: 'Search',
-    description:
-      'Accessibility text for the search button inside the Search input.',
+    description: 'Accessibility text for the search button inside the Search input.',
     id: 'components.SearchInput.button',
   },
 });
@@ -27,11 +26,7 @@ export const SearchInput = ({
   <div className="search-input">
     <input {...inputProps} />
     <button className="search-input__btn" onClick={onClick}>
-      <svg
-        aria-hidden={true}
-        role="img"
-        className="icon search-input__btn__icon"
-      >
+      <svg aria-hidden={true} role="img" className="icon search-input__btn__icon">
         <use xlinkHref="#icon-magnifying-glass" />
       </svg>{' '}
       <span className="offscreen">

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -3,10 +3,7 @@ import fetchMock from 'fetch-mock';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 
-import {
-  useCourseSearchParams,
-  CourseSearchParamsAction,
-} from 'data/useCourseSearchParams';
+import { useCourseSearchParams, CourseSearchParamsAction } from 'data/useCourseSearchParams';
 import { HistoryProvider } from 'data/useHistory';
 import { CommonDataProps } from 'types/commonDataProps';
 import { FilterDefinition } from 'types/filters';
@@ -15,9 +12,7 @@ import { SearchSuggestField } from '.';
 
 // Unexplained difficulties with fake timers were encountered in these tests.
 // We decided to mock the debounce function instead.
-jest.mock('lodash-es/debounce', () => (fn: any) => (...args: any[]) =>
-  fn(...args),
-);
+jest.mock('lodash-es/debounce', () => (fn: any) => (...args: any[]) => fn(...args));
 
 jest.mock('settings', () => ({
   API_LIST_DEFAULT_PARAMS: { limit: '13', offset: '0' },
@@ -180,35 +175,25 @@ describe('components/SearchSuggestField', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText(
-      'Search for courses, organizations, categories',
-    );
+    const field = getByPlaceholderText('Search for courses, organizations, categories');
 
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: 'aut' } });
 
     await waitFor(() => {
-      expect(
-        fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut'),
-      ).toEqual(true);
+      expect(fetchMock.called('/api/v1.0/subjects/autocomplete/?query=aut')).toEqual(true);
     });
     getByText('Subjects');
     getByText('Subject #311');
 
-    expect(
-      fetchMock.called('/api/v1.0/levels/autocomplete/?query=aut'),
-    ).toEqual(false);
+    expect(fetchMock.called('/api/v1.0/levels/autocomplete/?query=aut')).toEqual(false);
     expect(queryByText('Levels')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/organizations/autocomplete/?query=aut'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/organizations/autocomplete/?query=aut')).toEqual(true);
     expect(queryByText('Organizations')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/persons/autocomplete/?query=aut'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/persons/autocomplete/?query=aut')).toEqual(true);
     expect(queryByText('Persons')).toEqual(null);
   });
 
@@ -232,9 +217,7 @@ describe('components/SearchSuggestField', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText(
-      'Search for courses, organizations, categories',
-    );
+    const field = getByPlaceholderText('Search for courses, organizations, categories');
 
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
@@ -245,19 +228,11 @@ describe('components/SearchSuggestField', () => {
 
     fireEvent.change(field, { target: { value: 'xyz' } });
     await waitFor(() => {
-      expect(
-        fetchMock.called('/api/v1.0/subjects/autocomplete/?query=xyz'),
-      ).toEqual(true);
+      expect(fetchMock.called('/api/v1.0/subjects/autocomplete/?query=xyz')).toEqual(true);
     });
-    expect(
-      fetchMock.called('/api/v1.0/levels/autocomplete/?query=xyz'),
-    ).toEqual(false);
-    expect(
-      fetchMock.called('/api/v1.0/organizations/autocomplete/?query=xyz'),
-    ).toEqual(true);
-    expect(
-      fetchMock.called('/api/v1.0/persons/autocomplete/?query=xyz'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/levels/autocomplete/?query=xyz')).toEqual(false);
+    expect(fetchMock.called('/api/v1.0/organizations/autocomplete/?query=xyz')).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/persons/autocomplete/?query=xyz')).toEqual(true);
   });
 
   it('updates the search params when the user selects a filter suggestion', async () => {
@@ -287,9 +262,7 @@ describe('components/SearchSuggestField', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText(
-      'Search for courses, organizations, categories',
-    );
+    const field = getByPlaceholderText('Search for courses, organizations, categories');
 
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
@@ -310,25 +283,17 @@ describe('components/SearchSuggestField', () => {
       '/search?limit=13&offset=0&query=orga',
     );
 
-    expect(
-      fetchMock.called('/api/v1.0/levels/autocomplete/?query=orga'),
-    ).toEqual(false);
+    expect(fetchMock.called('/api/v1.0/levels/autocomplete/?query=orga')).toEqual(false);
     expect(queryByText('Levels')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/organizations/autocomplete/?query=orga'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/organizations/autocomplete/?query=orga')).toEqual(true);
     getByText('Organizations');
     getByText('Organization #27');
 
-    expect(
-      fetchMock.called('/api/v1.0/persons/autocomplete/?query=orga'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/persons/autocomplete/?query=orga')).toEqual(true);
     expect(queryByText('Persons')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=orga'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/subjects/autocomplete/?query=orga')).toEqual(true);
     expect(queryByText('Subjects')).toEqual(null);
 
     fireEvent.click(getByText('Organization #27'));
@@ -381,9 +346,7 @@ describe('components/SearchSuggestField', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText(
-      'Search for courses, organizations, categories',
-    );
+    const field = getByPlaceholderText('Search for courses, organizations, categories');
 
     // Simulate the user entering some text in the autocomplete field
     fireEvent.focus(field);
@@ -404,25 +367,17 @@ describe('components/SearchSuggestField', () => {
       '/search?limit=13&offset=0&query=doct',
     );
 
-    expect(
-      fetchMock.called('/api/v1.0/levels/autocomplete/?query=doct'),
-    ).toEqual(false);
+    expect(fetchMock.called('/api/v1.0/levels/autocomplete/?query=doct')).toEqual(false);
     expect(queryByText('Levels')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/organizations/autocomplete/?query=doct'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/organizations/autocomplete/?query=doct')).toEqual(true);
     expect(queryByText('Organizations')).toEqual(null);
 
-    expect(
-      fetchMock.called('/api/v1.0/persons/autocomplete/?query=doct'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/persons/autocomplete/?query=doct')).toEqual(true);
     getByText('Persons');
     getByText('Doctor Doom');
 
-    expect(
-      fetchMock.called('/api/v1.0/subjects/autocomplete/?query=doct'),
-    ).toEqual(true);
+    expect(fetchMock.called('/api/v1.0/subjects/autocomplete/?query=doct')).toEqual(true);
     expect(queryByText('Subjects')).toEqual(null);
 
     fireEvent.click(getByText('Doctor Doom'));
@@ -470,9 +425,7 @@ describe('components/SearchSuggestField', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText(
-      'Search for courses, organizations, categories',
-    );
+    const field = getByPlaceholderText('Search for courses, organizations, categories');
 
     // Simulate the user deleting the text in the autocomplete field
     fireEvent.focus(field);
@@ -514,9 +467,7 @@ describe('components/SearchSuggestField', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText(
-      'Search for courses, organizations, categories',
-    );
+    const field = getByPlaceholderText('Search for courses, organizations, categories');
     fireEvent.focus(field);
 
     // NB: the tests below rely on the very crude debounce mock for lodash-debounce.
@@ -595,9 +546,7 @@ describe('components/SearchSuggestField', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText(
-      'Search for courses, organizations, categories',
-    );
+    const field = getByPlaceholderText('Search for courses, organizations, categories');
     fireEvent.focus(field);
 
     // NB: the tests below rely on the very crude debounce mock for lodash-debounce.
@@ -663,9 +612,7 @@ describe('components/SearchSuggestField', () => {
       </IntlProvider>,
     );
 
-    const field = getByPlaceholderText(
-      'Search for courses, organizations, categories',
-    );
+    const field = getByPlaceholderText('Search for courses, organizations, categories');
     fireEvent.focus(field);
 
     // The user is typing an organization name

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -10,22 +10,15 @@ import {
   renderSuggestion,
 } from 'common/searchFields';
 import { SearchInput } from 'components/SearchInput';
-import {
-  CourseSearchParamsAction,
-  useCourseSearchParams,
-} from 'data/useCourseSearchParams';
+import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
 import { useStaticFilters } from 'data/useStaticFilters';
 import { CommonDataProps } from 'types/commonDataProps';
-import {
-  SearchAutosuggestProps,
-  SearchSuggestionSection,
-} from 'types/Suggestion';
+import { SearchAutosuggestProps, SearchSuggestionSection } from 'types/Suggestion';
 
 const messages = defineMessages({
   searchFieldPlaceholder: {
     defaultMessage: 'Search for courses, organizations, categories',
-    description:
-      'Placeholder text displayed in the search field when it is empty.',
+    description: 'Placeholder text displayed in the search field when it is empty.',
     id: 'components.SearchSuggestField.searchFieldPlaceholder',
   },
 });
@@ -94,11 +87,7 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
       });
     }
   };
-  const updateCourseSearchParamsDebounced = debounce(
-    searchAsTheUserTypes,
-    500,
-    { maxWait: 1100 },
-  );
+  const updateCourseSearchParamsDebounced = debounce(searchAsTheUserTypes, 500, { maxWait: 1100 });
 
   const inputProps: SearchAutosuggestProps['inputProps'] = {
     /**
@@ -168,11 +157,7 @@ export const SearchSuggestField = ({ context }: CommonDataProps) => {
       multiSection={true}
       onSuggestionsClearRequested={() => setSuggestions([])}
       onSuggestionsFetchRequested={async ({ value: incomingValue }) =>
-        onSuggestionsFetchRequested(
-          await getFilters(),
-          setSuggestions,
-          incomingValue,
-        )
+        onSuggestionsFetchRequested(await getFilters(), setSuggestions, incomingValue)
       }
       onSuggestionSelected={onSuggestionSelected}
       renderInputComponent={(passthroughInputProps) => (

--- a/src/frontend/js/components/UserLogin/_styles.scss
+++ b/src/frontend/js/components/UserLogin/_styles.scss
@@ -11,13 +11,7 @@
     display: flex;
     align-items: center;
     @include sv-flex(1, 0, auto);
-    @include button-size(
-      $btn-padding-y,
-      $btn-padding-x,
-      $btn-font-size,
-      $btn-line-height,
-      2rem
-    );
+    @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-line-height, 2rem);
     @include font-size($font-size-base);
     font-family: inherit;
     font-weight: inherit;

--- a/src/frontend/js/components/UserLogin/index.spec.tsx
+++ b/src/frontend/js/components/UserLogin/index.spec.tsx
@@ -77,8 +77,6 @@ describe('<UserLogin />', () => {
     getByText('Log in');
     getByText('Sign up');
     expect(queryByText('Loading login status...')).toBeNull();
-    expect(handle).toHaveBeenCalledWith(
-      new Error('Failed to get current user.'),
-    );
+    expect(handle).toHaveBeenCalledWith(new Error('Failed to get current user.'));
   });
 });

--- a/src/frontend/js/components/UserLogin/index.tsx
+++ b/src/frontend/js/components/UserLogin/index.tsx
@@ -36,11 +36,7 @@ interface UserLoginProps {
   signupUrl: string;
 }
 
-export const UserLogin = ({
-  loginUrl,
-  logoutUrl,
-  signupUrl,
-}: UserLoginProps) => {
+export const UserLogin = ({ loginUrl, logoutUrl, signupUrl }: UserLoginProps) => {
   /**
    * `user` is:
    * - `undefined` when we have not made the `whoami` request yet;
@@ -83,16 +79,10 @@ export const UserLogin = ({
         </Spinner>
       ) : user === null ? (
         <React.Fragment>
-          <a
-            href={signupUrl}
-            className="user-login__btn user-login__btn--sign-up"
-          >
+          <a href={signupUrl} className="user-login__btn user-login__btn--sign-up">
             <FormattedMessage {...messages.signUp} />
           </a>
-          <a
-            href={loginUrl}
-            className="user-login__btn user-login__btn--log-in"
-          >
+          <a href={loginUrl} className="user-login__btn user-login__btn--log-in">
             <svg aria-hidden={true} role="img" className="icon">
               <use xlinkHref="#icon-login" />
             </svg>
@@ -102,10 +92,7 @@ export const UserLogin = ({
       ) : (
         <div className="user-login__logged">
           <div className="user-login__logged__name">{user.full_name}</div>{' '}
-          <a
-            href={logoutUrl}
-            className="user-login__btn user-login__btn--log-out"
-          >
+          <a href={logoutUrl} className="user-login__btn user-login__btn--log-out">
             <FormattedMessage {...messages.logOut} />
           </a>
         </div>

--- a/src/frontend/js/data/getResourceList/index.spec.ts
+++ b/src/frontend/js/data/getResourceList/index.spec.ts
@@ -29,8 +29,7 @@ describe('data/getResourceList', () => {
     languages: ['fr', 'es'],
     organizations: [11],
     session_number: 1,
-    short_description:
-      'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
+    short_description: 'Phasellus hendrerit tortor nulla, ut tristique ante aliquam sed.',
     start: '2018-03-01T06:00:00.000Z',
     title: 'Programming 101 in Python',
   };

--- a/src/frontend/js/data/getResourceList/index.ts
+++ b/src/frontend/js/data/getResourceList/index.ts
@@ -1,11 +1,7 @@
 import { stringify } from 'query-string';
 
 import { API_LIST_DEFAULT_PARAMS } from 'settings';
-import {
-  APICourseSearchResponse,
-  APIListRequestParams,
-  requestStatus,
-} from 'types/api';
+import { APICourseSearchResponse, APIListRequestParams, requestStatus } from 'types/api';
 
 export interface GetListSagaSpecifics {
   endpoint: string;
@@ -29,9 +25,7 @@ export async function fetchList(
 
     if (!response.ok) {
       // Push remote errors to the error channel for consistency
-      throw new Error(
-        `Failed to get list from ${kind} search : ${response.status}.`,
-      );
+      throw new Error(`Failed to get list from ${kind} search : ${response.status}.`);
     }
 
     const content = await response.json();

--- a/src/frontend/js/data/useCourseSearch/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearch/index.spec.tsx
@@ -27,9 +27,7 @@ describe('data/useCourseSearch', () => {
     let doResolve: (value: any) => void;
     const responseOne = new Promise((resolve) => (doResolve = resolve));
     mockFetchList.mockReturnValue(responseOne as any);
-    const { rerender } = render(
-      <TestComponent params={{ limit: '999', offset: '0' }} />,
-    );
+    const { rerender } = render(<TestComponent params={{ limit: '999', offset: '0' }} />);
 
     // Initial pass gets us a null value but issues the call
     expect(getLatestHookValue()).toEqual(null);
@@ -48,11 +46,7 @@ describe('data/useCourseSearch', () => {
     mockFetchList.mockReset();
     const responseTwo = new Promise((resolve) => (doResolve = resolve));
     mockFetchList.mockReturnValue(responseTwo as any);
-    rerender(
-      <TestComponent
-        params={{ limit: '999', offset: '0', organizations: ['43'] }}
-      />,
-    );
+    rerender(<TestComponent params={{ limit: '999', offset: '0', organizations: ['43'] }} />);
 
     // A new request is issued (meanwhile we still return the existing response)
     expect(getLatestHookValue()).toEqual('the response');

--- a/src/frontend/js/data/useCourseSearch/index.ts
+++ b/src/frontend/js/data/useCourseSearch/index.ts
@@ -6,9 +6,9 @@ import { useAsyncEffect } from 'utils/useAsyncEffect';
 import { fetchList, fetchListResponse } from '../getResourceList';
 
 export const useCourseSearch = (searchParams: APIListRequestParams) => {
-  const [courseSearchResponse, setCourseSearchResponse] = useState<
-    Nullable<fetchListResponse>
-  >(null);
+  const [courseSearchResponse, setCourseSearchResponse] = useState<Nullable<fetchListResponse>>(
+    null,
+  );
 
   useAsyncEffect(async () => {
     const response = await fetchList('courses', searchParams);

--- a/src/frontend/js/data/useCourseSearchParams/computeNewFilterValue.ts
+++ b/src/frontend/js/data/useCourseSearchParams/computeNewFilterValue.ts
@@ -7,9 +7,7 @@ import { CourseSearchParamsAction } from '.';
 export const computeNewFilterValue = (
   existingValue: Maybe<string | string[]>,
   update: {
-    action:
-      | CourseSearchParamsAction.filterAdd
-      | CourseSearchParamsAction.filterRemove;
+    action: CourseSearchParamsAction.filterAdd | CourseSearchParamsAction.filterRemove;
     isDrilldown: boolean;
     payload: string;
   },
@@ -23,9 +21,7 @@ export const computeNewFilterValue = (
       // - Keep it otherwise
       [CourseSearchParamsAction.filterRemove]: () =>
         // Drilldown filters only support one value at a time
-        existingValue === update.payload
-          ? undefined
-          : existingValue || undefined,
+        existingValue === update.payload ? undefined : existingValue || undefined,
     }[update.action]();
   }
 

--- a/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
@@ -27,9 +27,7 @@ describe('data/useCourseSearchParams', () => {
 
   beforeEach(() => {
     // Remove any keys added to the mockWindow location object, reset pathname to /search
-    Object.keys(mockWindow.location).forEach(
-      (key) => delete (mockWindow.location as any)[key],
-    );
+    Object.keys(mockWindow.location).forEach((key) => delete (mockWindow.location as any)[key]);
     mockWindow.location.pathname = '/search';
     jest.resetAllMocks();
   });
@@ -86,10 +84,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'fr',
           limit: '13',
@@ -143,10 +138,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'en',
           limit: '17',
@@ -194,18 +186,14 @@ describe('data/useCourseSearchParams', () => {
     });
 
     it('replaces the query on courseSearchParams & updates history', () => {
-      mockWindow.location.search =
-        '?languages=fr&limit=999&offset=0&query=some%20previous%20query';
+      mockWindow.location.search = '?languages=fr&limit=999&offset=0&query=some%20previous%20query';
       render(
         <HistoryProvider>
           <TestComponent />
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'fr',
           limit: '999',
@@ -254,18 +242,14 @@ describe('data/useCourseSearchParams', () => {
     });
 
     it('clears the query on courseSearchParams & updates query history', () => {
-      mockWindow.location.search =
-        '?languages=es&limit=999&offset=0&query=some%20existing%20query';
+      mockWindow.location.search = '?languages=es&limit=999&offset=0&query=some%20existing%20query';
       render(
         <HistoryProvider>
           <TestComponent />
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'es',
           limit: '999',
@@ -324,10 +308,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '10',
           offset: '999',
@@ -382,18 +363,14 @@ describe('data/useCourseSearchParams', () => {
     });
 
     it('adds to the existing list for non-MPTT-formatted filter value keys and resets pagination', () => {
-      mockWindow.location.search =
-        '?languages=en&languages=fr&offset=999&limit=10';
+      mockWindow.location.search = '?languages=en&languages=fr&offset=999&limit=10';
       render(
         <HistoryProvider>
           <TestComponent />
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: ['en', 'fr'],
           limit: '10',
@@ -448,18 +425,14 @@ describe('data/useCourseSearchParams', () => {
     });
 
     it('creates a list with the existing single value and the new value, resets pagination & updates history', () => {
-      mockWindow.location.search =
-        '?organizations=L-00010003&offset=999&limit=10';
+      mockWindow.location.search = '?organizations=L-00010003&offset=999&limit=10';
       render(
         <HistoryProvider>
           <TestComponent />
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '10',
           offset: '999',
@@ -521,10 +494,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           languages: 'de',
           limit: '10',
@@ -586,10 +556,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -654,10 +621,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -704,20 +668,13 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
           offset: '0',
           query: 'a query',
-          subjects: [
-            'L-0002000300050001',
-            'L-0002000300050004',
-            'P-000200030012',
-          ],
+          subjects: ['L-0002000300050001', 'L-0002000300050004', 'P-000200030012'],
         });
 
         act(() =>
@@ -784,10 +741,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -862,10 +816,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -939,10 +890,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           levels: 'L-000200020005',
           limit: '999',
@@ -1013,10 +961,7 @@ describe('data/useCourseSearchParams', () => {
       );
       {
         // Set a value where there was no value
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1126,10 +1071,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010001',
           limit: '999',
@@ -1171,10 +1113,7 @@ describe('data/useCourseSearchParams', () => {
       );
       {
         // Remove from a list of more than one value
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1289,10 +1228,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1355,10 +1291,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1397,10 +1330,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1433,18 +1363,14 @@ describe('data/useCourseSearchParams', () => {
     it('does nothing if the existing single value does not match the payload', () => {
       // This is a special case when there is a single value not wrapper in an array after it was
       // just parsed and not interacted with yet.
-      mockWindow.location.search =
-        '?limit=999&offset=0&organizations=L-00010011';
+      mockWindow.location.search = '?limit=999&offset=0&organizations=L-00010011';
       render(
         <HistoryProvider>
           <TestComponent />
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1477,18 +1403,14 @@ describe('data/useCourseSearchParams', () => {
 
   describe('FILTER_REMOVE [drilldown]', () => {
     it('removes the value from the filter', () => {
-      mockWindow.location.search =
-        '?level=L-000200010001&limit=999&offset=0&query=some%20query';
+      mockWindow.location.search = '?level=L-000200010001&limit=999&offset=0&query=some%20query';
       render(
         <HistoryProvider>
           <TestComponent />
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010001',
           limit: '999',
@@ -1544,18 +1466,14 @@ describe('data/useCourseSearchParams', () => {
     });
 
     it('does nothing if the value to remove was not the existing value', () => {
-      mockWindow.location.search =
-        '?level=L-000200010001&limit=999&offset=0&query=some%20query';
+      mockWindow.location.search = '?level=L-000200010001&limit=999&offset=0&query=some%20query';
       render(
         <HistoryProvider>
           <TestComponent />
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           level: 'L-000200010001',
           limit: '999',
@@ -1596,10 +1514,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '999',
           offset: '0',
@@ -1642,10 +1557,7 @@ describe('data/useCourseSearchParams', () => {
         </HistoryProvider>,
       );
       {
-        const {
-          courseSearchParams,
-          dispatchCourseSearchParamsUpdate,
-        } = getLatestHookValues();
+        const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
         expect(courseSearchParams).toEqual({
           limit: '27',
           offset: '54',
@@ -1692,10 +1604,7 @@ describe('data/useCourseSearchParams', () => {
       </HistoryProvider>,
     );
     {
-      const {
-        courseSearchParams,
-        dispatchCourseSearchParamsUpdate,
-      } = getLatestHookValues();
+      const { courseSearchParams, dispatchCourseSearchParamsUpdate } = getLatestHookValues();
       expect(courseSearchParams).toEqual({
         limit: '20',
         offset: '0',

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -24,9 +24,7 @@ interface FilterResetAction {
 interface FilterSingleAction {
   filter: FilterDefinition;
   payload: string;
-  type:
-    | CourseSearchParamsAction.filterAdd
-    | CourseSearchParamsAction.filterRemove;
+  type: CourseSearchParamsAction.filterAdd | CourseSearchParamsAction.filterRemove;
 }
 
 interface PageChangeAction {
@@ -47,9 +45,7 @@ type CourseSearchParamsReducerAction =
 
 type CourseSearchParamsState = {
   courseSearchParams: APIListRequestParams;
-  dispatchCourseSearchParamsUpdate: (
-    ...Actions: CourseSearchParamsReducerAction[]
-  ) => void;
+  dispatchCourseSearchParamsUpdate: (...Actions: CourseSearchParamsReducerAction[]) => void;
   lastDispatchActions: Maybe<CourseSearchParamsReducerAction[]>;
 };
 
@@ -80,14 +76,11 @@ const courseSearchParamsReducer = (
         ...courseSearchParams,
         // Go back to page 1 when the query changes
         offset: '0',
-        [action.filter.name]: computeNewFilterValue(
-          courseSearchParams[action.filter.name],
-          {
-            action: action.type,
-            isDrilldown: !!action.filter.is_drilldown,
-            payload: action.payload,
-          },
-        ),
+        [action.filter.name]: computeNewFilterValue(courseSearchParams[action.filter.name], {
+          action: action.type,
+          isDrilldown: !!action.filter.is_drilldown,
+          payload: action.payload,
+        }),
       };
 
     case CourseSearchParamsAction.filterReset:
@@ -105,8 +98,7 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
   const [historyEntry, pushState, replaceState] = useContext(HistoryContext);
 
   // HistoryEntry.state includes parse query strings, which if we're on a search page should be course search params
-  const courseSearchParams: APIListRequestParams =
-    historyEntry.state.data.params;
+  const courseSearchParams: APIListRequestParams = historyEntry.state.data.params;
 
   // The dispatch + reducer pattern is useful to model changes in the course search params. However, we don't want
   // to duplicate behavior by having to sync the HistoryContext state with a `useReducer` call here.
@@ -114,10 +106,7 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
   const dispatch = (...actions: CourseSearchParamsReducerAction[]) => {
     // In some scenarios, we want to dispatch more than one action and only effect one actual history state change.
     // This is useful to eg. clean up the text query and add a filter the user selected through autosuggest.
-    const newParams = actions.reduce(
-      courseSearchParamsReducer,
-      courseSearchParams,
-    );
+    const newParams = actions.reduce(courseSearchParamsReducer, courseSearchParams);
     // We should only update the history if the params have actually changed
     // We're using `stringify(parse(location.search))` as a way to reorder location search to the same order
     // `stringify` would output for our courseSearchParams. This allows us to avoid doing a deep comparison on

--- a/src/frontend/js/data/useFilterValue/index.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/index.spec.tsx
@@ -39,9 +39,7 @@ describe('data/useFilterValue', () => {
 
   it('returns the active [false] status of the filter value and a function to toggle it', () => {
     render(
-      <HistoryContext.Provider
-        value={makeHistoryOf({ limit: '999', offset: '0' })}
-      >
+      <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
         <TestComponent
           filter={{
             base_path: '0003',

--- a/src/frontend/js/data/useFilterValue/index.ts
+++ b/src/frontend/js/data/useFilterValue/index.ts
@@ -1,7 +1,4 @@
-import {
-  CourseSearchParamsAction,
-  useCourseSearchParams,
-} from 'data/useCourseSearchParams';
+import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 
 type UseFilterValue = [boolean, () => void];
@@ -10,10 +7,7 @@ export const useFilterValue = (
   filter: FacetedFilterDefinition,
   value: FilterValue,
 ): UseFilterValue => {
-  const {
-    courseSearchParams,
-    dispatchCourseSearchParamsUpdate,
-  } = useCourseSearchParams();
+  const { courseSearchParams, dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
 
   const isActive = (courseSearchParams[filter.name] || []).includes(value.key);
 
@@ -21,9 +15,7 @@ export const useFilterValue = (
     dispatchCourseSearchParamsUpdate({
       filter,
       payload: value.key,
-      type: isActive
-        ? CourseSearchParamsAction.filterRemove
-        : CourseSearchParamsAction.filterAdd,
+      type: isActive ? CourseSearchParamsAction.filterRemove : CourseSearchParamsAction.filterAdd,
     });
 
   return [isActive, toggle];

--- a/src/frontend/js/data/useHistory/index.tsx
+++ b/src/frontend/js/data/useHistory/index.tsx
@@ -1,11 +1,5 @@
 import { parse } from 'query-string';
-import React, {
-  createContext,
-  PropsWithChildren,
-  useEffect,
-  useState,
-  useContext,
-} from 'react';
+import React, { createContext, PropsWithChildren, useEffect, useState, useContext } from 'react';
 
 import { history, location } from 'utils/indirection/window';
 import { Maybe, Nullable } from 'utils/types';
@@ -19,10 +13,7 @@ interface HistoryEntry {
 type pushStateFn = typeof history.pushState;
 type replaceStateFn = typeof history.replaceState;
 
-type popstateEventListener = (
-  this: Window,
-  ev: WindowEventMap['popstate'],
-) => any;
+type popstateEventListener = (this: Window, ev: WindowEventMap['popstate']) => any;
 
 export type History = [HistoryEntry, pushStateFn, replaceStateFn];
 
@@ -34,11 +25,7 @@ export const useHistory = () => {
 
 export const HistoryProvider = ({ children }: PropsWithChildren<{}>) => {
   const historyValue = useProvideHistory();
-  return (
-    <HistoryContext.Provider value={historyValue}>
-      {children}
-    </HistoryContext.Provider>
-  );
+  return <HistoryContext.Provider value={historyValue}>{children}</HistoryContext.Provider>;
 };
 
 const useProvideHistory: () => History = () => {

--- a/src/frontend/js/data/useStaticFilters/index.spec.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.spec.tsx
@@ -79,10 +79,7 @@ describe('data/useStaticFilters', () => {
     expect(filters).toEqual(staticFilterDefinitions);
     expect(fetchMock.calls('/api/v1.0/filter-definitions/').length).toEqual(1);
     fetchMock.restore();
-    fetchMock.get(
-      '/api/v1.0/filter-definitions/',
-      new Error('should not be called'),
-    );
+    fetchMock.get('/api/v1.0/filter-definitions/', new Error('should not be called'));
     // More calls return the filter but don't request on the API again
     let filtersAgain;
     await act(async () => (filtersAgain = await getLatestHookValues()()));

--- a/src/frontend/js/data/useStaticFilters/index.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.tsx
@@ -24,9 +24,7 @@ const coursesConfig: FilterDefinition = {
 export const useStaticFilters = (includeCoursesConfig = false) => {
   const [needsFilters, setNeedsFilters] = useState(false);
 
-  const filtersResolver = useRef<
-    Nullable<(filters: StaticFilterDefinitions) => void>
-  >(null);
+  const filtersResolver = useRef<Nullable<(filters: StaticFilterDefinitions) => void>>(null);
   const [filtersPromise] = useState<Promise<StaticFilterDefinitions>>(
     () => new Promise((resolve) => (filtersResolver.current = resolve)),
   );

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -21,9 +21,7 @@ import { handle } from 'utils/errors/handle';
 // Wait for the DOM to load before we scour it for an element that requires React to be rendered
 document.addEventListener('DOMContentLoaded', async (event) => {
   // Find all the elements that need React to render a component
-  const richieReactSpots = Array.prototype.slice.call(
-    document.querySelectorAll('.richie-react'),
-  );
+  const richieReactSpots = Array.prototype.slice.call(document.querySelectorAll('.richie-react'));
 
   // Only move on with anything if there are actually components to render
   if (richieReactSpots.length) {
@@ -31,9 +29,7 @@ document.addEventListener('DOMContentLoaded', async (event) => {
     const locale = document.querySelector('html')!.getAttribute('lang');
 
     if (!locale) {
-      throw new Error(
-        '<html> lang attribute is required to be set with a BCP47/RFC5646 locale.',
-      );
+      throw new Error('<html> lang attribute is required to be set with a BCP47/RFC5646 locale.');
     }
 
     // Polyfill outdated browsers who do not have Node.prototype.append
@@ -64,9 +60,7 @@ document.addEventListener('DOMContentLoaded', async (event) => {
           languageCode = locale.split('_')[0];
         }
         // Get `react-intl`/`formatjs` lang specific parameters and data
-        await import(
-          `@formatjs/intl-relativetimeformat/locale-data/${languageCode}`
-        );
+        await import(`@formatjs/intl-relativetimeformat/locale-data/${languageCode}`);
       }
     } catch (e) {
       handle(e);
@@ -84,9 +78,7 @@ document.addEventListener('DOMContentLoaded', async (event) => {
       // to the console so Richie users who provide their own 'en-US' strings are warned if they are not loaded.
       if (locale === 'en-US') {
         // tslint:disable:no-console
-        console.log(
-          'No localization file found for default en-US locale, using default messages.',
-        );
+        console.log('No localization file found for default en-US locale, using default messages.');
       } else {
         handle(e);
       }

--- a/src/frontend/js/types/Suggestion.ts
+++ b/src/frontend/js/types/Suggestion.ts
@@ -28,9 +28,7 @@ interface CourseSuggestion extends GenericSuggestion {
 /**
  * We also need a way to help TypeScript discriminate between CourseSuggestions and GenericSuggestions
  */
-export function isCourseSuggestion(
-  suggestion: Suggestion<string>,
-): suggestion is CourseSuggestion {
+export function isCourseSuggestion(suggestion: Suggestion<string>): suggestion is CourseSuggestion {
   return suggestion.kind === 'courses';
 }
 
@@ -75,18 +73,14 @@ interface DefaultSuggestionSection {
  * Utility type that allows a consumer to easily define the kinds of suggestion sections it supports and
  * get proper typechecking around them.
  */
-export type SuggestionSection<
-  S extends Suggestion<string>
-> = S extends DefaultSuggestion
+export type SuggestionSection<S extends Suggestion<string>> = S extends DefaultSuggestion
   ? DefaultSuggestionSection
   : ResourceSuggestionSection<GenericSuggestion>;
 
 /**
  * Define the kind of suggestions our `<SearchSuggestField />` and `<RootSearchSuggestField />` components support.
  */
-export type SearchSuggestion = Suggestion<
-  'categories' | 'courses' | 'organizations' | 'persons'
->;
+export type SearchSuggestion = Suggestion<'categories' | 'courses' | 'organizations' | 'persons'>;
 
 /**
  * Derive from `SearchSuggestion` the kind of suggestion sections our `<SearchSuggestField />` and
@@ -98,7 +92,4 @@ export type SearchSuggestionSection = SuggestionSection<SearchSuggestion>;
  * Helper to typecheck `react-autosuggest` expected props. Defines what is acceptable as a suggestion
  * throughout our code related to this instance of `<Autosuggest />`.
  */
-export type SearchAutosuggestProps = AutosuggestProps<
-  SearchSuggestion,
-  SearchSuggestionSection
->;
+export type SearchAutosuggestProps = AutosuggestProps<SearchSuggestion, SearchSuggestionSection>;

--- a/src/frontend/js/utils/errors/handle.ts
+++ b/src/frontend/js/utils/errors/handle.ts
@@ -2,8 +2,7 @@ import * as Sentry from '@sentry/browser';
 
 import { CommonDataProps } from 'types/commonDataProps';
 
-const context: CommonDataProps['context'] = (window as any)
-  .__richie_frontend_context__;
+const context: CommonDataProps['context'] = (window as any).__richie_frontend_context__;
 
 if (context && context.sentry_dsn) {
   Sentry.init({

--- a/src/frontend/js/utils/mptt/index.spec.ts
+++ b/src/frontend/js/utils/mptt/index.spec.ts
@@ -20,9 +20,7 @@ describe('utils/mptt', () => {
 
     it('returns true when both args are MPTT paths and x is a parent of y', () => {
       expect(isMPTTParentOf('P-00020004', 'L-000200040003')).toEqual(true);
-      expect(isMPTTParentOf('P-00020004', 'L-000200040003000C0009')).toEqual(
-        true,
-      );
+      expect(isMPTTParentOf('P-00020004', 'L-000200040003000C0009')).toEqual(true);
     });
   });
 
@@ -34,12 +32,8 @@ describe('utils/mptt', () => {
 
     it('returns a regex-string that will match paths for children of the passed MPTT path entity', () => {
       expect(getMPTTChildrenPathMatcher('P-0001')).toEqual('.-0001.{4,}');
-      expect(getMPTTChildrenPathMatcher('L-0001000C')).toEqual(
-        '.-0001000C.{4,}',
-      );
-      expect(getMPTTChildrenPathMatcher('P-000100090006000C')).toEqual(
-        '.-000100090006000C.{4,}',
-      );
+      expect(getMPTTChildrenPathMatcher('L-0001000C')).toEqual('.-0001000C.{4,}');
+      expect(getMPTTChildrenPathMatcher('P-000100090006000C')).toEqual('.-000100090006000C.{4,}');
     });
   });
 });

--- a/src/frontend/js/utils/mptt/index.ts
+++ b/src/frontend/js/utils/mptt/index.ts
@@ -33,9 +33,7 @@ export const isMPTTChildOf = (childKey: string, parentKey: string) =>
  */
 export const getMPTTChildrenPathMatcher = (parentMPTTPath: string) => {
   if (!isMPTTPath(parentMPTTPath)) {
-    throw new Error(
-      `${parentMPTTPath} is not an MPTT path, cannot build a children path matcher.`,
-    );
+    throw new Error(`${parentMPTTPath} is not an MPTT path, cannot build a children path matcher.`);
   }
 
   return `.-${parentMPTTPath.substr(2)}.{4,}`;

--- a/src/frontend/js/utils/types.ts
+++ b/src/frontend/js/utils/types.ts
@@ -1,7 +1,4 @@
-export type jestMockOf<T extends (...args: any[]) => any> = jest.Mock<
-  ReturnType<T>,
-  Parameters<T>
->;
+export type jestMockOf<T extends (...args: any[]) => any> = jest.Mock<ReturnType<T>, Parameters<T>>;
 
 export type Maybe<T> = T | undefined;
 

--- a/src/frontend/scss/components/_styleguide.scss
+++ b/src/frontend/scss/components/_styleguide.scss
@@ -5,11 +5,7 @@
 // Draw a background grid in pure CSS
 @mixin draw-grid($line-color: null, $border-color: null) {
   @if $line-color {
-    background: linear-gradient(
-        -90deg,
-        $line-color $onepixel,
-        transparent $onepixel
-      ),
+    background: linear-gradient(-90deg, $line-color $onepixel, transparent $onepixel),
       linear-gradient($line-color $onepixel, transparent $onepixel),
       linear-gradient(-90deg, $line-color $onepixel, transparent $onepixel),
       linear-gradient($line-color $onepixel, transparent $onepixel),
@@ -29,9 +25,8 @@
       ),
       linear-gradient(transparent $onepixel, transparent $onepixel), transparent;
   }
-  background-size: 0.625rem 0.625rem, 0.625rem 0.625rem, 0.625rem 0.625rem,
-    0.625rem 0.625rem, 0.625rem 0.625rem, 0.625rem 0.625rem, 0.625rem 0.625rem,
-    0.625rem 0.625rem;
+  background-size: 0.625rem 0.625rem, 0.625rem 0.625rem, 0.625rem 0.625rem, 0.625rem 0.625rem,
+    0.625rem 0.625rem, 0.625rem 0.625rem, 0.625rem 0.625rem, 0.625rem 0.625rem;
   @if $border-color {
     border: $onepixel solid $border-color;
   }

--- a/src/frontend/scss/components/templates/courses/cms/_blogpost_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_blogpost_detail.scss
@@ -58,10 +58,7 @@
         padding-right: 0.5rem;
         display: inline-block;
         color: r-theme-val(blogpost-detail, aside-glimpse-title-color);
-        background: r-theme-val(
-          blogpost-detail,
-          aside-glimpse-title-background
-        );
+        background: r-theme-val(blogpost-detail, aside-glimpse-title-background);
         z-index: 4;
       }
 
@@ -73,9 +70,7 @@
           left: 0;
           right: 0;
           display: block;
-          border-bottom: 0.625rem
-            solid
-            r-theme-val(blogpost-detail, aside-glimpse-title-border);
+          border-bottom: 0.625rem solid r-theme-val(blogpost-detail, aside-glimpse-title-border);
           z-index: 3;
         }
       }
@@ -171,9 +166,7 @@
         top: 50%;
         left: 0;
         width: 0.8rem;
-        border-top: $onepixel
-          solid
-          r-theme-val(blogpost-detail, pubdate-border);
+        border-top: $onepixel solid r-theme-val(blogpost-detail, pubdate-border);
 
         @include media-breakpoint-up(lg) {
           width: 1.5rem;
@@ -198,9 +191,7 @@
         top: 50%;
         left: 0;
         width: 1.5rem;
-        border-top: $onepixel
-          solid
-          r-theme-val(blogpost-detail, authors-border);
+        border-top: $onepixel solid r-theme-val(blogpost-detail, authors-border);
       }
     }
   }

--- a/src/frontend/scss/components/templates/courses/cms/_category_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_category_detail.scss
@@ -43,9 +43,7 @@ $richie-category-detail-banner-logo-sizing-xl: 25rem !default;
       object-position: center;
     }
 
-    @include m-o-media_empty(
-      $background: r-theme-val(category-detail, empty-background)
-    );
+    @include m-o-media_empty($background: r-theme-val(category-detail, empty-background));
 
     // Insert decoration over banner bottom
     @if r-theme-val(category-detail, insert-background-image) {

--- a/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -66,9 +66,7 @@
         @include font-size($h3-font-size);
         padding-bottom: 1rem;
         @if r-theme-val(course-detail, aside-title-border) {
-          border-bottom: $onepixel
-            solid
-            r-theme-val(course-detail, aside-title-border);
+          border-bottom: $onepixel solid r-theme-val(course-detail, aside-title-border);
         }
       }
     }
@@ -128,9 +126,7 @@
           display: block;
           width: 60%;
           margin: 2rem auto;
-          border-top: $onepixel
-            solid
-            r-theme-val(course-detail, run-descriptions-divider);
+          border-top: $onepixel solid r-theme-val(course-detail, run-descriptions-divider);
         }
       }
     }
@@ -208,10 +204,7 @@
             left: 0;
             width: 0.8rem;
             height: 0.8rem;
-            background-image: r-theme-val(
-              course-detail,
-              checkmark-list-decoration
-            );
+            background-image: r-theme-val(course-detail, checkmark-list-decoration);
             background-repeat: no-repeat;
             background-position: top left;
             background-size: 100% 100%;

--- a/src/frontend/scss/components/templates/courses/cms/_homepage.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_homepage.scss
@@ -28,11 +28,7 @@
     .course-glimpse {
       &:nth-child(-n + 3) {
         @include media-breakpoint-up(lg) {
-          @include sv-flex(
-            1,
-            0,
-            calc(33.3333% - #{$r-course-glimpse-gutter * 2})
-          );
+          @include sv-flex(1, 0, calc(33.3333% - #{$r-course-glimpse-gutter * 2}));
         }
       }
     }

--- a/src/frontend/scss/components/templates/courses/cms/_organization_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_organization_detail.scss
@@ -55,10 +55,7 @@
         bottom: -0.05rem;
         left: 0;
         right: 0;
-        background-image: r-theme-val(
-          organization-detail,
-          insert-background-image
-        );
+        background-image: r-theme-val(organization-detail, insert-background-image);
         background-repeat: no-repeat;
         background-position: top left;
         background-size: 100% 100%;

--- a/src/frontend/scss/components/templates/richie/nesteditem/_nesteditem.scss
+++ b/src/frontend/scss/components/templates/richie/nesteditem/_nesteditem.scss
@@ -102,9 +102,7 @@
                 left: -1.5rem;
                 bottom: 0;
                 width: $accordion-border-size;
-                border-left: $accordion-border-size
-                  solid
-                  $accordion-border-color;
+                border-left: $accordion-border-size solid $accordion-border-color;
               }
             }
           }

--- a/src/frontend/scss/components/templates/search/_search.scss
+++ b/src/frontend/scss/components/templates/search/_search.scss
@@ -166,11 +166,7 @@ $r-search-filters-width: 15rem !default;
         @include sv-flex(1, 0, calc(50% - #{$r-course-glimpse-gutter * 2}));
       }
       @include media-breakpoint-up(lg) {
-        @include sv-flex(
-          1,
-          0,
-          calc(33.3333% - #{$r-course-glimpse-gutter * 2})
-        );
+        @include sv-flex(1, 0, calc(33.3333% - #{$r-course-glimpse-gutter * 2}));
       }
     }
   }

--- a/src/frontend/scss/objects/_blogpost_glimpses.scss
+++ b/src/frontend/scss/objects/_blogpost_glimpses.scss
@@ -280,10 +280,7 @@ $glimpse-gutter: 0.6rem;
 
   &__cta {
     @include button-base($font-weight: bold);
-    @include r-button-colors(
-      r-theme-val(blogpost-glimpse-favorite, cta),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(blogpost-glimpse-favorite, cta), $apply-border: true);
     text-transform: uppercase;
 
     &:hover {

--- a/src/frontend/scss/objects/_buttons.scss
+++ b/src/frontend/scss/objects/_buttons.scss
@@ -68,11 +68,7 @@
         @include r-button-colors($scheme, $apply-border: true);
 
         &:hover {
-          @include r-button-colors(
-            $scheme,
-            $apply-border: true,
-            $prefix: 'hover'
-          );
+          @include r-button-colors($scheme, $apply-border: true, $prefix: 'hover');
         }
       }
       // Enforce colors opposed to avoid framework 'disabled'
@@ -93,10 +89,7 @@
   a {
     @include sv-flex(0, 1, auto);
     @include button-base($font-weight: bold);
-    @include r-button-colors(
-      r-theme-val(button-caesura, base),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(button-caesura, base), $apply-border: true);
     display: block;
     text-transform: uppercase;
 

--- a/src/frontend/scss/objects/_category_glimpses.scss
+++ b/src/frontend/scss/objects/_category_glimpses.scss
@@ -129,23 +129,14 @@
 
   // When using through a color scheme, adopts its colors
   &--primary {
-    @include r-button-colors(
-      r-theme-val(category-tags, primary-item),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(category-tags, primary-item), $apply-border: true);
   }
   &--secondary {
-    @include r-button-colors(
-      r-theme-val(category-tags, secondary-item),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(category-tags, secondary-item), $apply-border: true);
   }
 
   &--tertiary {
-    @include r-button-colors(
-      r-theme-val(category-tags, tertiary-item),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(category-tags, tertiary-item), $apply-border: true);
   }
 }
 
@@ -179,26 +170,17 @@
   // When using through a color scheme, adopts its colors
   &--primary {
     .category-tag {
-      @include r-button-colors(
-        r-theme-val(category-tags, primary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(category-tags, primary-item), $apply-border: true);
     }
   }
   &--secondary {
     .category-tag {
-      @include r-button-colors(
-        r-theme-val(category-tags, secondary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(category-tags, secondary-item), $apply-border: true);
     }
   }
   &--tertiary {
     .category-tag {
-      @include r-button-colors(
-        r-theme-val(category-tags, tertiary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(category-tags, tertiary-item), $apply-border: true);
     }
   }
 }
@@ -232,23 +214,14 @@
 
   // When using through a color scheme, adopts its colors
   &--primary {
-    @include r-button-colors(
-      r-theme-val(category-badges, primary-item),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(category-badges, primary-item), $apply-border: true);
   }
   &--secondary {
-    @include r-button-colors(
-      r-theme-val(category-badges, secondary-item),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(category-badges, secondary-item), $apply-border: true);
   }
 
   &--tertiary {
-    @include r-button-colors(
-      r-theme-val(category-badges, tertiary-item),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(category-badges, tertiary-item), $apply-border: true);
   }
 }
 
@@ -288,26 +261,17 @@
   // When using through a color scheme, adopts its colors
   &--primary {
     .category-badge {
-      @include r-button-colors(
-        r-theme-val(category-badges, primary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(category-badges, primary-item), $apply-border: true);
     }
   }
   &--secondary {
     .category-badge {
-      @include r-button-colors(
-        r-theme-val(category-badges, secondary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(category-badges, secondary-item), $apply-border: true);
     }
   }
   &--tertiary {
     .category-badge {
-      @include r-button-colors(
-        r-theme-val(category-badges, tertiary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(category-badges, tertiary-item), $apply-border: true);
     }
   }
 }

--- a/src/frontend/scss/objects/_characteristics.scss
+++ b/src/frontend/scss/objects/_characteristics.scss
@@ -26,30 +26,21 @@
   &--primary {
     .characteristics__item {
       @include button-tiny($form-factor: 'pill', $display: flex);
-      @include r-button-colors(
-        r-theme-val(characteristics, primary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(characteristics, primary-item), $apply-border: true);
     }
   }
 
   &--secondary {
     .characteristics__item {
       @include button-tiny($form-factor: 'pill', $display: flex);
-      @include r-button-colors(
-        r-theme-val(characteristics, secondary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(characteristics, secondary-item), $apply-border: true);
     }
   }
 
   &--tertiary {
     .characteristics__item {
       @include button-tiny($form-factor: 'pill', $display: flex);
-      @include r-button-colors(
-        r-theme-val(characteristics, tertiary-item),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(characteristics, tertiary-item), $apply-border: true);
     }
   }
 }

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -185,8 +185,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     @include m-o-media_empty(
       $width: 100%,
       $height: 16vh,
-      $background:
-        r-theme-val(course-glimpse, organization-media-empty-background),
+      $background: r-theme-val(course-glimpse, organization-media-empty-background),
       $absolute: false
     );
   }
@@ -208,10 +207,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
 }
 
 .course-glimpse-footer {
-  @include r-button-colors(
-    r-theme-val(course-glimpse, footer),
-    $apply-border: true
-  );
+  @include r-button-colors(r-theme-val(course-glimpse, footer), $apply-border: true);
   display: flex;
   padding: 0 $course-glimpse-content-padding-sides;
   border-bottom-left-radius: $border-radius-lg;

--- a/src/frontend/scss/objects/_organization_glimpses.scss
+++ b/src/frontend/scss/objects/_organization_glimpses.scss
@@ -82,9 +82,7 @@
       object-position: center;
     }
 
-    @include m-o-media_empty(
-      $background: r-theme-val(organization-glimpse, logo-empty-background)
-    );
+    @include m-o-media_empty($background: r-theme-val(organization-glimpse, logo-empty-background));
   }
 
   // Default form factor just display org's logo
@@ -149,9 +147,7 @@
       object-position: center;
     }
 
-    @include m-o-media_empty(
-      $background: r-theme-val(organization-glimpse, logo-empty-background)
-    );
+    @include m-o-media_empty($background: r-theme-val(organization-glimpse, logo-empty-background));
   }
 
   // Default form factor just display org's logo
@@ -217,9 +213,7 @@
       object-position: unset;
     }
 
-    @include m-o-media_empty(
-      $background: r-theme-val(organization-glimpse, logo-empty-background)
-    );
+    @include m-o-media_empty($background: r-theme-val(organization-glimpse, logo-empty-background));
   }
 
   &__content {

--- a/src/frontend/scss/objects/_person_glimpses.scss
+++ b/src/frontend/scss/objects/_person_glimpses.scss
@@ -88,10 +88,7 @@
 
     .category-tag {
       @include button-tiny($form-factor: 'pill');
-      @include r-button-colors(
-        r-theme-val(person-glimpse, category),
-        $apply-border: true
-      );
+      @include r-button-colors(r-theme-val(person-glimpse, category), $apply-border: true);
       max-width: 100%;
       display: flex;
       align-items: center;

--- a/src/frontend/scss/objects/_program_glimpses.scss
+++ b/src/frontend/scss/objects/_program_glimpses.scss
@@ -93,10 +93,7 @@ $r-program-glimpse-gutter: 0.8rem !default;
   );
 
   &__footer {
-    @include r-button-colors(
-      r-theme-val(program-glimpse, footer),
-      $apply-border: true
-    );
+    @include r-button-colors(r-theme-val(program-glimpse, footer), $apply-border: true);
     display: flex;
     padding: 0 0.5rem;
     font-size: 0.8rem;
@@ -143,9 +140,7 @@ $r-program-glimpse-gutter: 0.8rem !default;
     @if r-theme-val(program-glimpse-empty, hover-border) {
       &:hover,
       &:focus {
-        border: $onepixel
-          solid
-          r-theme-val(program-glimpse-empty, hover-border);
+        border: $onepixel solid r-theme-val(program-glimpse-empty, hover-border);
       }
     }
   }

--- a/src/frontend/scss/objects/_search-filter-value.scss
+++ b/src/frontend/scss/objects/_search-filter-value.scss
@@ -47,8 +47,7 @@
 // Most active styles are done on the filter button itself (which is the component itself for leaves
 // and an inner part for parents)
 .search-filter-value-leaf.active,
-.search-filter-value-parent__self.active
-  > .search-filter-value-parent__self__label {
+.search-filter-value-parent__self.active > .search-filter-value-parent__self__label {
   z-index: 2; // Place active items above their siblings for proper border styling
   color: r-theme-val(search-filters-value, active-color);
 }
@@ -60,16 +59,12 @@
   padding: 0.4rem 0.5rem;
   font-size: 1rem;
   @if r-theme-val(search-filters-value, base-border) {
-    border-bottom: $onepixel
-      solid
-      r-theme-val(search-filters-value, base-border);
+    border-bottom: $onepixel solid r-theme-val(search-filters-value, base-border);
   }
 
   &.active {
     @if r-theme-val(search-filters-value, hover-border) {
-      border-bottom: $onepixel
-        solid
-        r-theme-val(search-filters-value, hover-border);
+      border-bottom: $onepixel solid r-theme-val(search-filters-value, hover-border);
     }
   }
 }

--- a/src/frontend/scss/settings/_colors.scss
+++ b/src/frontend/scss/settings/_colors.scss
@@ -34,16 +34,8 @@ $neutral-gradient: linear-gradient(
   r-color('white') 14rem,
   r-color('white')
 );
-$middle-gradient: linear-gradient(
-  285deg,
-  r-color('grey59') 3%,
-  r-color('grey87') 98%
-);
-$dark-gradient: linear-gradient(
-  285deg,
-  r-color('grey32') 3%,
-  r-color('grey59') 98%
-);
+$middle-gradient: linear-gradient(285deg, r-color('grey59') 3%, r-color('grey87') 98%);
+$dark-gradient: linear-gradient(285deg, r-color('grey32') 3%, r-color('grey59') 98%);
 $white-mask-gradient: (
   linear-gradient(
     to right,
@@ -299,8 +291,7 @@ $r-theme: (
     base-shadow: r-color('black'),
   ),
   hero-intro: (
-    insert-background-image:
-      url('../../richie/images/components/wave-white.svg'),
+    insert-background-image: url('../../richie/images/components/wave-white.svg'),
     inner-background: $white-mask-gradient,
     title-color: r-color('firebrick6'),
     title-alt-color: r-color('charcoal'),
@@ -489,8 +480,7 @@ $r-theme: (
   ),
   category-detail: (
     empty-background: r-color('smoke'),
-    insert-background-image:
-      url('../../richie/images/components/wave-white.svg'),
+    insert-background-image: url('../../richie/images/components/wave-white.svg'),
     logo-background: r-color('white'),
     logo-border: r-color('light-grey'),
     logo-shadow: 0 0.25rem 1.5625rem r-color('slate-grey'),
@@ -507,13 +497,11 @@ $r-theme: (
     run-descriptions-divider: r-color('light-grey'),
     plan-title-color: r-color('firebrick6'),
     license-label-color: r-color('denim'),
-    checkmark-list-decoration:
-      url('../../richie/images/components/checkmark.svg'),
+    checkmark-list-decoration: url('../../richie/images/components/checkmark.svg'),
   ),
   organization-detail: (
     banner-empty-background: r-color('smoke'),
-    insert-background-image:
-      url('../../richie/images/components/wave-white.svg'),
+    insert-background-image: url('../../richie/images/components/wave-white.svg'),
     logo-border: r-color('light-grey'),
     logo-shadow: 0 0.25rem 1.5625rem r-color('slate-grey'),
     intro-title: r-color('firebrick6'),

--- a/src/frontend/scss/tools/_buttons.scss
+++ b/src/frontend/scss/tools/_buttons.scss
@@ -48,13 +48,7 @@
   user-select: none;
   background-color: transparent;
   border: $border-width solid transparent;
-  @include button-size(
-    $padding-y,
-    $padding-x,
-    $font-size,
-    $line-height,
-    $patched-radius
-  );
+  @include button-size($padding-y, $padding-x, $font-size, $line-height, $patched-radius);
   @include transition($transition);
 
   // Apply non default form factor radius behaviors

--- a/src/frontend/scss/tools/_colors.scss
+++ b/src/frontend/scss/tools/_colors.scss
@@ -120,10 +120,7 @@
       @error "A scheme color must define the background item";
     } @else if
       (
-        map-get($scheme, 'background') ==
-          transparent or
-          map-get($scheme, 'background') ==
-          inherit
+        map-get($scheme, 'background') == transparent or map-get($scheme, 'background') == inherit
       ) and
       map-get($scheme, 'font-color') ==
       null
@@ -214,12 +211,7 @@
 ///   If set to `true`, border properties for prefix "hover" will be
 ///   automatically added.
 ///
-@mixin r-button-colors(
-  $scheme,
-  $apply-border: false,
-  $prefix: null,
-  $include-hover: false
-) {
+@mixin r-button-colors($scheme, $apply-border: false, $prefix: null, $include-hover: false) {
   $props-prefix: '';
 
   @if $prefix {
@@ -251,11 +243,7 @@
 
   @if $include-hover {
     &:hover {
-      @include r-button-colors(
-        $scheme,
-        $apply-border: $apply-border,
-        $prefix: 'hover'
-      );
+      @include r-button-colors($scheme, $apply-border: $apply-border, $prefix: 'hover');
     }
   }
 }

--- a/src/frontend/scss/tools/_shapes.scss
+++ b/src/frontend/scss/tools/_shapes.scss
@@ -17,12 +17,7 @@
 //   triangle. Position is determined from peak direction such as "up"
 //   direction means positionnate triangle at bottom, "left" means triangle
 //   at right, etc..
-@mixin m-o-triangle(
-  $triangle-size,
-  $triangle-color,
-  $triangle-direction,
-  $absolute
-) {
+@mixin m-o-triangle($triangle-size, $triangle-color, $triangle-direction, $absolute) {
   display: block;
   width: 0;
   height: 0;

--- a/src/frontend/webpack.config.js
+++ b/src/frontend/webpack.config.js
@@ -31,8 +31,7 @@ const babelCompileDeps = [
 let version;
 // Get it from the dependent's version first (if there is one)
 if (argv.richieDependentBuild) {
-  version = require(path.resolve(__dirname, '..', '..', 'package.json'))
-    .version;
+  version = require(path.resolve(__dirname, '..', '..', 'package.json')).version;
 }
 // Otherwise get it from Richie itself
 else {
@@ -45,10 +44,7 @@ module.exports = {
   // webpack config for production.
   mode: 'development',
 
-  entry: [
-    path.resolve(__dirname, 'public-path.js'),
-    path.resolve(__dirname, 'js', 'index.tsx'),
-  ],
+  entry: [path.resolve(__dirname, 'public-path.js'), path.resolve(__dirname, 'js', 'index.tsx')],
 
   output: {
     filename: 'index.js',
@@ -110,10 +106,7 @@ module.exports = {
     // Use module replacement to override any number of Richie components as defined in the settings
     ...Object.entries(overrides).map(
       (entry) =>
-        new webpack.NormalModuleReplacementPlugin(
-          new RegExp(`components\/${entry[0]}$`),
-          entry[1],
-        ),
+        new webpack.NormalModuleReplacementPlugin(new RegExp(`components\/${entry[0]}$`), entry[1]),
     ),
     // Provide the current running version as a global to our bundle. This is useful for eg. reporting
     // errors when using different versions in the backend and frontend.

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -20,19 +20,13 @@ class Footer extends React.Component {
         <section className="sitemap">
           <div>
             <h5>Documentation</h5>
-            <a href={this.docUrl('quick-start.html', this.props.language)}>
-              Getting&nbsp;Started
-            </a>
+            <a href={this.docUrl('quick-start.html', this.props.language)}>Getting&nbsp;Started</a>
             <a href="/versions">Versions</a>
-            <a href={this.docUrl('contributing.html', this.props.language)}>
-              Contributing
-            </a>
+            <a href={this.docUrl('contributing.html', this.props.language)}>Contributing</a>
           </div>
           <div>
             <h5>Community</h5>
-            <a href={this.pageUrl('users.html', this.props.language)}>
-              User&nbsp;Showcase
-            </a>
+            <a href={this.pageUrl('users.html', this.props.language)}>User&nbsp;Showcase</a>
             <a href="https://github.com/openfun/richie">GitHub</a>
           </div>
         </section>

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -19,8 +19,7 @@ class HomeSplash extends React.Component {
 
     const ProjectTitle = () => (
       <h2 className="projectTitle">
-        Richie enables you to build rich education portals quickly and with less
-        code.
+        Richie enables you to build rich education portals quickly and with less code.
       </h2>
     );
 
@@ -45,9 +44,7 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle siteConfig={siteConfig} />
           <PromoSection>
-            <Button href="https://demo.richie.education">
-              Check out the demo
-            </Button>
+            <Button href="https://demo.richie.education">Check out the demo</Button>
           </PromoSection>
         </div>
       </SplashContainer>
@@ -64,16 +61,8 @@ module.exports = class Index extends React.Component {
     const docUrl = (doc) => `${baseUrl}${docsPart}${langPart}${doc}`;
 
     const Block = (props) => (
-      <Container
-        padding={['bottom', 'top']}
-        id={props.id}
-        background={props.background}
-      >
-        <GridBlock
-          align={props.textAlign}
-          contents={props.children}
-          layout={props.layout}
-        />
+      <Container padding={['bottom', 'top']} id={props.id} background={props.background}>
+        <GridBlock align={props.textAlign} contents={props.children} layout={props.layout} />
       </Container>
     );
 
@@ -84,9 +73,7 @@ module.exports = class Index extends React.Component {
             content:
               '<p>Richie is a specialized Content Management System designed to make learning portals. It is full-featured and ready-to-go.</p>' +
               '<p>It is a toolbox to easily create full fledged websites with a catalog of online courses in days, not months.</p>' +
-              `<a class="button" href="${docUrl(
-                'quick-start.html',
-              )}">Get started</a>`,
+              `<a class="button" href="${docUrl('quick-start.html')}">Get started</a>`,
             image: `${baseUrl}img/undraw_professor.svg`,
             imageAlign: 'left',
             title: siteConfig.tagline,
@@ -145,30 +132,26 @@ module.exports = class Index extends React.Component {
       <div className="container homepage__feature-list">
         <div className="wrapper">
           <div className="gridBlock">
-            <h2 className="homepage__feature-list__title">
-              What Richie brings you
-            </h2>
+            <h2 className="homepage__feature-list__title">What Richie brings you</h2>
             <div className="blockElement blockElement--left twoByGridBlock">
               <div className="blockContent">
                 <h3>An LMS-agnostic education portal</h3>
                 <p>
-                  Your course catalog can be synchronized with one or more LMS
-                  instances running different kinds of software, such as Open
-                  edX or Moodle. Richie is built to aggregate it all for your
-                  users.
+                  Your course catalog can be synchronized with one or more LMS instances running
+                  different kinds of software, such as Open edX or Moodle. Richie is built to
+                  aggregate it all for your users.
                 </p>
                 <h3>An editor back-office</h3>
                 <p>
-                  All the content in Richie is meant to be created and updated
-                  by regular editors, not software engineers. As it is based on
-                  Django CMS, you get a rich editor interface along with Richie.
+                  All the content in Richie is meant to be created and updated by regular editors,
+                  not software engineers. As it is based on Django CMS, you get a rich editor
+                  interface along with Richie.
                 </p>
                 <h3>Advanced access rights and moderation</h3>
                 <p>
-                  From CMS content structured objects like organizations,
-                  courses, and categories, everything is managed through
-                  comprehensive access rights. Those can be based on individual
-                  user or tied to organizations.
+                  From CMS content structured objects like organizations, courses, and categories,
+                  everything is managed through comprehensive access rights. Those can be based on
+                  individual user or tied to organizations.
                 </p>
               </div>
             </div>
@@ -176,15 +159,14 @@ module.exports = class Index extends React.Component {
               <div className="blockContent">
                 <h3>A multilingual website</h3>
                 <p>
-                  Richie itself is already available in more than one language,
-                  and you can add yours by talking to us. All the content can be
-                  added and managed in as many languages as you need.
+                  Richie itself is already available in more than one language, and you can add
+                  yours by talking to us. All the content can be added and managed in as many
+                  languages as you need.
                 </p>
                 <h3>An extensible platform</h3>
                 <p>
-                  Richie is offered as a Django application (and adjoining NPM
-                  packaged). You can install it as a third-party app to build
-                  your own learning platform with Django.
+                  Richie is offered as a Django application (and adjoining NPM packaged). You can
+                  install it as a third-party app to build your own learning platform with Django.
                 </p>
               </div>
             </div>
@@ -216,12 +198,7 @@ module.exports = class Index extends React.Component {
       const showcase = siteConfig.users
         .filter((user) => user.pinned)
         .map((user) => (
-          <img
-            src={user.image}
-            alt={user.caption}
-            title={user.caption}
-            key={user.caption}
-          />
+          <img src={user.image} alt={user.caption} title={user.caption} key={user.caption} />
         ));
 
       return (

--- a/website/pages/en/users.js
+++ b/website/pages/en/users.js
@@ -12,12 +12,7 @@ module.exports = class Users extends React.Component {
     }
 
     const showcase = siteConfig.users.map((user) => (
-      <img
-        src={user.image}
-        alt={user.caption}
-        title={user.caption}
-        key={user.caption}
-      />
+      <img src={user.image} alt={user.caption} title={user.caption} key={user.caption} />
     ));
 
     return (

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -21,12 +21,11 @@ module.exports = function Versions(props) {
             <h1>{siteConfig.title} versions and documentation</h1>
           </header>
           <p>
-            New versions of this project are shipped regularly. Every new
-            version includes its own version of the documentation.
+            New versions of this project are shipped regularly. Every new version includes its own
+            version of the documentation.
           </p>
           <p>
-            Versions below <code>1.12.0</code> did not have a dedicated
-            documentation website.
+            Versions below <code>1.12.0</code> did not have a dedicated documentation website.
           </p>
           <h3 id="latest">Current version (Stable)</h3>
           <table className="versions">
@@ -43,16 +42,14 @@ module.exports = function Versions(props) {
                   </a>
                 </td>
                 <td>
-                  <a href={`${repoUrl}/releases/tag/v${latestVersion}.0`}>
-                    Release Notes
-                  </a>
+                  <a href={`${repoUrl}/releases/tag/v${latestVersion}.0`}>Release Notes</a>
                 </td>
               </tr>
             </tbody>
           </table>
           <p>
-            This is the version that is configured automatically when you first
-            install this project.
+            This is the version that is configured automatically when you first install this
+            project.
           </p>
           <h3 id="rc">Pre-release versions</h3>
           <table className="versions">
@@ -94,9 +91,7 @@ module.exports = function Versions(props) {
                         </a>
                       </td>
                       <td>
-                        <a href={`${repoUrl}/releases/tag/v${version}`}>
-                          Release Notes
-                        </a>
+                        <a href={`${repoUrl}/releases/tag/v${version}`}>Release Notes</a>
                       </td>
                     </tr>
                   ),
@@ -104,8 +99,7 @@ module.exports = function Versions(props) {
             </tbody>
           </table>
           <p>
-            You can find past versions of this project on{' '}
-            <a href={repoUrl}>GitHub</a>.
+            You can find past versions of this project on <a href={repoUrl}>GitHub</a>.
           </p>
         </div>
       </Container>

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,19 +1,7 @@
 {
   "docs": {
-    "Getting started": [
-      "quick-start",
-      "docker-development",
-      "native-installation"
-    ],
-    "Recipes": [
-      "django-react-interop",
-      "building-the-frontend",
-      "lms-connection"
-    ],
-    "Contributing": [
-      "contributing-guide",
-      "accessibility-testing",
-      "css-guidelines"
-    ]
+    "Getting started": ["quick-start", "docker-development", "native-installation"],
+    "Recipes": ["django-react-interop", "building-the-frontend", "lms-connection"],
+    "Contributing": ["contributing-guide", "accessibility-testing", "css-guidelines"]
   }
 }

--- a/website/versioned_sidebars/version-1.12-sidebars.json
+++ b/website/versioned_sidebars/version-1.12-sidebars.json
@@ -6,9 +6,6 @@
       "version-1.12-native-installation"
     ],
     "Recipes": ["version-1.12-django-react-interop"],
-    "Contributing": [
-      "version-1.12-contributing-guide",
-      "version-1.12-css-guidelines"
-    ]
+    "Contributing": ["version-1.12-contributing-guide", "version-1.12-css-guidelines"]
   }
 }

--- a/website/versioned_sidebars/version-1.13-sidebars.json
+++ b/website/versioned_sidebars/version-1.13-sidebars.json
@@ -5,13 +5,7 @@
       "version-1.13-docker-development",
       "version-1.13-native-installation"
     ],
-    "Recipes": [
-      "version-1.13-django-react-interop",
-      "version-1.13-building-the-frontend"
-    ],
-    "Contributing": [
-      "version-1.13-contributing-guide",
-      "version-1.13-css-guidelines"
-    ]
+    "Recipes": ["version-1.13-django-react-interop", "version-1.13-building-the-frontend"],
+    "Contributing": ["version-1.13-contributing-guide", "version-1.13-css-guidelines"]
   }
 }

--- a/website/versioned_sidebars/version-1.16-sidebars.json
+++ b/website/versioned_sidebars/version-1.16-sidebars.json
@@ -5,10 +5,7 @@
       "version-1.16-docker-development",
       "version-1.16-native-installation"
     ],
-    "Recipes": [
-      "version-1.16-django-react-interop",
-      "version-1.16-building-the-frontend"
-    ],
+    "Recipes": ["version-1.16-django-react-interop", "version-1.16-building-the-frontend"],
     "Contributing": [
       "version-1.16-contributing-guide",
       "version-1.16-accessibility-testing",


### PR DESCRIPTION
## Purpose
In my VS Code configuration, Prettier auto format code on save. But when I would like to modify my first django template, there was an exception due to Prettier added line break at the wrong places.

Furthermore, to avoid other surprise like these and to homogenize coding style, I just add few rules in the prettierrc based on [Airbnb](https://github.com/airbnb/javascript) and [Google](https://google.github.io/styleguide/jsguide.html) JS Style guides:
- 100 characters per line
- 2 spaces indentation
- Single quote

## Proposal
- [x] Homogenize richie prettier rules
- [x] Prettier must ignore django html templates 
