### PR TITLE
🚸(Search) scroll after course fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Improve Course Search UX by triggering scroll up after courses are retrieved
+
 ## [2.0.0-beta.14] - 2020-09-03
 
 ### Changed
@@ -91,7 +95,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Lowered down global 'h1' and 'h2' font size and added new
   'extra-font-size' variable with previous h1 value.
 - Adjust title size 'large_banner' variants.
-- Fix accordion button 'nested-item__title' alignment to the left.
+- Fix accordion button 'nested-item\_\_title' alignment to the left.
 - Another attempt to definitively fix the glitch with wave decoration
   and Chrome zoom/unzoom.
 - Add a little bit of space between banner and title on organization
@@ -330,10 +334,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Frontend components now use `<html lang>` to pick up the locale instead
   of expecting a `data-locale` attribute.
 - Refactor the footer to use a static placeholder instead of the page tree:
-    * allow organizing footer links in columns or as flat links,
-    * allow customizing footer links (e.g. by setting the link target)
-    * allow adding any internal or external link to the footer,
-    * decorrelate the structure of footer links from the page tree.
+  - allow organizing footer links in columns or as flat links,
+  - allow customizing footer links (e.g. by setting the link target)
+  - allow adding any internal or external link to the footer,
+  - decorrelate the structure of footer links from the page tree.
 - Make the section plugin title optional,
 - Change the way frontend search field components are configured.
 

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { CourseGlimpseList } from 'components/CourseGlimpseList';
@@ -6,10 +6,10 @@ import { PaginateCourseSearch } from 'components/PaginateCourseSearch';
 import { SearchFiltersPane } from 'components/SearchFiltersPane';
 import { Spinner } from 'components/Spinner';
 import { useCourseSearch } from 'data/useCourseSearch';
-import { useCourseSearchParams } from 'data/useCourseSearchParams';
+import { useCourseSearchParams, CourseSearchParamsAction } from 'data/useCourseSearchParams';
 import { requestStatus } from 'types/api';
 import { CommonDataProps } from 'types/commonDataProps';
