### PR TITLE
💚(ci) fix docker login run with forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,17 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 19.03.13
+
+      # Login to Docker Hub with encrypted credentials stored as secret
+      # environment variables (set in CircleCI project settings) if the expected
+      # environment variable is set; switch to anonymous mode otherwise.
       - run:
           name: Login to DockerHub
-          command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          command: >
+            test -n "$DOCKER_USER" &&
+              echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin ||
+              echo "Docker Hub anonymous mode"
+
       # Each image is tagged with the current git commit sha1 to avoid
       # collisions in parallel builds.
       - run:


### PR DESCRIPTION
## Purpose

People which submit PR through a fork see ci job `docker-build` failed. For security reason, we don't share our CI environment variables with forked PR. This cause an issue on `docker login` because credential variables are not exposed.

## Proposal

- [x] As it did in [openedx-docker](https://github.com/openfun/openedx-docker) - tests that docker credentials are exposed, if not process continues in anonymous mode.
