### PR TITLE
🔖(chore) bump version to 2.0.0-beta.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+## [2.0.0-beta.21] - 2020-11-27
+
 ### Added
 
 - Add a frontend API Implementation for OpenEdX Dogwood/Eucalyptus
@@ -1096,7 +1098,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v2.0.0-beta.20...master
+[unreleased]: https://github.com/openfun/richie/compare/v2.0.0-beta.21...master
+[2.0.0-beta.21]: https://github.com/openfun/richie/compare/v2.0.0-beta.20...v2.0.0-beta.21
 [2.0.0-beta.20]: https://github.com/openfun/richie/compare/v2.0.0-beta.19...v2.0.0-beta.20
 [2.0.0-beta.19]: https://github.com/openfun/richie/compare/v2.0.0-beta.18...v2.0.0-beta.19
 [2.0.0-beta.18]: https://github.com/openfun/richie/compare/v2.0.0-beta.17...v2.0.0-beta.18

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 2.0.0-beta.20
+version = 2.0.0-beta.21
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "2.0.0-beta.20",
+  "version": "2.0.0-beta.21",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {

--- a/tests_e2e/package.json
+++ b/tests_e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-tests-e2e",
-  "version": "2.0.0-beta.20",
+  "version": "2.0.0-beta.21",
   "description": "End-to-end tests for the Richie project",
   "repository": "https://github.com/openfun/richie",
   "author": "Open FUN (France Université Numérique)",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education-docs",
-  "version": "2.0.0-beta.20",
+  "version": "2.0.0-beta.21",
   "description": "Documentation website for the Richie project",
   "scripts": {
     "build": "docusaurus-build",


### PR DESCRIPTION
### Added
- Add a frontend API Implementation for OpenEdX Dogwood/Eucalyptus
- Add a new variant "Badge" to glimpse plugin

### Changed
- Improve the layout of the footer to save space
- Allow ProgramPlugin in SectionPlugin on Homepage
- Allow only one CKEditorPlugin to program_body placeholder

### Fixed
- Fix an issue about PaginateSearchCourse layout
- Prevent enrollment failure if course run's resource_link does not match the
  course regexp