### PR TITLE
🐛(courses) fix displaying course runs in list on course detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Improve UX of course search pagination by avoiding truncation of page number
   when it is not relevant
 
+### Fixed
+
+- Fix unwanted comma when displaying course runs list on course detail page
+
 ## [2.0.1] - 2021-01-11
 
 ### Fixed

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_runs_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_runs_list.html
@@ -9,8 +9,15 @@
                 {% if course != run.direct_course %}
                     <a href="{{ run.direct_course.extended_object.get_absolute_url }}">
                 {% endif %}
-                {% blocktrans with title=run.title|default:"" start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' asvar run_title %}{{ title }} from {{ start }} to {{ end }}{% endblocktrans %}
-                {{ run_title.strip|capfirst }}
+                {% if run.title %}
+                    {% blocktrans with title=run.title|capfirst start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' %}
+                        {{ title }}, from {{ start }} to {{ end }}
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans with start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' %}
+                        From {{ start }} to {{ end }}
+                    {% endblocktrans %}
+                {% endif %}
                 {% if course != run.direct_course %}
                     </a>
                 {% endif %}

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -601,7 +601,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             '<ul class="course-detail__run-list"><li>'
-            "My course run from {:s} to {:s}</li></ul>".format(
+            "My course run, from {:s} to {:s}</li></ul>".format(
                 dateformat.format(course_run.start, "N j, Y"),
                 dateformat.format(course_run.end, "N j, Y"),
             ),
@@ -628,7 +628,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             '<ul class="course-detail__run-list"><li>'
-            "My course run from {:s} to {:s}</li></ul>".format(
+            "My course run, from {:s} to {:s}</li></ul>".format(
                 dateformat.format(course_run.start, "N j, Y"),
                 dateformat.format(course_run.end, "N j, Y"),
             ),
@@ -655,7 +655,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             '<ul class="course-detail__run-list"><li>'
-            "My course run from {:s} to {:s}</li></ul>".format(
+            "My course run, from {:s} to {:s}</li></ul>".format(
                 dateformat.format(course_run.start, "N j, Y"),
                 dateformat.format(course_run.end, "N j, Y"),
             ),
@@ -682,7 +682,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             '<ul class="course-detail__run-list"><li>'
-            "My course run from {:s} to {:s}</li></ul>".format(
+            "My course run, from {:s} to {:s}</li></ul>".format(
                 dateformat.format(course_run.start, "N j, Y"),
                 dateformat.format(course_run.end, "N j, Y"),
             ),
@@ -717,7 +717,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
 
         self.assertContains(
             response,
-            '<ul class="course-detail__run-list"><li>My course run from ... to ...</li></ul>',
+            '<ul class="course-detail__run-list"><li>My course run, from ... to ...</li></ul>',
             html=True,
         )
 


### PR DESCRIPTION
## Purpose

The template code that was taking care of displaying the course run details with or without a title, was broken in french because the translation included a comma where it shouldn't. It turns out that the implementation is a git too "smart" and thus fragile. 

## Proposal

We refactor it to use a good old "if" clause.