### PR TITLE
🔒(courses) add permissions to course run admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Add permission checks to course run admin based on their related course page
+
 ## [2.0.0-beta.22] - 2020-12-04
 
 ### Changed

--- a/src/richie/apps/courses/helpers.py
+++ b/src/richie/apps/courses/helpers.py
@@ -34,7 +34,7 @@ def snapshot_course(page, user, simulate_only=False):
 
     site = page.node.site
 
-    # User can only snapshot pages he can see
+    # User can only snapshot pages he can change
     can_snapshot = page_permissions.user_can_change_page(user, page, site)
 
     if can_snapshot:

--- a/tests/apps/courses/test_admin_course_run.py
+++ b/tests/apps/courses/test_admin_course_run.py
@@ -1,21 +1,27 @@
 """
-Test suite defining the admin pages for the Course model
+Test suite defining the admin pages for the CourseRun model
 """
+import random
 from datetime import datetime
 
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 import pytz
+from cms.models import PagePermission
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
 from richie.apps.courses.factories import CourseFactory, CourseRunFactory
+from richie.apps.courses.models import Course, CourseRun
+
+# pylint: disable=too-many-public-methods
 
 
 class CourseRunAdminTestCase(CMSTestCase):
     """
-    Integration test suite to validate the behavior of admin pages for the Course model
+    Integration test suite to validate the behavior of admin pages for the CourseRun model
     """
 
     def test_admin_course_run_index(self):
@@ -34,25 +40,6 @@ class CourseRunAdminTestCase(CMSTestCase):
         course_run_url = reverse("admin:courses_courserun_changelist")
         self.assertNotContains(response, course_run_url)
 
