### PR TITLE
🐛 (frontend) handle error invalid configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Frontend did not report error to Sentry
 - Fix how EDX_USER_PROFILE_TO_DJANGO default value is set
 - Use variables for button colors in language selector so it fits in
   with themes.

--- a/src/frontend/jest.config.js
+++ b/src/frontend/jest.config.js
@@ -10,4 +10,7 @@ module.exports = {
   testMatch: [`${__dirname}/js/**/*.spec.+(ts|tsx|js)`],
   testURL: 'https://localhost',
   transformIgnorePatterns: ['node_modules/(?!(lodash-es)/)'],
+  globals: {
+    RICHIE_VERSION: 'test',
+  },
 };

--- a/src/frontend/js/utils/errors/handle.spec.ts
+++ b/src/frontend/js/utils/errors/handle.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as Sentry from '@sentry/browser';
+
+jest.mock('@sentry/browser');
+
+describe('handle', () => {
+  (window as any).__richie_frontend_context__ = {
+    context: {
+      sentry_dsn: 'https://sentry.richie',
+      environment: 'test',
+    },
+  };
+
+  const { handle } = require('./handle');
+
+  it('should initialize sentry', () => {
+    expect(Sentry.init).toBeCalledTimes(1);
+    expect(Sentry.configureScope).toBeCalledTimes(1);
+  });
+
+  it('should report error to sentry', () => {
+    handle('An error for test');
+    expect(Sentry.captureException).toBeCalledTimes(1);
+  });
+});

--- a/src/frontend/js/utils/errors/handle.ts
+++ b/src/frontend/js/utils/errors/handle.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/browser';
 
 import { CommonDataProps } from 'types/commonDataProps';
 
-const context: CommonDataProps['context'] = (window as any).__richie_frontend_context__;
+const context: CommonDataProps['context'] = (window as any).__richie_frontend_context__?.context;
 
 if (context && context.sentry_dsn) {
   Sentry.init({

--- a/tests/apps/core/test_pages.py
+++ b/tests/apps/core/test_pages.py
@@ -44,6 +44,9 @@ class PagesTests(CMSTestCase):
         """
         Create a page and make sure it includes the frontend context as included
         in `base.html`.
+
+        ⚠️ If this test fails, before fixing it, identify if this change has had
+        ⚠️ an impact on frontend and update frontend accordingly.
         """
         page = PageFactory(should_publish=True, template="richie/single_column.html")
         response = self.client.get(page.get_public_url())


### PR DESCRIPTION
## Purpose

The path to get context from __richie_frontend_context__ was wrong so context variable was always undefined. In this way, Sentry was never initialize.


## Proposal

- [x] Use the correct path to get context data from `__richie_frontend_context__`
