### PR TITLE
🐛(frontend) fix autosuggest to redirect directly on course page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix autosuggest to redirect user directly on the course page when a course
+  entry has been selected from the suggestion dropdown
+
 ## [2.1.0] - 2021-01-22
 
 ### Added

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -31,8 +31,10 @@ describe('<RootSearchSuggestField />', () => {
     values: [],
   };
 
-  afterEach(() => fetchMock.restore());
-  afterEach(jest.resetAllMocks);
+  afterEach(() => {
+    fetchMock.restore();
+    jest.resetAllMocks();
+  });
 
   it('renders', () => {
     fetchMock.get('/api/v1.0/filter-definitions/', {
@@ -129,6 +131,7 @@ describe('<RootSearchSuggestField />', () => {
 
     fireEvent.click(course);
     await waitFor(() => {
+      expect(location.assign).toHaveBeenCalledTimes(1);
       expect(location.assign).toHaveBeenCalledWith('/en/courses/42');
     });
   });
@@ -168,6 +171,7 @@ describe('<RootSearchSuggestField />', () => {
 
     fireEvent.click(subject);
     await waitFor(() => {
+      expect(location.assign).toHaveBeenCalledTimes(1);
       expect(location.assign).toHaveBeenCalledWith(
         '/en/courses/?limit=13&offset=0&subjects=L-000300010001',
       );
@@ -197,6 +201,7 @@ describe('<RootSearchSuggestField />', () => {
     fireEvent.keyDown(field, { keyCode: 13 });
 
     await waitFor(() => {
+      expect(location.assign).toHaveBeenCalledTimes(1);
       expect(location.assign).toHaveBeenCalledWith(
         '/en/courses/?limit=13&offset=0&query=some%20query',
       );
@@ -240,6 +245,7 @@ describe('<RootSearchSuggestField />', () => {
     fireEvent.keyDown(field, { keyCode: 40 }); // Select the desired suggestion (there is only one)
     fireEvent.keyDown(field, { keyCode: 13 }); // Press enter
     await waitFor(() => {
+      expect(location.assign).toHaveBeenCalledTimes(1);
       expect(location.assign).toHaveBeenCalledWith('/en/courses/42');
     });
   });

--- a/src/frontend/js/components/RootSearchSuggestField/index.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.tsx
@@ -132,7 +132,7 @@ export const RootSearchSuggestField = ({
       onSuggestionsFetchRequested={async ({ value: incomingValue }) =>
         onSuggestionsFetchRequested(await getFilters(), setSuggestions, incomingValue)
       }
-      onSuggestionHighlighted={({ suggestion }) => setHasHighlightedSuggestion(!suggestion)}
+      onSuggestionHighlighted={({ suggestion }) => setHasHighlightedSuggestion(!!suggestion)}
       onSuggestionSelected={onSuggestionSelected}
       renderInputComponent={(passthroughInputProps) => (
         <SearchInput


### PR DESCRIPTION
## Purpose

When user select a course entry in the autosuggest menu, it should be redirect to the course page and not the search view. As `hasHighlightedSuggestion` state was not set correctly, that was not work.


## Proposal

- [x] Set `hasHighlightedSuggestion`correctly on `onSuggestionHighlighted` callback
