### PR TITLE
✨(development) allow connections from openedx-docker development stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,12 @@ services:
     ports:
       - "8070:8070"
     networks:
-      - default
-      - lms_outside
+      default:
+        aliases:
+          - nginx
+      lms_outside:
+        aliases:
+          - richie
     volumes:
       - ./docker/files/etc/nginx/${NGINX_CONF:-conf.d}:/etc/nginx/conf.d:ro
     depends_on:


### PR DESCRIPTION
## Purpose

For ouath2 we already allowed richie's development stack to access openedx-docker's development stack. For course runs synchronizations, it is the contrary: openedx-docker's development tack needs to be able
to call richie's course synchronization web hook on the development stack.

## Proposal

Connect nginx in the `lms_outside` network so it can be accessed from outside its docker-compose project with the `richie` host.

