### PR TITLE
🚸(frontend) hide console error in tests outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Mock error handler on frontend tests
 - Show 403 page instead of course run list when trying to edit a course run
   with insufficient permissions
 - Improve UX of course search pagination by avoiding truncation of page number

--- a/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
@@ -11,6 +11,11 @@ import { Deferred } from 'utils/test/deferred';
 import * as factories from 'utils/test/factories';
 import { SESSION_CACHE_KEY } from 'settings';
 
+import { handle } from 'utils/errors/handle';
+
+const mockHandle: jest.Mock<typeof handle> = handle as any;
+jest.mock('utils/errors/handle');
+
 describe('<CourseRunEnrollment />', () => {
   const endpoint = 'https://demo.endpoint';
 
@@ -138,6 +143,7 @@ describe('<CourseRunEnrollment />', () => {
 
     screen.getByRole('button', { name: 'Enroll now' });
     screen.getByText('Your enrollment request failed.');
+    expect(mockHandle).toHaveBeenCalledWith('500 - Internal Server Error');
   });
 
   it('shows a link to the course if the user is already enrolled', async () => {

--- a/src/frontend/js/utils/api/lms/index.spec.ts
+++ b/src/frontend/js/utils/api/lms/index.spec.ts
@@ -1,5 +1,10 @@
 import { ApiBackend } from 'types/api';
 
+import { handle } from 'utils/errors/handle';
+
+const mockHandle: jest.Mock<typeof handle> = handle as any;
+jest.mock('utils/errors/handle');
+
 describe('API LMS', () => {
   (window as any).__richie_frontend_context__ = {
     context: {
@@ -34,6 +39,9 @@ describe('API LMS', () => {
   it('throw an error if an unknown url is provided', () => {
     expect(() => LMSHandler('https://unknown.org/course/a-test-course')).toThrow(
       `No LMS Backend found for https://unknown.org/course/a-test-course.`,
+    );
+    expect(mockHandle).toHaveBeenCalledWith(
+      new Error('No LMS Backend found for https://unknown.org/course/a-test-course.'),
     );
   });
 });

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
@@ -3,6 +3,11 @@ import { ApiBackend } from 'types/api';
 import { ContextFactory } from 'utils/test/factories';
 import faker from 'faker';
 
+import { handle } from 'utils/errors/handle';
+
+const mockHandle: jest.Mock<typeof handle> = handle as any;
+jest.mock('utils/errors/handle');
+
 describe('OpenEdX Hawthorn API', () => {
   const EDX_ENDPOINT = 'https://demo.endpoint/api';
   let courseId = '';
@@ -39,6 +44,7 @@ describe('OpenEdX Hawthorn API', () => {
       courseId = faker.random.uuid();
       username = faker.internet.userName();
       fetchMock.restore();
+      mockHandle.mockRestore();
     });
 
     describe('get', () => {
@@ -67,6 +73,10 @@ describe('OpenEdX Hawthorn API', () => {
             username,
           }),
         ).resolves.toBeNull();
+
+        expect(mockHandle).toHaveBeenCalledWith(
+          new Error('[GET - Enrollment] > 500 - Internal Server Error'),
+        );
       });
 
       it('returns course run information if user is enrolled', async () => {
@@ -143,6 +153,9 @@ describe('OpenEdX Hawthorn API', () => {
         );
 
         expect(response).toBeFalsy();
+        expect(mockHandle).toHaveBeenCalledWith(
+          new Error('[SET - Enrollment] > 500 - Internal Server Error'),
+        );
       });
     });
   });


### PR DESCRIPTION
## Purpose

When frontend tests are run, as console.error and console.warning are displayed, developer can think that some tests are failing.


## Proposal

Capture console.error and console.warning on concerned tests, and assert they have been called.
Only test displaying errors has been modified for now, but if the approach is ok, remaining test has to be updated as well.

fixes https://github.com/openfun/richie/issues/1263