### PR TITLE
🔥(core) remove copyright notice from footer in base template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Remove copyright notice from footer in base template and allow customizing it
 - Allow customizing the side pages created by the demo site
 - Make demo site work without licences placeholder
 - Allow empty content on glimpse plugins

--- a/src/frontend/scss/components/_footer.scss
+++ b/src/frontend/scss/components/_footer.scss
@@ -247,22 +247,6 @@
     justify-content: space-between;
   }
 
-  &__copyright {
-    @include font-size($h5-font-size);
-    @include sv-flex(1, 0, 100%);
-    font-family: $r-font-family-montserrat;
-    text-align: center;
-
-    @include media-breakpoint-up($r-footer-breakpoint) {
-      @include sv-flex(1, 0, auto);
-      text-align: left;
-    }
-
-    p {
-      margin-bottom: 0;
-    }
-  }
-
   &__poweredby {
     @include font-size($h6-font-size);
     @include sv-flex(1, 0, 100%);

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -140,15 +140,14 @@
             </div>
             <div class="body-mentions">
                 <div class="body-mentions__container">
-                    <div class="body-mentions__copyright">
-                        <p>{% now "Y" %} &copy; Acme {% trans "All Rights Reserved." %}</p>
-                    </div>
+                    {% block body_mentions %}
                     <div class="body-mentions__poweredby">
                         <a href="https://richie.education">
                             <small>{% trans "Powered by" %}</small>
                             <strong>Richie</strong>
                         </a>
                     </div>
+                    {% endblock body_mentions %}
                 </div>
             </div>
             {% endblock body_footer %}


### PR DESCRIPTION
## Purpose

The copyright notice is something specific to each site. Let's not propose anything in richie templates but just a template block to
add it if necessary.

## Proposal

- [x] Remove default copyright notice
- [x] Add a new block for the mentions at the bottom of the page to allow customization
