### PR TITLE
🐛 Use variables for language selector colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Improve Course Search UX by triggering scroll up after courses are retrieved
 
+### Fixed
+
+- Use variables for button colors in language selector so it fits in
+  with themes.
+
 ## [2.0.0-beta.14] - 2020-09-03
 
 ### Changed

--- a/src/frontend/scss/components/_footer.scss
+++ b/src/frontend/scss/components/_footer.scss
@@ -187,13 +187,13 @@
     align-items: center;
 
     .language-selector {
-      color: white;
+      color: r-theme-val(body-footer, base-color);
 
       &__button {
         padding-left: 0;
 
         &__icon {
-          fill: white;
+          fill: r-theme-val(body-footer, base-color);
         }
       }
 

--- a/src/frontend/scss/components/_header.scss
+++ b/src/frontend/scss/components/_header.scss
@@ -338,5 +338,10 @@
     display: flex;
     align-items: center;
     margin-left: 0;
+    color: r-theme-val(topbar, item-color);
+
+    &__button__icon {
+      fill: r-theme-val(topbar, item-color);
+    }
   }
 }


### PR DESCRIPTION
## Purpose

When the language selector is displayed in the footer/header, it must adapt to its surroundings by using appropriate colors. (otherwise it might appear black on black, or white on white). This mostly goes for the text, which appears directly on the background of the footer/header.

## Proposal

To achieve this, we can use variables from sass theming when defining language selector colors. This is only used for the button which is integrated into its parent element. The dropdown itself has its own background.
