### PR TITLE
Demo site: allow removing licences placeholders and customizing pages info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Allow customizing the side pages created by the demo site
 - Make demo site work without licences placeholder
 - Allow empty content on glimpse plugins
 - Switch from deprecated tslint to eslint js linter and update codebase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Create a function checking username in social auth pipeline
 - Extend social-auth middleware to use a page to display error
-
-### Fixed
-
-- Fix how EDX_USER_PROFILE_TO_DJANGO default value is set
-
-### Added
-
 - Add `urls` property to `UserSerializer`. The urls are built with a new setting
   `MAIN_LMS_USER_URLS` which contains custom links to access to LMS profile
   views from richie.
@@ -27,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Make demo site work without licences placeholder
 - Allow empty content on glimpse plugins
 - Switch from deprecated tslint to eslint js linter and update codebase
   accordingly.
@@ -34,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix how EDX_USER_PROFILE_TO_DJANGO default value is set
 - Use variables for button colors in language selector so it fits in
   with themes.
 

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -91,6 +91,7 @@ PAGES_INFO = {
         },
     },
 }
+PAGES_INFO.update(getattr(settings, "RICHIE_DEMO_PAGES_INFO", {}))
 
 
 LEVELS_INFO = {

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -105,8 +105,13 @@ def create_demo_site():
                     )
 
     # Create some licences
-    licences = factories.LicenceFactory.create_batch(
-        defaults.NB_OBJECTS["licences"], logo__file__from_path=pick_image("licence")()
+    licences = (
+        factories.LicenceFactory.create_batch(
+            defaults.NB_OBJECTS["licences"],
+            logo__file__from_path=pick_image("licence")(),
+        )
+        if defaults.NB_OBJECTS.get("licences")
+        else []
     )
 
     # Generate each category tree and return a list of the leaf categories
@@ -221,14 +226,20 @@ def create_demo_site():
             for person in persons_for_organization[o.id]
         )
 
+        course_licences = (
+            [
+                ("course_license_content", random.choice(licences)),  # nosec
+                ("course_license_participation", random.choice(licences)),  # nosec
+            ]
+            if licences
+            else []
+        )
+
         course = factories.CourseFactory(
             page_in_navigation=True,
             page_languages=["en", "fr"],
             page_parent=pages_created["courses"],
-            fill_licences=[
-                ("course_license_content", random.choice(licences)),  # nosec
-                ("course_license_participation", random.choice(licences)),  # nosec
-            ],
+            fill_licences=course_licences,
             fill_team=random.sample(
                 eligible_persons,
                 min(
@@ -707,12 +718,13 @@ def create_demo_site():
             internal_link=pages_created["home"],
         )
         # Add a licence
-        add_plugin(
-            language=language,
-            placeholder=placeholder,
-            plugin_type="LicencePlugin",
-            licence=random.choice(licences),  # nosec
-        )
+        if licences:
+            add_plugin(
+                language=language,
+                placeholder=placeholder,
+                plugin_type="LicencePlugin",
+                licence=random.choice(licences),  # nosec
+            )
         # Add a simple picture entry
         add_plugin(
             language=language,

--- a/tests/apps/demo/test_commands_create_demo_site.py
+++ b/tests/apps/demo/test_commands_create_demo_site.py
@@ -2,6 +2,7 @@
 create_demo_site management command tests
 """
 from logging import Logger
+import random
 from unittest import mock
 
 from django.conf import settings
@@ -15,6 +16,30 @@ from cms.test_utils.testcases import CMSTestCase
 from richie.apps.courses import models
 from richie.apps.demo import defaults
 from richie.apps.demo.management.commands.create_demo_site import create_demo_site
+
+TEST_NB_OBJECTS = {
+    "courses": 1,
+    "course_courseruns": 1,
+    "course_icons": 1,
+    "course_organizations": 1,
+    "course_persons": 1,
+    "course_subjects": 1,
+    "person_organizations": 1,
+    "person_subjects": 1,
+    "organizations": 1,
+    "licences": random.randint(0, 1),
+    "persons": 1,
+    "blogposts": 1,
+    "blogpost_categories": 1,
+    "programs": 1,
+    "programs_courses": 1,
+    "home_blogposts": 1,
+    "home_courses": 1,
+    "home_organizations": 1,
+    "home_subjects": 1,
+    "home_persons": 1,
+    "home_programs": 1,
+}
 
 
 class CreateDemoSiteCommandsTestCase(CMSTestCase):
@@ -53,32 +78,7 @@ class CreateDemoSiteCommandsTestCase(CMSTestCase):
         "richie.apps.demo.management.commands.create_demo_site.get_number_of_icons",
         return_value=1,
     )
-    @mock.patch.dict(
-        defaults.NB_OBJECTS,
-        {
-            "courses": 1,
-            "course_courseruns": 1,
-            "course_icons": 1,
-            "course_organizations": 1,
-            "course_persons": 1,
-            "course_subjects": 1,
-            "person_organizations": 1,
-            "person_subjects": 1,
-            "organizations": 1,
-            "licences": 1,
-            "persons": 1,
-            "blogposts": 1,
-            "blogpost_categories": 1,
-            "programs": 1,
-            "programs_courses": 1,
-            "home_blogposts": 1,
-            "home_courses": 1,
-            "home_organizations": 1,
-            "home_subjects": 1,
-            "home_persons": 1,
-            "home_programs": 1,
-        },
-    )
+    @mock.patch.dict(defaults.NB_OBJECTS, TEST_NB_OBJECTS)
     @mock.patch.dict(
         defaults.SUBJECTS_INFO,
         {
@@ -110,7 +110,7 @@ class CreateDemoSiteCommandsTestCase(CMSTestCase):
         self.assertEqual(models.Category.objects.count(), 48)
         self.assertEqual(models.Organization.objects.count(), 2)
         self.assertEqual(models.Person.objects.count(), 2)
-        self.assertEqual(models.Licence.objects.count(), 1)
+        self.assertEqual(models.Licence.objects.count(), TEST_NB_OBJECTS["licences"])
         self.assertEqual(models.Program.objects.count(), 2)
 
         self.assertEqual(Site.objects.first().domain, "richie.education:9999")

--- a/tests/apps/demo/test_commands_create_demo_site.py
+++ b/tests/apps/demo/test_commands_create_demo_site.py
@@ -1,8 +1,8 @@
 """
 create_demo_site management command tests
 """
-from logging import Logger
 import random
+from logging import Logger
 from unittest import mock
 
 from django.conf import settings


### PR DESCRIPTION
## Purpose

Some customizations that we make in themed sites using richie (cf https://github.com/openfun/richie-site-factory) are breaking the demo site. It makes it difficult to work on such sites in development if we can't generate a demo site.

## Proposal

- [x] Allow deactivating the licences placeholders without breaking the demo site
- [x] Allow customizing pages info (e.g to create a page linked to a button via its reverse id)