-    def test_admin_course_run_list_view(self):
-        """
-        The admin list view of course runs should display the title of the related page.
-        """
-        user = UserFactory(is_staff=True, is_superuser=True)
-        self.client.login(username=user.username, password="password")
-
-        # Create a course run linked to a page
-        course_run = CourseRunFactory()
-
-        # Get the admin list view
-        url = reverse("admin:courses_courserun_changelist")
-        response = self.client.get(url, follow=True)
-        self.assertEqual(response.status_code, 200)
-
-        # Check that the page includes the course run
-        self.assertContains(response, course_run.title)
-        self.assertContains(response, course_run.resource_link)
-
     def test_admin_course_run_add_view(self):
         """
         The admin add view should work for course runs.
@@ -65,13 +52,125 @@ class CourseRunAdminTestCase(CMSTestCase):
         response = self.client.get(url, follow=True)
 
         # Check that the page includes all our fields
+        self.assertContains(response, "id_title")
         self.assertContains(response, "id_resource_link")
         self.assertContains(response, "id_start_", count=3)
         self.assertContains(response, "id_end_", count=3)
         self.assertContains(response, "id_enrollment_start_", count=3)
         self.assertContains(response, "id_enrollment_end_", count=3)
+        self.assertContains(response, "id_languages")
 
-    def test_admin_course_run_change_view_get(self):
+    # List
+
+    def test_admin_course_run_list_view_anonymous(self):
+        """
+        Anonymous users should not be allowed to access the change list view.
+        """
+        CourseRunFactory()
+
+        # Get the admin list view
+        url = reverse("admin:courses_courserun_changelist")
+        response = self.client.get(url, follow=True)
+
+        # Check that the user is redirected to the login page
+        self.assertContains(
+            response, "<title>Log in | Django site admin</title>", html=True
+        )
+
+    def test_admin_course_run_list_view_superuser(self):
+        """
+        The admin list view of course runs should only show draft objects.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create a course run linked to a page
+        course = CourseFactory()
+        course_run = CourseRunFactory(direct_course=course)
+        course.extended_object.publish("en")
+        self.assertEqual(CourseRun.objects.count(), 2)
+
+        # Get the admin list view
+        url = reverse("admin:courses_courserun_changelist")
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        # Check that the page includes only the draft course run
+        self.assertContains(
+            response, '<p class="paginator">1 course run</p>', html=True
+        )
+        change_url = reverse("admin:courses_courserun_change", args=[course_run.id])
+        self.assertContains(response, change_url)
+
+    def test_admin_course_run_list_view_staff(self):
+        """
+        On the course run change list view, staff users should only see course runs related
+        to course pages for on which they have change permission.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create a course run linked to a page
+        course_run1 = CourseRunFactory()
+        course_run2 = CourseRunFactory()
+
+        # Create the required permissions only for the first course run
+        self.add_permission(user, "change_courserun")
+        self.add_permission(user, "change_page")
+        PagePermission.objects.create(
+            page=course_run1.direct_course.extended_object,
+            user=user,
+            can_add=False,
+            can_change=True,
+            can_delete=False,
+            can_publish=False,
+            can_move_page=False,
+        )
+
+        # Get the admin list view
+        url = reverse("admin:courses_courserun_changelist")
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        # Check that the page includes only the first course run
+        self.assertContains(
+            response, '<p class="paginator">1 course run</p>', html=True
+        )
+        change_url = reverse("admin:courses_courserun_change", args=[course_run1.id])
+        self.assertContains(response, change_url)
+
+        # Unless the CMS permissions are not activated
+        with override_settings(CMS_PERMISSION=False):
+            response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        # Check that the page includes both course runs
+        self.assertContains(
+            response, '<p class="paginator">2 course runs</p>', html=True
+        )
+        change_url1 = reverse("admin:courses_courserun_change", args=[course_run1.id])
+        self.assertContains(response, change_url1)
+        change_url2 = reverse("admin:courses_courserun_change", args=[course_run2.id])
+        self.assertContains(response, change_url2)
+
+    # Get
+
+    def test_admin_course_run_change_view_get_anonymous(self):
+        """
+        Anonymous users should not be allowed to view course runs via the admin.
+        """
+        course_run = CourseRunFactory()
+
+        # Get the admin change view
+        url = reverse("admin:courses_courserun_change", args=[course_run.id])
+        response = self.client.get(url, follow=True)
+
+        # Check that the user is redirected to the login page
+        self.assertContains(
+            response, "<title>Log in | Django site admin</title>", html=True
+        )
+
+    def test_admin_course_run_change_view_get_superuser_draft(self):
         """
         The admin change view should include the editable and readonly fields as expected.
         In particular, the relation fields should only include options for related objects in
@@ -99,23 +198,126 @@ class CourseRunAdminTestCase(CMSTestCase):
         self.assertContains(response, "id_enrollment_end_", count=3)
         self.assertContains(response, "id_languages", count=2)
 
