### PR TITLE
Fix/course resource link validator

### DIFF
--- a/env.d/development/dev
+++ b/env.d/development/dev
@@ -4,6 +4,6 @@ AUTHENTICATION_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
 
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
-EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/info$
-EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/info$
+EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/course$
+EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/course$
 EDX_BASE_URL=http://localhost:8073


### PR DESCRIPTION
## Purpose
When a course use a known `LMS_BACKEND` but its associated `COURSE_REGEX` does not match a `courseId` an exception occured.


## Proposal

- [x] `select_lms` now checks that course run has an associated LMS_BACKEND and that COURSE_REGEX finds a `courseId` in its resource link.
