### PR TITLE
💄(footer) avoid stretching of footer menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Allow use of columns in footer menu items
+- Avoid stretching of footer menu items
+
 ## [2.0.0-beta.16] - 2020-10-23
 
 ### Fixed
 
 - Hide unpublished pages from public version of organizations list page
-- Avoid stretching of footer menu items
 - Improve sanitizing of input text on CKEditor plugin
 - Replace course-detail__run-cta in fragment_course_run template by
   course-run-enrollment__cta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Hide unpublished pages from public version of organizations list page
+- Avoid stretching of footer menu items
 - Improve sanitizing of input text on CKEditor plugin
 - Replace course-detail__run-cta in fragment_course_run template by
   course-run-enrollment__cta

--- a/src/frontend/scss/components/_footer.scss
+++ b/src/frontend/scss/components/_footer.scss
@@ -45,13 +45,14 @@
   &__insert {
     @include sv-flex(1, 0, 100%);
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
+    justify-content: start;
     flex-wrap: wrap;
     margin-top: 1rem;
     order: 3;
 
     @include media-breakpoint-up($r-footer-breakpoint) {
-      @include sv-flex(1, 0, 35%);
+      @include sv-flex(1, 0, auto);
       margin-top: 0;
       order: 2;
     }
@@ -61,8 +62,9 @@
       margin-top: 1rem;
     }
 
-    .languages-menu {
-      @include sv-flex(1, 0, 100%);
+    .richie-react--language-selector {
+      align-items: flex-start;
+      @include sv-flex(1, 0, auto);
       padding: 0;
       margin-bottom: 0;
       font-family: $r-font-family-montserrat;
@@ -86,7 +88,7 @@
   }
 
   &__title {
-    @include sv-flex(1, 0, 100%);
+    @include sv-flex(0, 0, auto);
     @include font-size($h4-font-size);
     margin-bottom: 0;
     font-family: $r-font-family-montserrat;
@@ -94,7 +96,7 @@
   }
 
   &__badges {
-    @include sv-flex(1, 0, 100%);
+    @include sv-flex(0, 0, auto);
     display: flex;
   }
 
@@ -110,16 +112,32 @@
     height: 2.75rem;
   }
 
