### PR TITLE
🐛(LMSHandler) check resource_link matches lms COURSE_REGEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix an issue about PaginateSearchCourse layout
+- Prevent enrollment failure if course run's resource_link does not match the
+  course regexp
 
 ## [2.0.0-beta.20] - 2020-11-10
 

--- a/env.d/development/dev
+++ b/env.d/development/dev
@@ -4,5 +4,6 @@ AUTHENTICATION_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
 
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
+EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/info$
 EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/info$
 EDX_BASE_URL=http://localhost:8073

--- a/env.d/development/dev-ssl
+++ b/env.d/development/dev-ssl
@@ -4,5 +4,6 @@ AUTHENTICATION_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
 
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
+EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/info$
 EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/info$
 EDX_BASE_URL=https://edx.local.dev:8073

--- a/env.d/development/dev-ssl
+++ b/env.d/development/dev-ssl
@@ -4,6 +4,6 @@ AUTHENTICATION_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
 
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
-EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/info$
-EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/info$
+EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/course$
+EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/course$
 EDX_BASE_URL=https://edx.local.dev:8073

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -275,8 +275,13 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_name="EDX_BACKEND",
                 environ_prefix=None,
             ),
+            "COURSE_REGEX": values.Value(
+                r".*", environ_name="EDX_COURSE_REGEX", environ_prefix=None
+            ),
             "SELECTOR_REGEX": values.Value(
-                r".*", environ_name="EDX_SELECTOR_REGEX", environ_prefix=None
+                r"^(?P<course_id>.*)$",
+                environ_name="EDX_SELECTOR_REGEX",
+                environ_prefix=None,
             ),
             "JS_SELECTOR_REGEX": values.Value(
                 r".*", environ_name="EDX_JS_SELECTOR_REGEX", environ_prefix=None

--- a/src/richie/apps/courses/lms/__init__.py
+++ b/src/richie/apps/courses/lms/__init__.py
@@ -25,7 +25,9 @@ class LMSHandler:
             return None
 
         for lms_configuration in settings.LMS_BACKENDS:
-            if re.match(lms_configuration.get("SELECTOR_REGEX", r".*"), url):
+            if re.match(
+                lms_configuration.get("SELECTOR_REGEX", r".*"), url
+            ) and re.match(lms_configuration.get("COURSE_REGEX", r".*"), url):
                 return import_string(lms_configuration["BACKEND"])(lms_configuration)
 
         return None

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -380,7 +380,7 @@ def create_demo_site():
                 page_in_navigation=False,
                 page_languages=["en", "fr"],
                 page_parent=course.extended_object,
-                resource_link=f"{lms_endpoint}/courses/course-v1:edX+DemoX+Demo_Course/info",
+                resource_link=f"{lms_endpoint}/courses/course-v1:edX+DemoX+Demo_Course/course",
                 should_publish=True,
             )
 

--- a/tests/apps/courses/lms/test_lms_select.py
+++ b/tests/apps/courses/lms/test_lms_select.py
@@ -13,11 +13,13 @@ class LMSSelectTestCase(TestCase):
     @override_settings(
         LMS_BACKENDS=[
             {
+                "COURSE_REGEX": r"^.*/moocs/(?P<course_id>.*)",
                 "SELECTOR_REGEX": r".*example.com.*",
                 "BACKEND": "richie.apps.courses.lms.edx.TokenEdXLMSBackend",
                 "BASE_URL": "https://www.example.com",
             },
             {
+                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)",
                 "SELECTOR_REGEX": r".*edx.org.*",
                 "BACKEND": "richie.apps.courses.lms.edx.BaseLMSBackend",
                 "BASE_URL": "https://edx.org",
@@ -27,15 +29,18 @@ class LMSSelectTestCase(TestCase):
     def test_lms_select(self):
         """
         The "select_lms" util function should return a backend instance with its configuration
-        or raise an ImproperlyConfigurer error if the url does not match any backend or is blank.
+        or raise an ImproperlyConfigurer error if the url does not match any backend or is blank or
+        any course id can be extract from the resource_link.
         """
-        backend = LMSHandler.select_lms("https://www.example.com/course/123")
+        backend = LMSHandler.select_lms("https://www.example.com/moocs/123")
         self.assertEqual(type(backend), TokenEdXLMSBackend)
         self.assertEqual(backend.configuration["BASE_URL"], "https://www.example.com")
 
-        backend = LMSHandler.select_lms("https://edx.org/course/123")
+        backend = LMSHandler.select_lms("https://edx.org/courses/123")
         self.assertEqual(type(backend), BaseLMSBackend)
         self.assertEqual(backend.configuration["BASE_URL"], "https://edx.org")
+
+        self.assertIsNone(LMSHandler.select_lms("https://edx.org/wrong-path/123"))
 
         self.assertIsNone(LMSHandler.select_lms("https://unknown.io/course/123"))
 

--- a/tests/apps/courses/test_templatetags_extra_tags_has_connected_lms.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_has_connected_lms.py
@@ -39,3 +39,22 @@ class HasConnectedLMSFilterTestCase(CMSTestCase):
         """
         course_run = CourseRunFactory()
         self.assertEqual(has_connected_lms(course_run), False)
+
+    @override_settings(
+        LMS_BACKENDS=[
+            {
+                "BACKEND": "richie.apps.courses.lms.edx.TokenEdXLMSBackend",
+                "BASE_URL": "http://example.edx:8073",
+                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course",
+                "API_TOKEN": "fakesecret",
+            }
+        ]
+    )
+    def test_course_run_with_malformed_resource_link_has_no_connected_lms(self):
+        """
+        When the course run resource_link is malformed, the filter returns False.
+        """
+        course_run = CourseRunFactory(
+            resource_link="http://example.edx:8073/courses/course-v1:edX+DemoX+Demo_Course/info/"
+        )
+        self.assertEqual(has_connected_lms(course_run), False)


### PR DESCRIPTION
## Purpose
Enrollment widget can fail to enroll if course run resource_link is malformed.

## Proposal

- [x] Display enrollment widget only if there is a backend for the course run and a course_id can be extracted from its resource_link