-    def test_admin_course_run_change_view_post(self):
-        """
-        Validate that the course run can be updated via the admin.
-        """
+    def test_admin_course_run_change_view_get_superuser_public(self):
+        """Public course runs should not render a change view."""
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
-        # Create a course run
+        # Create a public course run
+        course = CourseFactory()
+        CourseRunFactory(direct_course=course)
+        course.extended_object.publish("en")
+
+        self.assertEqual(CourseRun.objects.count(), 2)
+        public_course_run = CourseRun.objects.get(draft_course_run__isnull=False)
+
+        # Get the admin change view
+        url = reverse("admin:courses_courserun_change", args=[public_course_run.id])
+        response = self.client.get(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "id_title")
+        self.assertContains(response, "Perhaps it was deleted?")
+
+    def test_admin_course_run_change_view_get_staff_missing_model_permission(self):
+        """
+        Staff users missing permissions should not be allowed to view a course run's change view.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
         course_run = CourseRunFactory()
 
-        # A course run can be moved to its course's snapshot
-        snapshot = CourseFactory(page_parent=course_run.direct_course.extended_object)
+        # Create the required model permissions except one
+        missing = random.randint(0, 1)
+        if missing != 0:
+            self.add_permission(user, "change_courserun")
+        if missing != 1:
+            self.add_permission(user, "change_page")
+
+        # Create the object permission on the course page
+        PagePermission.objects.create(
+            page=course_run.direct_course.extended_object,
+            user=user,
+            can_add=False,
+            can_change=True,
+            can_delete=False,
+            can_publish=False,
+            can_move_page=False,
+        )
 
         # Get the admin change view
         url = reverse("admin:courses_courserun_change", args=[course_run.id])
+        response = self.client.get(url, follow=True)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_course_run_change_view_get_staff_missing_object_permission(self):
+        """
+        Staff users missing permissions should not be allowed to view a course run's change view.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        course_run = CourseRunFactory()
+
+        # Create the required model permissions but not the page permission
+        self.add_permission(user, "change_courserun")
+        self.add_permission(user, "change_page")
+
+        # Get the admin change view
+        url = reverse("admin:courses_courserun_change", args=[course_run.id])
+        response = self.client.get(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "id_title")
+        self.assertContains(response, "Perhaps it was deleted?")
+
+    def test_admin_course_run_change_view_get_staff_all_permissions(self):
+        """
+        Staff users with all permissions should allowed to view a course run's change view.
+        """
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        course_run = CourseRunFactory()
+
+        # Create the required permissions
+        self.add_permission(user, "change_courserun")
+        self.add_permission(user, "change_page")
+        PagePermission.objects.create(
+            page=course_run.direct_course.extended_object,
+            user=user,
+            can_add=False,
+            can_change=True,
+            can_delete=False,
+            can_publish=False,
+            can_move_page=False,
+        )
+
+        # Get the admin change view
+        url = reverse("admin:courses_courserun_change", args=[course_run.id])
+        response = self.client.get(url, follow=True)
+
+        # Check that the page includes the page title
+        self.assertContains(response, course_run.title, status_code=200)
+
+        # Check that the page includes all our fields
+        self.assertContains(response, "id_title", count=2)
+        self.assertContains(response, "id_resource_link", count=2)
+        self.assertContains(response, "id_start_", count=3)
+        self.assertContains(response, "id_end_", count=3)
+        self.assertContains(response, "id_enrollment_start_", count=3)
+        self.assertContains(response, "id_enrollment_end_", count=3)
+        self.assertContains(response, "id_languages", count=2)
+
+    # Add
+
+    def _prepare_add_view_post(self, course, status_code):
+        """Helper method to test the add view."""
+        url = reverse("admin:courses_courserun_add")
         data = {
-            "direct_course": snapshot.id,
+            "direct_course": course.id,
             "title": "My title",
             "languages": ["fr", "en"],
             "resource_link": "https://example.com/my-resource-link",
@@ -129,27 +331,316 @@ class CourseRunAdminTestCase(CMSTestCase):
             "enrollment_end_1": "09:07:11",
         }
         with timezone.override(pytz.utc):
