### PR TITLE
🐛(persons) allow adding plugins to main content when empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix maincontent placeholder on person detail page when empty
+
 ## [2.0.0-beta.19] - 2020-11-09
 
 ### Added

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -76,7 +76,7 @@
 {% block content %}{% spaceless %}
 {% with header_level=2 person=current_page.person %}
 <div class="person-detail">
-    {% if not current_page|is_empty_placeholder:"maincontent" %}
+    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"maincontent" %}
     <div class="person-detail__maincontent person-detail__block">
         <div class="person-detail__row">
             {% placeholder "maincontent" %}

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -292,7 +292,8 @@ class PersonCMSTestCase(CMSTestCase):
 
     def test_templates_person_detail_maincontent_empty(self):
         """
-        The "maincontent" placeholder block should not be displayed when empty.
+        The "maincontent" placeholder block should not be displayed on the public
+        page when empty but only on the draft version for staff.
         """
         person = PersonFactory(should_publish=True)
 
@@ -301,6 +302,15 @@ class PersonCMSTestCase(CMSTestCase):
         response = self.client.get(url)
         self.assertContains(response, person.extended_object.get_title())
         self.assertNotContains(response, "person-detail__maincontent")
+
+        # But it should be present on the draft page
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        url = person.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertContains(response, person.extended_object.get_title())
+        self.assertContains(response, "person-detail__maincontent")
 
     def test_templates_person_detail_related_courses(self):
         """


### PR DESCRIPTION
## Purpose

We did not include the "maincontent" placeholder in the page when it was empty, even for staff users. As a result the placeholder
was not functional in the plugin side bar.

## Proposal

Add a condition to add the `mainbody` placedholder in the draft person detail page for staff users, even if the placeholder is empty.