### PR TITLE
🚸(plugins) improve sanitizing of input text on CKEditor plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Improve sanitizing of input text on CKEditor plugin
 - Replace course-detail__run-cta in fragment_course_run template by
   course-run-enrollment__cta
 

--- a/src/richie/plugins/simple_text_ckeditor/forms.py
+++ b/src/richie/plugins/simple_text_ckeditor/forms.py
@@ -1,7 +1,11 @@
 """
 Simple text plugin forms
 """
+from html import unescape
+from unicodedata import normalize
+
 from django import forms
+from django.utils.html import strip_spaces_between_tags
 
 from djangocms_text_ckeditor.widgets import TextEditorWidget
 
@@ -21,3 +25,10 @@ class CKEditorPluginForm(forms.ModelForm):
         model = SimpleText
         widgets = {"body": TextEditorWidget}
         fields = ["body"]
+
+    def clean_body(self):
+        """Normalize and unescape the text submitted by CKEditor then remove useless spaces."""
+        body = self.cleaned_data.get("body", "")
+        body = normalize("NFKC", body)
+        body = unescape(body)
+        return strip_spaces_between_tags(body)

--- a/src/richie/plugins/simple_text_ckeditor/validators.py
+++ b/src/richie/plugins/simple_text_ckeditor/validators.py
@@ -1,4 +1,7 @@
 """Custom validators for the simple text editor plugin."""
+from html import unescape
+from unicodedata import normalize
+
 from django.core.validators import BaseValidator
 from django.utils.deconstruct import deconstructible
 from django.utils.html import strip_spaces_between_tags, strip_tags
@@ -24,5 +27,13 @@ class HTMLMaxLengthValidator(BaseValidator):
         return a > b
 
     def clean(self, x):
-        """Strip all HTML tags and useless spaces before counting the number of characters."""
-        return len(strip_tags(strip_spaces_between_tags(x)).replace("&nbsp;", ""))
+        """
+        Before counting the number of characters in the text submitted by CKEditor:
+        - normalize it,
+        - unescape it,
+        - strip all HTML tags,
+        - strip useless spaces.
+        """
+        x = normalize("NFKC", unescape(x))
+        x = strip_tags(strip_spaces_between_tags(x))
+        return len(x)

--- a/tests/plugins/simple_text_ckeditor/test_forms.py
+++ b/tests/plugins/simple_text_ckeditor/test_forms.py
@@ -1,0 +1,26 @@
+"""
+Forms tests
+"""
+from django.test import TestCase
+
+from richie.plugins.simple_text_ckeditor.forms import CKEditorPluginForm
+
+
+class CKEditorPluginFormsTestCase(TestCase):
+    """Tests for the SimpleText forms"""
+
+    def test_forms_simpletext_clean_body(self):
+        """
+        Upon submission, the form should be cleaned:
+        - normalization,
+        - unescaping,
+        - strip useless spaces.
+        """
+        data = {
+            "body": "<div> <h1>株ＫＡ&nbsp;&ecirc;  </h1>   <b>&eacute;</b></div>",
+        }
+        form = CKEditorPluginForm(data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["body"], "<div><h1>株KA\xa0ê  </h1><b>é</b></div>"
+        )

--- a/tests/plugins/simple_text_ckeditor/test_validators.py
+++ b/tests/plugins/simple_text_ckeditor/test_validators.py
@@ -1,0 +1,20 @@
+"""
+Validators tests
+"""
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from richie.plugins.simple_text_ckeditor.validators import HTMLMaxLengthValidator
+
+
+class SimpleTextValidatorTestCase(TestCase):
+    """Tests for the SimpleText validator"""
+
+    def test_validators_simpletext_valid(self):
+        """A text with just the right number of characters should validate."""
+        dirty_text = "<div>株ＫＡ&nbsp;&ecirc;  <b>&eacute;</b></div>"
+        # => The text taken into account for the count should be: "株KA ê  é" (8 characters)
+        with self.assertRaises(ValidationError):
+            HTMLMaxLengthValidator(7)(dirty_text)
+
+        self.assertIsNone(HTMLMaxLengthValidator(8)(dirty_text))


### PR DESCRIPTION
## Purpose

CKEditor is submitting text with web entities (e.g. `&eacute;` for `é`) and potentially exotic characters. Our support team complained that the count of the max number of characters was wrong. 

## Proposal

This commit fixes it by normalizing and unescaping input strings. We do it for counting and also before saving it to database.
