### PR TITLE
🐛(frontend) fix intlrelativeformat polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- intl-relativetimeformat polyfill did not use the right locale filename
+  when locale was composed of a languageCode identical to countryCode
 - Make generate demo site work when the default language is set to "fr"
 - Add permission checks to course run admin based on their related course page
 

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -53,13 +53,17 @@ async function render() {
       // TODO: remove type assertion when typescript libs include RelativeTimeFormat
       if (!(Intl as any).RelativeTimeFormat) {
         await import('@formatjs/intl-relativetimeformat');
-        // Polyfilled locale data is keyed by 2-letter language code
-        let languageCode = locale;
-        if (languageCode.match(/^.*_.*$/)) {
-          [languageCode] = locale.split('_');
+
+        // When countryCode is identical to languageCode, intlrelativeformat uses
+        // only languageCode as locale file name
+        let localeFilename = locale;
+        const [languageCode, countryCode] = localeFilename.split('-');
+        if (RegExp(languageCode, 'i').test(countryCode)) {
+          localeFilename = languageCode;
         }
+
         // Get `react-intl`/`formatjs` lang specific parameters and data
-        await import(`@formatjs/intl-relativetimeformat/locale-data/${languageCode}`);
+        await import(`@formatjs/intl-relativetimeformat/locale-data/${localeFilename}`);
       }
     } catch (e) {
       handle(e);


### PR DESCRIPTION
## Purpose

When intl-relativetimeformat polyfill must be applied, the locale module was
not found. In fact when locale is composed of a languageCode identical
to its countryCode, intl-relativetimeformat locale filename is only languageCode

i.e: if locale is fr-FR related locale filename is fr.js
if locale is fr-CA related locale filename is fr-CA.js


## Proposal

- [x] check if locale languageCode is identical to countryCode, if yes just use languageCode as locale filename
