### PR TITLE
🐛(frontend) refresh js on cms-content-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Reinitialize JS after saving a modification in edit mode
 - has_connected_lms crashed when course_run is blank
 - Avoid stretching of footer menu items
 

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -18,7 +18,7 @@ import { Root } from 'components/Root';
 import { handle } from 'utils/errors/handle';
 
 // Wait for the DOM to load before we scour it for an element that requires React to be rendered
-document.addEventListener('DOMContentLoaded', async () => {
+async function render() {
   // Find all the elements that need React to render a component
   const richieReactSpots = Array.prototype.slice.call(document.querySelectorAll('.richie-react'));
 
@@ -97,4 +97,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       reactRoot,
     );
   }
-});
+}
+
+document.addEventListener('DOMContentLoaded', render);
+
+// In some case, you would like to render Richie components manually
+(window as any).__RICHIE__ = Object.create({ render });

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -160,41 +160,59 @@
         </script>
         <script src="{% static 'richie/js/index.js' %}"></script>
         <script>
-        document.addEventListener("DOMContentLoaded", function() {
-            // Get all topbar burger elements
-            const topbarBurgers = Array.prototype.slice.call(
-                document.querySelectorAll(".topbar__hamburger"), 0
-            );
+            function initializeHamburgerMenu() {
+                // Get all topbar burger elements
+                const topbarBurgers = Array.prototype.slice.call(
+                    document.querySelectorAll(".topbar__hamburger"), 0
+                );
 
-            // Check if there are any navbar burgers
-            if (topbarBurgers.length > 0) {
-                // Add a click event on each of them
-                topbarBurgers.forEach(function(el) {
-                    el.addEventListener("click", function() {
-                        // Get the target from the "data-target" attribute
-                        const target = document.getElementById(el.dataset.target);
-                        // Toggle the "is-active" class on both the burger and container
-                        el.classList.toggle("is-active");
-                        target.classList.toggle("is-open");
+                // Check if there are any navbar burgers
+                if (topbarBurgers.length > 0) {
+                    // Add a click event on each of them
+                    topbarBurgers.forEach(function(el) {
+                        el.addEventListener("click", function() {
+                            // Get the target from the "data-target" attribute
+                            const target = document.getElementById(el.dataset.target);
+                            // Toggle the "is-active" class on both the burger and container
+                            el.classList.toggle("is-active");
+                            target.classList.toggle("is-open");
+                        });
                     });
-                });
+                }
             }
 
-            // Implement accordion item behaviors
-            const $accordionItems = Array.prototype.slice.call(
-                document.querySelectorAll('[data-accordion-button]'), 0
-            );
+            function initializeAccordions() {
+                // Implement accordion item behaviors
+                const $accordionItems = Array.prototype.slice.call(
+                    document.querySelectorAll('[data-accordion-button]'), 0
+                );
 
-            if ($accordionItems.length > 0) {
-                $accordionItems.forEach(function(itemObject, itemIndex) {
-                    itemObject.addEventListener('click', function () {
-                        itemObject.closest('li').toggleAttribute('data-accordion-active');
-                        itemObject.toggleAttribute('data-accordion-open');
+                if ($accordionItems.length > 0) {
+                    $accordionItems.forEach(function(itemObject, itemIndex) {
+                        itemObject.addEventListener('click', function () {
+                            itemObject.closest('li').toggleAttribute('data-accordion-active');
+                            itemObject.toggleAttribute('data-accordion-open');
+                        });
                     });
-                });
+                }
             }
-        });
+
+            document.addEventListener("DOMContentLoaded", function() {
+                initializeAccordions();
+                initializeHamburgerMenu();
+            });
         </script>
+        // When edit mode is active, we have to refresh js scripts after saving modifications
+        // https://docs.django-cms.org/en/latest/topics/frontend-integration.html
+        {% if request.toolbar and request.toolbar.edit_mode_active %}
+        <script>
+            CMS.$(window).on('cms-content-refresh', function () {
+                __RICHIE__.build();
+                initializeAccordions();
+                initializeHamburgerMenu();
+            });
+        </script>
+        {% endif %}
         {% block body_js %}{% endblock body_js %}
     </body>
 </html>


### PR DESCRIPTION
## Purpose

In edit mode, when user saves a modification, the new content is hot replaced
but js scripts are not reinitiliazed. In our case, as we use React, all React
components are not rendered after a content modification in Edit mode.

To solve this issue, Django-CMS provides an event "cms-content-refresh".
https://docs.django-cms.org/en/latest/topics/frontend-integration.html

## Proposal

- [x] Listen `cms-content-refresh` event and reinitialize our js each time this event is triggered.
