### PR TITLE
📌(djangocms-admin-style) use a forked version waiting next release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,10 @@ COPY --from=front-builder \
 RUN pip install --upgrade pip
 
 RUN mkdir /install && \
-    pip install --prefix=/install .[sandbox]
+    pip install --prefix=/install .[sandbox] \
+    # Use temporarily a forked version of djangocms-admin-style
+    # Remove this when djangocms-admin-style 2.0.3 will be released
+    pip install --prefix=/install git+https://github.com/jbpenrath/djangocms-admin-style@fun#egg=djangocms-admin-style
 
 # ---- Core application image ----
 FROM base as core


### PR DESCRIPTION
## Purpose

We submited a fix to djangocms-admin-style project but it is still pending review.
So to enable fix now, we could use our forked version of this package.

## Proposal

- [x] Install djangocms-admin-style from our forked version available on github
