### PR TITLE
✨(persons) allow linking person plugins on a person's page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Allow person and glimpse plugins on the person detail page
 - Allow overriding a person's bio on the person plugin
 - Add new section on the course detail page to display related programs
 - Display "code" on the course detail page and allow frontend editing

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ demo-site: ## create a demo site if app container is running
 	@$(MANAGE) flush
 	@$(COMPOSE_EXEC_APP) python sandbox/manage.py create_demo_site
 	@${MAKE} search-index
+	@${MAKE} superuser
 .PHONY: demo-site
 
 # Nota bene: Black should come after isort just in case they don't agree...

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -379,12 +379,14 @@ class CourseFactory(PageExtensionDjangoModelFactory):
         in a list of slot names.
         """
         if create and extracted:
-            for slot in extracted:
+            for slot, plugin_type in extracted.items():
                 create_text_plugin(
                     self.extended_object,
                     slot,
                     nb_paragraphs=1,
                     languages=self.extended_object.get_languages(),
+                    is_html=plugin_type != "PlainTextPlugin",
+                    plugin_type=plugin_type,
                 )
 
 
@@ -747,6 +749,8 @@ class PersonFactory(PageExtensionDjangoModelFactory):
                 "bio",
                 nb_paragraphs=1,
                 languages=self.extended_object.get_languages(),
+                is_html=False,
+                plugin_type="PlainTextPlugin",
             )
 
     @factory.post_generation

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -254,7 +254,10 @@ CMS_PLACEHOLDER_CONF = {
     },
     "courses/cms/person_detail.html maincontent": {
         "name": _("Main Content"),
-        "plugins": ["CKEditorPlugin"],
+        "plugins": ["CKEditorPlugin", "PersonPlugin", "SectionPlugin", "GlimpsePlugin"],
+        "child_classes": {
+            "SectionPlugin": ["CKEditorPlugin", "GlimpsePlugin", "PersonPlugin"]
+        },
         "limits": {"CKEditorPlugin": 1},
     },
     "courses/cms/person_detail.html organizations": {
@@ -423,10 +426,7 @@ CKEDITOR_INLINE_BOLD_CONFIGURATION = {
     # Enabled showblocks as default behavior
     "startupOutlineBlocks": True,
     # Default toolbar configurations for djangocms_text_ckeditor
-    "toolbar_HTMLField": [
-        ["Undo", "Redo"],
-        ["Bold"],
-    ],
+    "toolbar_HTMLField": [["Undo", "Redo"], ["Bold"]],
     "enterMode": 2,
     "autoParagraph": False,
     "resize_enabled": False,

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -275,14 +275,14 @@ def create_demo_site():
             fill_icons=random.sample(icons, get_number_of_icons()),
             fill_organizations=course_organizations,
             fill_plan=True,
-            fill_texts=[
-                "course_assessment",
-                "course_description",
-                "course_introduction",
-                "course_format",
-                "course_prerequisites",
-                "course_skills",
-            ],
+            fill_texts={
+                "course_assessment": "CKEditorPlugin",
+                "course_description": "CKEditorPlugin",
+                "course_introduction": "PlainTextPlugin",
+                "course_format": "CKEditorPlugin",
+                "course_prerequisites": "CKEditorPlugin",
+                "course_skills": "CKEditorPlugin",
+            },
         )
         course.create_permissions_for_organization(course_organizations[0])
         courses.append(course)

--- a/tests/apps/courses/test_factories_person.py
+++ b/tests/apps/courses/test_factories_person.py
@@ -50,6 +50,6 @@ class PersonFactoryTestCase(TestCase):
         # The bio plugins should contain paragraphs
         for language in ["fr", "en"]:
             bio_plugin = bio.cmsplugin_set.get(
-                plugin_type="CKEditorPlugin", language=language
+                plugin_type="PlainTextPlugin", language=language
             )
-            self.assertIn("<p>", bio_plugin.simple_text_ckeditor_simpletext.body)
+            self.assertTrue(bio_plugin.plain_text_plaintext.body.count(".") >= 2)


### PR DESCRIPTION
## Purpose

Some person pages are in fact collectives. In this case, we want to include thumbnails of the persons in this collective.

## Proposal

Allow the person plugin on the person detail page.

closes https://github.com/openfun/richie/issues/1239