### PR TITLE
✨(search) take into account search fulltext search score for sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Take into account fulltext search score for sorting
 - Add new state for courses archived yet open for enrollment and position them
   well in search results
 - Add a banner component to display brief messages to the user

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -313,6 +313,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     RICHIE_ES_INDICES_PREFIX = values.Value(
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None
     )
+    RICHIE_ES_STATE_WEIGHTS = values.ListValue(None)
 
     # LTI Content
     RICHIE_LTI_PROVIDERS = {

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -30,6 +30,16 @@ FACET_SORTING_DEFAULT = "conf"
 FACET_COUNTS_DEFAULT_LIMIT = getattr(settings, "RICHIE_FACET_COUNTS_DEFAULT_LIMIT", 10)
 FACET_COUNTS_MAX_LIMIT = getattr(settings, "RICHIE_FACET_COUNTS_MAX_LIMIT", 50)
 
+ES_STATE_WEIGHTS = getattr(settings, "RICHIE_ES_STATE_WEIGHTS", None) or [
+    80,  # ONGOING_OPEN
+    40,  # FUTURE_OPEN
+    20,  # ARCHIVED_OPEN
+    10,  # FUTURE_NOT_YET_OPEN
+    6,  # FUTURE_CLOSED
+    5,  # ONGOING_CLOSED
+    1,  # ARCHIVED_CLOSED
+]
+
 FILTERS_CONFIGURATION = [
     (
         "richie.apps.search.filter_definitions.StaticChoicesFilterDefinition",

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -40,7 +40,6 @@ class CoursesViewSet(AutocompleteMixin, ViewSet):
 
         body = {
             "script_fields": params_form.get_script_fields(),
-            "sort": params_form.get_sorting_script(),
         }
 
         # The querystring may request only the query or only the aggregations

--- a/tests/apps/search/test_autocomplete_courses.py
+++ b/tests/apps/search/test_autocomplete_courses.py
@@ -103,7 +103,11 @@ class AutocompleteCoursesTestCase(TestCase):
             body=CoursesIndexer.mapping, doc_type="course", index=COURSES_INDEX
         )
         # Add the sorting script
-        ES_CLIENT.put_script(id="state", body=CoursesIndexer.scripts["state"])
+        ES_CLIENT.put_script(id="score", body=CoursesIndexer.scripts["score"])
+        ES_CLIENT.put_script(
+            id="state_field", body=CoursesIndexer.scripts["state_field"]
+        )
+
         # Actually insert our courses in the index
         actions = [
             {

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -216,11 +216,11 @@ class CourseSearchFormTestCase(TestCase):
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(
-            form.build_es_query()[2],
+            form.build_es_query()[2]["function_score"]["query"],
             {
                 "bool": {
+                    "filter": {"term": {"is_listed": True}},
                     "must": [
-                        {"term": {"is_listed": True}},
                         {
                             "multi_match": {
                                 "analyzer": "english",
@@ -232,10 +232,10 @@ class CourseSearchFormTestCase(TestCase):
                                     "persons_names.*^0.05",
                                 ],
                                 "query": "some phrase terms",
-                                "type": "cross_fields",
+                                "type": "best_fields",
                             }
-                        },
-                    ]
+                        }
+                    ],
                 }
             },
         )

--- a/tests/apps/search/test_query_courses_edge_cases.py
+++ b/tests/apps/search/test_query_courses_edge_cases.py
@@ -85,7 +85,11 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
             body=CoursesIndexer.mapping, doc_type="course", index="test_courses"
         )
         # Add the sorting script
-        ES_CLIENT.put_script(id="state", body=CoursesIndexer.scripts["state"])
+        ES_CLIENT.put_script(id="score", body=CoursesIndexer.scripts["score"])
+        ES_CLIENT.put_script(
+            id="state_field", body=CoursesIndexer.scripts["state_field"]
+        )
+
         # Actually insert our courses in the index
         actions = [
             {

--- a/tests/apps/search/test_query_courses_facets.py
+++ b/tests/apps/search/test_query_courses_facets.py
@@ -170,7 +170,11 @@ class FacetsCoursesQueryTestCase(TestCase):
             body=CoursesIndexer.mapping, doc_type="course", index="test_courses"
         )
         # Add the sorting script
-        ES_CLIENT.put_script(id="state", body=CoursesIndexer.scripts["state"])
+        ES_CLIENT.put_script(id="score", body=CoursesIndexer.scripts["score"])
+        ES_CLIENT.put_script(
+            id="state_field", body=CoursesIndexer.scripts["state_field"]
+        )
+
         # Actually insert our courses in the index
         actions = [
             {

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -63,10 +63,6 @@ class CoursesViewsetsTestCase(CMSTestCase):
         lambda *args: (2, 77, {"some": "query"}, {"some": "aggs"}),
     )
     @mock.patch(
-        "richie.apps.search.forms.CourseSearchForm.get_sorting_script",
-        lambda *args: {"some": "sorting"},
-    )
-    @mock.patch(
         "richie.apps.search.forms.CourseSearchForm.get_script_fields",
         lambda *args: {"some": "fields"},
     )
@@ -306,7 +302,6 @@ class CoursesViewsetsTestCase(CMSTestCase):
                 "aggs": {"some": "aggs"},
                 "query": {"some": "query"},
                 "script_fields": {"some": "fields"},
-                "sort": {"some": "sorting"},
             },
             doc_type="course",
             from_=77,


### PR DESCRIPTION
### Purpose

Sorting was only taking into account the state of a course's course runs. Now that we have opened enrollment for much more courses (archived yet open), we need to take into account the pertinence score of the fulltext search to try to improve the search experience.

## Proposal

I propose to replace the custom `sorting` script (that was overriding the relevance "_score") by a `score_script` which combines with it.

A weight is associated with each course run state to give it more or less importance. It is adjustable as a setting to fine-tune the search experience depending on real data.