-            response = self.client.post(url, data)
-        self.assertEqual(response.status_code, 302)
+            response = self.client.post(url, data, follow=True)
+        self.assertEqual(response.status_code, status_code)
+
+        return response
+
+    def test_admin_course_run_add_view_post_anonymous(self):
+        """
+        Anonymous users should not be allowed to add course runs via the admin.
+        """
+        course = CourseFactory()
+
+        response = self._prepare_add_view_post(course, 200)
+        self.assertFalse(CourseRun.objects.exists())
+        self.assertContains(
+            response, "<title>Log in | Django site admin</title>", html=True
+        )
+
+    def test_admin_course_run_add_view_post_superuser_draft(self):
+        """
+        Validate that the draft course run can be created via the admin.
+        """
+        course = CourseFactory()
+
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self._prepare_add_view_post(course, 200)
+
+        self.assertTrue(CourseRun.objects.exists())
+        self.assertContains(response, "successful")
+
+    def test_admin_course_run_add_view_post_staff_user_missing_permission(self):
+        """
+        Staff users with missing page permissions can not add a course run via the admin
+        unless CMS permissions are not activated.
+        """
+        course = CourseFactory()
+
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add only model permissions, not page permission on the course page
+        self.add_permission(user, "add_courserun")
+        self.add_permission(user, "change_page")
+
+        response = self._prepare_add_view_post(course, 200)
+        self.assertContains(
+            response, "You do not have permission to change this course page."
+        )
+        self.assertFalse(CourseRun.objects.exists())
+
+        # But it should work if CMS permissions are not activated
+        with override_settings(CMS_PERMISSION=False):
+            self._prepare_add_view_post(course, 200)
+        self.assertTrue(CourseRun.objects.exists())
+
+    def test_admin_course_run_add_view_post_staff_user_page_permission(self):
+        """Staff users with all necessary permissions can add a course run via the admin."""
+        course = CourseFactory()
+
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add all necessary model and object level permissions
+        self.add_permission(user, "add_courserun")
+        self.add_permission(user, "change_page")
+        PagePermission.objects.create(
+            page=course.extended_object,
+            user=user,
+            can_add=False,
+            can_change=True,
+            can_delete=False,
+            can_publish=False,
+            can_move_page=False,
+        )
+
+        response = self._prepare_add_view_post(course, 200)
+        self.assertTrue(CourseRun.objects.exists())
+        self.assertContains(response, "successful")
+
+    # Change
+
+    def _prepare_change_view_post(self, course_run, course, status_code, check_method):
+        """Helper method to test the change view."""
+        url = reverse("admin:courses_courserun_change", args=[course_run.id])
+        data = {
+            "direct_course": course.id,
+            "title": "My title",
+            "languages": ["fr", "en"],
+            "resource_link": "https://example.com/my-resource-link",
+            "start_0": "2015-01-15",
+            "start_1": "07:06:15",
+            "end_0": "2015-01-30",
+            "end_1": "23:52:34",
+            "enrollment_start_0": "2015-01-02",
+            "enrollment_start_1": "13:13:07",
+            "enrollment_end_0": "2015-01-23",
+            "enrollment_end_1": "09:07:11",
+        }
+        with timezone.override(pytz.utc):
+            response = self.client.post(url, data, follow=True)
+        self.assertEqual(response.status_code, status_code)
 
         # Check that the course run was updated as expected
         course_run.refresh_from_db()
