### PR TITLE
♻️(templates) remove use of deprecated xlink:href attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Migrate factories to factory_boy 3.2.0
 - Remove a xhr request by passing course run information to the
   CourseRunEnrollment widget via data-props
+- Make the course run "title" field optional
+- Replace deprecated xlink:href svg attribute by href
 
 ### Added
 
 - Add an API endpoint to synchronize course runs from e.g. an external LMS
 - Add a "code" field on the course model to allow reference & synchronization
-
-### Changed
-
-- Make the course run "title" field optional
 
 ### Fixed
 

--- a/src/richie/apps/core/templates/richie/styleguide/index.html
+++ b/src/richie/apps/core/templates/richie/styleguide/index.html
@@ -228,17 +228,17 @@
                 <div class="social-network-badges mt-4">
                     <a href="#" class="social-network-badges__item">
                         <svg role="img" class="icon social-network-badges__item__icon">
-                            <use xlink:href="#icon-facebook" />
+                            <use href="#icon-facebook" />
                         </svg>
                     </a>
                     <a href="#" class="social-network-badges__item">
                         <svg role="img" class="icon social-network-badges__item__icon">
-                            <use xlink:href="#icon-twitter" />
+                            <use href="#icon-twitter" />
                         </svg>
                     </a>
                     <a href="#" class="social-network-badges__item">
                         <svg role="img" class="icon social-network-badges__item__icon">
-                            <use xlink:href="#icon-envelope" />
+                            <use href="#icon-envelope" />
                         </svg>
                     </a>
                 </div>

--- a/src/richie/apps/core/templates/social-networks/blogpost-badges.html
+++ b/src/richie/apps/core/templates/social-networks/blogpost-badges.html
@@ -10,7 +10,7 @@
             title="{% trans "Share on Facebook" %}"
         >
             <svg role="img">
-                <use xlink:href="#icon-facebook" />
+                <use href="#icon-facebook" />
             </svg>
         </a>
         <a
@@ -20,7 +20,7 @@
             title="{% trans "Share on Twitter" %}"
         >
             <svg role="img">
-                <use xlink:href="#icon-twitter" />
+                <use href="#icon-twitter" />
             </svg>
         </a>
         <a
@@ -30,7 +30,7 @@
             title="{% trans "Share on Linkedin" %}"
         >
             <svg role="img">
-                <use xlink:href="#icon-linkedin" />
+                <use href="#icon-linkedin" />
             </svg>
         </a>
         <a
@@ -40,7 +40,7 @@
             title="{% trans "Share by Email" %}"
         >
             <svg role="img">
-                <use xlink:href="#icon-envelope" />
+                <use href="#icon-envelope" />
             </svg>
         </a>
     </div>

--- a/src/richie/apps/core/templates/social-networks/course-badges.html
+++ b/src/richie/apps/core/templates/social-networks/course-badges.html
@@ -10,7 +10,7 @@
             title="{% trans "Share on Facebook" %}"
         >
             <svg role="img">
-                <use xlink:href="#icon-facebook" />
+                <use href="#icon-facebook" />
             </svg>
         </a>
         <a
@@ -20,7 +20,7 @@
             title="{% trans "Share on Twitter" %}"
         >
             <svg role="img">
-                <use xlink:href="#icon-twitter" />
+                <use href="#icon-twitter" />
             </svg>
         </a>
         <a
@@ -30,7 +30,7 @@
             title="{% trans "Share on Linkedin" %}"
         >
             <svg role="img">
-                <use xlink:href="#icon-linkedin" />
+                <use href="#icon-linkedin" />
             </svg>
         </a>
         <a
@@ -40,7 +40,7 @@
             title="{% trans "Share by Email" %}"
         >
             <svg role="img">
-                <use xlink:href="#icon-envelope" />
+                <use href="#icon-envelope" />
             </svg>
         </a>
   </div>