-import { matchMedia } from 'utils/indirection/window';
+import { matchMedia, scroll } from 'utils/indirection/window';
 
 const messages = defineMessages({
   errorMessage: {
@@ -37,13 +37,27 @@ const messages = defineMessages({
 });
 
 export const Search = ({ context }: CommonDataProps) => {
-  const { courseSearchParams } = useCourseSearchParams();
+  const { courseSearchParams, lastDispatchActions } = useCourseSearchParams();
   const courseSearchResponse = useCourseSearch(courseSearchParams);
 
   const alwaysShowFilters = matchMedia('(min-width: 992px)').matches;
   const [showFilters, setShowFilters] = useState(false);
 
   const [referenceId] = useState(`control-${Math.random()}`);
+
+  useEffect(() => {
+    // We want to scroll back to the top when courses have changed, unless the last action resulted
+    // from a user interaction with the SuggestField, eg. changed the query
+    if (
+      lastDispatchActions &&
+      lastDispatchActions?.every((action) => action.type !== CourseSearchParamsAction.queryUpdate)
+    ) {
+      scroll({
+        behavior: 'smooth',
+        top: 0,
+      });
+    }
+  }, [courseSearchResponse]);
 
   return (
     <div className="search">

--- a/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearchParams/index.spec.tsx
@@ -12,7 +12,6 @@ jest.mock('settings', () => ({
 jest.mock('utils/indirection/window', () => ({
   history: { pushState: jest.fn(), replaceState: jest.fn() },
   location: {},
-  scroll: jest.fn(),
 }));
 
 describe('data/useCourseSearchParams', () => {
@@ -122,10 +121,6 @@ describe('data/useCourseSearchParams', () => {
           '/search?languages=fr&limit=13&offset=39',
         );
       }
-      expect(mockWindow.scroll).toHaveBeenCalledWith({
-        behavior: 'smooth',
-        top: 0,
-      });
     });
   });
 
@@ -181,7 +176,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?languages=en&limit=17&offset=0&query=some%20text%20query',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -237,7 +231,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?languages=fr&limit=999&offset=0&query=some%20new%20query',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -293,7 +286,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?languages=es&limit=999&offset=0',
         );
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -358,7 +350,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=10&offset=0&organizations=L-00010003&organizations=L-00010009&organizations=L-00010017',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -420,7 +411,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?languages=en&languages=fr&languages=it&limit=10&offset=0',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -482,7 +472,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=10&offset=0&organizations=L-00010003&organizations=L-00010017',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -544,7 +533,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?languages=de&languages=zh&limit=10&offset=0',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -608,7 +596,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&organizations=L-00010014&query=some%20query',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -649,7 +636,6 @@ describe('data/useCourseSearchParams', () => {
           query: 'some query',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -724,7 +710,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=a%20query&subjects=P-000200030012&subjects=L-000200030005',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -797,7 +782,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query&subjects=L-000200030005',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -873,7 +857,6 @@ describe('data/useCourseSearchParams', () => {
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query' +
             '&subjects=P-000200030012&subjects=L-0002000300050013',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -946,7 +929,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?levels=L-000200020005&limit=999&offset=0&query=some%20query&subjects=L-0002000300050013',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
   });
@@ -1010,7 +992,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?level=L-000200010003&limit=999&offset=0',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
       {
         // Replace an existing value
@@ -1059,7 +1040,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?level=L-000200010002&limit=999&offset=0',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -1097,7 +1077,6 @@ describe('data/useCourseSearchParams', () => {
           offset: '0',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -1166,7 +1145,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&organizations=L00010011&query=some%20query',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
       {
         // Remove from a list of just one value
@@ -1213,7 +1191,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&query=some%20query',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -1279,7 +1256,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&query=some%20query',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -1317,7 +1293,6 @@ describe('data/useCourseSearchParams', () => {
           query: 'some query',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -1356,7 +1331,6 @@ describe('data/useCourseSearchParams', () => {
           organizations: ['L-00010003', 'L-00010009'],
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -1396,7 +1370,6 @@ describe('data/useCourseSearchParams', () => {
           organizations: 'L-00010011',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -1461,7 +1434,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=999&offset=0&query=some%20query',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
 
@@ -1501,7 +1473,6 @@ describe('data/useCourseSearchParams', () => {
           query: 'some query',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
 
@@ -1542,7 +1513,6 @@ describe('data/useCourseSearchParams', () => {
           query: 'some query',
         });
         expect(mockWindow.history.pushState).not.toHaveBeenCalled();
-        expect(mockWindow.scroll).not.toHaveBeenCalled();
       }
     });
   });
@@ -1590,7 +1560,6 @@ describe('data/useCourseSearchParams', () => {
           '',
           '/search?limit=27&offset=0',
         );
-        expect(mockWindow.scroll).toHaveBeenCalled();
       }
     });
   });

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -5,7 +5,7 @@ import { HistoryContext } from 'data/useHistory';
 import { API_LIST_DEFAULT_PARAMS } from 'settings';
 import { APIListRequestParams } from 'types/api';
 import { FilterDefinition } from 'types/filters';
-import { location, scroll } from 'utils/indirection/window';
+import { location } from 'utils/indirection/window';
 import { Maybe } from 'utils/types';
 import { computeNewFilterValue } from './computeNewFilterValue';
 
@@ -136,21 +136,6 @@ export const useCourseSearchParams = (): CourseSearchParamsState => {
   };
 
   useEffect(() => {
-    // We want to scroll back to the top when course search params have changed, unless the last action resulted
-    // from a user interaction with the SuggestField, eg. changed the query
-    if (
-      historyEntry.state.data &&
-      historyEntry.state.data.lastDispatchActions &&
-      !historyEntry.state.data?.lastDispatchActions
-        ?.map((action: CourseSearchParamsReducerAction) => action.type)
-        .includes(CourseSearchParamsAction.queryUpdate)
-    ) {
-      scroll({
-        behavior: 'smooth',
-        top: 0,
-      });
-    }
-
     // The Search view & components operate with default params, and we don't want to have all other pages in Richie
     // bear the burden of setting them whenever they link to Search.
     // We can solve this problem by replacing the current history entry if it is lacking the default parameters. This


### PR DESCRIPTION
## Purpose

Currently, on the course search page, when user filters courses, UI scrolls to top directly on filter change. But in some case (e.g: if the network is slow), new courses has not been yet retrieved and it causes flickering that may be disappointing for the user.

Related to #1103 

## Proposal
- [x] Trigger scroll up after courses have been retrieved
