### PR TITLE
🐛(cms_plugins) fix HTMLSiteMap plugin when current_page is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix course pages subtree following removal of course run pages
 - Fix HTMLSiteMap plugin when placed in a static placeholder
+- Fix HTMLSiteMap plugin when `current_page` property context is not defined
 - Delete template `course_run_detail.html` was still referenced in settings
 - Fix unwanted comma when displaying course runs list on course detail page
 

--- a/src/richie/plugins/html_sitemap/cms_plugins.py
+++ b/src/richie/plugins/html_sitemap/cms_plugins.py
@@ -93,7 +93,14 @@ class HTMLSitemapPagePlugin(CMSPluginBase):
         to construct the <ul> <li> structure in the template.
         """
         language = translation.get_language()
-        current_page_is_draft = context["current_page"].publisher_is_draft
+
+        # It is possible to have a view without `current_page` in its context
+        # In this case, we consider this page as public. i.e : error views.
+        current_page_is_draft = (
+            context["current_page"].publisher_is_draft
+            if context.get("current_page")
+            else False
+        )
 
         if instance.root_page:
             if current_page_is_draft:


### PR DESCRIPTION
## Purpose

HTMLSiteMap plugin use current_page context property to know if this page is a draft. If this property is not defined in the context, an exception is raised and we got a 500 error.

## Proposal

- [x] Add default value to `current_page_is_draft` (`False`) to manage case where current_page is not defined
