### PR TITLE
🐛(settings) sentry dsn is misconfigured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix Sentry SDK initialization enrivonment and release parameters
 - intl-relativetimeformat polyfill did not use the right locale filename
   when locale was composed of a languageCode identical to countryCode
 - Make generate demo site work when the default language is set to "fr"

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -552,8 +552,8 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         if cls.SENTRY_DSN is not None:
             sentry_sdk.init(
                 dsn=cls.SENTRY_DSN,
-                environment=cls.ENVIRONMENT,
-                release=cls.RELEASE,
+                environment=cls.__name__.lower(),
+                release=get_release(),
                 integrations=[DjangoIntegration()],
             )
             with sentry_sdk.configure_scope() as scope:


### PR DESCRIPTION
## Purpose

When used in settings file where they are defined, properties ENVIRONMENT and RELEASE
return the property object signature not the value they should return elsewhere.

## Proposal

- [x] Do not use `@property` to set environment and release attributes to initialize `sentry_dsk`

![Capture d’écran 2020-12-16 à 18 00 22](https://user-images.githubusercontent.com/9265241/102383748-303b4100-3fcc-11eb-8fac-af97584e64d3.png)
