### PR TITLE
✨(back) add protected fields to lms backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add pace and duration icons.
 - Add `get_pace` and `get_pace_display` methods to course model
 - Add new plugin "LTI consumer" to include LTI provided content.
+- Add `COURSE_RUN_SYNC_NO_UPDATE_FIELDS` setting into `RICHIE_LMS_BACKENDS`
 
 ### Changed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,9 @@ $ make migrate
 
 ## Unreleased
 
+- A new `COURSE_RUN_SYNC_NO_UPDATE_FIELDS` setting has been added to `RICHIE_LMS_BACKENDS`.
+  These fields will not be updated by the course run synchronization hook.
+
 ## 2.1.x to 2.2.x
 
 - A css `.banner` component has been created. You may have to import the component style

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -290,6 +290,8 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_name="EDX_COURSE_REGEX",
                 environ_prefix=None,
             ),
+            # Synchronization
+            "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
             "DEFAULT_COURSE_RUN_SYNC_MODE": "sync_to_public",
             # React frontend
             "JS_BACKEND": values.Value(

--- a/src/richie/apps/courses/api.py
+++ b/src/richie/apps/courses/api.py
@@ -139,6 +139,9 @@ def course_runs_sync(request, version):
         return Response(serializer.errors, status=400)
 
     if draft_course_runs:
+        # Remove protected fields before update
+        cleaned_data = lms.clean_course_run_data(serializer.validated_data)
+
         for course_run in draft_course_runs.filter(
             sync_mode__in=[
                 CourseRunSyncMode.SYNC_TO_DRAFT,
@@ -151,7 +154,7 @@ def course_runs_sync(request, version):
                     draft_course_run__sync_mode=CourseRunSyncMode.SYNC_TO_PUBLIC,
                     draft_course_run=course_run,
                 )
-            ).update(**serializer.validated_data)
+            ).update(**cleaned_data)
 
             public_course = course_run.direct_course.public_extension
             if course_run.sync_mode == CourseRunSyncMode.SYNC_TO_PUBLIC:

--- a/src/richie/apps/courses/lms/edx.py
+++ b/src/richie/apps/courses/lms/edx.py
@@ -74,6 +74,14 @@ class EdXLMSBackend(BaseLMSBackend):
         course_id = self.extract_course_id(data.get("resource_link"))
         return split_course_key(course_id)[1]
 
+    def clean_course_run_data(self, data):
+        """Remove course run's protected fields to the data dictionnary."""
+        return {
+            key: value
+            for (key, value) in data.items()
+            if key not in self.configuration.get("COURSE_RUN_SYNC_NO_UPDATE_FIELDS", [])
+        }
+
     @staticmethod
     def get_course_run_serializer(data, partial=False):
         """Prepare data and return a bound serializer."""


### PR DESCRIPTION
## Purpose

In some case, we would like to protect some fields from update when course run synchronization hook is called.

## Proposal

- [x] Add a setting `COURSE_RUN_SYNC_PROTECTED_FIELDS` to `LMS_BACKENDS` to protect fields from update.
