### PR TITLE
✨(back) allow to configure EDX_USER_PROFILE_TO_DJANGO setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Change CTA enrollment button for anonymous users
+- Allow to configure EDX_USER_PROFILE_TO_DJANGO setting
 
 ### Fixed
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -194,6 +194,9 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     SOCIAL_AUTH_EDX_OIDC_ENDPOINT = values.Value()
     SOCIAL_AUTH_POSTGRES_JSONFIELD = False  # Mysql compatibility by default
 
+    # Mapping between edx and richie profile fields
+    EDX_USER_PROFILE_TO_DJANGO = values.DictValue()
+
     # LMS
     LMS_BACKENDS = [
         {

--- a/src/richie/apps/core/backends.py
+++ b/src/richie/apps/core/backends.py
@@ -11,6 +11,7 @@ import base64
 import datetime
 from calendar import timegm
 
+from django.conf import settings
 from django.core.cache import cache
 
 from jose import jwk, jwt
@@ -19,15 +20,19 @@ from social_core.backends.oauth import BaseOAuth2
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_core.exceptions import AuthTokenError
 
-EDX_USER_PROFILE_TO_DJANGO = {
-    "preferred_username": "username",
-    "email": "email",
-    "name": "full_name",
-    "given_name": "first_name",
-    "family_name": "last_name",
-    "locale": "language",
-    "user_id": "user_id",
-}
+EDX_USER_PROFILE_TO_DJANGO = getattr(
+    settings,
+    "EDX_USER_PROFILE_TO_DJANGO",
+    {
+        "preferred_username": "username",
+        "email": "email",
+        "name": "full_name",
+        "given_name": "first_name",
+        "family_name": "last_name",
+        "locale": "language",
+        "user_id": "user_id",
+    },
+)
 
 
 # pylint: disable=abstract-method,invalid-name


### PR DESCRIPTION
## Purpose

in richie.core.backends module we want to configure EDX_USER_PROFILE_TO_DJANGO
setting. We try to pick it in django.conf.settings and fallback to a
default value if not configured.


## Proposal

- [x] allow to configure EDX_USER_PROFILE_TO_DJANGO setting
