### PR TITLE
🐛(organizations) fix organizations list page hiding unpublished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Hide unpublished pages from public version of organizations list page
 - Improve sanitizing of input text on CKEditor plugin
 - Replace course-detail__run-cta in fragment_course_run template by
   course-run-enrollment__cta

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
@@ -32,7 +32,7 @@
         {% endif %}
     {% empty %}
         <p class="blogpost-glimpse blogpost-glimpse--empty">
-        {% trans "No associated blogposts" %}
+            {% trans "No associated blogposts" %}
         </p>
     {% endfor %}
 

--- a/src/richie/apps/courses/templates/courses/cms/organization_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_list.html
@@ -1,5 +1,5 @@
 {% extends "richie/fullwidth.html" %}
-{% load cms_tags i18n %}
+{% load cms_tags i18n pagination_tags %}
 
 {% block subheader_content %}
 <div class="subheader__container">
@@ -11,13 +11,18 @@
 {% block content %}
 <div class="organization-list">
     <div class="organization-list__content">
-    {% for page in current_page.get_child_pages %}
-        {% if page.organization %}
-            {% include "courses/cms/fragment_organization_glimpse.html" with organization=page.organization organization_variant="card" %}
+        {% if current_page.publisher_is_draft %}
+            {% autopaginate current_page.get_child_pages 100 as object_list %}
+        {% else %}
+            {% autopaginate current_page.get_child_pages.published.distinct 100 as object_list %}
         {% endif %}
-    {% empty %}
-        <p class="organization-list__empty">{% trans "No organization yet" %}</p>
-    {% endfor %}
+        {% for page in object_list %}
+            {% if page.organization %}
+                {% include "courses/cms/fragment_organization_glimpse.html" with organization=page.organization organization_variant="card" %}
+            {% endif %}
+        {% empty %}
+            <p class="organization-list__empty">{% trans "No organization yet" %}</p>
+        {% endfor %}
     </div>
 </div>
 {% endblock content %}

--- a/tests/apps/courses/test_templates_organization_list.py
+++ b/tests/apps/courses/test_templates_organization_list.py
@@ -1,0 +1,59 @@
+"""
+End-to-end tests for the organization list view
+"""
+from datetime import timedelta
+from unittest import mock
+
+from django.utils import timezone
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.factories import PageFactory, UserFactory
+from richie.apps.courses.factories import OrganizationFactory
+
+
+class ListOrganizationCMSTestCase(CMSTestCase):
+    """
+    End-to-end test suite to validate the content and Ux of the organization list view
+    """
+
+    def test_templates_organization_list_cms_content(self):
+        """
+        Validate that the public website only displays organizations that are currently published,
+        while staff users can see draft and unpublished organizations.
+        """
+        page = PageFactory(
+            template="courses/cms/organization_list.html",
+            title__language="en",
+            should_publish=True,
+        )
+
+        OrganizationFactory(page_parent=page, page_title="First organization")
+        OrganizationFactory(
+            page_parent=page, page_title="Second organization", should_publish=True
+        )
+
+        # Publish with a publication date in the future
+        future = timezone.now() + timedelta(hours=1)
+        with mock.patch("cms.models.pagemodel.now", return_value=future):
+            OrganizationFactory(
+                page_parent=page, page_title="Third organization", should_publish=True
+            )
+
+        # Anonymous users should only see published organizations
+        response = self.client.get(page.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "First")
+        self.assertContains(response, "Second")
+        self.assertNotContains(response, "Third")
+
+        # Staff users can see draft and unpublished organizations
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self.client.get(page.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+        for title in ["First", "Second", "Third"]:
+            self.assertContains(response, title)


### PR DESCRIPTION

## Purpose

Unpublished organizations were showing on the public version of the organizations list page. We should only show them to staff users.

## Proposal

- [x] Filter out unpublished organizations on the public version of the organizations list page (basically a copy/paste of what is already done for blog posts... we also get pagination for free)
- [x] Add an integration test to secure this behavior
