### PR TITLE
✨(plugins) add a "person" variant to the glimpse plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a "person" variant to the glimpse plugin for persons without a page
 - Allow person and glimpse plugins on the person detail page
 - Allow overriding a person's bio on the person plugin
 - Add new section on the course detail page to display related programs

--- a/src/richie/plugins/glimpse/cms_plugins.py
+++ b/src/richie/plugins/glimpse/cms_plugins.py
@@ -8,6 +8,7 @@ from cms.plugin_pool import plugin_pool
 
 from richie.apps.core.defaults import PLUGINS_GROUP
 
+from .defaults import CARD_SQUARE
 from .models import Glimpse
 
 
@@ -40,7 +41,7 @@ class GlimpsePlugin(CMSPluginBase):
         * If model instance has a not null "variant" attribute use it, no
           matter what the value from parent template context is;
         """
-        return instance.variant or context.get("glimpse_variant")
+        return instance.variant or context.get("glimpse_variant") or CARD_SQUARE
 
     def render(self, context, instance, placeholder):
         context.update(

--- a/src/richie/plugins/glimpse/defaults.py
+++ b/src/richie/plugins/glimpse/defaults.py
@@ -4,12 +4,13 @@ Glimpse plugin default settings
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
-CARD_SQUARE, ROW_HALF, ROW_FULL, QUOTE, BADGE = (
+BADGE, CARD_SQUARE, PERSON, QUOTE, ROW_HALF, ROW_FULL = (
+    "badge",
     "card_square",
+    "person",
+    "quote",
     "row_half",
     "row_full",
-    "quote",
-    "badge",
 )
 
 GLIMPSE_VARIANTS = getattr(
@@ -17,10 +18,11 @@ GLIMPSE_VARIANTS = getattr(
     "RICHIE_GLIMPSE_VARIANTS",
     [
         (None, _("Inherit")),
+        (BADGE, _("Badge")),
         (CARD_SQUARE, _("Square card")),
+        (PERSON, _("Person")),
+        (QUOTE, _("Quote")),
         (ROW_HALF, _("Half row")),
         (ROW_FULL, _("Full row")),
-        (QUOTE, _("Quote")),
-        (BADGE, _("Badge")),
     ],
 )

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse.html
@@ -1,6 +1,8 @@
 {% load thumbnail %}{% spaceless %}
 
-{% with glimpse_variant=glimpse_variant|default:"card_square" %}
+{% if glimpse_variant in "quote,person" %}
+    {% include "richie/glimpse/glimpse_"|add:glimpse_variant|add:".html" %}
+{% else %}
 
     {% if instance.get_link %}
         <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel=”noopener noreferrer”{% endif %}
@@ -9,73 +11,39 @@
         <div class="glimpse-{{ glimpse_variant }}">
     {% endif %}
 
-    {% comment %}
-    Quote variant is actually the only one to have its own structure, every
-    other variants share the same one
-    {% endcomment %}
-    {% if glimpse_variant == "quote" %}
-        <div class="glimpse-{{ glimpse_variant }}__wrapper">
-            {% if instance.image %}
-            <div class="glimpse-{{ glimpse_variant }}__media">
-                <img src="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %}"
-                    srcset="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %} 200w
-                        {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
-                        {% if instance.image.width >= 800 %},{% thumbnail instance.image 800x800 crop upscale subject_location=instance.image.subject_location %} 800w{% endif %}"
-                    sizes="200px"
-                    alt="">
-            </div>
-            {% endif %}
+    {% if instance.image %}
+    <div class="glimpse-{{ glimpse_variant }}__media">
+        {% if glimpse_variant == "card_square" %}
+        <img src="{% thumbnail instance.image 300x170 crop upscale subject_location=instance.image.subject_location %}"
+            srcset="{% thumbnail instance.image 300x170 crop upscale subject_location=instance.image.subject_location %} 300w
+                {% if instance.image.width >= 600 %},{% thumbnail instance.image 600x340 crop upscale subject_location=instance.image.subject_location %} 600w{% endif %}
+                {% if instance.image.width >= 900 %},{% thumbnail instance.image 900x510 crop upscale subject_location=instance.image.subject_location %} 900w{% endif %}"
+            sizes="300px"
+            alt="">
+        {% else %}
+        <img src="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %}"
+            srcset="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %} 200w
+                {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
+                {% if instance.image.width >= 800 %},{% thumbnail instance.image 800x800 crop upscale subject_location=instance.image.subject_location %} 800w{% endif %}"
+            sizes="200px"
+            alt="">
+        {% endif %}
+    </div>
+    {% endif %}
 
-            {% if instance.title %}
-                <h{{ header_level|default:2 }} class="glimpse-{{ glimpse_variant }}__title">
-                    {{ instance.title }}
-                </h{{ header_level|default:2 }}>
-            {% endif %}
-        </div>
+    <div class="glimpse-{{ glimpse_variant }}__wrapper">
+        {% if instance.title %}
+            <h{{ header_level|default:2 }} class="glimpse-{{ glimpse_variant }}__title">
+                {{ instance.title }}
+            </h{{ header_level|default:2 }}>
+        {% endif %}
 
         {% if instance.content %}
         <div class="glimpse-{{ glimpse_variant }}__content">
-            <svg role="img">
-                <use href="#icon-quote" />
-            </svg>
             {{ instance.content|linebreaks }}
         </div>
         {% endif %}
-    {% else %}
-        {% if instance.image %}
-        <div class="glimpse-{{ glimpse_variant }}__media">
-            {% if glimpse_variant == "card_square" %}
-            <img src="{% thumbnail instance.image 300x170 crop upscale subject_location=instance.image.subject_location %}"
-                srcset="{% thumbnail instance.image 300x170 crop upscale subject_location=instance.image.subject_location %} 300w
-                    {% if instance.image.width >= 600 %},{% thumbnail instance.image 600x340 crop upscale subject_location=instance.image.subject_location %} 600w{% endif %}
-                    {% if instance.image.width >= 900 %},{% thumbnail instance.image 900x510 crop upscale subject_location=instance.image.subject_location %} 900w{% endif %}"
-                sizes="300px"
-                alt="">
-            {% else %}
-            <img src="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %}"
-                srcset="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %} 200w
-                    {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
-                    {% if instance.image.width >= 800 %},{% thumbnail instance.image 800x800 crop upscale subject_location=instance.image.subject_location %} 800w{% endif %}"
-                sizes="200px"
-                alt="">
-            {% endif %}
-        </div>
-        {% endif %}
-
-        <div class="glimpse-{{ glimpse_variant }}__wrapper">
-            {% if instance.title %}
-                <h{{ header_level|default:2 }} class="glimpse-{{ glimpse_variant }}__title">
-                    {{ instance.title }}
-                </h{{ header_level|default:2 }}>
-            {% endif %}
-
-            {% if instance.content %}
-            <div class="glimpse-{{ glimpse_variant }}__content">
-                {{ instance.content|linebreaks }}
-            </div>
-            {% endif %}
-        </div>
-    {% endif %}
+    </div>
 
     {% if instance.get_link %}
         </a>
@@ -83,5 +51,5 @@
         </div>
     {% endif %}
 
-{% endwith %}
+{% endif %}
 {% endspaceless %}

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse.html
@@ -5,7 +5,7 @@
 {% else %}
 
     {% if instance.get_link %}
-        <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel=”noopener noreferrer”{% endif %}
+        <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel="noopener noreferrer"{% endif %}
         class="glimpse-{{ glimpse_variant }}">
     {% else %}
         <div class="glimpse-{{ glimpse_variant }}">

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_person.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_person.html
@@ -1,0 +1,38 @@
+{% load thumbnail %}{% spaceless %}
+<div class="person-glimpse">
+    {% if instance.get_link %}
+        <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel=”noopener noreferrer”{% endif %}
+        class="person-glimpse__media" tabindex="-1" aria-hidden="true">
+    {% else %}
+        <div class="person-glimpse__media">
+    {% endif %}
+    <img src="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %}"
+    srcset="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %} 200w
+        {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
+        {% if instance.image.width >= 600 %},{% thumbnail instance.image 600x600 crop upscale subject_location=instance.image.subject_location %} 600w{% endif %}"
+    sizes="200px"
+    alt="">
+    {% if instance.get_link %}
+        </a>
+    {% else %}
+        </div>
+    {% endif %}
+
+    <div class="person-glimpse__content">
+        <div class="person-glimpse__wrapper">
+            {% if instance.get_link %}
+                <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel=”noopener noreferrer”{% endif %}>
+            {% endif %}
+                <h3 class="person-glimpse__title">{{ instance.title }}</h3>
+            {% if instance.get_link %}
+                </a>
+            {% endif %}
+            <div class="person-glimpse__categories">
+                <div class="category-tag-list category-tag-list--primary"></div>
+            </div>
+            <div class="person-glimpse__bio">{{ instance.content }}</div>
+        </div>
+    </div>
+
+</div>
+{% endspaceless %}

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_person.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_person.html
@@ -1,7 +1,7 @@
 {% load thumbnail %}{% spaceless %}
 <div class="person-glimpse">
     {% if instance.get_link %}
-        <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel=”noopener noreferrer”{% endif %}
+        <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel="noopener noreferrer"{% endif %}
         class="person-glimpse__media" tabindex="-1" aria-hidden="true">
     {% else %}
         <div class="person-glimpse__media">
@@ -21,7 +21,7 @@
     <div class="person-glimpse__content">
         <div class="person-glimpse__wrapper">
             {% if instance.get_link %}
-                <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel=”noopener noreferrer”{% endif %}>
+                <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel="noopener noreferrer"{% endif %}>
             {% endif %}
                 <h3 class="person-glimpse__title">{{ instance.title }}</h3>
             {% if instance.get_link %}

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_quote.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_quote.html
@@ -1,0 +1,44 @@
+{% load thumbnail %}{% spaceless %}
+
+{% if instance.get_link %}
+    <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel=”noopener noreferrer”{% endif %}
+    class="glimpse-{{ glimpse_variant }}">
+{% else %}
+    <div class="glimpse-{{ glimpse_variant }}">
+{% endif %}
+
+<div class="glimpse-{{ glimpse_variant }}__wrapper">
+    {% if instance.image %}
+    <div class="glimpse-{{ glimpse_variant }}__media">
+        <img src="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %}"
+            srcset="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %} 200w
+                {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
+                {% if instance.image.width >= 800 %},{% thumbnail instance.image 800x800 crop upscale subject_location=instance.image.subject_location %} 800w{% endif %}"
+            sizes="200px"
+            alt="">
+    </div>
+    {% endif %}
+
+    {% if instance.title %}
+        <h{{ header_level|default:2 }} class="glimpse-{{ glimpse_variant }}__title">
+            {{ instance.title }}
+        </h{{ header_level|default:2 }}>
+    {% endif %}
+</div>
+
+{% if instance.content %}
+<div class="glimpse-{{ glimpse_variant }}__content">
+    <svg role="img">
+        <use href="#icon-quote" />
+    </svg>
+    {{ instance.content|linebreaks }}
+</div>
+{% endif %}
+
+{% if instance.get_link %}
+    </a>
+{% else %}
+    </div>
+{% endif %}
+
+{% endspaceless %}

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_quote.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_quote.html
@@ -1,7 +1,7 @@
 {% load thumbnail %}{% spaceless %}
 
 {% if instance.get_link %}
-    <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel=”noopener noreferrer”{% endif %}
+    <a href="{{ instance.get_link }}"{% if instance.is_blank_target %} target="_blank" rel="noopener noreferrer"{% endif %}
     class="glimpse-{{ glimpse_variant }}">
 {% else %}
     <div class="glimpse-{{ glimpse_variant }}">

--- a/tests/plugins/glimpse/test_cms_plugins.py
+++ b/tests/plugins/glimpse/test_cms_plugins.py
@@ -133,11 +133,10 @@ class GlimpseCMSPluginsTestCase(CMSPluginTestCase):
         # variable
         self.assertInHTML(expected_header, html)
 
-    def test_cms_plugins_glimpse_compute_variant_without_context_value(self):
+    def test_cms_plugins_glimpse_compute_variant_default(self):
         """
         When there is no "variant" value set from template parent, if instance
