### PR TITLE
💄(frontend) fix selector arrow color in footer

### DIFF
--- a/src/frontend/scss/components/_footer.scss
+++ b/src/frontend/scss/components/_footer.scss
@@ -186,15 +186,11 @@
     display: flex;
     align-items: center;
 
-    .language-selector {
+    .selector {
       color: r-theme-val(body-footer, base-color);
 
       &__button {
         padding-left: 0;
-
-        &__icon {
-          fill: r-theme-val(body-footer, base-color);
-        }
       }
 
       &__list {

--- a/src/frontend/scss/objects/_selector.scss
+++ b/src/frontend/scss/objects/_selector.scss
@@ -12,6 +12,7 @@
     padding: 0.7rem 1.3rem;
 
     &__icon {
+      fill: currentColor;
       height: 1rem;
       margin-left: 0.5rem;
       width: 1rem;


### PR DESCRIPTION
## Purpose
The language selector arrow in the footer has not the good color.
`.language-selector` was renamed into `.selector` and Footer styles had not been updated accordingly.


## Proposal
- [x] Apply `color: currentColor` to `.selector__icon`. In this way, arrow color herits of the parent color. Less code to write, easier to maintain.
