### PR TITLE
✅(pytest) ignore warnings from 3rd party library

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -109,3 +109,5 @@ python_files =
     tests.py
 testpaths =
     tests
+filterwarnings = 
+    ignore:::(?!(tests|richie))


### PR DESCRIPTION
## Purpose
Since upgrade of Django CMS to 3.8 and Django 3, we have a log of warnings
during backend tests that pollutes ci stacktrace.

There are two available options: 
First we can use `filterwarnings` to ignore all warnings coming from another packages than richie or tests.
```
filterwarnings = 
    ignore:::(?!(tests|richie))
```

On the other hand we can use `--disable-warnings`. In this case, Pytest does not ignore warnings, instead it just does not display details of them in the stacktrace. But If you read the tests resume, you see the number of warnings catched. And locally you can run make test-back and see all details.


## Proposal

- [x] Silent warnings from third party library