--- a/src/richie/apps/core/templates/social-networks/footer-badges.html
+++ b/src/richie/apps/core/templates/social-networks/footer-badges.html
@@ -6,7 +6,7 @@
     >
         <svg role="img">
             <title>{% trans "Facebook" %}</title>
-            <use xlink:href="#icon-facebook" />
+            <use href="#icon-facebook" />
         </svg>
     </a>
     <a
@@ -17,7 +17,7 @@
     >
         <svg role="img">
             <title>{% trans "Twitter" %}</title>
-            <use xlink:href="#icon-twitter" />
+            <use href="#icon-twitter" />
         </svg>
     </a>
     <a
@@ -28,7 +28,7 @@
     >
         <svg role="img">
             <title>{% trans "Linkedin" %}</title>
-            <use xlink:href="#icon-linkedin" />
+            <use href="#icon-linkedin" />
         </svg>
     </a>
 {% endspaceless %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -76,7 +76,7 @@
                                 {% if instance.duration or current_page.publisher_is_draft %}
                                 <li class="characteristics__item">
                                     <svg role="img" class="characteristics__icon" aria-hidden="true">
-                                        <use xlink:href="#icon-clock" />
+                                        <use href="#icon-clock" />
                                     </svg>
                                     <span class="characteristics__term">{% trans "Duration:" %} {{ instance.get_duration_display|default:"NA" }}</span>
                                 </li>
@@ -84,7 +84,7 @@
                                 {% if instance.effort or current_page.publisher_is_draft %}
                                 <li class="characteristics__item">
                                     <svg role="img" class="characteristics__icon" aria-hidden="true">
-                                        <use xlink:href="#icon-stopwatch" />
+                                        <use href="#icon-stopwatch" />
                                     </svg>
                                     <span class="characteristics__term">{% trans "Effort:" %} {{ instance.get_effort_display|default:"NA" }}</span>
                                 </li>

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -35,7 +35,7 @@
             {% if main_org_title %}
             <div class="course-{{ course_variant }}__organization">
                 <svg role="img" aria-hidden="true" class="icon">
-                    <use xlink:href="#icon-pin" />
+                    <use href="#icon-pin" />
                 </svg>
                 <span>{{ main_org_title }}</span>
             </div>
@@ -46,7 +46,7 @@
         <div class="course-{{ course_variant }}-footer">
             <div class="course-{{ course_variant }}-footer__date">
                 <svg role="img" aria-hidden="true" class="icon">
-                    <use xlink:href="#icon-calendar" />
+                    <use href="#icon-calendar" />
                 </svg>
                 {{ course_state.text|capfirst }}
                 {% if course_state.datetime %}

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse.html
@@ -36,7 +36,7 @@
         {% if instance.content %}
         <div class="glimpse-{{ glimpse_variant }}__content">
             <svg role="img">
-                <use xlink:href="#icon-quote" />
+                <use href="#icon-quote" />
             </svg>
             {{ instance.content|linebreaks }}
         </div>

--- a/tests/apps/courses/test_cms_plugins_course.py
+++ b/tests/apps/courses/test_cms_plugins_course.py
@@ -121,7 +121,7 @@ class CoursePluginTestCase(TestCase):
                 (
                     r'<div class="course-glimpse__organization">'
                     r'<svg role="img".*'
-                    r'<use xlink:href="#icon-pin" />'
+                    r'<use href="#icon-pin" />'
                 ),
                 str(response.content),
             )
@@ -182,7 +182,7 @@ class CoursePluginTestCase(TestCase):
                 (
                     r'<div class="course-glimpse__organization">'
                     r'<svg role="img".*'
-                    r'<use xlink:href="#icon-pin" />'
+                    r'<use href="#icon-pin" />'
                 ),
                 str(response.content),
             )


### PR DESCRIPTION
## Purpose

Since SVG 2, `xlink:href` attribute has been replaced by `href`.
http://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href


## Proposal

- [x] Replace xlink:href by href
