### PR TITLE
Fix/course template with no course

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Prevent a 500 error when an editor uses a template for a page
+  that requires to have a model attached as a page extension
+  (course, person, organization and category detail templates)
 - Fix autosuggest to redirect user directly on the course page when a course
   entry has been selected from the suggestion dropdown
 - Pin `django-treebeard` to `4.4` as the 4.5 release introduces BC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add new state for courses archived yet open for enrollment and position them
   well in search results
+- Add a banner component to display brief messages to the user
 
 ### Fixed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,7 +16,13 @@ $ make migrate
 
 ## Unreleased
 
+## 2.1.x to 2.2.x
+
+- A css `.banner` component has been created. You may have to import the component style
+  `objects/_banner.scss` into your main stylesheet to be able to use it.
+
 ## 2.0.x to 2.1.x
+
 - `RICHIE_AUTHENTICATION_DELEGATION["PROFILE_URLS"]` setting is now a dictionary : a key has been
   added to each url, permitting to get one easily.
 - Richie has now its own error templates. You can use them by setting `handler400`, `handler403`,
@@ -32,6 +38,7 @@ $ make migrate
     ```
 
 ## 1.17.x to 2.0.x
+
 - Richie version 2 introduces a new `AUTHENTICATION_BACKEND` setting used to get session information
   from OpenEdX through CORS requests. So login, register and logout routes are constructed from
   the BASE_URL of this setting. Furthermore it takes an extra property `PROFILE_URLS`.

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -54,6 +54,7 @@
 @import './generic/icons';
 
 // Shared object styles
+@import './objects/banner';
 @import './objects/breadcrumbs';
 @import './objects/course_glimpses';
 @import './objects/blogpost_glimpses';

--- a/src/frontend/scss/objects/_banner.scss
+++ b/src/frontend/scss/objects/_banner.scss
@@ -1,0 +1,42 @@
+// Banner
+//
+// A Row to display an inlined message
+
+.banner {
+  @include make-container();
+  @include make-container-max-widths();
+  display: flex;
+  padding: 1.4rem 1rem;
+  margin: 1rem auto;
+
+  &--error {
+    @include r-scheme-colors(r-theme-val(banner, error));
+  }
+
+  &--success {
+    @include r-scheme-colors(r-theme-val(banner, success));
+  }
+
+  &--info {
+    @include r-scheme-colors(r-theme-val(banner, info));
+  }
+
+  &--warning {
+    @include r-scheme-colors(r-theme-val(banner, warning));
+  }
+
+  &--rounded {
+    border-radius: 6px;
+  }
+
+  &__icon {
+    height: 1rem;
+    margin-right: 1rem;
+    width: 1rem;
+  }
+
+  &__message {
+    font-size: 1em;
+    margin-bottom: 0;
+  }
+}

--- a/src/frontend/scss/settings/_colors.scss
+++ b/src/frontend/scss/settings/_colors.scss
@@ -184,24 +184,30 @@ $white-mask-gradient-scheme: (
 // Theme schemes
 $r-theme: (
   // Used from styleguide to build available scheme to demonstrate, used to create button variant
-  base-schemes:
+  banner:
     (
-      primary: $firebrick6-scheme,
-      secondary: $indianred3-scheme,
-      tertiary: $smoke-scheme,
-      clear: $white-scheme,
-      light: $light-grey-scheme,
-      lightest: $azure2,
-      neutral-gradient: $neutral-gradient-scheme,
-      middle-gradient: $middle-gradient-scheme,
-      dark-gradient: $dark-gradient-scheme,
-      white-mask-gradient: $white-mask-gradient-scheme,
-      transparent-darkest: $transparent-dark-scheme,
-      clouds: $clouds-scheme,
-      waves: $waves-scheme,
-      purplish-grey: $purplish-grey-scheme,
-      battleship-grey: $battleship-grey-scheme,
+      error: $firebrick6-scheme,
+      warning: $indianred3-scheme,
+      success: $azure2,
+      info: $battleship-grey-scheme,
     ),
+  base-schemes: (
+    primary: $firebrick6-scheme,
+    secondary: $indianred3-scheme,
+    tertiary: $smoke-scheme,
+    clear: $white-scheme,
+    light: $light-grey-scheme,
+    lightest: $azure2,
+    neutral-gradient: $neutral-gradient-scheme,
+    middle-gradient: $middle-gradient-scheme,
+    dark-gradient: $dark-gradient-scheme,
+    white-mask-gradient: $white-mask-gradient-scheme,
+    transparent-darkest: $transparent-dark-scheme,
+    clouds: $clouds-scheme,
+    waves: $waves-scheme,
+    purplish-grey: $purplish-grey-scheme,
+    battleship-grey: $battleship-grey-scheme,
+  ),
   base-gradients: (
     neutral-gradient: $neutral-gradient,
     middle-gradient: $middle-gradient,

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -8,185 +8,188 @@
 
 {% block content %}{% spaceless %}
 {% with category=current_page.category header_level=2 %}
-<div class="category-detail">
-    <div class="category-detail__block category-detail__block--unpadded">
-        <div class="category-detail__row category-detail__row--unpadded">
-            <div class="category-detail__banner">
-                {% get_placeholder_plugins "banner" as banner_plugins or %}
-                    <div class="category-detail__empty">{% trans "Banner" %}</div>
-                {% endget_placeholder_plugins %}
-                {% blockplugin banner_plugins.0 %}
-                    <img
-                        src="{% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %}"
-                        srcset="
-                            {% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %} 1140w
-                            {% if instance.picture.width >= 2280 %},{% thumbnail instance.picture 2280x800 crop upscale subject_location=instance.picture.subject_location %} 2280w{% endif %}
-                            {% if instance.picture.width >= 3420 %},{% thumbnail instance.picture 3420x600 crop upscale subject_location=instance.picture.subject_location %} 3420w{% endif %}
-                        "
-                        sizes="1140px"
-                        alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'category banner' %}{% endif %}"
-                    />
-                {% endblockplugin %}
-            </div>
+{% if category %}
+    <div class="category-detail">
+        <div class="category-detail__block category-detail__block--unpadded">
+            <div class="category-detail__row category-detail__row--unpadded">
+                <div class="category-detail__banner">
+                    {% get_placeholder_plugins "banner" as banner_plugins or %}
+                        <div class="category-detail__empty">{% trans "Banner" %}</div>
+                    {% endget_placeholder_plugins %}
+                    {% blockplugin banner_plugins.0 %}
+                        <img
+                            src="{% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %}"
+                            srcset="
+                                {% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %} 1140w
+                                {% if instance.picture.width >= 2280 %},{% thumbnail instance.picture 2280x800 crop upscale subject_location=instance.picture.subject_location %} 2280w{% endif %}
+                                {% if instance.picture.width >= 3420 %},{% thumbnail instance.picture 3420x600 crop upscale subject_location=instance.picture.subject_location %} 3420w{% endif %}
+                            "
+                            sizes="1140px"
+                            alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'category banner' %}{% endif %}"
+                        />
+                    {% endblockplugin %}
+                </div>
 
-            <div class="category-detail__logo">
-                {% get_placeholder_plugins "logo" as logo_plugins or %}
-                    <div class="category-detail__empty">{% trans "Logo" %}</div>
-                {% endget_placeholder_plugins %}
-                {% blockplugin logo_plugins.0 %}
-                    <img
-                        src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
-                        srcset="
-                            {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
-                            {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                            {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                        "
-                        sizes="200px"
-                        alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'category logo' %}{% endif %}"
-                    />
-                {% endblockplugin %}
+                <div class="category-detail__logo">
+                    {% get_placeholder_plugins "logo" as logo_plugins or %}
+                        <div class="category-detail__empty">{% trans "Logo" %}</div>
+                    {% endget_placeholder_plugins %}
+                    {% blockplugin logo_plugins.0 %}
+                        <img
+                            src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
+                            srcset="
+                                {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
+                                {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                            "
+                            sizes="200px"
+                            alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'category logo' %}{% endif %}"
+                        />
+                    {% endblockplugin %}
+                </div>
             </div>
         </div>
-    </div>
 
-    <div class="category-detail__intro category-detail__block category-detail__block--unpadded">
-        <div class="category-detail__row">
-            <h1 class="category-detail__title">
-                {% get_placeholder_plugins "icon" as icon_plugins %}
-                {% blockplugin icon_plugins.0 %}
-                    <img
-                        src="{% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %}"
-                        srcset="
-                            {% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %} 60w
-                            {% if instance.picture.width >= 120 %},{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 80w{% endif %}
-                            {% if instance.picture.width >= 180 %},{% thumbnail instance.picture 180x180 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
-                        "
-                        sizes="60px"
-                        alt=""
-                    />
-                {% endblockplugin %}
+        <div class="category-detail__intro category-detail__block category-detail__block--unpadded">
+            <div class="category-detail__row">
+                <h1 class="category-detail__title">
+                    {% get_placeholder_plugins "icon" as icon_plugins %}
+                    {% blockplugin icon_plugins.0 %}
+                        <img
+                            src="{% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %}"
+                            srcset="
+                                {% thumbnail instance.picture 60x60 crop upscale subject_location=instance.picture.subject_location %} 60w
+                                {% if instance.picture.width >= 120 %},{% thumbnail instance.picture 120x120 crop upscale subject_location=instance.picture.subject_location %} 80w{% endif %}
+                                {% if instance.picture.width >= 180 %},{% thumbnail instance.picture 180x180 crop upscale subject_location=instance.picture.subject_location %} 120w{% endif %}
+                            "
+                            sizes="60px"
+                            alt=""
+                        />
+                    {% endblockplugin %}
 
-                {% render_model current_page "title" %}
-            </h1>
+                    {% render_model current_page "title" %}
+                </h1>
 
-            <div class="category-detail__description">
-                {% placeholder "description" %}
+                <div class="category-detail__description">
+                    {% placeholder "description" %}
+                </div>
             </div>
         </div>
+
+        {% with children_categories=category.get_children_categories %}
+            {% if children_categories %}
+                <div class="category-detail__courses category-detail__block">
+                    <div class="category-detail__row">
+                        <section class="category-glimpse-list">
+                            <h2 class="category-detail__title">{% trans "Sub categories" %}</h2>
+                            {% for child_category in children_categories %}
+                                {% include "courses/cms/fragment_category_glimpse.html" with category=child_category category_variant="glimpse" %}
+                            {% endfor %}
+                        </section>
+                    </div>
+                </div>
+            {% endif %}
+        {% endwith %}
+
+        {% with courses=category.get_courses %}
+            {% if courses %}
+                {% autopaginate courses GLIMPSE_PAGINATION_COURSES as object_list %}
+                <div id="page{{ page_suffix }}" class="category-detail__courses category-detail__block">
+                    <div class="category-detail__row">
+                        <section class="course-glimpse-list">
+                            <h2 class="category-detail__title">{% trans "Related courses" %}</h2>
+                            {% for course in page_obj.object_list %}
+                                {% if course.extended_object.publisher_is_draft or course.check_publication %}
+                                    {% include "courses/cms/fragment_course_glimpse.html" %}
+                                {% endif %}
+                            {% endfor %}
+                            {% if paginator.num_pages > 1 %}
+                                {% paginate using "richie/pagination.html" %}
+                                <div class="button-caesura">
+                                {% if category.get_meta_category %}
+                                    <a href="{% page_url 'courses' %}?{{ category.get_meta_category.extended_object.reverse_id }}={{ category.get_es_id }}" class="category-detail__see-more">
+                                    {% blocktrans with category_title=category.extended_object.get_title %}
+                                        See all courses related to {{ category_title }}
+                                    {% endblocktrans %}
+                                    </a>
+                                {% else %}
+                                    <a href="{% page_url 'courses' %}" class="category-detail__see-more">
+                                    {% trans "See all courses" %}
+                                    </a>
+                                {% endif %}
+                                </div>
+                            {% endif %}
+                        </section>
+                    </div>
+                </div>
+            {% endif %}
+        {% endwith %}
+
+        {% with organizations=category.get_organizations %}
+            {% if organizations %}
+                {% autopaginate organizations GLIMPSE_PAGINATION_ORGANIZATIONS %}
+                <div id="page{{ page_suffix }}" class="category-detail__organizations category-detail__block">
+                    <div class="category-detail__row">
+                        <section class="organization-glimpse-list">
+                            <h2 class="category-detail__title">{% trans "Related organizations" %}</h2>
+                            {% for organization in page_obj.object_list %}
+                                {% if organization.extended_object.publisher_is_draft or organization.check_publication %}
+                                    {% include "courses/cms/fragment_organization_glimpse.html" %}
+                                {% endif %}
+                            {% endfor %}
+                            {% if paginator.num_pages > 1 %}
+                                {% paginate using "richie/pagination.html" %}
+                            {% endif %}
+                        </section>
+                    </div>
+                </div>
+            {% endif %}
+        {% endwith %}
+
+        {% with blogposts=category.get_blogposts %}
+            {% if blogposts %}
+                {% autopaginate blogposts GLIMPSE_PAGINATION_BLOGPOSTS %}
+                <div id="page{{ page_suffix }}" class="category-detail__blogposts category-detail__block">
+                    <div class="category-detail__row">
+                        <section class="blogpost-glimpse-list">
+                            <h2 class="category-detail__title">{% trans "Related blogposts" %}</h2>
+                            {% for blogpost in page_obj.object_list %}
+                                {% if blogpost.extended_object.publisher_is_draft or blogpost.check_publication %}
+                                    {% include "courses/cms/fragment_blogpost_glimpse.html" %}
+                                {% endif %}
+                            {% endfor %}
+                            {% if paginator.num_pages > 1 %}
+                                {% paginate using "richie/pagination.html" %}
+                            {% endif %}
+                        </section>
+                    </div>
+                </div>
+            {% endif %}
+        {% endwith %}
+
+        {% with persons=category.get_persons %}
+            {% if persons %}
+                {% autopaginate persons GLIMPSE_PAGINATION_PERSONS %}
+                <div id="page{{ page_suffix }}" class="category-detail__persons category-detail__block category-detail__block--lightest">
+                    <div class="category-detail__row">
+                        <section class="person-glimpse-list">
+                            <h2 class="category-detail__title">{% trans "Related persons" %}</h2>
+                            {% for person in page_obj.object_list %}
+                                {% if person.extended_object.publisher_is_draft or person.check_publication %}
+                                    {% include "courses/cms/fragment_person_glimpse.html" %}
+                                {% endif %}
+                            {% endfor %}
+                            {% if paginator.num_pages > 1 %}
+                                {% paginate using "richie/pagination.html" %}
+                            {% endif %}
+                        </section>
+                    </div>
+                </div>
+            {% endif %}
+        {% endwith %}
     </div>
-
-    {% with children_categories=category.get_children_categories %}
-        {% if children_categories %}
-            <div class="category-detail__courses category-detail__block">
-                <div class="category-detail__row">
-                    <section class="category-glimpse-list">
-                        <h2 class="category-detail__title">{% trans "Sub categories" %}</h2>
-                        {% for child_category in children_categories %}
-                            {% include "courses/cms/fragment_category_glimpse.html" with category=child_category category_variant="glimpse" %}
-                        {% endfor %}
-                    </section>
-                </div>
-            </div>
-        {% endif %}
-    {% endwith %}
-
-    {% with courses=category.get_courses %}
-        {% if courses %}
-            {% autopaginate courses GLIMPSE_PAGINATION_COURSES as object_list %}
-            <div id="page{{ page_suffix }}" class="category-detail__courses category-detail__block">
-                <div class="category-detail__row">
-                    <section class="course-glimpse-list">
-                        <h2 class="category-detail__title">{% trans "Related courses" %}</h2>
-                        {% for course in page_obj.object_list %}
-                            {% if course.extended_object.publisher_is_draft or course.check_publication %}
-                                {% include "courses/cms/fragment_course_glimpse.html" %}
-                            {% endif %}
-                        {% endfor %}
-                        {% if paginator.num_pages > 1 %}
-                            {% paginate using "richie/pagination.html" %}
-                            <div class="button-caesura">
-                              {% if category.get_meta_category %}
-                                <a href="{% page_url 'courses' %}?{{ category.get_meta_category.extended_object.reverse_id }}={{ category.get_es_id }}" class="category-detail__see-more">
-                                  {% blocktrans with category_title=category.extended_object.get_title %}
-                                    See all courses related to {{ category_title }}
-                                  {% endblocktrans %}
-                                </a>
-                              {% else %}
-                                <a href="{% page_url 'courses' %}" class="category-detail__see-more">
-                                  {% trans "See all courses" %}
-                                </a>
-                              {% endif %}
-                            </div>
-                        {% endif %}
-                    </section>
-                </div>
-            </div>
-        {% endif %}
-    {% endwith %}
-
-    {% with organizations=category.get_organizations %}
-        {% if organizations %}
-            {% autopaginate organizations GLIMPSE_PAGINATION_ORGANIZATIONS %}
-            <div id="page{{ page_suffix }}" class="category-detail__organizations category-detail__block">
-                <div class="category-detail__row">
-                    <section class="organization-glimpse-list">
-                        <h2 class="category-detail__title">{% trans "Related organizations" %}</h2>
-                        {% for organization in page_obj.object_list %}
-                            {% if organization.extended_object.publisher_is_draft or organization.check_publication %}
-                                {% include "courses/cms/fragment_organization_glimpse.html" %}
-                            {% endif %}
-                        {% endfor %}
-                        {% if paginator.num_pages > 1 %}
-                            {% paginate using "richie/pagination.html" %}
-                        {% endif %}
-                    </section>
-                </div>
-            </div>
-        {% endif %}
-    {% endwith %}
-
-    {% with blogposts=category.get_blogposts %}
-        {% if blogposts %}
-            {% autopaginate blogposts GLIMPSE_PAGINATION_BLOGPOSTS %}
-            <div id="page{{ page_suffix }}" class="category-detail__blogposts category-detail__block">
-                <div class="category-detail__row">
-                    <section class="blogpost-glimpse-list">
-                        <h2 class="category-detail__title">{% trans "Related blogposts" %}</h2>
-                        {% for blogpost in page_obj.object_list %}
-                            {% if blogpost.extended_object.publisher_is_draft or blogpost.check_publication %}
-                                {% include "courses/cms/fragment_blogpost_glimpse.html" %}
-                            {% endif %}
-                        {% endfor %}
-                        {% if paginator.num_pages > 1 %}
-                            {% paginate using "richie/pagination.html" %}
-                        {% endif %}
-                    </section>
-                </div>
-            </div>
-        {% endif %}
-    {% endwith %}
-
-    {% with persons=category.get_persons %}
-        {% if persons %}
-            {% autopaginate persons GLIMPSE_PAGINATION_PERSONS %}
-            <div id="page{{ page_suffix }}" class="category-detail__persons category-detail__block category-detail__block--lightest">
-                <div class="category-detail__row">
-                    <section class="person-glimpse-list">
-                        <h2 class="category-detail__title">{% trans "Related persons" %}</h2>
-                        {% for person in page_obj.object_list %}
-                            {% if person.extended_object.publisher_is_draft or person.check_publication %}
-                                {% include "courses/cms/fragment_person_glimpse.html" %}
-                            {% endif %}
-                        {% endfor %}
-                        {% if paginator.num_pages > 1 %}
-                            {% paginate using "richie/pagination.html" %}
-                        {% endif %}
-                    </section>
-                </div>
-            </div>
-        {% endif %}
-    {% endwith %}
-</div>
-
+{% else %}
+    {% include "courses/cms/fragment_error_detail_template_banner.html" with model="category" %}
+{% endif %}
 {% endwith %}
 {% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -25,6 +25,7 @@
 
     {% block subheader_content %}{% spaceless %}
         {% with course=current_page.course header_level=2 %}
+        {% if course %}
         <div class="subheader__container">
             <div class="subheader__intro">
                 <div class="subheader__main">
@@ -133,6 +134,7 @@
                 </div>
             </div>
         </div>
+        {% endif %}
         {% endwith %}
     {% endspaceless %}{% endblock subheader_content %}
 </div>
@@ -143,6 +145,7 @@
 {% block content %}{% spaceless %}
 {% with course=current_page.course header_level=2 %}
 <div class="course-detail">
+    {% if course %}
 
     <div class="course-detail__grid">
         <div class="course-detail__wrapper">
@@ -434,6 +437,9 @@
     </div>
     {% endblock fragment_relations %}
 
+    {% else %}
+        {% include "courses/cms/fragment_error_detail_template_banner.html" with model="course" %}
+    {% endif %}
 </div>
 {% endwith %}
 {% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_error_detail_template_banner.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_error_detail_template_banner.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+{% spaceless %}
+<div class="banner banner--error banner--rounded" role="alert">
+    <svg class="banner__icon"><use href="#icon-cross" /></svg>
+    <p class="banner__message">
+        {% blocktrans %}
+        A {{model}} object is missing on this {{model}} page. Please select another page template.
+        <br />
+        If what you need is a {{model}} page, you need to create it via the wizard and choose "New {{model}} page".
+        {% endblocktrans %}
+    </p>
+</div>
+{% endspaceless %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -9,127 +9,131 @@
 
 {% block content %}{% spaceless %}
 {% with organization=current_page.organization header_level=2 %}
-<div class="organization-detail">
-    <div class="organization-detail__block organization-detail__block--unpadded">
-        <div class="organization-detail__row organization-detail__row--unpadded">
-            <div class="organization-detail__banner">
-                {% get_placeholder_plugins "banner" as plugins or %}
-                    <img src="{% static "richie/images/empty/organization_banner.jpg" %}"
-                         class="organization-detail__banner--empty"
-                         alt="">
-                {% endget_placeholder_plugins %}
-                {% blockplugin plugins.0 %}
-                    <img
-                        src="{% thumbnail instance.picture 320x100 upscale %}"
-                        srcset="
-                            {% thumbnail instance.picture 640x200 upscale %} 640w,
-                            {% thumbnail instance.picture 1280x300 upscale %} 1280w,
-                            {% if instance.picture.width >= 1500 %},{% thumbnail instance.picture 1500x351 upscale %} 1500w,{% endif %}
-                            {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x468 upscale %} 2000w,{% endif %}
-                            {% if instance.picture.width >= 2500 %},{% thumbnail instance.picture 2500x585 upscale %} 2500w,{% endif %}
-                        "
-                        sizes="(min-width: 576px) 80vw, (min-width: 1200px) 1140px, 100vw"
-                        alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization banner' %}{% endif %}"
-                    />
-                {% endblockplugin %}
-            </div>
+{% if organization %}
+    <div class="organization-detail">
+        <div class="organization-detail__block organization-detail__block--unpadded">
+            <div class="organization-detail__row organization-detail__row--unpadded">
+                <div class="organization-detail__banner">
+                    {% get_placeholder_plugins "banner" as plugins or %}
+                        <img src="{% static "richie/images/empty/organization_banner.jpg" %}"
+                            class="organization-detail__banner--empty"
+                            alt="">
+                    {% endget_placeholder_plugins %}
+                    {% blockplugin plugins.0 %}
+                        <img
+                            src="{% thumbnail instance.picture 320x100 upscale %}"
+                            srcset="
+                                {% thumbnail instance.picture 640x200 upscale %} 640w,
+                                {% thumbnail instance.picture 1280x300 upscale %} 1280w,
+                                {% if instance.picture.width >= 1500 %},{% thumbnail instance.picture 1500x351 upscale %} 1500w,{% endif %}
+                                {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x468 upscale %} 2000w,{% endif %}
+                                {% if instance.picture.width >= 2500 %},{% thumbnail instance.picture 2500x585 upscale %} 2500w,{% endif %}
+                            "
+                            sizes="(min-width: 576px) 80vw, (min-width: 1200px) 1140px, 100vw"
+                            alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization banner' %}{% endif %}"
+                        />
+                    {% endblockplugin %}
+                </div>
 
-            <div class="organization-detail__logo">
-                {% get_placeholder_plugins "logo" as plugins or %}
-                    <img src="{% static "richie/images/empty/organization_logo.png" %}"
-                         class="organization-detail__logo--empty"
-                         alt="">
-                {% endget_placeholder_plugins %}
-                {% blockplugin plugins.0 %}
-                    <img
-                        src="{% thumbnail instance.picture 200x113 upscale %}"
-                        srcset="
-                            {% thumbnail instance.picture 200x113 upscale %} 200w,
-                            {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale %} 400w,{% endif %}
-                            {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale %} 600w,{% endif %}
-                            {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale %} 800w{% endif %}
-                        "
-                        sizes="(min-width: 768px) 16rem, (min-width: 1200px) 20rem, 12rem"
-                        alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization logo' %}{% endif %}"
-                    />
-                {% endblockplugin %}
-            </div>
-        </div>
-    </div>
-
-    <div class="organization-detail__intro organization-detail__block organization-detail__block--unpadded">
-        <div class="organization-detail__row">
-            <h1 class="organization-detail__title">{% render_model request.current_page "title" %}</h1>
-
-            {% if current_page.publisher_is_draft %}
-            <div class="category-tag-list category-tag-list--primary">
-              {% with category_variant="tag" %}
-                {% placeholder "categories" or %}
-                  <p class="category-tag-list__empty">
-                    {% trans "No associated categories" %}
-                  </p>
-                {% endplaceholder %}
-              {% endwith %}
-            </div>
-            {% endif %}
-
-            <div class="organization-detail__description">
-                {% placeholder "description" %}
+                <div class="organization-detail__logo">
+                    {% get_placeholder_plugins "logo" as plugins or %}
+                        <img src="{% static "richie/images/empty/organization_logo.png" %}"
+                            class="organization-detail__logo--empty"
+                            alt="">
+                    {% endget_placeholder_plugins %}
+                    {% blockplugin plugins.0 %}
+                        <img
+                            src="{% thumbnail instance.picture 200x113 upscale %}"
+                            srcset="
+                                {% thumbnail instance.picture 200x113 upscale %} 200w,
+                                {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale %} 400w,{% endif %}
+                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale %} 600w,{% endif %}
+                                {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale %} 800w{% endif %}
+                            "
+                            sizes="(min-width: 768px) 16rem, (min-width: 1200px) 20rem, 12rem"
+                            alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization logo' %}{% endif %}"
+                        />
+                    {% endblockplugin %}
+                </div>
             </div>
         </div>
-    </div>
 
-{% with courses=organization.get_courses %}
-    {% if courses %}
-        {% autopaginate courses GLIMPSE_PAGINATION_COURSES %}
-        <div id="page{{ page_suffix }}" class="organization-detail__courses organization-detail__block">
+        <div class="organization-detail__intro organization-detail__block organization-detail__block--unpadded">
             <div class="organization-detail__row">
-                <section class="course-glimpse-list">
-                    <h2 class="organization-detail__title">{% trans "Related courses" %}</h2>
-                    {% for course in page_obj.object_list %}
-                        {% if course.extended_object.publisher_is_draft or course.check_publication %}
-                            {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
-                        {% endif %}
-                    {% endfor %}
-                    {% if paginator.num_pages > 1 %}
-                        {% paginate using "richie/pagination.html" %}
-                        <div class="button-caesura">
-                            <a href="{% page_url 'courses' %}?organizations={{ organization.get_es_id }}" class="organization-detail__see-more">
-                                {% blocktrans with organization_title=organization.extended_object.get_title %}
-                                    See all courses related to {{ organization_title }}
-                                {% endblocktrans %}
-                            </a>
-                        </div>
-                    {% endif %}
-                </section>
+                <h1 class="organization-detail__title">{% render_model request.current_page "title" %}</h1>
+
+                {% if current_page.publisher_is_draft %}
+                <div class="category-tag-list category-tag-list--primary">
+                {% with category_variant="tag" %}
+                    {% placeholder "categories" or %}
+                    <p class="category-tag-list__empty">
+                        {% trans "No associated categories" %}
+                    </p>
+                    {% endplaceholder %}
+                {% endwith %}
+                </div>
+                {% endif %}
+
+                <div class="organization-detail__description">
+                    {% placeholder "description" %}
+                </div>
             </div>
         </div>
-    {% endif %}
-{% endwith %}
 
-{% with persons=organization.get_persons %}
-    {% if persons %}
-        {% autopaginate persons GLIMPSE_PAGINATION_PERSONS %}
-        <div id="page{{ page_suffix }}" class="organization-detail__persons organization-detail__block organization-detail__block--lightest">
-            <div class="organization-detail__row">
-                <section class="person-glimpse-list">
-                    <h2 class="organization-detail__title">{% trans "Related persons" %}</h2>
-                    {% for person in page_obj.object_list %}
-                        {% if person.extended_object.publisher_is_draft or person.check_publication %}
-                            {% with header_level=3 %}
-                                {% include "courses/cms/fragment_person_glimpse.html" with person=person %}
-                            {% endwith %}
+    {% with courses=organization.get_courses %}
+        {% if courses %}
+            {% autopaginate courses GLIMPSE_PAGINATION_COURSES %}
+            <div id="page{{ page_suffix }}" class="organization-detail__courses organization-detail__block">
+                <div class="organization-detail__row">
+                    <section class="course-glimpse-list">
+                        <h2 class="organization-detail__title">{% trans "Related courses" %}</h2>
+                        {% for course in page_obj.object_list %}
+                            {% if course.extended_object.publisher_is_draft or course.check_publication %}
+                                {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
+                            {% endif %}
+                        {% endfor %}
+                        {% if paginator.num_pages > 1 %}
+                            {% paginate using "richie/pagination.html" %}
+                            <div class="button-caesura">
+                                <a href="{% page_url 'courses' %}?organizations={{ organization.get_es_id }}" class="organization-detail__see-more">
+                                    {% blocktrans with organization_title=organization.extended_object.get_title %}
+                                        See all courses related to {{ organization_title }}
+                                    {% endblocktrans %}
+                                </a>
+                            </div>
                         {% endif %}
-                    {% endfor %}
-                    {% if paginator.num_pages > 1 %}
-                        {% paginate using "richie/pagination.html" %}
-                    {% endif %}
-                </section>
+                    </section>
+                </div>
             </div>
-        </div>
-    {% endif %}
-{% endwith %}
+        {% endif %}
+    {% endwith %}
 
-</div>
+    {% with persons=organization.get_persons %}
+        {% if persons %}
+            {% autopaginate persons GLIMPSE_PAGINATION_PERSONS %}
+            <div id="page{{ page_suffix }}" class="organization-detail__persons organization-detail__block organization-detail__block--lightest">
+                <div class="organization-detail__row">
+                    <section class="person-glimpse-list">
+                        <h2 class="organization-detail__title">{% trans "Related persons" %}</h2>
+                        {% for person in page_obj.object_list %}
+                            {% if person.extended_object.publisher_is_draft or person.check_publication %}
+                                {% with header_level=3 %}
+                                    {% include "courses/cms/fragment_person_glimpse.html" with person=person %}
+                                {% endwith %}
+                            {% endif %}
+                        {% endfor %}
+                        {% if paginator.num_pages > 1 %}
+                            {% paginate using "richie/pagination.html" %}
+                        {% endif %}
+                    </section>
+                </div>
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    </div>
+{% else %}
+    {% include "courses/cms/fragment_error_detail_template_banner.html" with model="organization" %}
+{% endif %}
 {% endwith %}
 {% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -7,6 +7,7 @@
 {% endblock meta_opengraph_contextuals %}
 
 
+
 {% block subheader %}
 <div class="subheader subheader--alternative">
     {% block breadcrumbs %}
@@ -14,140 +15,146 @@
     {% endblock breadcrumbs %}
 
     {% block subheader_content %}{% spaceless %}
-        {% with course=current_page.course header_level=2 %}
-        <div class="subheader__container">
-            <div class="subheader__intro">
-                <div class="subheader__main">
-                    <h1 class="subheader__title">{% render_model current_page "title" %}</h1>
+        {% with person=current_page.person header_level=2 %}
+            {% if person %}
+            <div class="subheader__container">
+                <div class="subheader__intro">
+                    <div class="subheader__main">
+                        <h1 class="subheader__title">{% render_model current_page "title" %}</h1>
 
-                    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"categories" %}
-                    <div class="category-badge-list category-badge-list--tertiary">
-                        <div class="category-badge-list__container">
-                        {% with category_variant="badge" %}
-                            {% placeholder "categories" or %}
-                                <span class="category-badge-list__empty">
-                                    {% trans "No associated categories" %}
-                                </span>
+                        {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"categories" %}
+                        <div class="category-badge-list category-badge-list--tertiary">
+                            <div class="category-badge-list__container">
+                            {% with category_variant="badge" %}
+                                {% placeholder "categories" or %}
+                                    <span class="category-badge-list__empty">
+                                        {% trans "No associated categories" %}
+                                    </span>
+                                {% endplaceholder %}
+                            {% endwith %}
+                            </div>
+                        </div>
+                        {% endif %}
+
+                        <div class="subheader__content">
+                            {% placeholder "bio" or %}
+                                <p class="subheader__empty">{% trans "Enter your bio here..." %}</p>
                             {% endplaceholder %}
-                        {% endwith %}
                         </div>
                     </div>
-                    {% endif %}
 
-                    <div class="subheader__content">
-                        {% placeholder "bio" or %}
-                            <p class="subheader__empty">{% trans "Enter your bio here..." %}</p>
-                        {% endplaceholder %}
-                    </div>
-                </div>
-
-                <div class="subheader__aside">
-                    <div class="subheader__cartouche">
-                        {% get_placeholder_plugins "portrait" as plugins or %}
-                        <div class="subheader__media subheader__media--locket subheader__empty">
-                            <img src="{% static "richie/images/empty/person_portrait.png" %}"
-                                 class="subheader__empty--avatar"
-                                 alt="">
+                    <div class="subheader__aside">
+                        <div class="subheader__cartouche">
+                            {% get_placeholder_plugins "portrait" as plugins or %}
+                            <div class="subheader__media subheader__media--locket subheader__empty">
+                                <img src="{% static "richie/images/empty/person_portrait.png" %}"
+                                        class="subheader__empty--avatar"
+                                        alt="">
+                            </div>
+                            {% endget_placeholder_plugins %}
+                            {% blockplugin plugins.0 %}
+                            <div class="subheader__media subheader__media--locket">
+                                <img
+                                    src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
+                                    srcset="
+                                        {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
+                                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                                    "
+                                    sizes="200px"
+                                    alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% blocktrans with title=current_page.get_title %}{{ title }} avatar{% endblocktrans %}{% endif %}"
+                                />
+                            </div>
+                            {% endblockplugin %}
                         </div>
-                        {% endget_placeholder_plugins %}
-                        {% blockplugin plugins.0 %}
-                        <div class="subheader__media subheader__media--locket">
-                            <img
-                                src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
-                                srcset="
-                                    {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
-                                    {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                                    {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                                "
-                                sizes="200px"
-                                alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% blocktrans with title=current_page.get_title %}{{ title }} avatar{% endblocktrans %}{% endif %}"
-                            />
-                        </div>
-                        {% endblockplugin %}
                     </div>
                 </div>
             </div>
-        </div>
+            {% endif %}
         {% endwith %}
     {% endspaceless %}{% endblock subheader_content %}
 </div>
 {% endblock subheader %}
 
 {% block content %}{% spaceless %}
-{% with header_level=2 person=current_page.person %}
-<div class="person-detail">
-    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"maincontent" %}
-    <div class="person-detail__maincontent person-detail__block">
-        <div class="person-detail__row">
-            {% placeholder "maincontent" %}
-        </div>
-    </div>
-    {% endif %}
 
-    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"organizations" %}
-    <div class="person-detail__organizations person-detail__block person-detail__block--gradient-neutral person-detail__block--arc">
-        <div class="person-detail__row">
-            <section class="organization-glimpse-list">
-                <h2 class="person-detail__title">{% trans "Organizations" %}</h2>
-                {% placeholder "organizations" or %}
-                    <p class="organization-glimpse-list__empty">
-                        {% trans "No associated organizations" %}
-                    </p>
-                {% endplaceholder %}
-            </section>
-        </div>
-    </div>
-    {% endif %}
-
-    {% with courses=person.get_courses %}
-        {% if courses %}
-            {% autopaginate courses GLIMPSE_PAGINATION_COURSES %}
-            <div id="page{{ page_suffix }}" class="person-detail__courses person-detail__block">
-                <div class="person-detail__row">
-                    <section class="course-glimpse-list">
-                        <h2 class="person-detail__title">{% trans "Courses" %}</h2>
-                        {% for course in page_obj.object_list %}
-                            {% if course.extended_object.publisher_is_draft or course.check_publication %}
-                                {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
-                            {% endif %}
-                        {% endfor %}
-                        {% if paginator.num_pages > 1 %}
-                            {% paginate using "richie/pagination.html" %}
-                            <div class="button-caesura">
-                                <a href="{% page_url 'courses' %}?persons={{ person.extended_object_id }}" class="person-detail__see-more">
-                                {% blocktrans with person_title=person.extended_object.get_title %}
-                                    See all courses related to {{ person_title }}
-                                {% endblocktrans %}
-                                </a>
-                            </div>
-                        {% endif %}
-                    </section>
-                </div>
+{% with person=current_page.person header_level=2 %}
+    {% if person %}
+    <div class="person-detail">
+        {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"maincontent" %}
+        <div class="person-detail__maincontent person-detail__block">
+            <div class="person-detail__row">
+                {% placeholder "maincontent" %}
             </div>
+        </div>
         {% endif %}
-    {% endwith %}
 
-    {% with blogposts=person.get_blogposts %}
-        {% if blogposts %}
-            {% autopaginate blogposts GLIMPSE_PAGINATION_BLOGPOSTS %}
-            <div id="page{{ page_suffix }}" class="person-detail__blogposts person-detail__block person-detail__block--divider">
-                <div class="person-detail__row">
-                    <section class="blogpost-glimpse-list">
-                        <h2 class="person-detail__title">{% trans "Blogposts" %}</h2>
-                        {% for blogpost in page_obj.object_list %}
-                            {% if blogpost.extended_object.publisher_is_draft or blogpost.check_publication %}
-                                {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=blogpost %}
-                            {% endif %}
-                        {% endfor %}
-                        {% if paginator.num_pages > 1 %}
-                            {% paginate using "richie/pagination.html" %}
-                        {% endif %}
-                    </section>
-                </div>
+        {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"organizations" %}
+        <div class="person-detail__organizations person-detail__block person-detail__block--gradient-neutral person-detail__block--arc">
+            <div class="person-detail__row">
+                <section class="organization-glimpse-list">
+                    <h2 class="person-detail__title">{% trans "Organizations" %}</h2>
+                    {% placeholder "organizations" or %}
+                        <p class="organization-glimpse-list__empty">
+                            {% trans "No associated organizations" %}
+                        </p>
+                    {% endplaceholder %}
+                </section>
             </div>
+        </div>
         {% endif %}
-    {% endwith %}
 
-</div>
+        {% with courses=person.get_courses %}
+            {% if courses %}
+                {% autopaginate courses GLIMPSE_PAGINATION_COURSES %}
+                <div id="page{{ page_suffix }}" class="person-detail__courses person-detail__block">
+                    <div class="person-detail__row">
+                        <section class="course-glimpse-list">
+                            <h2 class="person-detail__title">{% trans "Courses" %}</h2>
+                            {% for course in page_obj.object_list %}
+                                {% if course.extended_object.publisher_is_draft or course.check_publication %}
+                                    {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
+                                {% endif %}
+                            {% endfor %}
+                            {% if paginator.num_pages > 1 %}
+                                {% paginate using "richie/pagination.html" %}
+                                <div class="button-caesura">
+                                    <a href="{% page_url 'courses' %}?persons={{ person.extended_object_id }}" class="person-detail__see-more">
+                                    {% blocktrans with person_title=person.extended_object.get_title %}
+                                        See all courses related to {{ person_title }}
+                                    {% endblocktrans %}
+                                    </a>
+                                </div>
+                            {% endif %}
+                        </section>
+                    </div>
+                </div>
+            {% endif %}
+        {% endwith %}
+
+        {% with blogposts=person.get_blogposts %}
+            {% if blogposts %}
+                {% autopaginate blogposts GLIMPSE_PAGINATION_BLOGPOSTS %}
+                <div id="page{{ page_suffix }}" class="person-detail__blogposts person-detail__block person-detail__block--divider">
+                    <div class="person-detail__row">
+                        <section class="blogpost-glimpse-list">
+                            <h2 class="person-detail__title">{% trans "Blogposts" %}</h2>
+                            {% for blogpost in page_obj.object_list %}
+                                {% if blogpost.extended_object.publisher_is_draft or blogpost.check_publication %}
+                                    {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=blogpost %}
+                                {% endif %}
+                            {% endfor %}
+                            {% if paginator.num_pages > 1 %}
+                                {% paginate using "richie/pagination.html" %}
+                            {% endif %}
+                        </section>
+                    </div>
+                </div>
+            {% endif %}
+        {% endwith %}
+    </div>
+    {% else %}
+        {% include "courses/cms/fragment_error_detail_template_banner.html" with model="person" %}
+    {% endif %}
 {% endwith %}
 {% endspaceless %}{% endblock content %}

--- a/tests/apps/courses/test_templates_course_detail.py
+++ b/tests/apps/courses/test_templates_course_detail.py
@@ -10,7 +10,7 @@ from django.utils import dateformat, timezone
 import pytz
 from cms.test_utils.testcases import CMSTestCase
 
-from richie.apps.core.factories import UserFactory
+from richie.apps.core.factories import PageFactory, UserFactory
 from richie.apps.courses.factories import (
     CategoryFactory,
     CourseFactory,
@@ -875,4 +875,38 @@ class RunsCourseCMSTestCase(CMSTestCase):
         # The description line should start with a capital letter
         self.assertContains(
             response, "<li>From Dec. 12, 2020 to Dec. 15, 2020</li>", html=True
+        )
+
+    def test_template_course_detail_without_course(self):
+        """
+        A course template page without attached course should show an error banner
+        explaining to the user that he/she is misusing the template.
+        """
+        page = PageFactory(
+            template="courses/cms/course_detail.html",
+            title__language="en",
+            should_publish=True,
+        )
+
+        with self.assertTemplateUsed(
+            "courses/cms/fragment_error_detail_template_banner.html"
+        ):
+            response = self.client.get(page.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            (
+                '<div class="banner banner--error banner--rounded" role="alert">'
+                '<svg class="banner__icon"><use href="#icon-cross" /></svg>'
+                '<p class="banner__message">'
+                "A course object is missing on this course page. "
+                "Please select another page template."
+                "<br />"
+                "If what you need is a course page, you need to create it "
+                'via the wizard and choose "New course page".'
+                "</p>"
+                "</div>"
+            ),
+            html=True,
         )

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 
-from richie.apps.core.factories import UserFactory
+from richie.apps.core.factories import PageFactory, UserFactory
 from richie.apps.courses.cms_plugins import CategoryPlugin, OrganizationPlugin
 from richie.apps.courses.factories import (
     CategoryFactory,
@@ -323,3 +323,37 @@ class OrganizationCMSTestCase(CMSTestCase):
             name=person.extended_object.get_title(),
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))
+
+    def test_template_organization_detail_without_organization(self):
+        """
+        A organization template page without attached organization should show an error banner
+        explaining to the user that he/she is misusing the template.
+        """
+        page = PageFactory(
+            template="courses/cms/organization_detail.html",
+            title__language="en",
+            should_publish=True,
+        )
+
+        with self.assertTemplateUsed(
+            "courses/cms/fragment_error_detail_template_banner.html"
+        ):
+            response = self.client.get(page.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            (
+                '<div class="banner banner--error banner--rounded" role="alert">'
+                '<svg class="banner__icon"><use href="#icon-cross" /></svg>'
+                '<p class="banner__message">'
+                "A organization object is missing on this organization page. "
+                "Please select another page template."
+                "<br />"
+                "If what you need is a organization page, you need to create it "
+                'via the wizard and choose "New organization page".'
+                "</p>"
+                "</div>"
+            ),
+            html=True,
+        )

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 
-from richie.apps.core.factories import UserFactory
+from richie.apps.core.factories import PageFactory, UserFactory
 from richie.apps.courses.cms_plugins import (
     CategoryPlugin,
     OrganizationPlugin,
@@ -392,6 +392,40 @@ class PersonCMSTestCase(CMSTestCase):
             response,
             '<p class="blogpost-glimpse__title">{:s}</p>'.format(
                 blog_post.extended_object.get_title()
+            ),
+            html=True,
+        )
+
+    def test_template_person_detail_without_person(self):
+        """
+        A person template page without attached person should show an error banner
+        explaining to the user that he/she is misusing the template.
+        """
+        page = PageFactory(
+            template="courses/cms/person_detail.html",
+            title__language="en",
+            should_publish=True,
+        )
+
+        with self.assertTemplateUsed(
+            "courses/cms/fragment_error_detail_template_banner.html"
+        ):
+            response = self.client.get(page.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            (
+                '<div class="banner banner--error banner--rounded" role="alert">'
+                '<svg class="banner__icon"><use href="#icon-cross" /></svg>'
+                '<p class="banner__message">'
+                "A person object is missing on this person page. "
+                "Please select another page template."
+                "<br />"
+                "If what you need is a person page, you need to create it "
+                'via the wizard and choose "New person page".'
+                "</p>"
+                "</div>"
             ),
             html=True,
         )


### PR DESCRIPTION
## Purpose
Currently if a user uses a template requiring an attached model (e.g course_detail requires to have a course object attached) and there is no model attached, an error 500 occured that it is not relevant about user experience.

Instead we should alert the user that he/she is misusing the template and he/she be able to easily revert its changes.


## Proposal

- [x] Create a banner component to display brief messages
- [x] If a template must have an attached model and it has not, display a banner to alert the user that he/she is miusing the current template. Concerns category, course, organization and person models.

<img width="980" alt="Capture d’écran 2021-02-12 à 19 28 15" src="https://user-images.githubusercontent.com/9265241/107809386-4d418580-6d6b-11eb-891b-d1955f969787.png">
