### PR TITLE
✨(course_teaser) display cover image by befault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Change type of `effort` course field
   from `EffortField` to `CompositeDurationField`
-
-### Changed
-
 - Order blog posts by their publication date on the blog post list view
+- Removed SimplePicturePlugin in course_teaser placeholder
+- In course_teaser placeholder, image from course_cover placeholder is used
+  if no video is present
 
 ### Fixed
 

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -128,8 +128,8 @@ CMS_PLACEHOLDER_CONF = {
     },
     "courses/cms/course_detail.html course_teaser": {
         "name": _("Teaser"),
-        "plugins": ["VideoPlayerPlugin", "SimplePicturePlugin"],
-        "limits": {"VideoPlayerPlugin": 1, "SimplePicturePlugin": 1},
+        "plugins": ["VideoPlayerPlugin"],
+        "limits": {"VideoPlayerPlugin": 1},
     },
     "courses/cms/course_detail.html course_description": {
         "name": _("About the course"),

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -106,7 +106,24 @@
 
                     <div class="subheader__teaser">
                         {% placeholder "course_teaser" or %}
-                        <div class="empty">{% trans 'Add a video or teaser.' %}</div>
+                            {% get_placeholder_plugins "course_cover" as plugins or %}
+                                {% if current_page.publisher_is_draft %}
+                                    <p class="empty">{% trans 'Add a teaser video or add a cover image below and it will be used as teaser image as well.' %}</p>
+                                {% endif %}
+                            {% endget_placeholder_plugins %}
+                            {% blockplugin plugins.0 %}
+                                <img
+                                    src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
+                                    srcset="
+                                    {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w
+                                    {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                                    {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+                                    "
+                                    sizes="300px"
+                                    alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"
+                                />
+                            {% endblockplugin %}
+
                         {% endplaceholder %}
                     </div>
                 </div>


### PR DESCRIPTION
## Purpose

Display the glimpse used in course_cover if no video in course_teaser is defined, and remove the possibility to add a SimplePicturePlugin plugin to course_teaser placeholder.

## Proposal

SimplePicturePlugin in course_teaser placeholder has been removed.
If no video is present in course_teaser placeholder, image from course_cover placeholder is used instead.

#1297
