### PR TITLE
🐛(back) fix how EDX_USER_PROFILE_TO_DJANGO default value is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix how EDX_USER_PROFILE_TO_DJANGO default value is set
+
 ### Changed
 
 - Improve Course Search UX by triggering scroll up after courses are retrieved

--- a/src/richie/apps/core/backends.py
+++ b/src/richie/apps/core/backends.py
@@ -20,19 +20,15 @@ from social_core.backends.oauth import BaseOAuth2
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_core.exceptions import AuthTokenError
 
-EDX_USER_PROFILE_TO_DJANGO = getattr(
-    settings,
-    "EDX_USER_PROFILE_TO_DJANGO",
-    {
-        "preferred_username": "username",
-        "email": "email",
-        "name": "full_name",
-        "given_name": "first_name",
-        "family_name": "last_name",
-        "locale": "language",
-        "user_id": "user_id",
-    },
-)
+EDX_USER_PROFILE_TO_DJANGO = getattr(settings, "EDX_USER_PROFILE_TO_DJANGO", None) or {
+    "preferred_username": "username",
+    "email": "email",
+    "name": "full_name",
+    "given_name": "first_name",
+    "family_name": "last_name",
+    "locale": "language",
+    "user_id": "user_id",
+}
 
 
 # pylint: disable=abstract-method,invalid-name


### PR DESCRIPTION
## Purpose

When EDX_USER_PROFILE_TO_DJANGO is adding in the settings but without
default value, its value will be an empty dict. To avoid this we change
how default value is set.


## Proposal

- [x] fix how EDX_USER_PROFILE_TO_DJANGO default value is set
