### PR TITLE
🐛(plugins) fix HTMLSiteMap plugin when placed in a static placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix HTMLSiteMap plugin when placed in a static placeholder
 - Delete template `course_run_detail.html` was still referenced in settings
 - Fix unwanted comma when displaying course runs list on course detail page
 

--- a/src/richie/plugins/html_sitemap/cms_plugins.py
+++ b/src/richie/plugins/html_sitemap/cms_plugins.py
@@ -93,7 +93,7 @@ class HTMLSitemapPagePlugin(CMSPluginBase):
         to construct the <ul> <li> structure in the template.
         """
         language = translation.get_language()
-        current_page_is_draft = instance.placeholder.page.publisher_is_draft
+        current_page_is_draft = context["current_page"].publisher_is_draft
 
         if instance.root_page:
             if current_page_is_draft:


### PR DESCRIPTION
## Purpose

Fix HTMLSiteMap plugin when placed in a static placeholder

This is not the preferred use case but it can nevertheless be done and
should not raise a 500 error 😱

## Proposal

Get page from context instead of poking the placeholder (static placeholders are not linked to any page).