-        self.assertEqual(course_run.direct_course, snapshot)
-        self.assertEqual(course_run.title, "My title")
-        self.assertEqual(course_run.languages, ["fr", "en"])
-        self.assertEqual(
-            course_run.resource_link, "https://example.com/my-resource-link"
-        )
-        self.assertEqual(
-            course_run.start, datetime(2015, 1, 15, 7, 6, 15, tzinfo=pytz.utc)
-        )
-        self.assertEqual(
-            course_run.end, datetime(2015, 1, 30, 23, 52, 34, tzinfo=pytz.utc)
-        )
-        self.assertEqual(
+        check_method(course_run.direct_course, course)
+        check_method(course_run.title, "My title")
+        check_method(course_run.languages, ["fr", "en"])
+        check_method(course_run.resource_link, "https://example.com/my-resource-link")
+        check_method(course_run.start, datetime(2015, 1, 15, 7, 6, 15, tzinfo=pytz.utc))
+        check_method(course_run.end, datetime(2015, 1, 30, 23, 52, 34, tzinfo=pytz.utc))
+        check_method(
             course_run.enrollment_start,
             datetime(2015, 1, 2, 13, 13, 7, tzinfo=pytz.utc),
         )
-        self.assertEqual(
+        check_method(
             course_run.enrollment_end, datetime(2015, 1, 23, 9, 7, 11, tzinfo=pytz.utc)
         )
+        return response
+
+    def test_admin_course_run_change_view_post_anonymous(self):
+        """
+        Anonymous users should not be allowed to update course runs via the admin.
+        """
+        course_run = CourseRunFactory()
+        snapshot = CourseFactory(page_parent=course_run.direct_course.extended_object)
+
+        response = self._prepare_change_view_post(
+            course_run, snapshot, 200, self.assertNotEqual
+        )
+        self.assertContains(
+            response, "<title>Log in | Django site admin</title>", html=True
+        )
+
+    def test_admin_course_run_change_view_post_superuser_draft(self):
+        """
+        Validate that the draft course run can be updated via the admin.
+        """
+        course_run = CourseRunFactory()
+        snapshot = CourseFactory(page_parent=course_run.direct_course.extended_object)
+
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        self._prepare_change_view_post(course_run, snapshot, 200, self.assertEqual)
+
+    def test_admin_course_run_change_view_post_superuser_public(self):
+        """
+        Validate that the public course run can not be updated via the admin.
+        """
+        course_run = CourseRunFactory()
+        snapshot = CourseFactory(page_parent=course_run.direct_course.extended_object)
+        course_run.direct_course.extended_object.publish("en")
+        course_run.refresh_from_db()
+
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self._prepare_change_view_post(
+            course_run.public_course_run, snapshot, 200, self.assertNotEqual
+        )
+        self.assertContains(response, "Perhaps it was deleted?")
+
+    def test_admin_course_run_change_view_post_staff_user_missing_permission(self):
+        """
+        Staff users with missing page permissions can not update a course run via the admin
+        unless CMS permissions are not activated.
+        """
+        course_run = CourseRunFactory()
+        snapshot = CourseFactory(page_parent=course_run.direct_course.extended_object)
+
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add only model permissions, not page permission on the course page
+        self.add_permission(user, "add_courserun")
+        self.add_permission(user, "change_courserun")
+        self.add_permission(user, "change_page")
+
+        self._prepare_change_view_post(course_run, snapshot, 200, self.assertNotEqual)
+
+        # But it should work if CMS permissions are not activated
+        with override_settings(CMS_PERMISSION=False):
+            self._prepare_change_view_post(course_run, snapshot, 200, self.assertEqual)
+
+    def test_admin_course_run_change_view_post_staff_user_page_permission(self):
+        """Staff users with all necessary permissions can update a course run via the admin."""
+        course_run = CourseRunFactory()
+        snapshot = CourseFactory(page_parent=course_run.direct_course.extended_object)
+
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add all necessary model and object level permissions
+        self.add_permission(user, "add_courserun")
+        self.add_permission(user, "change_courserun")
+        self.add_permission(user, "change_page")
+        PagePermission.objects.create(
+            page=course_run.direct_course.extended_object,
+            user=user,
+            can_add=False,
+            can_change=True,
+            can_delete=False,
+            can_publish=False,
+            can_move_page=False,
+        )
+
+        self._prepare_change_view_post(course_run, snapshot, 200, self.assertEqual)
+
+    # Delete
+
+    def _prepare_delete(self, course_run, status_code, check_method):
+        """Helper method to test the delete view."""
+        url = reverse("admin:courses_courserun_delete", args=[course_run.id])
+
+        response = self.client.post(url, {"post": "yes"}, follow=True)
+        self.assertEqual(response.status_code, status_code)
+
+        # Check whether the course run was deleted
+        check_method(CourseRun.objects.exists())
+        return response
+
+    def test_admin_course_run_delete_anonymous(self):
+        """
+        Anonymous users should not be allowed to delete course runs via the admin.
+        """
+        course_run = CourseRunFactory()
+        response = self._prepare_delete(course_run, 200, self.assertTrue)
+
+        # Anonymous users are redirected to the login form
+        self.assertContains(
+            response, "<title>Log in | Django site admin</title>", html=True
+        )
+
+    def test_admin_course_run_delete_superuser_draft(self):
+        """
+        Validate that the draft course run can be deleted via the admin and that
+        it deletes the associated public course run.
+        """
+        course_run = CourseRunFactory()
+        course_run.direct_course.extended_object.publish("en")
+        course_run.refresh_from_db()
+        self.assertEqual(CourseRun.objects.count(), 2)
+
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self._prepare_delete(course_run, 200, self.assertFalse)
+        self.assertEqual(Course.objects.count(), 2)
+        self.assertContains(response, "was deleted successfully")
+
+    def test_admin_course_run_delete_superuser_public(self):
+        """
+        Validate that the public course run can not be deleted via the admin.
+        """
+        course_run = CourseRunFactory()
+        course_run.direct_course.extended_object.publish("en")
+        course_run.refresh_from_db()
+
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self._prepare_delete(
+            course_run.public_course_run, 200, self.assertTrue
+        )
+        self.assertContains(response, "Perhaps it was deleted?")
+
+    def test_admin_course_run_delete_staff_user_missing_permission(self):
+        """
+        Staff users with missing page permissions can not delete a course run via the admin
+        unless CMS permissions are not activated.
+        """
+        course_run = CourseRunFactory()
+
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add only model permissions, not page permission on the course page
+        self.add_permission(user, "delete_courserun")
+        self.add_permission(user, "change_page")
+
+        self._prepare_delete(course_run, 200, self.assertTrue)
+
+        # But it should work if CMS permissions are not activated
+        with override_settings(CMS_PERMISSION=False):
+            self._prepare_delete(course_run, 200, self.assertFalse)
+
+        # The course object should not be deleted
+        self.assertEqual(Course.objects.count(), 1)
+
+    def test_admin_course_run_delete_staff_user_page_permission(self):
+        """Staff users with all necessary permissions can delete a course run via the admin."""
+        course_run = CourseRunFactory()
+        course_run.direct_course.extended_object.publish("en")
+        course_run.refresh_from_db()
+
+        user = UserFactory(is_staff=True)
+        self.client.login(username=user.username, password="password")
+
+        # Add all necessary model and object level permissions
+        self.add_permission(user, "delete_courserun")
+        self.add_permission(user, "change_page")
+        PagePermission.objects.create(
+            page=course_run.direct_course.extended_object,
+            user=user,
+            can_add=False,
+            can_change=True,
+            can_delete=False,
+            can_publish=False,
+            can_move_page=False,
+        )
+
+        self._prepare_delete(course_run, 200, self.assertFalse)

--- a/tests/apps/courses/test_admin_form_course_run.py
+++ b/tests/apps/courses/test_admin_form_course_run.py
@@ -1,0 +1,240 @@
+"""
+Test suite covering the admin form for the CourseRun model
+"""
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+
+from cms.models import PagePermission
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.factories import UserFactory
+from richie.apps.courses.admin import CourseRunAdminForm
+from richie.apps.courses.factories import CourseFactory, CourseRunFactory
+
+
+class CourseRunAdminTestCase(CMSTestCase):
+    """
+    Test suite to validate the behavior of admin form for the CourseRun model
+    """
+
+    @staticmethod
+    def _get_admin_form(course, user):
+        """Helper method to create a course run admin form for testing."""
+        data = {
+            "direct_course": course.id,
+            "title": "Title",
+            "languages": ["fr", "en"],
+            "resource_link": "https://example.com",
+            "start_0": "2015-01-15",
+            "start_1": "07:06:15",
+            "end_0": "2015-01-30",
+            "end_1": "23:52:34",
+            "enrollment_start_0": "2015-01-02",
+            "enrollment_start_1": "13:13:07",
+            "enrollment_end_0": "2015-01-23",
+            "enrollment_end_1": "09:07:11",
+        }
+        request = RequestFactory().get("/")
+        request.user = user
+        CourseRunAdminForm.request = request
+        return CourseRunAdminForm(data=data)
+
+    # Validation
+
+    def test_admin_form_course_run_superuser(self):
+        """A superuser can submit a form without any further permissions."""
+        course = CourseFactory()
+        user = UserFactory(is_staff=True, is_superuser=True)
+        form = self._get_admin_form(course, user)
+
+        self.assertTrue(form.is_valid())
+
+    def test_admin_form_course_run_staff_missing_permissions(self):
+        """
+        A staff user with missing page permissions submitting a course run admin form should
+        see an error message, unless CMS permissions are not activated.
+        """
+        course = CourseFactory()
+        user = UserFactory(is_staff=True)
+        self.add_permission(user, "change_page")
+
+        form = self._get_admin_form(course, user)
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors,
+            {
+                "direct_course": [
+                    "You do not have permission to change this course page."
+                ]
+            },
+        )
+
+        # But it should work if CMS permissions are not activated
+        form = self._get_admin_form(course, user)
+        with override_settings(CMS_PERMISSION=False):
+            self.assertTrue(form.is_valid())
+
+    def test_admin_form_course_run_staff_all_permissions(self):
+        """A staff user with all permissions can submit a form."""
+        course = CourseFactory()
+        user = UserFactory(is_staff=True)
+
+        self.add_permission(user, "change_page")
+        PagePermission.objects.create(
+            page=course.extended_object,
+            user=user,
+            can_add=False,
+            can_change=True,
+            can_delete=False,
+            can_publish=False,
+            can_move_page=False,
+        )
+
+        form = self._get_admin_form(course, user)
+
+        self.assertTrue(form.is_valid())
+
+    def test_admin_form_course_run_superuser_empty_form(self):
+        """A user submitting an empty form should see error messages for required fields."""
+        user = UserFactory(is_staff=True, is_superuser=True)
+        factory = RequestFactory()
+        request = factory.get("/")
+        request.user = user
+        CourseRunAdminForm.request = request
+        form = CourseRunAdminForm(data={"resource_link": "https://example.com"})
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors,
+            {
+                "direct_course": ["This field is required."],
+                "title": ["This field is required."],
+                "languages": ["This field is required."],
+            },
+        )
+
+    # Direct course choices
+
+    def test_admin_form_course_run_choices_superuser_one_course(self):
+        """
+        If there is only 1 course, the choice is implicit and the "direct_course" field is hidden.
+        """
+        course = CourseFactory(page_title="Title", should_publish=True)
+        user = UserFactory(is_staff=True, is_superuser=True)
+        form = self._get_admin_form(course, user)
+
+        self.assertEqual(len(form.fields["direct_course"].choices), 2)
+        self.assertIn(
+            (
+                f'<input type="hidden" name="direct_course" value="{course.id:d}" '
+                'id="id_direct_course">'
+            ),
+            form.as_ul(),
+        )
+
+    def test_admin_form_course_run_choices_superuser_several_courses(self):
+        """
+        If there are several courses, a superuser should see them in the "direct_course" field.
+        """
+        course1 = CourseFactory(page_title="Title 1", should_publish=True)
+        course2 = CourseFactory(page_title="Title 2", should_publish=True)
+        user = UserFactory(is_staff=True, is_superuser=True)
+        form = self._get_admin_form(course2, user)
+
+        self.assertEqual(len(form.fields["direct_course"].choices), 3)
+        html = form.as_ul()
+        self.assertIn('<option value="">---------</option>', html)
+        self.assertIn(f'<option value="{course1.id:d}">Title 1</option>', html)
+        self.assertIn(f'<option value="{course2.id:d}" selected>Title 2</option>', html)
+
+    def test_admin_form_course_run_choices_superuser_several_courses_initial(self):
+        """
+        If there are several courses but an initial value is passed for the "direct_course" field,
+        the choice is made and the "direct_course" field is hidden.
+        """
+        course = CourseFactory(page_title="Title 1", should_publish=True)
+        CourseFactory(page_title="Title 2", should_publish=True)
+        user = UserFactory(is_staff=True, is_superuser=True)
+
+        request = RequestFactory().get("/")
+        request.user = user
+        CourseRunAdminForm.request = request
+        form = CourseRunAdminForm(initial={"direct_course": course.id})
+
+        self.assertEqual(len(form.fields["direct_course"].choices), 3)
+        self.assertIn(
+            (
+                f'<input type="hidden" name="direct_course" value="{course.id:d}" '
+                'id="id_direct_course">'
+            ),
+            form.as_ul(),
+        )
+
+    def test_admin_form_course_run_choices_staff_permissions(self):
+        """
+        Staff users should only see course pages on which they have change permission.
+        Unless CMS permissions are not activated.
+        """
+        course1 = CourseFactory(page_title="Title 1", should_publish=True)
+        course2 = CourseFactory(page_title="Title 2", should_publish=True)
+        course3 = CourseFactory(page_title="Title 3", should_publish=True)
+        user = UserFactory(is_staff=True)
+
+        # Add permission only for courses 2 and 3
+        self.add_permission(user, "change_page")
+        for course in [course2, course3]:
+            PagePermission.objects.create(
+                page=course.extended_object,
+                user=user,
+                can_add=False,
+                can_change=True,
+                can_delete=False,
+                can_publish=False,
+                can_move_page=False,
+            )
+
+        # The user should only see the 2 courses on which he has permissions
+        form = self._get_admin_form(course2, user)
+        self.assertEqual(len(form.fields["direct_course"].choices), 3)
+        html = form.as_ul()
+        self.assertIn('<option value="">---------</option>', html)
+        self.assertNotIn("Title 1", html)
+        self.assertIn(f'<option value="{course2.id:d}" selected>Title 2</option>', html)
+        self.assertIn(f'<option value="{course3.id:d}">Title 3</option>', html)
+
+        # Unless CMS permissions are not activated
+        with override_settings(CMS_PERMISSION=False):
+            form = self._get_admin_form(course2, user)
+
+        self.assertEqual(len(form.fields["direct_course"].choices), 4)
+        self.assertIn(f'<option value="{course1.id:d}">Title 1</option>', form.as_ul())
+
+    def test_admin_form_course_run_choices_instance(self):
+        """
+        A course run admin form bound to an instance lists the related course and its snapshots.
+        It is not proposed to move the course run to another unrelated course.
+        """
+        course = CourseFactory(page_title="Title 1", should_publish=True)
+        snapshot = CourseFactory(
+            page_title="Title 1 Snapshot",
+            page_parent=course.extended_object,
+            should_publish=True,
+        )
+        CourseFactory(page_title="Title 2", should_publish=True)
+        user = UserFactory(is_staff=True, is_superuser=True)
+        course_run = CourseRunFactory(direct_course=course)
+
+        # Get form bound to the course run instance
+        request = RequestFactory().get("/")
+        request.user = user
+        CourseRunAdminForm.request = request
+        form = CourseRunAdminForm(instance=course_run)
+
+        self.assertEqual(len(form.fields["direct_course"].choices), 3)
+        html = form.as_ul()
+        self.assertIn('<option value="">---------</option>', html)
+        self.assertIn(f'<option value="{course.id:d}" selected>Title 1</option>', html)
+        self.assertIn(
+            f'<option value="{snapshot.id:d}">Title 1 Snapshot</option>', html
+        )


### PR DESCRIPTION

## Purpose

The permissions course run admin pages are only classical django admin model level permissions because CourseRun is now a simple model. We need to limit permissions according to the course page to which a course run is linked.

## Proposal

- [x] Add permissions on add view, change list view, change form view, delete view
- [x] Customize the choices on the select box of the "direct_course" field to only list courses on which the user has permissions
- [x] Add tests to secure permissions
