### PR TITLE
♻️(CourseRunEnrollment) pass course run data from data-props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Remove a xhr request by passing course run information to the
+  CourseRunEnrollment widget via data-props
+
 ### Fixed
 
 - Fix Sentry SDK initialization enrivonment and release parameters

--- a/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
@@ -48,6 +48,12 @@ describe('<CourseRunEnrollment />', () => {
     return loggedin ? username : null;
   };
 
+  const getCourseRunProp = (courseRun: CourseRun) => ({
+    id: courseRun.id,
+    resource_link: courseRun.resource_link,
+    priority: courseRun.state.priority,
+  });
+
   afterEach(() => {
     sessionStorage.clear();
     fetchMock.restore();
@@ -58,8 +64,6 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 0;
 
-    const courseRunDeferred = new Deferred();
-    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const enrollmentsDeferred = new Deferred();
     fetchMock.get(
       `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
@@ -69,14 +73,13 @@ describe('<CourseRunEnrollment />', () => {
     render(
       <IntlProvider locale="en">
         <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRunId={courseRun.id} />
+          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
         </SessionProvider>
       </IntlProvider>,
     );
     screen.getByRole('status', { name: 'Loading enrollment information...' });
 
     await act(async () => {
-      courseRunDeferred.resolve(courseRun);
       enrollmentsDeferred.resolve({});
     });
 
@@ -96,13 +99,11 @@ describe('<CourseRunEnrollment />', () => {
     screen.getByText('You are enrolled in this course run');
   });
 
-  it('shows an error message and the enrollment button when the enrollment fails', async () => {
+  it.only('shows an error message and the enrollment button when the enrollment fails', async () => {
     const username = initializeUser();
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 0;
 
-    const courseRunDeferred = new Deferred();
-    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const enrollmentsDeferred = new Deferred();
     fetchMock.get(
       `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
@@ -114,7 +115,7 @@ describe('<CourseRunEnrollment />', () => {
         <SessionProvider>
           <CourseRunEnrollment
             context={contextProps}
-            courseRunId={courseRun.id}
+            courseRun={getCourseRunProp(courseRun)}
             loginUrl="/oauth/login/edx-oauth2/?next=/en/courses/"
           />
         </SessionProvider>
@@ -123,7 +124,6 @@ describe('<CourseRunEnrollment />', () => {
     screen.getByRole('status', { name: 'Loading enrollment information...' });
 
     await act(async () => {
-      courseRunDeferred.resolve(courseRun);
       enrollmentsDeferred.resolve(false);
     });
 
@@ -134,7 +134,7 @@ describe('<CourseRunEnrollment />', () => {
     fireEvent.click(button);
 
     await act(async () => {
-      enrollmentAction.reject();
+      enrollmentAction.reject('500 - Internal Server Error');
     });
 
     screen.getByRole('button', { name: 'Enroll now' });
@@ -157,7 +157,7 @@ describe('<CourseRunEnrollment />', () => {
     render(
       <IntlProvider locale="en">
         <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRunId={courseRun.id} />
+          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
         </SessionProvider>
       </IntlProvider>,
     );
@@ -177,27 +177,13 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 4;
 
-    const courseRunDeferred = new Deferred();
-    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
-    const enrollmentsDeferred = new Deferred();
-    fetchMock.get(
-      `${endpoint}/api/enrollment/v1/enrollment/${courseRun.resource_link}`,
-      enrollmentsDeferred.promise,
-    );
-
     render(
       <IntlProvider locale="en">
         <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRunId={courseRun.id} />
+          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
         </SessionProvider>
       </IntlProvider>,
     );
-    screen.getByRole('status', { name: 'Loading enrollment information...' });
-
-    await act(async () => {
-      courseRunDeferred.resolve(courseRun);
-      enrollmentsDeferred.resolve(false);
-    });
 
     screen.getByText('Enrollment in this course run is closed at the moment');
     expect(screen.queryByRole('button', { name: 'Enroll now' })).toBeNull();
@@ -208,27 +194,13 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 0;
 
-    const courseRunDeferred = new Deferred();
-    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
-    const enrollmentsDeferred = new Deferred();
-    fetchMock.get(
-      `${endpoint}/api/enrollment/v1/enrollment/${courseRun.resource_link}`,
-      enrollmentsDeferred.promise,
-    );
-
     render(
       <IntlProvider locale="en">
         <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRunId={courseRun.id} />
+          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
         </SessionProvider>
       </IntlProvider>,
     );
-    screen.getByRole('status', { name: 'Loading enrollment information...' });
-
-    await act(async () => {
-      courseRunDeferred.resolve(courseRun);
-      enrollmentsDeferred.resolve(false);
-    });
 
     screen.getByRole('button', { name: 'Log in to enroll' });
   });

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_run.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_run.html
@@ -18,7 +18,7 @@
     {% if run|has_connected_lms %}
         <div
             class="richie-react richie-react--course-run-enrollment"
-            data-props='{"courseRunId": {{ run.id }}}'
+            data-props="{% course_enrollment_widget_props %}"
         ></div>
     {% else %}
         <a href="{{ run.resource_link }}" class="course-run-enrollment__cta">

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -1,4 +1,6 @@
 """Custom template tags for the courses application of Richie."""
+import json
+
 from django import template
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
@@ -217,3 +219,22 @@ def has_connected_lms(course_run):
     link to the course run.
     """
     return LMSHandler.select_lms(course_run.resource_link) is not None
+
+
+@register.simple_tag(takes_context=True)
+def course_enrollment_widget_props(context):
+    """
+    Return a json dumps which contains all course_run's properties required by
+    CourseEnrollment React widget
+    """
+    course_run = context["run"]
+
+    return json.dumps(
+        {
+            "courseRun": {
+                "id": course_run.id,
+                "resource_link": course_run.resource_link,
+                "priority": course_run.state["priority"],
+            }
+        }
+    )

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -492,16 +492,20 @@ class RunsCourseCMSTestCase(CMSTestCase):
 
         response = self.client.get(course.extended_object.get_absolute_url())
 
-        self.assertIsNotNone(
-            re.search(
-                (
-                    r'.*class="richie-react richie-react--course-run-enrollment".*'
-                    r"data-props=\\\'{{\"courseRunId\": {}}}\\\'".format(
-                        course_run.public_course_run.id
-                    )
-                ),
-                str(response.content),
-            )
+        pattern = r".*data-props=\"{{.*{}.*{}.*{}.*{}.*{}.*{}.*{}.*}}\"".format(
+            "courseRun",
+            "id",
+            course_run.public_course_run.id,
+            "resource_link",
+            re.escape(course_run.public_course_run.resource_link),
+            "priority",
+            course_run.public_course_run.state["priority"],
+        )
+
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        self.assertContains(
+            response,
+            r'class="richie-react richie-react--course-run-enrollment"',
         )
 
     @override_settings(LMS_BACKENDS=[])
@@ -562,16 +566,21 @@ class RunsCourseCMSTestCase(CMSTestCase):
         course_run.refresh_from_db()
 
         response = self.client.get(course.extended_object.get_absolute_url())
-        self.assertIsNotNone(
-            re.search(
-                (
-                    r'.*class="richie-react richie-react--course-run-enrollment".*'
-                    r"data-props=\\\'{{\"courseRunId\": {}}}\\\'".format(
-                        course_run.public_course_run.id
-                    )
-                ),
-                str(response.content),
-            )
+
+        pattern = r".*data-props=\"{{.*{}.*{}.*{}.*{}.*{}.*{}.*{}.*}}\"".format(
+            "courseRun",
+            "id",
+            course_run.public_course_run.id,
+            "resource_link",
+            re.escape(course_run.public_course_run.resource_link),
+            "priority",
+            course_run.public_course_run.state["priority"],
+        )
+
+        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        self.assertContains(
+            response,
+            r'class="richie-react richie-react--course-run-enrollment"',
         )
 
     @timezone.override(pytz.utc)

--- a/tests/apps/courses/test_templatetags_extra_tags_course_enrollment_widget_props.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_course_enrollment_widget_props.py
@@ -1,0 +1,38 @@
+"""
+Unit tests for the `course_enrollment_widget_props` template filter.
+"""
+import json
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.courses.factories import CourseRunFactory
+from richie.apps.courses.templatetags.extra_tags import course_enrollment_widget_props
+
+
+class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
+    """
+    Unit test suite to validate the behavior of the `course_enrollment_widget_props` tag
+    """
+
+    def test_course_enrollment_widget_props_tag(self):
+        """
+        CourseEnrollment required id, resource_link and state.priority course run's properties.
+        course_enrollment_widget_props should return these properties wrapped into
+        a courseRun object as a stringified json.
+        """
+        course_run = CourseRunFactory(
+            resource_link="http://example.edx:8073/courses/course-v1:edX+DemoX+Demo_Course/course/"
+        )
+        context = {"run": course_run}
+        self.assertEqual(
+            course_enrollment_widget_props(context),
+            json.dumps(
+                {
+                    "courseRun": {
+                        "id": course_run.id,
+                        "resource_link": course_run.resource_link,
+                        "priority": course_run.direct_course.state["priority"],
+                    }
+                }
+            ),
+        )


### PR DESCRIPTION
## Purpose

CourseRunEnrollment widget retrieves course run information by making a request to richie course-run api. It is useless as we could pass directly these information through `data-props` attribute.

## Proposal

- [x] Pass course run required information from data-props
