### PR TITLE
🔖(chore) bump version to 2.0.0-beta.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+## [2.0.0-beta.22] - 2020-12-04
+
 ### Changed
 
 - Refactor course runs to not be CMS pages anymore
@@ -1107,7 +1109,8 @@ us:
 - finish integrating the missing pages and improve the sandbox environment;
 - test and polish the use of richie as a django app / node dependency.
 
-[unreleased]: https://github.com/openfun/richie/compare/v2.0.0-beta.21...master
+[unreleased]: https://github.com/openfun/richie/compare/v2.0.0-beta.22...master
+[2.0.0-beta.22]: https://github.com/openfun/richie/compare/v2.0.0-beta.21...v2.0.0-beta.22
 [2.0.0-beta.21]: https://github.com/openfun/richie/compare/v2.0.0-beta.20...v2.0.0-beta.21
 [2.0.0-beta.20]: https://github.com/openfun/richie/compare/v2.0.0-beta.19...v2.0.0-beta.20
 [2.0.0-beta.19]: https://github.com/openfun/richie/compare/v2.0.0-beta.18...v2.0.0-beta.19

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = richie
-version = 2.0.0-beta.21
+version = 2.0.0-beta.22
 description = A FUN portal for Open edX
 long_description = file:README.md
 long_description_content_type = text/markdown

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education",
-  "version": "2.0.0-beta.21",
+  "version": "2.0.0-beta.22",
   "description": "A CMS for Open Education",
   "main": "sandbox/manage.py",
   "scripts": {

--- a/tests_e2e/package.json
+++ b/tests_e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-tests-e2e",
-  "version": "2.0.0-beta.21",
+  "version": "2.0.0-beta.22",
   "description": "End-to-end tests for the Richie project",
   "repository": "https://github.com/openfun/richie",
   "author": "Open FUN (France Université Numérique)",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie-education-docs",
-  "version": "2.0.0-beta.21",
+  "version": "2.0.0-beta.22",
   "description": "Documentation website for the Richie project",
   "scripts": {
     "build": "docusaurus-build",


### PR DESCRIPTION
### Changed

- Refactor course runs to not be CMS pages anymore

### Fixed

- Stop indexing snapshots on signal update
- Fix object names plurals in admin
