### PR TITLE
✨(courses) display code on course detail page with frontend editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Display "code" on the course detail page and allow frontend editing
+
 ### Changed
 
 - Improve UX of course search pagination by avoiding truncation of page number

--- a/src/frontend/scss/components/_subheader.scss
+++ b/src/frontend/scss/components/_subheader.scss
@@ -31,6 +31,22 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
     }
   }
 
+  // Main document title
+  &__code {
+    @include make-container();
+    @include make-container-max-widths();
+    @include sv-flex(1, 0, 100%);
+
+    margin-top: -0.5rem;
+    margin-bottom: 0.5rem;
+
+    @include media-breakpoint-down(lg) {
+      padding-left: 0;
+      padding-right: 0;
+      text-align: center;
+    }
+  }
+
   // Common base Control To Action
   &__cta {
     @include button-base($font-weight: bold);
@@ -107,13 +123,13 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
 
   // Main content with possible categories
   &__content {
-    margin-top: 1rem;
+    margin-top: 0.5rem;
     padding: 0.5rem 0;
     font-size: 1rem;
 
     @include media-breakpoint-up(lg) {
       @include sv-flex(1, 0, 75%);
-      margin-top: 1.5rem;
+      margin-top: 0.5rem;
     }
 
     // Variant to preserve some space for teaser
@@ -137,14 +153,14 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
   // Video container aside main content
   &__teaser {
     width: 100%;
-    margin-top: 1rem;
+    margin-top: 0.5rem;
     @if r-theme-val(subheader, teaser-border) {
       border: 0.25rem solid r-theme-val(subheader, teaser-border);
     }
 
     @include media-breakpoint-up(lg) {
       @include sv-flex(1, 0, 32%);
-      margin-top: 1.5rem;
+      margin-top: 0.5rem;
     }
 
     iframe,

--- a/src/richie/apps/courses/admin.py
+++ b/src/richie/apps/courses/admin.py
@@ -231,7 +231,7 @@ class CourseAdmin(FrontendEditableAdminMixin, PageExtensionAdmin):
     """Admin class for the Course model"""
 
     list_display = ["title", "is_listed"]
-    frontend_editable_fields = ("effort", "duration", "is_listed")
+    frontend_editable_fields = ("code", "duration", "effort", "is_listed")
 
     # pylint: disable=no-self-use
     def title(self, obj):

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -49,8 +49,13 @@
 
                     {% block title %}
                     <h1 class="subheader__title">
-                        {% render_model request.current_page "title" %}
+                        {% render_model current_page "title" %}
                     </h1>
+                    {% if course.code or current_page.publisher_is_draft %}
+                        <div class="subheader__code">
+                            {% trans "Ref. " %}{% render_model course "code" "code,is_listed" "" "default:'...'" %}
+                        </div>
+                    {% endif %}
                     {% endblock title %}
 
                     <div class="subheader__teaser">


### PR DESCRIPTION
## Purpose

It was not straightforward to go through the "course settings..." menu item to edit a course code. 

## Proposal

Since this is an important and uniquely defining information about the course, we propose to display it on the
detail page and allow frontend editing.

Fixes https://github.com/openfun/richie/issues/1249

## Snapshots

![Screenshot from 2021-01-19 15-45-16](https://user-images.githubusercontent.com/1427165/105052080-bfc28c80-5a6f-11eb-80b3-6bb409e9e36f.png)
