### PR TITLE
 🚑(LMSHandler) select_lms returns None if url is blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Allow use of columns in footer menu items
-- Avoid stretching of footer menu items
+### Fixed
+  - has_connected_lms crashed when course_run is blank
+
+### Added
+  - Allow use of columns in footer menu items
+
+### Changed
+  - Avoid stretching of footer menu items
 
 ## [2.0.0-beta.16] - 2020-10-23
 

--- a/src/richie/apps/courses/lms/__init__.py
+++ b/src/richie/apps/courses/lms/__init__.py
@@ -22,6 +22,8 @@ class LMSHandler:
         a course run has a matching LMS or not. Callers can determine if not finding an LMS
         backend is an exception or not.
         """
+        if url is None:
+            return None
 
         for lms_configuration in settings.LMS_BACKENDS:
             if re.match(lms_configuration.get("SELECTOR_REGEX", r".*"), url):

--- a/tests/apps/courses/lms/test_lms_select.py
+++ b/tests/apps/courses/lms/test_lms_select.py
@@ -27,7 +27,7 @@ class LMSSelectTestCase(TestCase):
     def test_lms_select(self):
         """
         The "select_lms" util function should return a backend instance with its configuration
-        or raise an ImproperlyConfigurer error if the url does not match any backend.
+        or raise an ImproperlyConfigurer error if the url does not match any backend or is blank.
         """
         backend = LMSHandler.select_lms("https://www.example.com/course/123")
         self.assertEqual(type(backend), TokenEdXLMSBackend)
@@ -38,3 +38,5 @@ class LMSSelectTestCase(TestCase):
         self.assertEqual(backend.configuration["BASE_URL"], "https://edx.org")
 
         self.assertIsNone(LMSHandler.select_lms("https://unknown.io/course/123"))
+
+        self.assertIsNone(LMSHandler.select_lms(None))


### PR DESCRIPTION
## Purpose

When a new course run page is created, a blank course run object is created.
But the course run page used has_connected_lms to check if the course run has an
associated known LMS. However the course run is blank, has_connected_lms crashes
because it send None value to LMSHandler.

## Proposal
- [x] `has_connected_lms` returns False directly if `course_run.resource_link` is blank
