### PR TITLE
✨(courses) display related programs on course detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Allow overriding a person's bio on the person plugin
+- Add new section on the course detail page to display related programs
 - Display "code" on the course detail page and allow frontend editing
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Delete template `course_run_detail.html` was still referenced in settings
 - Fix unwanted comma when displaying course runs list on course detail page
 
 ## [2.0.1] - 2021-01-11

--- a/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -152,6 +152,12 @@
     }
   }
 
+  &__programs {
+    #{$detail-selector}__title {
+      text-align: center;
+    }
+  }
+
   &__team {
     #{$detail-selector}__title {
       text-align: center;

--- a/src/frontend/scss/components/templates/richie/section/_section.scss
+++ b/src/frontend/scss/components/templates/richie/section/_section.scss
@@ -29,6 +29,7 @@ section {
   }
 
   &__items {
+    @include sv-flex(1, 0, 100%);
     display: flex;
     flex-wrap: wrap;
     justify-content: center;

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -33,7 +33,6 @@ THUMBNAIL_PROCESSORS = (
 # Django CMS
 CMS_TEMPLATES = (
     ("courses/cms/course_detail.html", _("Course page")),
-    ("courses/cms/course_run_detail.html", _("Course run page")),
     ("courses/cms/organization_list.html", _("Organization list")),
     ("courses/cms/organization_detail.html", _("Organization page")),
     ("courses/cms/category_list.html", _("Category list")),

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -1,5 +1,5 @@
 {% extends "richie/fullwidth.html" %}
-{% load cms_tags i18n extra_tags static thumbnail %}
+{% load cms_tags i18n extra_tags pagination_tags static thumbnail %}
 
 {% block meta_index_rules %}
     {# Make sure course snapshot pages are not indexed by search engines #}
@@ -329,6 +329,37 @@
 
     {% block fragment_relations %}
     <div class="course-detail__relations">
+        {% block programs %}
+            {% with programs=course.get_programs %}
+                {% if programs %}
+                    {% autopaginate programs GLIMPSE_PAGINATION_PROGRAMS %}
+                    <div id="page{{ page_suffix }}" class="course-detail__programs course-detail__block">
+                        <div class="course-detail__row">
+                            <section class="course-glimpse-list">
+                                <h2 class="course-detail__title">
+                                    {% blocktrans count counter=programs|length %}
+                                        This course is part of a program
+                                    {% plural %}
+                                        This course is part of programs
+                                    {% endblocktrans %}
+                                </h2>
+                                <div class="section__items section__items--programs">
+                                    {% for program in page_obj.object_list %}
+                                        {% if program.extended_object.publisher_is_draft or program.check_publication %}
+                                            {% include "courses/cms/fragment_program_glimpse.html" with program=program %}
+                                        {% endif %}
+                                    {% endfor %}
+                                </div>
+                                {% if paginator.num_pages > 1 %}
+                                    {% paginate using "richie/pagination.html" %}
+                                {% endif %}
+                            </section>
+                        </div>
+                    </div>
+                {% endif %}
+            {% endwith %}
+        {% endblock programs %}
+
         {% block team %}
             {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_team" %}
             <div class="course-detail__team course-detail__block course-detail__block--lightest">

--- a/tests/apps/courses/test_settings_mixins.py
+++ b/tests/apps/courses/test_settings_mixins.py
@@ -20,7 +20,7 @@ class SettingsMixinsTestCase(TestCase):
 
         # pylint: disable=no-member
         cms_templates = TestConfiguration().CMS_TEMPLATES
-        self.assertEqual(len(cms_templates), 16)
+        self.assertEqual(len(cms_templates), 15)
         self.assertEqual(cms_templates[0][0], "courses/cms/course_detail.html")
 
     def test_settings_mixins_override(self):


### PR DESCRIPTION
## Purpose

Courses can be linked on a program detail page. In this case, it is interesting to link the related programs on the page. 

## Proposal

I adapted what had been done to list related courses on an organization detail page.

closes https://github.com/openfun/richie/issues/1237

## Screenshots

<img src="https://user-images.githubusercontent.com/1427165/105082304-a5020f00-5a93-11eb-8825-5c4fa5264016.png" width="350">