-        variant is empty the variant should be null and if instance variant is
-        set the variant should be set accorded to the instance variant.
+        variant is empty, the variant should default to "square_card".
         """
         placeholder = Placeholder.objects.create(slot="test")
 
@@ -152,7 +151,14 @@ class GlimpseCMSPluginsTestCase(CMSPluginTestCase):
         )
         plugin_instance = model_instance.get_plugin_class_instance()
         computed_variant = plugin_instance.compute_variant({}, glimpse_neutral)
-        self.assertEqual(computed_variant, None)
+        self.assertEqual(computed_variant, "card_square")
+
+    def test_cms_plugins_glimpse_compute_variant_without_context_value(self):
+        """
+        If instance variant is set, the variant should be set according to the
+        instance variant.
+        """
+        placeholder = Placeholder.objects.create(slot="test")
 
         # Create plugin with a dummy variant
         glimpse_variantized = GlimpseFactory(variant="foo")


### PR DESCRIPTION
## Purpose

We want to be able to refer to a person without having to create a person page. 

## Proposal

The glimpse plugin is perfect for this because it has the required fields: avatar, name, bio and link.

I chose to make the glimpse plugin generate the exact same markup as the person glimpse so that the css is entirely shared.

closes https://github.com/openfun/richie/issues/1255