### PR TITLE
🚸(PaginateCourseSearch) do not truncate pagination if it is not relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Improve UX of course search pagination by avoiding truncation of page number
+  when it is not relevant
+
 ## [2.0.1] - 2021-01-11
 
 ### Fixed

--- a/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
@@ -77,6 +77,7 @@ describe('<PaginateCourseSearch />', () => {
     screen.getByRole('navigation', { name: 'Pagination' });
     // Common text for the first page
     screen.getAllByText('Page 1');
+    screen.getAllByText('...');
     // Accessibility helpers
     screen.getByText('Page 10');
     screen.getByText('Previous page 11');
@@ -91,6 +92,34 @@ describe('<PaginateCourseSearch />', () => {
     screen.getByText('13');
     screen.getByText('14');
     screen.getByText('35');
+  });
+
+  it('does not truncate pagination number with ... if all page numbers follow each other.', () => {
+    render(
+      <IntlProvider locale="en">
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '21', offset: '0' })}>
+          <PaginateCourseSearch courseSearchTotalCount={101} />
+        </HistoryContext.Provider>
+      </IntlProvider>,
+    );
+
+    screen.getByRole('navigation', { name: 'Pagination' });
+    // Accessibility helpers
+    screen.getByText('Currently reading page 1');
+    screen.getByText('Next page 2');
+    screen.getByText('Page 3');
+    screen.getByText('Last page 5');
+
+    // Visual pagination
+    screen.getAllByText('Page 1');
+    screen.getByText('2');
+    screen.getByText('3');
+    screen.getByText('4');
+    screen.getByText('5');
+
+    // Any truncation label is displayed
+    const truncationLabel = screen.queryAllByText('...');
+    expect(truncationLabel).toHaveLength(0);
   });
 
   it('does not render itself when there is only one page', () => {

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -68,11 +68,17 @@ export const PaginateCourseSearch = ({ courseSearchTotalCount }: PaginateCourseS
   // Create the default list of all the page numbers we intend to show
   const pageList = [
     1,
+    // If there is just one page between first page and currentPage - 2,
+    // we can display this page number instead of "..."
+    currentPage - 2 === 3 ? currentPage - 3 : -1,
     currentPage - 2,
     currentPage - 1,
     currentPage,
     currentPage + 1,
     currentPage + 2,
+    // If there is just one page between maxPage and currentPage + 2,
+    // we can display this page number instead of "..."
+    currentPage + 3 === maxPage - 1 ? currentPage + 3 : -1,
     maxPage,
   ]
     // Filter out page numbers below 1 (when currentPage is 1 or 2)


### PR DESCRIPTION
## Purpose
Pagination course truncate page number where there are too much element to show. But in some case, truncation is not relevant. 

E.g:
Before if we had 5 pages, pagination looked like this:
`Page 1 2 3 ... 5`
Showing the fourth page number is more relevant is this case.


## Proposal

- [x] Show page number instead of `...` when it is relevant

### Before
<img width="248" alt="Capture d’écran 2021-01-18 à 14 40 52" src="https://user-images.githubusercontent.com/9265241/104924784-35f6be80-599e-11eb-96d6-9ed9aa849b24.png">

### After
<img width="267" alt="Capture d’écran 2021-01-18 à 14 40 22" src="https://user-images.githubusercontent.com/9265241/104924791-38591880-599e-11eb-8b8c-99c8a1b7f756.png">
