### PR TITLE
💄(frontend) fix text selection on search input on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix an issue about text selection on search input on Firefox
+
 ## [2.2.0] - 2021-03-05
 
 ### Added

--- a/src/frontend/scss/objects/_react-autosuggest.scss
+++ b/src/frontend/scss/objects/_react-autosuggest.scss
@@ -7,8 +7,9 @@
   &__input {
     @extend .form-control;
     @include button-base($text-align: left, $form-factor: 'pill');
-    padding-right: 3.6rem;
     height: auto;
+    padding-right: 3.6rem;
+    user-select: inherit;
     @if r-theme-val(base-search, input-border) {
       border: 1px solid r-theme-val(base-search, input-border);
     }


### PR DESCRIPTION
## Purpose

On Firefox, user cannot select text in search input.
A `user-select: none` rule was applied to the search input that makes text
unselectable only on Firefox.

#1302

## Proposal

- [x] Inherit `user-select` rule from `button-base` mixin for search-input element
