### PR TITLE
✨(courses) add "archived open" state for course runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Add new state for courses archived yet open for enrollment and position them
+  well in search results
+
 ### Fixed
 
 - Fix autosuggest to redirect user directly on the course page when a course

--- a/src/frontend/js/components/CourseRunEnrollment/index.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.tsx
@@ -3,6 +3,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { Spinner } from 'components/Spinner';
 import { useSession } from 'data/useSession';
+import { Priority } from 'types';
 import { User } from 'types/User';
 import { Maybe, Nullable } from 'utils/types';
 import { handle } from 'utils/errors/handle';
@@ -55,7 +56,7 @@ interface CourseRunEnrollmentProps {
   courseRun: {
     id: number;
     resource_link: string;
-    priority: number;
+    priority: Priority;
     starts_in_message: Nullable<string>;
     dashboard_link: Nullable<string>;
   };
@@ -105,7 +106,7 @@ const getStepFromContext = (
   previousStep: Step,
 ) => {
   switch (true) {
-    case courseRun.priority > 1:
+    case courseRun.priority > Priority.ARCHIVED_OPEN:
       return Step.CLOSED;
     case previousStep === Step.ENROLLING && !isEnrolled:
       return Step.ENROLLMENT_FAILED;

--- a/src/frontend/js/types/Course.ts
+++ b/src/frontend/js/types/Course.ts
@@ -1,3 +1,4 @@
+import { Priority } from 'types';
 import { Resource } from 'types/Resource';
 import { Nullable } from 'utils/types';
 
@@ -23,7 +24,7 @@ export interface Course extends Resource {
   state: {
     call_to_action: Nullable<string>;
     datetime: Nullable<string>;
-    priority: number;
+    priority: Priority;
     text: string;
   };
 }

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -13,8 +13,19 @@ export interface CourseRun {
   dashboard_link: Nullable<string>;
 }
 
+export enum Priority {
+  ONGOING_OPEN,
+  FUTURE_OPEN,
+  ARCHIVED_OPEN,
+  FUTURE_NOT_YET_OPEN,
+  FUTURE_CLOSED,
+  ONGOING_CLOSED,
+  ARCHIVED_CLOSED,
+  TO_BE_SCHEDULED,
+}
+
 export interface CourseState {
-  priority: number;
+  priority: Priority;
   datetime: string;
   call_to_action: string;
   text: string;

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -268,7 +268,7 @@
                                     {% blocktrans context "course_detail__title" %}Course runs{% endblocktrans %}
                                     {% render_model_add course "" "" "get_admin_url_to_add_run" %}
                                 </h2>
-                                {% for run in runs_dict.0|add:runs_dict.1 %}
+                                {% for run in runs_dict.0|add:runs_dict.1|add:runs_dict.2 %}
                                     {% include "courses/cms/fragment_course_run.html" %}
                                 {% empty %}
                                     <div class="course-detail__empty">{% trans "No open course runs" %}</div>
@@ -277,45 +277,45 @@
                         {% endblock runs_open %}
 
                         {% block runs_to_be_scheduled %}
-                        {% if runs_dict.6 and current_page.publisher_is_draft %}
+                        {% if runs_dict.7 and current_page.publisher_is_draft %}
                             <div class="course-detail__row course-detail__runs course-detail__runs--inactive">
                                 <h3 class="course-detail__title">
                                     {% trans "To be scheduled" context "Course runs to be scheduled (plural)" %}
                                 </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.6 %}
+                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.7 %}
                             </div>
                         {% endif %}
                         {% endblock runs_to_be_scheduled %}
 
                         {% block runs_upcoming %}
-                        {% if runs_dict.2 %}
+                        {% if runs_dict.3 %}
                             <div class="course-detail__row course-detail__runs course-detail__runs--inactive">
                                 <h3 class="course-detail__title">
                                     {% trans "Upcoming" context "Upcoming course runs (plural)" %}
                                 </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.2 %}
+                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.3 %}
                             </div>
                         {% endif %}
                         {% endblock runs_upcoming %}
 
                         {% block runs_ongoing %}
-                        {% if runs_dict.3 or runs_dict.4 %}
+                        {% if runs_dict.4 or runs_dict.5 %}
                             <div class="course-detail__row course-detail__runs course-detail__runs--inactive">
                                 <h3 class="course-detail__title">
                                     {% trans "Ongoing" context "Ongoing course runs (plural)" %}
                                 </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.3|add:runs_dict.4 %}
+                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.4|add:runs_dict.5 %}
                             </div>
                         {% endif %}
                         {% endblock runs_ongoing %}
 
                         {% block runs_archived %}
-                        {% if runs_dict.5 %}
+                        {% if runs_dict.6 %}
                             <div class="course-detail__row course-detail__runs course-detail__runs--inactive">
                                 <h3 class="course-detail__title">
                                     {% trans "Archived" context "Archived course runs (plural)" %}
                                 </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.5 %}
+                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.6 %}
                             </div>
                         {% endif %}
                         {% endblock runs_archived %}

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -10,6 +10,8 @@ from django.utils.translation import get_language
 
 import arrow
 
+from richie.apps.courses.models import CourseState
+
 from .defaults import QUERY_ANALYZERS, RELATED_CONTENT_BOOST
 from .filter_definitions import FILTERS, AvailabilityFilterDefinition
 
@@ -88,13 +90,21 @@ class CourseSearchForm(SearchForm):
         """
         availabilities = self.cleaned_data.get("availability", [])
         if AvailabilityFilterDefinition.OPEN in availabilities:
-            self.states = [0, 1]
+            self.states = [
+                CourseState.ONGOING_OPEN,
+                CourseState.FUTURE_OPEN,
+                CourseState.ARCHIVED_OPEN,
+            ]
         elif AvailabilityFilterDefinition.ONGOING in availabilities:
-            self.states = [0, 4]
+            self.states = [CourseState.ONGOING_OPEN, CourseState.ONGOING_CLOSED]
         elif AvailabilityFilterDefinition.COMING_SOON in availabilities:
-            self.states = [1, 2, 3]
+            self.states = [
+                CourseState.FUTURE_OPEN,
+                CourseState.FUTURE_NOT_YET_OPEN,
+                CourseState.FUTURE_CLOSED,
+            ]
         elif AvailabilityFilterDefinition.ARCHIVED in availabilities:
-            self.states = [5]
+            self.states = [CourseState.ARCHIVED_OPEN, CourseState.ARCHIVED_CLOSED]
 
         return availabilities
 


### PR DESCRIPTION
## Purpose 

In our catalog, we have the case of archived courses (with past dates) that are still open for enrollment.
This case is used for courses that are not followed by a teachers team but just left open for consultation.

## Proposal

We propose a new course state for these courses: `ARCHIVED_OPEN`

Courses in this state should be well positioned in results:

- just after "future course open for enrollment"
- before "future courses not yet open for enrollment". 
