### PR TITLE
Feat/edx dogwood js api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a frontend API Implementation for OpenEdX Dogwood/Eucalyptus
 - Add a new variant "Badge" to glimpse plugin
 
 ### Changed

--- a/docs/lms-connection.md
+++ b/docs/lms-connection.md
@@ -20,6 +20,7 @@ based on a regex match on the URL of the course.
 LMS_BACKENDS=[
     {
         "BACKEND": "richie.apps.courses.lms.edx.TokenEdXLMSBackend",
+        "JS_BACKEND": "openedx-hawthorn",
         "SELECTOR_REGEX": r".*lms-example2.org.*",
         "JS_SELECTOR_REGEX": r".*lms-example2.org.*",
         "BASE_URL": "https://www.lms-example2.org",
@@ -31,6 +32,12 @@ LMS_BACKENDS=[
 For information about how to generate an API access on your OpenEdx instance, refer to the
 documentation.
 
+_Note: `JS_BACKEND` accepts `base`, `openedx-dogwood` and `openedx-hawthorn` values._
+_We have to implement several interfaces to be compatible to OpenEdx API:_
+_`openedx-dogwood` has been tested with Dogwood and Eucalyptus versions._
+_`openedx-hawthorn` has been tested with Hawthorn and Ironwood versions._
+_If you encounter an issue with these API interfaces or need to have a new interface, propose a PR_
+_or create an issue on our repository_
 
 ## Connecting Richie and OpenEdx over TLS
 

--- a/env.d/development/dev
+++ b/env.d/development/dev
@@ -1,9 +1,10 @@
 # Authentication Backend
 AUTHENTICATION_BASE_URL=http://localhost:8073
-AUTHENTICATION_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
+AUTHENTICATION_BACKEND=base
 
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
+EDX_JS_BACKEND=base
 EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/info$
 EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/info$
 EDX_BASE_URL=http://localhost:8073

--- a/env.d/development/dev-ssl
+++ b/env.d/development/dev-ssl
@@ -4,6 +4,6 @@ AUTHENTICATION_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
 
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
-EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/course$
-EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/course$
+EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/info$
+EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/info$
 EDX_BASE_URL=https://edx.local.dev:8073

--- a/env.d/development/dev-ssl
+++ b/env.d/development/dev-ssl
@@ -1,9 +1,10 @@
 # Authentication Backend
 AUTHENTICATION_BASE_URL=https://edx.local.dev:8073
-AUTHENTICATION_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
+AUTHENTICATION_BACKEND=openedx-hawthorn
 
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.edx.TokenEdXLMSBackend
+EDX_JS_BACKEND=openedx-hawthorn
 EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/info$
 EDX_JS_COURSE_REGEX=^.*/courses/(?<course_id>.*)/info$
 EDX_BASE_URL=https://edx.local.dev:8073

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -246,7 +246,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
             "", environ_name="AUTHENTICATION_BASE_URL", environ_prefix=None
         ),
         "BACKEND": values.Value(
-            "richie.apps.courses.lms.base.BaseLMSBackend",
+            "base",
             environ_name="AUTHENTICATION_BACKEND",
             environ_prefix=None,
         ),
@@ -273,6 +273,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
             "BACKEND": values.Value(
                 "richie.apps.courses.lms.base.BaseLMSBackend",
                 environ_name="EDX_BACKEND",
+                environ_prefix=None,
+            ),
+            "JS_BACKEND": values.Value(
+                "base",
+                environ_name="EDX_JS_BACKEND",
                 environ_prefix=None,
             ),
             "COURSE_REGEX": values.Value(

--- a/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
@@ -6,6 +6,7 @@ import faker from 'faker';
 
 import { CourseRun } from 'types';
 import { CommonDataProps } from 'types/commonDataProps';
+import { ApiBackend } from 'types/api';
 import { Deferred } from 'utils/test/deferred';
 import * as factories from 'utils/test/factories';
 import { SESSION_CACHE_KEY } from 'settings';
@@ -17,11 +18,11 @@ describe('<CourseRunEnrollment />', () => {
     .ContextFactory({
       authentication: {
         endpoint,
-        backend: 'richie.apps.courses.lms.edx.TokenEdXLMSBackend',
+        backend: ApiBackend.OPENEDX_HAWTHORN,
       },
       lms_backends: [
         {
-          backend: 'richie.apps.courses.lms.edx.TokenEdXLMSBackend',
+          backend: ApiBackend.OPENEDX_HAWTHORN,
           course_regexp: '(?<course_id>.*)',
           endpoint,
           selector_regexp: '.*',

--- a/src/frontend/js/data/useSession/index.tsx
+++ b/src/frontend/js/data/useSession/index.tsx
@@ -10,11 +10,11 @@ import { SESSION_CACHE_KEY } from 'settings';
  * useSession
  *
  * An utils to manage user session in Richie
- * User session information are extracted from EDX cookies.
- * This means that EDX and Richie must be accessible through the same domain and
- * EDX must be configured to share cookies to Richie sub domain.
+ * User session information are extracted from OpenEdX cookies.
+ * This means that OpenEdX and Richie must be accessible through the same domain and
+ * OpenEdX must be configured to share cookies to Richie sub domain.
  *
- * "edxloggedin" cookie is used to know if an EDX session is active or not,
+ * "edxloggedin" cookie is used to know if an OpenEdX session is active or not,
  * then user information are extracted from "edx-user-info" cookie.
  *
  * useSession use a context to dispatch any change to all react widgets.
@@ -36,7 +36,7 @@ const Session = createContext<SessionContext>({} as any);
  *
  * Session:
  * @param user the current user state. Read below to see possible states
- * @param destroy set Session to undefined then make a request to logout user from EDX
+ * @param destroy set Session to undefined then make a request to logout user from OpenEdX
  */
 export const SessionProvider = ({ children }: PropsWithChildren<any>) => {
   /**

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -1,6 +1,8 @@
 import { Course } from 'types/Course';
 import { FacetedFilterDefinition } from 'types/filters';
-import { Maybe } from 'utils/types';
+import { Maybe, Nullable } from 'utils/types';
+import { User } from 'types/User';
+import { Enrollment } from 'types';
 
 export enum RequestStatus {
   FAILURE = 'failure',
@@ -33,4 +35,32 @@ export interface APICourseSearchResponse {
   };
   meta: APIResponseListMeta;
   objects: Course[];
+}
+
+export interface ApiImplementation {
+  user: {
+    me: () => Promise<Nullable<User>>;
+    login: () => void;
+    register: () => void;
+    logout: () => Promise<void>;
+  };
+  enrollment: {
+    get: (url: string, user: Nullable<User>) => Promise<Nullable<Enrollment>>;
+    isEnrolled: (url: string, user: Nullable<User>) => Promise<boolean>;
+    set: (url: string, user: User) => Promise<boolean>;
+  };
+}
+
+export interface ApiOptions {
+  routes: {
+    [Model: string]: {
+      [Method: string]: string;
+    };
+  };
+}
+
+export enum ApiBackend {
+  BASE = 'base',
+  OPENEDX_DOGWOOD = 'openedx-dogwood',
+  OPENEDX_HAWTHORN = 'openedx-hawthorn',
 }

--- a/src/frontend/js/utils/api/authentication.ts
+++ b/src/frontend/js/utils/api/authentication.ts
@@ -8,9 +8,10 @@
 import { handle } from 'utils/errors/handle';
 import { AuthenticationBackend } from 'types/commonDataProps';
 import { Nullable } from 'utils/types';
-import { ApiImplementation } from './lms';
+import { ApiImplementation, ApiBackend } from 'types/api';
 import BaseApiInterface from './lms/base';
-import OpenEdxApiInterface from './lms/edx';
+import OpenEdxDogwoodApiInterface from './lms/openedx-dogwood';
+import OpenEdxHawthornApiInterface from './lms/openedx-hawthorn';
 
 const AuthenticationAPIHandler = (): Nullable<ApiImplementation['user']> => {
   const AUTHENTICATION: AuthenticationBackend = (window as any).__richie_frontend_context__?.context
@@ -18,10 +19,12 @@ const AuthenticationAPIHandler = (): Nullable<ApiImplementation['user']> => {
   if (!AUTHENTICATION) return null;
 
   switch (AUTHENTICATION.backend) {
-    case 'richie.apps.courses.lms.base.BaseLMSBackend':
+    case ApiBackend.BASE:
       return BaseApiInterface(AUTHENTICATION).user;
-    case 'richie.apps.courses.lms.edx.TokenEdXLMSBackend':
-      return OpenEdxApiInterface(AUTHENTICATION).user;
+    case ApiBackend.OPENEDX_DOGWOOD:
+      return OpenEdxDogwoodApiInterface(AUTHENTICATION).user;
+    case ApiBackend.OPENEDX_HAWTHORN:
+      return OpenEdxHawthornApiInterface(AUTHENTICATION).user;
     default:
       handle(new Error(`No Authentication Backend found for ${AUTHENTICATION.backend}.`));
       return null;

--- a/src/frontend/js/utils/api/lms/base.spec.ts
+++ b/src/frontend/js/utils/api/lms/base.spec.ts
@@ -1,10 +1,11 @@
 import { ContextFactory } from 'utils/test/factories';
+import { ApiBackend } from 'types/api';
 
 describe('Base API', () => {
   const context = ContextFactory({
     lms_backends: [
       {
-        backend: 'richie.apps.courses.lms.base.BaseLMSBackend',
+        backend: ApiBackend.BASE,
         course_regexp: '(?<course_id>.*)',
         endpoint: 'https://demo.endpoint/api',
         selector_regexp: '.*',

--- a/src/frontend/js/utils/api/lms/base.ts
+++ b/src/frontend/js/utils/api/lms/base.ts
@@ -1,15 +1,15 @@
 import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
 import { Nullable, Maybe } from 'utils/types';
 import { User } from 'types/User';
-import { ApiImplementation } from '.';
-import EDX from './edx';
+import { ApiImplementation } from 'types/api';
+import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
 const API = (APIConf: LMSBackend | AuthenticationBackend): ApiImplementation => {
   const extractCourseIdFromUrl = (url: string): Maybe<Nullable<string>> =>
     url.match((APIConf as LMSBackend).course_regexp)?.groups?.course_id;
 
   return {
-    user: EDX(APIConf).user,
+    user: OpenEdxHawthornApiInterface(APIConf).user,
     enrollment: {
       get: async (url: string, user: Nullable<User>) =>
         new Promise((resolve) => {

--- a/src/frontend/js/utils/api/lms/index.spec.ts
+++ b/src/frontend/js/utils/api/lms/index.spec.ts
@@ -21,7 +21,7 @@ describe('API LMS', () => {
 
   const { default: LMSHandler } = require('./index');
 
-  it('returns EDX API if url that match edx selector is provided', () => {
+  it('returns OpenEdX API if url that match edx selector is provided', () => {
     const api = LMSHandler('https://edx.org/courses/a-test-course');
     expect(api).toBeDefined();
   });

--- a/src/frontend/js/utils/api/lms/index.spec.ts
+++ b/src/frontend/js/utils/api/lms/index.spec.ts
@@ -1,14 +1,16 @@
+import { ApiBackend } from 'types/api';
+
 describe('API LMS', () => {
   (window as any).__richie_frontend_context__ = {
     context: {
       lms_backends: [
         {
-          backend: 'richie.apps.courses.lms.base.BaseLMSBackend',
+          backend: ApiBackend.BASE,
           endpoint: 'https://demo.endpoint/api',
           selector_regexp: /.*base.org\/.*/,
         },
         {
-          backend: 'richie.apps.courses.lms.edx.TokenEdXLMSBackend',
+          backend: ApiBackend.OPENEDX_HAWTHORN,
           endpoint: 'https://edx.endpoint/api',
           selector_regexp: /.*edx.org\/.*/,
         },

--- a/src/frontend/js/utils/api/lms/index.ts
+++ b/src/frontend/js/utils/api/lms/index.ts
@@ -1,24 +1,9 @@
 import { CommonDataProps } from 'types/commonDataProps';
 import { handle } from 'utils/errors/handle';
-import { Nullable } from 'utils/types';
-import { User } from 'types/User';
-import { Enrollment } from 'types';
+import { ApiImplementation, ApiBackend } from 'types/api';
 import BaseApiInterface from './base';
-import OpenEdxApiInterface from './edx';
-
-export interface ApiImplementation {
-  user: {
-    me: () => Promise<Nullable<User>>;
-    login: () => void;
-    register: () => void;
-    logout: () => Promise<void>;
-  };
-  enrollment: {
-    get: (url: string, user: Nullable<User>) => Promise<Nullable<Enrollment>>;
-    isEnrolled: (url: string, user: Nullable<User>) => Promise<boolean>;
-    set: (url: string, user: User) => Promise<boolean>;
-  };
-}
+import OpenEdxDogwoodApiInterface from './openedx-dogwood';
+import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
 const context: CommonDataProps['context'] = (window as any).__richie_frontend_context__?.context;
 if (!context) throw new Error('No context frontend context available');
@@ -34,10 +19,12 @@ const LmsAPIHandler = (url: string): ApiImplementation => {
   const api = selectAPIWithUrl(url);
 
   switch (api?.backend) {
-    case 'richie.apps.courses.lms.base.BaseLMSBackend':
+    case ApiBackend.BASE:
       return BaseApiInterface(api);
-    case 'richie.apps.courses.lms.edx.TokenEdXLMSBackend':
-      return OpenEdxApiInterface(api);
+    case ApiBackend.OPENEDX_DOGWOOD:
+      return OpenEdxDogwoodApiInterface(api);
+    case ApiBackend.OPENEDX_HAWTHORN:
+      return OpenEdxHawthornApiInterface(api);
   }
 
   const error = new Error(`No LMS Backend found for ${url}.`);

--- a/src/frontend/js/utils/api/lms/openedx-dogwood.ts
+++ b/src/frontend/js/utils/api/lms/openedx-dogwood.ts
@@ -4,7 +4,7 @@ import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
 /**
  *
- * EDX Dogwood API Implementation
+ * OpenEdX Dogwood API Implementation
  *
  * This implementation inherits from Hawthorn implementation.
  * The `user.me` methods has to be overriden since `/user/v1/me` route does not

--- a/src/frontend/js/utils/api/lms/openedx-dogwood.ts
+++ b/src/frontend/js/utils/api/lms/openedx-dogwood.ts
@@ -1,0 +1,27 @@
+import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
+import { ApiImplementation } from 'types/api';
+import OpenEdxHawthornApiInterface from './openedx-hawthorn';
+
+/**
+ *
+ * EDX Dogwood API Implementation
+ *
+ * This implementation inherits from Hawthorn implementation.
+ * The `user.me` methods has to be overriden since `/user/v1/me` route does not
+ * exist in OpenEdX Dogwood & Eucalyptus Rest API.
+ *
+ */
+
+const API = (APIConf: LMSBackend | AuthenticationBackend): ApiImplementation => {
+  const ApiOptions = {
+    routes: {
+      user: {
+        me: '/api/mobile/v0.5/my_user_info',
+      },
+    },
+  };
+
+  return OpenEdxHawthornApiInterface(APIConf, ApiOptions);
+};
+
+export default API;

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
@@ -9,9 +9,9 @@ import { EDX_CSRF_TOKEN_COOKIE_NAME } from 'settings';
 
 /**
  *
- * EDX Hawthorn API Implementation
+ * OpenEdX Hawthorn API Implementation
  *
- * This implementation is used for EDX Hawthorn and upper until routes used
+ * This implementation is used for OpenEdX Hawthorn and upper until routes used
  * will not be compatible.
  *
  */
@@ -48,7 +48,7 @@ const API = (
           .then((res) => {
             if (res.ok) return res.json();
             if (res.status === 401) return null;
-            throw new Error(`[SESSION EDX API] > Cannot retrieve user`);
+            throw new Error(`[SESSION OpenEdX API] > Cannot retrieve user`);
           })
           .catch((error) => {
             handle(error);

--- a/src/frontend/js/utils/test/factories.ts
+++ b/src/frontend/js/utils/test/factories.ts
@@ -1,5 +1,6 @@
 import { createSpec, derived, faker } from '@helpscout/helix';
 import { CommonDataProps } from 'types/commonDataProps';
+import { ApiBackend } from 'types/api';
 
 const CourseStateFactory = createSpec({
   priority: derived(() => Math.floor(Math.random() * 7)),
@@ -37,12 +38,12 @@ export const ContextFactory = (context: Partial<CommonDataProps['context']> = {}
     csrftoken: faker.random.alphaNumeric(64),
     environment: 'test',
     authentication: {
-      backend: 'richie.apps.courses.lms.base.BaseLMSBackend',
+      backend: ApiBackend.BASE,
       endpoint: 'https://endpoint.test',
     },
     lms_backends: [
       {
-        backend: 'richie.apps.courses.lms.base.BaseLMSBackend',
+        backend: ApiBackend.BASE,
         selector_regexp: '.*',
         course_regexp: '.*',
         endpoint: 'https://endpoint.test',

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -74,7 +74,7 @@ def site_metas(request):
         context["FRONTEND_CONTEXT"]["context"]["lms_backends"] = [
             {
                 "endpoint": lms["BASE_URL"],
-                "backend": lms["BACKEND"],
+                "backend": lms["JS_BACKEND"],
                 "course_regexp": lms["JS_COURSE_REGEX"],
                 "selector_regexp": lms["JS_SELECTOR_REGEX"],
             }

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -380,7 +380,7 @@ def create_demo_site():
                 page_in_navigation=False,
                 page_languages=["en", "fr"],
                 page_parent=course.extended_object,
-                resource_link=f"{lms_endpoint}/courses/course-v1:edX+DemoX+Demo_Course/course",
+                resource_link=f"{lms_endpoint}/courses/course-v1:edX+DemoX+Demo_Course/info",
                 should_publish=True,
             )
 

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -470,6 +470,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
         LMS_BACKENDS=[
             {
                 "BACKEND": "richie.apps.courses.lms.edx.TokenEdXLMSBackend",
+                "JS_BACKEND": "openedx-hawthorn",
                 "SELECTOR_REGEX": r".*",
                 "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
                 "JS_SELECTOR_REGEX": r".*",
@@ -536,6 +537,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
         LMS_BACKENDS=[
             {
                 "BACKEND": "richie.apps.courses.lms.edx.TokenEdXLMSBackend",
+                "JS_BACKEND": "openedx-hawthorn",
                 "SELECTOR_REGEX": r".*",
                 "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
                 "JS_SELECTOR_REGEX": r".*",

--- a/tests/apps/courses/test_templates_course_run_detail.py
+++ b/tests/apps/courses/test_templates_course_run_detail.py
@@ -323,6 +323,7 @@ class CourseRunCMSTestCase(CMSTestCase):
         LMS_BACKENDS=[
             {
                 "BACKEND": "richie.apps.courses.lms.edx.TokenEdXLMSBackend",
+                "JS_BACKEND": "openedx-hawthorn",
                 "SELECTOR_REGEX": r".*",
                 "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
                 "JS_SELECTOR_REGEX": r".*",
@@ -353,6 +354,7 @@ class CourseRunCMSTestCase(CMSTestCase):
         LMS_BACKENDS=[
             {
                 "BACKEND": "richie.apps.courses.lms.edx.TokenEdXLMSBackend",
+                "JS_BACKEND": "openedx-hawthorn",
                 "SELECTOR_REGEX": r".*",
                 "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
                 "JS_SELECTOR_REGEX": r".*",


### PR DESCRIPTION
## Purpose

Since EDX Api may vary according to its version, frontend must be able to use the right API implementation for a specific EDX version. As backend do not care about that, we have to distinguish the lms implementation of backend to the implementation for frontend.


## Proposal

- [x] Refactor LMS_BACKEND to separate frontend & backend implementation
- [x] Ensure that frontend is compatible with OpenEdx Dogwood, Eucalyptus and Ironwood APIs
