### PR TITLE
🚑(dependency) pin django-treebeard to 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix autosuggest to redirect user directly on the course page when a course
   entry has been selected from the suggestion dropdown
+- Pin `django-treebeard` to `4.4` as the 4.5 release introduces BC
 
 ## [2.1.0] - 2021-01-22
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     social-auth-core[openidconnect]==3.2.0 # pyup: ignore
     social-auth-app-django==3.1.0 # pyup: ignore
     django-redis>=4.11.0
+    django-treebeard==4.4
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
## Purpose

django-treebeard 4.5 release seems introduce a breaking change that leads to
several issues from django-cms concerning PK management. Waiting to identify
the origin of this issue, we pinned django-treebeard to 4.4.


## Proposal

- [x] Pin `django-treebeard` to 4.4
