### PR TITLE
🔧(cms) limit number of plugin in course description to one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Change CTA enrollment button for anonymous users
 
+### Fixed
+
+- Limit number of text plugins to 1 in the course description placeholder
+
 ## [2.0.0-beta.13] - 2020-08-27
 
 ### Added

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -132,6 +132,7 @@ CMS_PLACEHOLDER_CONF = {
     "courses/cms/course_detail.html course_description": {
         "name": _("About the course"),
         "plugins": ["CKEditorPlugin"],
+        "limits": {"CKEditorPlugin": 1},
     },
     "courses/cms/course_detail.html course_skills": {
         "name": _("What you will learn"),


### PR DESCRIPTION
## Purpose

There is a limit on the number of characters that this placeholder can receive, which only makes sense if the number of plugins is
also limited to one.

## Proposal

Limit number of text plugins to 1 in the course description placeholder.