### PR TITLE
✨(blogposts) order blog posts by reverse publication date on list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   well in search results
 - Add a banner component to display brief messages to the user
 
+### Changed
+
+- Order blog posts by their publication date on the blog post list view
+
 ### Fixed
 
 - Prevent a 500 error when an editor uses a template for a page

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
@@ -1,5 +1,5 @@
 {% extends "richie/fullwidth.html" %}
-{% load category_tags cms_tags i18n pagination_tags %}
+{% load category_tags cms_tags extra_tags i18n pagination_tags %}
 
 {% block subheader_content %}
 <div class="subheader__container">
@@ -21,23 +21,25 @@
 {% endif %}
 
 <div class="blogpost-list">
-    {% if current_page.publisher_is_draft %}
-        {% autopaginate current_page.get_child_pages 20 as object_list %}
-    {% else %}
-        {% autopaginate current_page.get_child_pages.published.distinct 20 as object_list %}
-    {% endif %}
-    {% for page in object_list %}
-        {% if page.blogpost %}
-            {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=page.blogpost %}
+    {% with sorted_pages=current_page.get_child_pages|order_by:"-publication_date" %}
+        {% if current_page.publisher_is_draft %}
+            {% autopaginate sorted_pages 20 as object_list %}
+        {% else %}
+            {% autopaginate sorted_pages.published.distinct 20 as object_list %}
         {% endif %}
-    {% empty %}
-        <p class="blogpost-glimpse blogpost-glimpse--empty">
-            {% trans "No associated blogposts" %}
-        </p>
-    {% endfor %}
+        {% for page in object_list %}
+            {% if page.blogpost %}
+                {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=page.blogpost %}
+            {% endif %}
+        {% empty %}
+            <p class="blogpost-glimpse blogpost-glimpse--empty">
+                {% trans "No associated blogposts" %}
+            </p>
+        {% endfor %}
 
-    {% if object_list %}
-        {% paginate using "richie/pagination.html" %}
-    {% endif %}
+        {% if object_list %}
+            {% paginate using "richie/pagination.html" %}
+        {% endif %}
+    {% endwith %}
 </div>
 {% endspaceless %}{% endblock content %}

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -216,6 +216,17 @@ def is_empty_placeholder(page, slot):
 
 
 @register.filter()
+def order_by(queryset, args):
+    """A template filter to force ordering on a queryset.
+
+    Taken from: https://djangosnippets.org/snippets/741/
+    This is useful for DjangoCMS page querysets because we don't have access to the view.
+    """
+    args = [x.strip() for x in args.split(",")]
+    return queryset.order_by(*args)
+
+
+@register.filter()
 def has_connected_lms(course_run):
     """
     Determine if the passed course run has a connected LMS (as determined through out LMSHandler

--- a/tests/apps/courses/test_templatetags_extra_tags_order_by.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_order_by.py
@@ -1,0 +1,47 @@
+"""
+Unit tests for the `order_by` template filter.
+"""
+import random
+
+from django.contrib.auth import get_user_model
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.factories import UserFactory
+from richie.apps.courses.templatetags.extra_tags import order_by
+
+User = get_user_model()
+
+
+class OrderByFilterTestCase(CMSTestCase):
+    """
+    Unit test suite to validate the behavior of the `order_by` template filter.
+    """
+
+    def test_templatetags_extra_tags_order_by(self):
+        """
+        The query passed as argument should be ordered according to arguments.
+        """
+        for name, is_active in random.sample(
+            [
+                ("Léa", True),
+                ("François", False),
+                ("Géraldine", False),
+                ("Gérard", True),
+            ],
+            4,
+        ):
+            UserFactory(username=name, is_active=is_active)
+
+        self.assertEqual(
+            ["Léa", "Gérard", "Géraldine", "François"],
+            [u.username for u in order_by(User.objects.all(), "-username")],
+        )
+        self.assertEqual(
+            ["François", "Géraldine", "Gérard", "Léa"],
+            [u.username for u in order_by(User.objects.all(), "is_active,username")],
+        )
+        self.assertEqual(
+            ["Gérard", "Léa", "François", "Géraldine"],
+            [u.username for u in order_by(User.objects.all(), "-is_active,username")],
+        )


### PR DESCRIPTION

## Purpose

We were sorting blog posts as per the page tree to allow drag-and-drop reordering.

However, the DjangoCMS page tree does not scale to a big number of pages and we deactivated digging into blog post pages via the admin on some of our sites.

As a result we needed to find a better way to order blog posts.

## Proposal

The publication date seems like the best ordering criteria for blog posts. It can be changed via the toolbar on a given blog post.