### PR TITLE
🐛(frontend) replace "go to course" button with dashboard link for unstarted lms courses and add keys to profile_url settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+- Hide "Go to course" button if lms course hasn't started yet 
+
 ### Added
 
 - Add a "person" variant to the glimpse plugin for persons without a page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
-- Hide "Go to course" button if lms course hasn't started yet 
-- Add dashboard link to user menu
-- Use dashboard link if enrolled lms course hasn't started yet
-- Urls keys added in profile_url settings 
-
 ### Added
 
 - Add a "person" variant to the glimpse plugin for persons without a page
@@ -20,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Allow overriding a person's bio on the person plugin
 - Add new section on the course detail page to display related programs
 - Display "code" on the course detail page and allow frontend editing
+- Add dashboard link to user menu
+- Use dashboard link if enrolled lms course hasn't started yet
 
 ### Changed
 
@@ -28,6 +25,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   with insufficient permissions
 - Improve UX of course search pagination by avoiding truncation of page number
   when it is not relevant
+- Hide "Go to course" button if lms course hasn't started yet
+- Add Urls `key` property in profile_url settings
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unrealeased]
 
 - Hide "Go to course" button if lms course hasn't started yet 
-- Add dashboard link to user menu 
+- Add dashboard link to user menu
+- Use dashboard link if enrolled lms course hasn't started yet
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Hide "Go to course" button if lms course hasn't started yet 
 - Add dashboard link to user menu
 - Use dashboard link if enrolled lms course hasn't started yet
+- Urls keys added in profile_url settings 
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unrealeased]
 
 - Hide "Go to course" button if lms course hasn't started yet 
+- Add dashboard link to user menu 
 
 ### Added
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,10 @@ $ make migrate
 
 ## Unreleased
 
+## 2.0.x to 2.1.x
+- `RICHIE_AUTHENTICATION_DELEGATION["PROFILE_URLS"]` setting is now a dictionary : a key has been
+  added to each url, permitting to get one easily.
+
 ## 1.17.x to 2.0.x
 - Richie version 2 introduces a new `AUTHENTICATION_BACKEND` setting used to get session information
   from OpenEdX through CORS requests. So login, register and logout routes are constructed from

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -253,12 +253,21 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         # (i) Info - {base_url} is RICHIE_AUTHENTICATION_DELEGATION.BASE_URL
         # (i) If you need to bind user data into href url, wrap the property between ()
         # e.g: for user.username = johndoe, /u/(username) will be /u/johndoe
