### PR TITLE
🐛 (frontend) fix layout of PaginateCourseSearch placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix an issue about PaginateSearchCourse layout
+
 ## [2.0.0-beta.20] - 2020-11-10
 
 ### Fixed

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -93,7 +93,7 @@ export const PaginateCourseSearch = ({ courseSearchTotalCount }: PaginateCourseS
             <React.Fragment key={page}>
               {/* Prepend a cell with "..." when the page number we're rendering does not follow the previous one */}
               {page > (pageList[index - 1] || 0) + 1 && (
-                <li className="pagination__list__item pagination__list__item--placeholder">...</li>
+                <li className="pagination__item pagination__item--placeholder">...</li>
               )}
 
               {page === currentPage ? (


### PR DESCRIPTION
## Purpose

PaginateCourseSearch placeholder used a wrong class name so this element was not styled correctly.


## Proposal

- [x] Replace wrong `pagination__list__item` by `pagination__item`

### Before
![Capture d’écran 2020-11-16 à 14 22 20](https://user-images.githubusercontent.com/9265241/99257400-4318f500-2817-11eb-955c-5289281627fc.png)

### After
![Capture d’écran 2020-11-16 à 14 22 10](https://user-images.githubusercontent.com/9265241/99257405-44e2b880-2817-11eb-8e1e-b94656b33641.png)