-  &__menu {
+  &__items {
+    align-content: flex-start;
     @include sv-flex(1, 0, 100%);
     display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+
+    & > * {
+      margin-bottom: 1rem;
+    }
+
+    @include media-breakpoint-up($r-footer-breakpoint) {
+      flex-direction: row;
+    }
+  }
+
+  &__menu {
+    @include sv-flex(1, 0, 100%);
     flex-wrap: wrap;
     flex-direction: row;
     align-content: flex-start;
     order: 2;
+    margin-right: -3vw;
 
     @include media-breakpoint-up($r-footer-breakpoint) {
-      @include sv-flex(1, 0, 65%);
+      @include sv-flex(0, 0, auto);
       order: 3;
     }
 
@@ -133,7 +151,8 @@
     //
     .nested-item--list {
       $nesteditem-base-selector: '.nested-item';
-      @include sv-flex(1, 0, 100%);
+      @include sv-flex(0, 0, auto);
+      padding-right: 3vw;
 
       a {
         display: block;
@@ -151,21 +170,22 @@
       }
 
       #{$nesteditem-base-selector}__items {
-        @include sv-flex(1, 0, 100%);
+        @include sv-flex(0, 0, auto);
         display: flex;
         padding: 0;
         margin-bottom: 0;
-        flex-direction: row;
+        flex-direction: column;
         flex-wrap: wrap;
         list-style-type: none;
 
         li {
           @include sv-flex(1, 0, calc(100% - 0.2rem));
           margin: 0.1rem;
-          padding: 0.25rem 0.25rem 0.25rem 0;
+          padding: 0.25rem 0.25rem 0.25rem 0rem;
 
           @include media-breakpoint-up($r-footer-breakpoint) {
-            @include sv-flex(1, 0, auto);
+            @include sv-flex(0, 0, auto);
+            min-width: 15%;
           }
         }
       }
@@ -184,7 +204,6 @@
 
   .richie-react--language-selector {
     display: flex;
-    align-items: center;
 
     .selector {
       color: r-theme-val(body-footer, base-color);

--- a/src/frontend/scss/components/_footer.scss
+++ b/src/frontend/scss/components/_footer.scss
@@ -146,22 +146,21 @@
       margin-top: 1rem;
     }
 
+    a {
+      color: inherit;
+      display: block;
+    }
+
     //
     // Default variant acts like a simple horizontal menu
     //
-    .nested-item--list {
+    .nested-item--list,
+    a {
       $nesteditem-base-selector: '.nested-item';
       @include sv-flex(0, 0, auto);
       padding-right: 3vw;
 
-      a {
-        display: block;
-        color: inherit;
-      }
-
       #{$nesteditem-base-selector}__content {
-        margin: 0.1rem;
-        padding: 0.25rem 0.25rem 0.25rem 0;
         font-weight: bold;
 
         p {
@@ -196,7 +195,6 @@
     @include sv-flex(1, 0, 100%);
     @include font-size($h4-font-size);
     margin-bottom: 0;
-    padding: 0 0.25rem;
     color: r-theme-val(body-footer, subtitle-color);
     font-family: $r-font-family-montserrat;
     font-weight: $font-weight-boldest;

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -120,7 +120,9 @@
                 <div class="body-footer__container">
                     <div class="body-footer__menu">
                         <p class="body-footer__subtitle">{% trans "Learn more" %}</p>
-                        {% static_placeholder "footer" %}
+                        <div class="body-footer__items">
+                            {% static_placeholder "footer" %}
+                        </div>
                     </div>
                     <div class="body-footer__brand">
                         <a href="/">

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -55,8 +55,8 @@ CMS_PLACEHOLDER_CONF = {
     # Footer
     "footer": {
         "name": _("Footer"),
-        "plugins": ["NestedItemPlugin"],
-        "NestedItemPlugin": ["NestedItemPlugin", "LinkPlugin"],
+        "plugins": ["NestedItemPlugin", "LinkPlugin"],
+        "NestedItemPlugin": ["LinkPlugin"],
     },
     "static_blogpost_headline": {
         "name": _("Static headline"),

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -371,21 +371,9 @@ SINGLECOLUMN_CONTENT.update(getattr(settings, "RICHIE_DEMO_SINGLECOLUMN_CONTENT"
 
 FOOTER_CONTENT = {
     "en": [
-        {
-            "items": [
-                {"name": "About", "internal_link": "annex__about"},
-            ]
-        },
-        {
-            "items": [
-                {"name": "Sitemap", "internal_link": "annex__sitemap"},
-            ]
-        },
-        {
-            "items": [
-                {"name": "Style guide", "external_link": "/styleguide/"},
-            ]
-        },
+        {"name": "About", "internal_link": "annex__about"},
+        {"name": "Sitemap", "internal_link": "annex__sitemap"},
+        {"name": "Style guide", "external_link": "/styleguide/"},
         {
             "title": "Richie community",
             "items": [
@@ -406,21 +394,9 @@ FOOTER_CONTENT = {
         },
     ],
     "fr": [
-        {
-            "items": [
-                {"name": "A propos", "internal_link": "annex__about"},
-            ]
-        },
-        {
-            "items": [
-                {"name": "Plan du site", "internal_link": "annex__sitemap"},
-            ]
-        },
-        {
-            "items": [
-                {"name": "Style guide", "external_link": "/styleguide/"},
-            ]
-        },
+        {"name": "A propos", "internal_link": "annex__about"},
+        {"name": "Plan du site", "internal_link": "annex__sitemap"},
+        {"name": "Style guide", "external_link": "/styleguide/"},
         {
             "title": "Communauté Richie",
             "items": [

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -374,7 +374,15 @@ FOOTER_CONTENT = {
         {
             "items": [
                 {"name": "About", "internal_link": "annex__about"},
+            ]
+        },
+        {
+            "items": [
                 {"name": "Sitemap", "internal_link": "annex__sitemap"},
+            ]
+        },
+        {
+            "items": [
                 {"name": "Style guide", "external_link": "/styleguide/"},
             ]
         },
@@ -386,6 +394,14 @@ FOOTER_CONTENT = {
                     "name": "Github",
                     "external_link": "https://github.com/openfun/richie",
                 },
+                {
+                    "name": "Site factory",
+                    "external_link": "https://github.com/openfun/richie-site-factory",
+                },
+                {
+                    "name": "Example site",
+                    "external_link": "https://www.fun-campus.fr",
+                },
             ],
         },
     ],
@@ -393,7 +409,15 @@ FOOTER_CONTENT = {
         {
             "items": [
                 {"name": "A propos", "internal_link": "annex__about"},
+            ]
+        },
+        {
+            "items": [
                 {"name": "Plan du site", "internal_link": "annex__sitemap"},
+            ]
+        },
+        {
+            "items": [
                 {"name": "Style guide", "external_link": "/styleguide/"},
             ]
         },
@@ -404,6 +428,14 @@ FOOTER_CONTENT = {
                 {
                     "name": "Github",
                     "external_link": "https://github.com/openfun/richie",
+                },
+                {
+                    "name": "Usine à sites",
+                    "external_link": "https://github.com/openfun/richie-site-factory",
+                },
+                {
+                    "name": "Site exemple",
+                    "external_link": "https://www.fun-campus.fr",
                 },
             ],
         },

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -75,17 +75,12 @@ def create_demo_site():
     footer_static_ph = StaticPlaceholder.objects.get_or_create(code="footer")[0]
     for footer_placeholder in [footer_static_ph.draft, footer_static_ph.public]:
         for language, content in defaults.FOOTER_CONTENT.items():
-            # Create root nest
-            nest_root_plugin = add_plugin(
-                footer_placeholder, plugin_type="NestedItemPlugin", language=language
-            )
             for footer_info in content:
                 # Create the first level items for main columns
                 nest_column_plugin = add_plugin(
                     footer_placeholder,
                     plugin_type="NestedItemPlugin",
                     language=language,
-                    target=nest_root_plugin,
                     content=footer_info.get("title", ""),
                 )
 


### PR DESCRIPTION
## Purpose

Footer menu items stretchs according to space available on a row which broke
layout if there was few elements on a row.

## Proposal
- [x] Improve stretching of footer menu items
- [x] Second level nested items are now displayed in column

## Screenshot

![image](https://user-images.githubusercontent.com/1427165/97278767-72e96400-183a-11eb-8cfe-5272c9d0c571.png)