-        "PROFILE_URLS": values.ListValue(
-            [
-                {"label": _("Dashboard"), "href": _("{base_url:s}/dashboard")},
-                {"label": _("Profile"), "href": _("{base_url:s}/u/(username)")},
-                {"label": _("Account"), "href": _("{base_url:s}/account/settings")},
-            ],
+        "PROFILE_URLS": values.DictValue(
+            {
+                "dashboard": {
+                    "label": _("Dashboard"),
+                    "href": _("{base_url:s}/dashboard"),
+                },
+                "profile": {
+                    "label": _("Profile"),
+                    "href": _("{base_url:s}/u/(username)"),
+                },
+                "account": {
+                    "label": _("Account"),
+                    "href": _("{base_url:s}/account/settings"),
+                },
+            },
             environ_name="AUTHENTICATION_PROFILE_URLS",
             environ_prefix=None,
         ),

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -255,6 +255,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         # e.g: for user.username = johndoe, /u/(username) will be /u/johndoe
         "PROFILE_URLS": values.ListValue(
             [
+                {"label": _("Dashboard"), "href": _("{base_url:s}/dashboard")},
                 {"label": _("Profile"), "href": _("{base_url:s}/u/(username)")},
                 {"label": _("Account"), "href": _("{base_url:s}/account/settings")},
             ],

--- a/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
@@ -57,6 +57,7 @@ describe('<CourseRunEnrollment />', () => {
     resource_link: courseRun.resource_link,
     priority: courseRun.state.priority,
     starts_in_message: courseRun.starts_in_message,
+    dashboard_link: courseRun.dashboard_link,
   });
 
   afterEach(() => {
@@ -183,6 +184,7 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 0;
     courseRun.starts_in_message = 'The course will start in 3 days';
+    courseRun.dashboard_link = 'https://edx.local.dev:8073/dashboard';
 
     const courseRunDeferred = new Deferred();
     fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
@@ -207,8 +209,10 @@ describe('<CourseRunEnrollment />', () => {
     });
 
     expect(screen.queryByRole('link', { name: 'Go to course' })).toBeNull();
-    // screen.getByRole('link', { name: 'Go to dashboard' });
-    screen.getByText('You are enrolled in this course run');
+    expect(screen.getByText('You are enrolled in this course run')).toHaveAttribute(
+      'href',
+      'https://edx.local.dev:8073/dashboard',
+    );
     screen.getByText('The course will start in 3 days');
   });
 

--- a/src/frontend/js/components/CourseRunEnrollment/index.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.tsx
@@ -57,6 +57,7 @@ interface CourseRunEnrollmentProps {
     resource_link: string;
     priority: number;
     starts_in_message: Nullable<string>;
+    dashboard_link: string;
   };
 }
 
@@ -236,7 +237,7 @@ export const CourseRunEnrollment: React.FC<CourseRunEnrollmentProps & CommonData
         <React.Fragment>
           {courseRun.starts_in_message ? (
             <div>
-              <a href={courseRun.resource_link} className="course-run-enrollment__cta">
+              <a href={courseRun.dashboard_link} className="course-run-enrollment__cta">
                 <FormattedMessage {...messages.enrolled} />
               </a>
               <div className="course-run-enrollment__helptext">{courseRun.starts_in_message}</div>

--- a/src/frontend/js/components/CourseRunEnrollment/index.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.tsx
@@ -56,6 +56,7 @@ interface CourseRunEnrollmentProps {
     id: number;
     resource_link: string;
     priority: number;
+    starts_in_message: Nullable<string>;
   };
 }
 
@@ -233,12 +234,23 @@ export const CourseRunEnrollment: React.FC<CourseRunEnrollmentProps & CommonData
     case step === Step.ENROLLED:
       return (
         <React.Fragment>
-          <a href={courseRun.resource_link} className="course-run-enrollment__cta">
-            <FormattedMessage {...messages.goToCourse} />
-          </a>
-          <div className="course-run-enrollment__helptext">
-            <FormattedMessage {...messages.enrolled} />
-          </div>
+          {courseRun.starts_in_message ? (
+            <div>
+              <a href={courseRun.resource_link} className="course-run-enrollment__cta">
+                <FormattedMessage {...messages.enrolled} />
+              </a>
+              <div className="course-run-enrollment__helptext">{courseRun.starts_in_message}</div>
+            </div>
+          ) : (
+            <div>
+              <a href={courseRun.resource_link} className="course-run-enrollment__cta">
+                <FormattedMessage {...messages.goToCourse} />
+              </a>
+              <div className="course-run-enrollment__helptext">
+                <FormattedMessage {...messages.enrolled} />
+              </div>
+            </div>
+          )}
         </React.Fragment>
       );
   }

--- a/src/frontend/js/components/CourseRunEnrollment/index.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.tsx
@@ -242,11 +242,11 @@ export const CourseRunEnrollment: React.FC<CourseRunEnrollmentProps & CommonData
                   <FormattedMessage {...messages.enrolled} />
                 </a>
               ) : (
-                <div className="course-run-enrollment__helptext">
+                <p className="course-run-enrollment__helptext">
                   <FormattedMessage {...messages.enrolled} />
-                </div>
+                </p>
               )}
