### PR TITLE
👽(project) point powered by to https://richie.education

### DIFF
--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -144,7 +144,7 @@
                         <p>{% now "Y" %} &copy; Acme {% trans "All Rights Reserved." %}</p>
                     </div>
                     <div class="body-mentions__poweredby">
-                        <a href="https://github.com/openfun/richie">
+                        <a href="https://richie.education">
                             <small>{% trans "Powered by" %}</small>
                             <strong>Richie</strong>
                         </a>


### PR DESCRIPTION
## Purpose

The "powered by" mention was pointing to the github repository, which is only good for developpers.

## Proposal

Point to the https://richie.education site.