-              <div className="course-run-enrollment__helptext">{courseRun.starts_in_message}</div>
+              <p className="course-run-enrollment__helptext">{courseRun.starts_in_message}</p>
             </div>
           ) : (
             <div>

--- a/src/frontend/js/components/CourseRunEnrollment/index.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.tsx
@@ -57,7 +57,7 @@ interface CourseRunEnrollmentProps {
     resource_link: string;
     priority: number;
     starts_in_message: Nullable<string>;
-    dashboard_link: string;
+    dashboard_link: Nullable<string>;
   };
 }
 
@@ -237,9 +237,15 @@ export const CourseRunEnrollment: React.FC<CourseRunEnrollmentProps & CommonData
         <React.Fragment>
           {courseRun.starts_in_message ? (
             <div>
-              <a href={courseRun.dashboard_link} className="course-run-enrollment__cta">
-                <FormattedMessage {...messages.enrolled} />
-              </a>
+              {courseRun.dashboard_link ? (
+                <a href={courseRun.dashboard_link} className="course-run-enrollment__cta">
+                  <FormattedMessage {...messages.enrolled} />
+                </a>
+              ) : (
+                <div className="course-run-enrollment__helptext">
+                  <FormattedMessage {...messages.enrolled} />
+                </div>
+              )}
               <div className="course-run-enrollment__helptext">{courseRun.starts_in_message}</div>
             </div>
           ) : (

--- a/src/frontend/js/components/UserLogin/index.spec.tsx
+++ b/src/frontend/js/components/UserLogin/index.spec.tsx
@@ -92,10 +92,10 @@ describe('<UserLogin />', () => {
 
   it('should renders profile urls and bind user info if needed', () => {
     const username = initializeUser();
-    const profileUrls = [
-      { label: 'Settings', action: 'https://auth.local.test/settings' },
-      { label: 'Account', action: 'https://auth.local.test/u/(username)' },
-    ];
+    const profileUrls = {
+      settings: { label: 'Settings', action: 'https://auth.local.test/settings' },
+      account: { label: 'Account', action: 'https://auth.local.test/u/(username)' },
+    };
 
     const { getByText, getByRole } = render(
       <IntlProvider locale="en">

--- a/src/frontend/js/components/UserLogin/index.tsx
+++ b/src/frontend/js/components/UserLogin/index.tsx
@@ -93,11 +93,13 @@ export const UserLogin = ({ profileUrls = [] }: UserLoginProps) => {
           user={{
             ...user,
             urls: [
-              ...profileUrls.map(({ label, action }) => ({
+              ...Object.entries(profileUrls).map(([key, { label, action }]) => ({
+                key,
                 label,
                 action: typeof action === 'string' ? bindUserDataToUrl(action, user) : action,
               })),
               {
+                key: 'logout',
                 label: intl.formatMessage(messages.logOut),
                 action: destroy,
               },

--- a/src/frontend/js/components/UserMenu/DesktopUserMenu.tsx
+++ b/src/frontend/js/components/UserMenu/DesktopUserMenu.tsx
@@ -51,7 +51,7 @@ export const DesktopUserMenu: React.FC<UserMenuProps> = ({ user }) => {
       >
         {isOpen &&
           user.urls.map((link, index) => (
-            <li key={`user-link-${link.label}-${index}`} {...getItemProps({ item: link, index })}>
+            <li key={link.key} {...getItemProps({ item: link, index })}>
               {typeof link.action === 'string' ? (
                 <a
                   className={`selector__list__link ${

--- a/src/frontend/js/components/UserMenu/MobileUserMenu.tsx
+++ b/src/frontend/js/components/UserMenu/MobileUserMenu.tsx
@@ -10,8 +10,8 @@ export const MobileUserMenu: React.FC<UserMenuProps> = ({ user }) => (
       {user.username}
     </h6>
     <ul className="user-menu__list">
-      {user.urls.map(({ label, action }, index) => (
-        <li className="user-menu__list__item" key={`user-link-${label}-${index}`}>
+      {user.urls.map(({ key, label, action }) => (
+        <li className="user-menu__list__item" key={key}>
           {typeof action === 'string' ? (
             <a href={action}>{label}</a>
           ) : (

--- a/src/frontend/js/components/UserMenu/index.spec.tsx
+++ b/src/frontend/js/components/UserMenu/index.spec.tsx
@@ -12,14 +12,17 @@ const props = {
     username: 'John Doe',
     urls: [
       {
+        key: 'logout',
         label: 'Log out',
         action: '/logout',
       },
       {
+        key: 'profile',
         label: 'Profile',
         action: 'https://acme.org/profile/johndoe',
       },
       {
+        key: 'dashboard',
         label: 'My Dashboard',
         action: 'https://acme.org/dashboard',
       },

--- a/src/frontend/js/types/User.ts
+++ b/src/frontend/js/types/User.ts
@@ -2,6 +2,7 @@ export interface User {
   full_name?: string;
   username: string;
   urls: {
+    key: string;
     label: string;
     action: string | (() => void);
   }[];

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -7,6 +7,7 @@ export interface CourseRun {
   enrollment_end: string;
   languages: string[];
   state: CourseState;
+  starts_in_message: string;
 }
 
 export interface CourseState {

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -8,6 +8,7 @@ export interface CourseRun {
   languages: string[];
   state: CourseState;
   starts_in_message: string;
+  dashboard_link: string;
 }
 
 export interface CourseState {

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -1,3 +1,5 @@
+import { Nullable } from 'utils/types';
+
 export interface CourseRun {
   id: number;
   resource_link: string;
@@ -7,8 +9,8 @@ export interface CourseRun {
   enrollment_end: string;
   languages: string[];
   state: CourseState;
-  starts_in_message: string;
-  dashboard_link: string;
+  starts_in_message: Nullable<string>;
+  dashboard_link: Nullable<string>;
 }
 
 export interface CourseState {

--- a/src/frontend/js/utils/test/factories.ts
+++ b/src/frontend/js/utils/test/factories.ts
@@ -18,6 +18,7 @@ export const CourseRunFactory = createSpec({
   enrollment_end: derived(() => faker.date.past()().toISOString()),
   languages: faker.random.locale(),
   state: CourseStateFactory,
+  starts_in_message: null,
 });
 
 export const EnrollmentFactory = createSpec({

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -53,8 +53,8 @@ def site_metas(request):
 
         context["AUTHENTICATION"] = {
             "profile_urls": json.dumps(
-                [
-                    {
+                {
+                    key: {
                         "label": str(url["label"]),
                         "action": str(
                             url["href"].format(
@@ -62,8 +62,10 @@ def site_metas(request):
                             )
                         ),
                     }
-                    for url in authentication_delegation.get("PROFILE_URLS", [])
-                ]
+                    for key, url in authentication_delegation.get(
+                        "PROFILE_URLS", {}
+                    ).items()
+                }
             ),
         }
 

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -234,12 +234,10 @@ def course_enrollment_widget_props(context):
     """
     course_run = context["run"]
 
-    dashboard_link = None
-    profile_urls = json.loads(context.get("AUTHENTICATION").get("profile_urls"))
-    for url in profile_urls:
-        action = url.get("action")
-        if "dashboard" in action:
-            dashboard_link = action
+    profile_urls = json.loads(
+        context.get("AUTHENTICATION", {}).get("profile_urls", "{}")
+    )
+    dashboard_link = profile_urls.get("dashboard", {}).get("action")
 
     starts_in_message = None
     if course_run.start > timezone.now():

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -234,13 +234,22 @@ def course_enrollment_widget_props(context):
     """
     course_run = context["run"]
 
+    dashboard_link = None
+    profile_urls = json.loads(context.get("AUTHENTICATION").get("profile_urls"))
+    for url in profile_urls:
+        action = url.get("action")
+        if "dashboard" in action:
+            dashboard_link = action
+
     starts_in_message = None
     if course_run.start > timezone.now():
         course_start = arrow.get(course_run.start)
         humanized_course_start = course_start.humanize(
             arrow.now(), locale=to_locale(get_language())
         )
-        starts_in_message = _("The course will start {:s}").format(humanized_course_start)
+        starts_in_message = _("The course will start {:s}").format(
+            humanized_course_start
+        )
 
     return json.dumps(
         {
@@ -249,6 +258,7 @@ def course_enrollment_widget_props(context):
                 "resource_link": course_run.resource_link,
                 "priority": course_run.state["priority"],
                 "starts_in_message": starts_in_message,
+                "dashboard_link": dashboard_link,
             }
         }
     )

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -4,7 +4,12 @@ import json
 from django import template
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.loader import render_to_string
+from django.utils import timezone
+from django.utils.translation import get_language
+from django.utils.translation import gettext as _
+from django.utils.translation import to_locale
 
+import arrow
 from classytags.arguments import Argument, MultiValueArgument
 from classytags.core import Options, Tag
 from classytags.utils import flatten_context
@@ -229,12 +234,21 @@ def course_enrollment_widget_props(context):
     """
     course_run = context["run"]
 
+    starts_in_message = None
+    if course_run.start > timezone.now():
+        course_start = arrow.get(course_run.start)
+        humanized_course_start = course_start.humanize(
+            arrow.now(), locale=to_locale(get_language())
+        )
+        starts_in_message = _("The course will start {:s}").format(humanized_course_start)
+
     return json.dumps(
         {
             "courseRun": {
                 "id": course_run.id,
                 "resource_link": course_run.resource_link,
                 "priority": course_run.state["priority"],
+                "starts_in_message": starts_in_message,
             }
         }
     )

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -245,8 +245,10 @@ def course_enrollment_widget_props(context):
         humanized_course_start = course_start.humanize(
             arrow.now(), locale=to_locale(get_language())
         )
-        starts_in_message = _("The course will start {:s}").format(
-            humanized_course_start
+        # Translators: delay indicates when the course will start as a duration.
+        # In english the string will be "The course will start in 3 days"
+        starts_in_message = _("The course will start {delay:s}").format(
+            delay=humanized_course_start
         )
 
     return json.dumps(

--- a/tests/apps/core/test_authentication_delegation.py
+++ b/tests/apps/core/test_authentication_delegation.py
@@ -18,12 +18,12 @@ class UserMenuTests(CMSTestCase):
         RICHIE_AUTHENTICATION_DELEGATION={
             "BASE_URL": "https://richie.education:9999",
             "BACKEND": "richie.apps.courses.lms.base.BaseLMSBackend",
-            "PROFILE_URLS": [
-                {
+            "PROFILE_URLS": {
+                "profile": {
                     "label": "Profile",
                     "href": _("{base_url:s}/profile"),
                 }
-            ],
+            },
         }
     )
     def test_user_menu_with_profile_urls(self):
@@ -85,7 +85,7 @@ class UserMenuTests(CMSTestCase):
         """
         If RICHIE_AUTHENTICATION_DELEGATION.PROFILE_URLS is not defined,
         user menu should render correctly and
-        profileUrls data-props should be an empty array
+        profileUrls data-props should be an empty object
         """
         page = create_page(
             title="Home",
@@ -96,4 +96,4 @@ class UserMenuTests(CMSTestCase):
         response = self.client.get(page.get_public_url())
 
         self.assertContains(response, "richie-react richie-react--user-login")
-        self.assertContains(response, "data-props='{\"profileUrls\": []}'")
+        self.assertContains(response, "data-props='{\"profileUrls\": {}}'")

--- a/tests/apps/courses/test_templatetags_extra_tags_course_enrollment_widget_props.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_course_enrollment_widget_props.py
@@ -31,7 +31,14 @@ class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
             ),
             start=now + timedelta(days=1),
         )
-        context = {"run": course_run}
+        profile_urls = json.dumps(
+            [
+                {"action": "http://example.edx:8073/dashboard"},
+                {"action": "http://example.edx:8073/u/edx"},
+                {"action": "http://example.edx:8073/account/settings"},
+            ]
+        )
+        context = {"run": course_run, "AUTHENTICATION": {"profile_urls": profile_urls}}
 
         with mock.patch.object(timezone, "now", return_value=now):
             self.assertEqual(
@@ -43,6 +50,7 @@ class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
                             "resource_link": course_run.resource_link,
                             "priority": course_run.direct_course.state["priority"],
                             "starts_in_message": "The course will start in a day",
+                            "dashboard_link": "http://example.edx:8073/dashboard",
                         }
                     }
                 ),

--- a/tests/apps/courses/test_templatetags_extra_tags_course_enrollment_widget_props.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_course_enrollment_widget_props.py
@@ -21,6 +21,7 @@ class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
     def test_course_enrollment_widget_props_tag(self):
         """
         CourseEnrollment required id, resource_link and state.priority course run's properties.
+        Dashboard url is added if defined in profile_urls.
         course_enrollment_widget_props should return these properties wrapped into
         a courseRun object as a stringified json.
         """
@@ -32,11 +33,11 @@ class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
             start=now + timedelta(days=1),
         )
         profile_urls = json.dumps(
-            [
-                {"action": "http://example.edx:8073/dashboard"},
-                {"action": "http://example.edx:8073/u/edx"},
-                {"action": "http://example.edx:8073/account/settings"},
-            ]
+            {
+                "dashboard": {"action": "http://example.edx:8073/dashboard"},
+                "profile": {"action": "http://example.edx:8073/u/edx"},
+                "account": {"action": "http://example.edx:8073/account/settings"},
+            }
         )
         context = {"run": course_run, "AUTHENTICATION": {"profile_urls": profile_urls}}
 
@@ -51,6 +52,38 @@ class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
                             "priority": course_run.direct_course.state["priority"],
                             "starts_in_message": "The course will start in a day",
                             "dashboard_link": "http://example.edx:8073/dashboard",
+                        }
+                    }
+                ),
+            )
+
+    def test_course_enrollment_widget_props_tag_undefined_profile_urls(self):
+        """
+        CourseEnrollment required id, resource_link and state.priority course run's properties.
+        Dashboard url is null if not defined in profile_urls.
+        course_enrollment_widget_props should return these properties wrapped into
+        a courseRun object as a stringified json.
+        """
+        now = timezone.now()
+        course_run = CourseRunFactory(
+            resource_link=(
+                "http://example.edx:8073/courses/course-v1:edX+DemoX+Demo_Course/course/"
+            ),
+            start=now + timedelta(days=1),
+        )
+        context = {"run": course_run}
+
+        with mock.patch.object(timezone, "now", return_value=now):
+            self.assertEqual(
+                course_enrollment_widget_props(context),
+                json.dumps(
+                    {
+                        "courseRun": {
+                            "id": course_run.id,
+                            "resource_link": course_run.resource_link,
+                            "priority": course_run.direct_course.state["priority"],
+                            "starts_in_message": "The course will start in a day",
+                            "dashboard_link": None,
                         }
                     }
                 ),


### PR DESCRIPTION
## Purpose

In openedx, when we try to start a course which is not open yet, we might get a 500 error. The "go to course" button is not displayed in this case, and has been replaced with a dashboard link.

Also, as discussed, profile_urls in settings are stored in a list, which we need to loop on to find a particular url

## Proposal

New prop attributes have been added to CourseRunEnrollment component with a message indicating when the course will start and a dashboard link.
If the message is defined we display the button.

A key has been added to each url in profile_urls settings.

fixes #1260
