### PR TITLE
Add language fallback on page extension plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Take fallback languages into account in page extension plugins
+
 ### Fixed
 
 - Fix an issue about text selection on search input on Firefox

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -459,7 +459,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "default": {
             "public": True,
             "hide_untranslated": False,
-            "redirect_on_fallback": True,
+            "redirect_on_fallback": False,
             "fallbacks": ["en", "fr"],
         },
         1: [
@@ -469,7 +469,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 "hide_untranslated": False,
                 "name": _("English"),
                 "fallbacks": ["fr"],
-                "redirect_on_fallback": True,
+                "redirect_on_fallback": False,
             },
             {
                 "public": True,
@@ -477,7 +477,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 "hide_untranslated": False,
                 "name": _("French"),
                 "fallbacks": ["en"],
-                "redirect_on_fallback": True,
+                "redirect_on_fallback": False,
             },
         ],
     }

--- a/src/richie/apps/courses/cms_plugins.py
+++ b/src/richie/apps/courses/cms_plugins.py
@@ -8,6 +8,7 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
 from richie.apps.core.defaults import PLUGINS_GROUP
+from richie.apps.core.models import get_public_page_with_fallbacks
 
 from .forms import LicencePluginForm
 from .models import (
@@ -36,10 +37,12 @@ class OrganizationPlugin(CMSPluginBase):
     render_template = "courses/plugins/organization.html"
 
     def render(self, context, instance, placeholder):
+        """Populate and return the context for rendering."""
+        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
         context.update(
             {
                 "instance": instance,
-                "relevant_page": instance.relevant_page,
+                "target_page": target_page,
                 "placeholder": placeholder,
                 "organization_variant": instance.variant
                 or context.get("organization_variant"),
@@ -65,10 +68,12 @@ class OrganizationsByCategoryPlugin(CMSPluginBase):
         Add to context a query of all the organizations linked to the target category or one of
         its descendants via a category plugin on the organization detail page.
         """
+        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
+        organizations = target_page.category.get_organizations() if target_page else []
         context.update(
             {
                 "instance": instance,
-                "organizations": instance.relevant_page.category.get_organizations(),
+                "organizations": organizations,
                 "organization_variant": instance.variant
                 or context.get("organization_variant"),
             }
@@ -90,12 +95,14 @@ class CategoryPlugin(CMSPluginBase):
     render_template = "courses/plugins/category_plugin.html"
 
     def render(self, context, instance, placeholder):
+        """Populate and return the context for rendering."""
+        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
         context.update(
             {
-                "instance": instance,
-                "relevant_page": instance.relevant_page,
-                "placeholder": placeholder,
                 "category_variant": instance.variant or context.get("category_variant"),
+                "instance": instance,
+                "placeholder": placeholder,
+                "target_page": target_page,
             }
         )
 
@@ -116,12 +123,14 @@ class CoursePlugin(CMSPluginBase):
     render_template = "courses/plugins/course_plugin.html"
 
     def render(self, context, instance, placeholder):
+        """Populate and return the context for rendering."""
+        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
         context.update(
             {
                 "instance": instance,
-                "relevant_page": instance.relevant_page,
-                "placeholder": placeholder,
                 "course_variant": instance.variant or context.get("course_variant"),
+                "placeholder": placeholder,
+                "target_page": target_page,
             }
         )
         return context
@@ -140,11 +149,13 @@ class PersonPlugin(CMSPluginBase):
     render_template = "courses/plugins/person.html"
 
     def render(self, context, instance, placeholder):
+        """Populate and return the context for rendering."""
+        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
         context.update(
             {
                 "instance": instance,
-                "relevant_page": instance.relevant_page,
                 "placeholder": placeholder,
+                "target_page": target_page,
             }
         )
         return context
@@ -167,6 +178,7 @@ class LicencePlugin(CMSPluginBase):
     render_template = "courses/plugins/licence_plugin.html"
 
     def render(self, context, instance, placeholder):
+        """Populate and return the context for rendering."""
         context.update({"instance": instance, "placeholder": placeholder})
         return context
 
@@ -185,12 +197,14 @@ class BlogPostPlugin(CMSPluginBase):
     render_template = "courses/plugins/blogpost.html"
 
     def render(self, context, instance, placeholder):
+        """Populate and return the context for rendering."""
+        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
         context.update(
             {
-                "instance": instance,
-                "relevant_page": instance.relevant_page,
-                "placeholder": placeholder,
                 "blogpost_variant": instance.variant or context.get("blogpost_variant"),
+                "instance": instance,
+                "placeholder": placeholder,
+                "target_page": target_page,
             }
         )
         return context
@@ -209,11 +223,13 @@ class ProgramPlugin(CMSPluginBase):
     render_template = "courses/plugins/program.html"
 
     def render(self, context, instance, placeholder):
+        """Populate and return the context for rendering."""
+        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
         context.update(
             {
                 "instance": instance,
-                "relevant_page": instance.relevant_page,
                 "placeholder": placeholder,
+                "target_page": target_page,
             }
         )
         return context

--- a/src/richie/apps/courses/migrations/0001_initial.py
+++ b/src/richie/apps/courses/migrations/0001_initial.py
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
                 "verbose_name": "blog post plugin",
                 "db_table": "richie_blog_post_plugin",
             },
-            bases=(richie.apps.core.models.PagePluginMixin, "cms.cmsplugin"),
+            bases=("cms.cmsplugin",),
         ),
         migrations.CreateModel(
             name="Category",
@@ -159,7 +159,7 @@ class Migration(migrations.Migration):
                 "verbose_name": "category plugin",
                 "db_table": "richie_category_plugin",
             },
-            bases=(richie.apps.core.models.PagePluginMixin, "cms.cmsplugin"),
+            bases=("cms.cmsplugin",),
         ),
         migrations.CreateModel(
             name="Course",
@@ -228,7 +228,7 @@ class Migration(migrations.Migration):
                 "verbose_name": "course plugin",
                 "db_table": "richie_course_plugin",
             },
-            bases=(richie.apps.core.models.PagePluginMixin, "cms.cmsplugin"),
+            bases=("cms.cmsplugin",),
         ),
         migrations.CreateModel(
             name="CourseRun",
@@ -536,7 +536,7 @@ class Migration(migrations.Migration):
                 "verbose_name": "organization plugin",
                 "db_table": "richie_organization_plugin",
             },
-            bases=(richie.apps.core.models.PagePluginMixin, "cms.cmsplugin"),
+            bases=("cms.cmsplugin",),
         ),
         migrations.CreateModel(
             name="Person",
@@ -600,7 +600,7 @@ class Migration(migrations.Migration):
                 "verbose_name": "person plugin",
                 "db_table": "richie_person_plugin",
             },
-            bases=(richie.apps.core.models.PagePluginMixin, "cms.cmsplugin"),
+            bases=("cms.cmsplugin",),
         ),
         migrations.CreateModel(
             name="PersonTitle",

--- a/src/richie/apps/courses/migrations/0006_add_program.py
+++ b/src/richie/apps/courses/migrations/0006_add_program.py
@@ -83,6 +83,6 @@ class Migration(migrations.Migration):
                 "verbose_name": "program plugin",
                 "db_table": "richie_program_plugin",
             },
-            bases=(richie.apps.core.models.PagePluginMixin, "cms.cmsplugin"),
+            bases=("cms.cmsplugin",),
         ),
     ]

--- a/src/richie/apps/courses/migrations/0008_auto_20191001_1212.py
+++ b/src/richie/apps/courses/migrations/0008_auto_20191001_1212.py
@@ -57,7 +57,7 @@ class Migration(migrations.Migration):
                 "verbose_name": "organizations by category plugin",
                 "db_table": "richie_organizations_by_category_plugin",
             },
-            bases=(richie.apps.core.models.PagePluginMixin, "cms.cmsplugin"),
+            bases=("cms.cmsplugin",),
         ),
         migrations.AlterField(
             model_name="organizationpluginmodel",

--- a/src/richie/apps/courses/models/blog.py
+++ b/src/richie/apps/courses/models/blog.py
@@ -9,7 +9,7 @@ from cms.api import Page
 from cms.extensions.extension_pool import extension_pool
 from cms.models.pluginmodel import CMSPlugin
 
-from ...core.models import BasePageExtension, PagePluginMixin
+from ...core.models import BasePageExtension
 from .. import defaults
 
 
@@ -79,7 +79,7 @@ class BlogPost(BasePageExtension):
         )
 
 
-class BlogPostPluginModel(PagePluginMixin, CMSPlugin):
+class BlogPostPluginModel(CMSPlugin):
     """
     BlogPost plugin model handles the relation between the BlogPostPluginModel
     and its blogpost instance

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -13,7 +13,7 @@ from cms.extensions.extension_pool import extension_pool
 from cms.models import Title
 from cms.models.pluginmodel import CMSPlugin
 
-from ...core.models import BasePageExtension, PagePluginMixin
+from ...core.models import BasePageExtension
 from ..defaults import CATEGORIES_PAGE, CATEGORY_GLIMPSE_VARIANT_CHOICES
 
 
@@ -193,7 +193,7 @@ def get_category_limit_choices_to():
     return limit_choices_to
 
 
-class CategoryPluginModel(PagePluginMixin, CMSPlugin):
+class CategoryPluginModel(CMSPlugin):
     """
     Category plugin model handles the relation between CategoryPlugin
     and their Category instance

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -27,7 +27,7 @@ from ...core.defaults import ALL_LANGUAGES
 from ...core.fields.duration import CompositeDurationField
 from ...core.fields.multiselect import MultiSelectField
 from ...core.helpers import get_permissions
-from ...core.models import BasePageExtension, PagePluginMixin
+from ...core.models import BasePageExtension
 from .. import defaults
 from .category import Category
 from .organization import Organization
@@ -942,7 +942,7 @@ class CourseRunTranslation(TranslatedFieldsModel):
         return super().save(*args, **kwargs)
 
 
-class CoursePluginModel(PagePluginMixin, CMSPlugin):
+class CoursePluginModel(CMSPlugin):
     """
     Course plugin model handles the relation from CoursePlugin
     to their Course instance

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -16,7 +16,7 @@ from cms.models import CMSPlugin, Title
 from filer.models import FolderPermission
 
 from ...core.helpers import get_permissions
-from ...core.models import BasePageExtension, PagePluginMixin
+from ...core.models import BasePageExtension
 from .. import defaults
 from .role import PageRole
 
@@ -219,7 +219,7 @@ class Organization(BasePageExtension):
         )
 
 
-class OrganizationPluginModel(PagePluginMixin, CMSPlugin):
+class OrganizationPluginModel(CMSPlugin):
     """
     Organization plugin model handles the relation from OrganizationPlugin
     to their Organization instance
@@ -249,7 +249,7 @@ class OrganizationPluginModel(PagePluginMixin, CMSPlugin):
         verbose_name_plural = _("organization plugins")
 
 
-class OrganizationsByCategoryPluginModel(PagePluginMixin, CMSPlugin):
+class OrganizationsByCategoryPluginModel(CMSPlugin):
     """
     Handle the relation between a OrganizationsByCategoryPlugin plugin and its Category
     instance.

--- a/src/richie/apps/courses/models/person.py
+++ b/src/richie/apps/courses/models/person.py
@@ -12,7 +12,7 @@ from cms.extensions.extension_pool import extension_pool
 from cms.models import Title
 from cms.models.pluginmodel import CMSPlugin
 
-from ...core.models import BasePageExtension, PagePluginMixin
+from ...core.models import BasePageExtension
 from ..defaults import PERSONS_PAGE
 
 
@@ -115,7 +115,7 @@ class Person(BasePageExtension):
         )
 
 
-class PersonPluginModel(PagePluginMixin, CMSPlugin):
+class PersonPluginModel(CMSPlugin):
     """
     Person plugin model handles the relation from PersonPlugin
     to their Person instance

--- a/src/richie/apps/courses/models/program.py
+++ b/src/richie/apps/courses/models/program.py
@@ -8,7 +8,7 @@ from cms.api import Page
 from cms.extensions.extension_pool import extension_pool
 from cms.models.pluginmodel import CMSPlugin
 
-from ...core.models import BasePageExtension, PagePluginMixin
+from ...core.models import BasePageExtension
 from ..defaults import PROGRAMS_PAGE
 
 
@@ -32,7 +32,7 @@ class Program(BasePageExtension):
         )
 
 
-class ProgramPluginModel(PagePluginMixin, CMSPlugin):
+class ProgramPluginModel(CMSPlugin):
     """
     Program plugin model handles the relation between the ProgramPluginModel
     and its program instance

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -132,14 +132,7 @@
                     {% block main_organization %}
                     {% with main_organization=course.get_main_organization %}
                         {% if main_organization %}
-                            {% if current_page.publisher_is_draft %}
-                                {% if main_organization.check_publication is True %}
-                                    {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
-                                {% else %}
-                                    {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization %}
-                                {% endif %}
-                            {# If the current page is the published version, show only the organizations that are published #}
-                            {% elif main_organization.check_publication is True %}
+                            {% if main_organization.check_publication is True %}
                                 {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
                             {% endif %}
                         {% else %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
@@ -1,7 +1,7 @@
 {% load i18n cms_tags extra_tags thumbnail %}
 {% comment %}Obviously, the context template variable "program" is required and must be a Program page extension{% endcomment %}
 {% with program_page=program.extended_object %}
-<a href="{{ program.extended_object.get_absolute_url }}" class="program-glimpse program-glimpse--link {% if program.extended_object.publisher_is_draft %}program-glimpse--draft{% endif %}" >
+<a href="{{ program.extended_object.get_absolute_url }}" class="program-glimpse program-glimpse--link{% if program.extended_object.publisher_is_draft %} program-glimpse--draft{% endif %}" >
     <div class="program-glimpse__media">
     {% get_page_plugins "program_cover" program_page as plugins or %}
         <div class="program-glimpse__empty">{% trans 'Cover' %}</div>

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -88,7 +88,7 @@
                     <section class="course-glimpse-list">
                         <h2 class="organization-detail__title">{% trans "Related courses" %}</h2>
                         {% for course in page_obj.object_list %}
-                            {% if course.extended_object.publisher_is_draft or course.check_publication %}
+                            {% if course.check_publication %}
                                 {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
                             {% endif %}
                         {% endfor %}

--- a/src/richie/apps/courses/templates/courses/plugins/blogpost.html
+++ b/src/richie/apps/courses/templates/courses/plugins/blogpost.html
@@ -1,8 +1,8 @@
 {% load cms_tags i18n %}
 {% spaceless %}
-{% if current_page.publisher_is_draft or instance.check_publication is True %}
-  {% with blogpost=relevant_page.blogpost %}
-    {% include "courses/cms/fragment_blogpost_glimpse.html" %}
-  {% endwith %}
+{% if target_page %}
+    {% with blogpost=target_page.blogpost %}
+      {% include "courses/cms/fragment_blogpost_glimpse.html" %}
+    {% endwith %}
 {% endif %}
 {% endspaceless %}

--- a/src/richie/apps/courses/templates/courses/plugins/category_plugin.html
+++ b/src/richie/apps/courses/templates/courses/plugins/category_plugin.html
@@ -1,7 +1,7 @@
 {% load cms_tags i18n %}
 {% spaceless %}
-{% if current_page.publisher_is_draft or instance.check_publication is True %}
-  {% with category=relevant_page.category %}
+{% if target_page %}
+  {% with category=target_page.category %}
     {% include "courses/cms/fragment_category_glimpse.html" %}
   {% endwith %}
 {% endif %}

--- a/src/richie/apps/courses/templates/courses/plugins/course_plugin.html
+++ b/src/richie/apps/courses/templates/courses/plugins/course_plugin.html
@@ -1,7 +1,7 @@
 {% load cms_tags i18n %}
 {% spaceless %}
-{% if current_page.publisher_is_draft or instance.check_publication is True %}
-  {% with course=relevant_page.course %}
+{% if target_page %}
+  {% with course=target_page.course %}
     {% include "courses/cms/fragment_course_glimpse.html" %}
   {% endwith %}
 {% endif %}

--- a/src/richie/apps/courses/templates/courses/plugins/organization.html
+++ b/src/richie/apps/courses/templates/courses/plugins/organization.html
@@ -1,7 +1,7 @@
 {% load cms_tags i18n %}
 {% spaceless %}
-{% if current_page.publisher_is_draft or instance.check_publication is True %}
-  {% with organization=relevant_page.organization %}
+{% if target_page %}
+  {% with organization=target_page.organization %}
     {% include "courses/cms/fragment_organization_glimpse.html" %}
   {% endwith %}
 {% endif %}

--- a/src/richie/apps/courses/templates/courses/plugins/organizations_by_category.html
+++ b/src/richie/apps/courses/templates/courses/plugins/organizations_by_category.html
@@ -1,5 +1,5 @@
 {% spaceless %}
-{% if current_page.publisher_is_draft or instance.check_publication is True %}
+{% if organizations %}
     <div class="organization-glimpse-list">
         {% for organization in organizations %}
             {% include "courses/cms/fragment_organization_glimpse.html" %}

--- a/src/richie/apps/courses/templates/courses/plugins/person.html
+++ b/src/richie/apps/courses/templates/courses/plugins/person.html
@@ -1,12 +1,12 @@
 {% load cms_tags i18n %}
 {% spaceless %}
-{% if current_page.publisher_is_draft or instance.check_publication is True %}
+{% if target_page %}
   {% if person_variant == "tag" %}
-    <a class="person-plugin-tag" href="{{ relevant_page.get_absolute_url }}">
-      {{ relevant_page.get_title }}
+    <a class="person-plugin-tag" href="{{ target_page.get_absolute_url }}">
+      {{ target_page.get_title }}
     </a>
   {% else %}
-    {% include "courses/cms/fragment_person_glimpse.html" with person=relevant_page.person %}
+    {% include "courses/cms/fragment_person_glimpse.html" with person=target_page.person %}
   {% endif %}
 {% endif %}
 {% endspaceless %}

--- a/src/richie/apps/courses/templates/courses/plugins/program.html
+++ b/src/richie/apps/courses/templates/courses/plugins/program.html
@@ -1,6 +1,6 @@
 {% load cms_tags i18n %}
 {% spaceless %}
-{% if current_page.publisher_is_draft or instance.check_publication %}
-  {% include "courses/cms/fragment_program_glimpse.html" with program=relevant_page.program %}
+{% if target_page %}
+  {% include "courses/cms/fragment_program_glimpse.html" with program=target_page.program %}
 {% endif %}
 {% endspaceless %}

--- a/tests/apps/courses/test_templates_blogpost_detail.py
+++ b/tests/apps/courses/test_templates_blogpost_detail.py
@@ -63,13 +63,13 @@ class DetailBlogPostCMSTestCase(CMSTestCase):
 
     def test_templates_blogpost_detail_cms_draft_content(self):
         """
-        A staff user should see a draft blogpost including its draft elements with an
-        annotation.
+        A staff user should see a draft blogpost including only its published linked objects.
         """
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
-        category = CategoryFactory(page_title="Very interesting category")
+        category = CategoryFactory()
+        published_category = CategoryFactory(should_publish=True)
         author = PersonFactory(
             page_title={"en": "Comte de Saint-Germain"}, should_publish=True
         )
@@ -78,7 +78,7 @@ class DetailBlogPostCMSTestCase(CMSTestCase):
             page_title="Preums",
             fill_cover=True,
             fill_body=True,
-            fill_categories=[category],
+            fill_categories=[category, published_category],
             fill_author=[author],
         )
         page = blogpost.extended_object
@@ -94,17 +94,20 @@ class DetailBlogPostCMSTestCase(CMSTestCase):
             response, '<h1 class="blogpost-detail__title">Preums</h1>', html=True
         )
         self.assertContains(response, "Comte de Saint-Germain", html=True)
-
         self.assertContains(
             response,
             (
-                '<a class="category-tag category-tag--draft" '
+                '<a class="category-tag" '
                 'href="{:s}"><span class="category-tag__title">{:s}</span></a>'
             ).format(
-                category.extended_object.get_absolute_url(),
-                category.extended_object.get_title(),
+                published_category.extended_object.get_absolute_url(),
+                published_category.extended_object.get_title(),
             ),
             html=True,
+        )
+        self.assertNotContains(
+            response,
+            category.extended_object.get_title(),
         )
 
         self.assertContains(

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -202,8 +202,8 @@ class OrganizationCMSTestCase(CMSTestCase):
 
     def test_templates_organization_detail_cms_draft_content(self):
         """
-        A staff user should see a draft organization including its draft elements with an
-        annotation.
+        A staff user should see a draft organization including only the related objects that
+        are published.
         """
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
@@ -260,17 +260,10 @@ class OrganizationCMSTestCase(CMSTestCase):
             ),
             html=True,
         )
-        # The not published category should be on the page, mark as draft
-        self.assertContains(
+        # The not published category should not be on the page
+        self.assertNotContains(
             response,
-            (
-                '<a class="category-tag category-tag--draft" '
-                'href="{:s}"><span class="category-tag__title">{:s}</span></a>'
-            ).format(
-                not_published_category.extended_object.get_absolute_url(),
-                not_published_category.extended_object.get_title(),
-            ),
-            html=True,
+            not_published_category.extended_object.get_title(),
         )
         # The modified draft category should not be leaked
         self.assertNotContains(response, "modified category")
@@ -282,20 +275,10 @@ class OrganizationCMSTestCase(CMSTestCase):
             html=True,
         )
 
-        # The not published course should be on the page, mark as draft
-        self.assertContains(
+        # The not published course should not be on the page
+        self.assertNotContains(
             response,
-            '<p class="course-glimpse__title">{:s}</p>'.format(
-                not_published_course.extended_object.get_title()
-            ),
-            html=True,
-        )
-        self.assertIn(
-            '<a class="course-glimpse course-glimpse--draft" '
-            'href="{:s}"'.format(
-                not_published_course.extended_object.get_absolute_url()
-            ),
-            re.sub(" +", " ", str(response.content).replace("\\n", "")),
+            not_published_course.extended_object.get_title(),
         )
 
     def test_templates_organization_detail_related_persons(self):

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -1,7 +1,6 @@
 """
 End-to-end tests for the person detail view
 """
-import re
 from unittest import mock
 
 from django.test.utils import override_settings
@@ -226,17 +225,10 @@ class PersonCMSTestCase(CMSTestCase):
             ),
             html=True,
         )
-        # The not published category should be on the page, mark as draft
-        self.assertContains(
+        # The not published category should not be on the page
+        self.assertNotContains(
             response,
-            (
-                '<a class="category-badge category-badge--draft" '
-                'href="{:s}"><span class="category-badge__title">{:s}</span></a>'
-            ).format(
-                not_published_category.extended_object.get_absolute_url(),
-                not_published_category.extended_object.get_title(),
-            ),
-            html=True,
+            not_published_category.extended_object.get_title(),
         )
 
         # The published organization should be on the page in its published version
@@ -248,23 +240,9 @@ class PersonCMSTestCase(CMSTestCase):
             html=True,
         )
 
-        # The not published organization should be on the page, mark as draft
-        self.assertContains(
-            response,
-            '<div class="organization-glimpse__title">{:s}</div>'.format(
-                not_published_organization.extended_object.get_title()
-            ),
-            html=True,
-        )
-        self.assertIn(
-            (
-                '<a class="organization-glimpse organization-glimpse--draft" '
-                'href="{url:s}" title="{title:s}">'
-            ).format(
-                url=not_published_organization.extended_object.get_absolute_url(),
-                title=not_published_organization.extended_object.get_title(),
-            ),
-            re.sub(" +", " ", str(response.content).replace("\\n", "")),
+        # The not published organization should not be on the page
+        self.assertNotContains(
+            response, not_published_organization.extended_object.get_title()
         )
 
         self.assertNotContains(response, "modified")

--- a/tests/apps/courses/test_templates_program_detail.py
+++ b/tests/apps/courses/test_templates_program_detail.py
@@ -68,8 +68,7 @@ class ProgramCMSTestCase(CMSTestCase):
 
     def test_templates_program_detail_cms_draft_content(self):
         """
-        A staff user should see a draft program including its draft elements with an
-        annotation.
+        A staff user should see a draft program including only its public elements.
         """
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
@@ -113,17 +112,14 @@ class ProgramCMSTestCase(CMSTestCase):
                 ),
                 html=True,
             )
-        # Draft courses should also be present on the page with an annotation for styling
+        # Draft courses should not be present on the page
         for course in courses[-2:]:
-            self.assertIn(
-                '<a class="course-glimpse course-glimpse--draft" '
-                'href="{:s}"'.format(course.extended_object.get_absolute_url()),
+            self.assertNotIn(
+                course.extended_object.get_absolute_url(),
                 re.sub(" +", " ", str(response.content).replace("\\n", "")),
             )
-            self.assertContains(
+            self.assertNotContains(
                 response,
-                '<p class="course-glimpse__title">{title:s}</p>'.format(
-                    title=course.extended_object.get_title()
-                ),
+                course.extended_object.get_title(),
                 html=True,
             )


### PR DESCRIPTION
## Purpose

When a page extension plugin (CoursePlugin, OrganizationPlugin, etc.) was pointing to a page that had **never been published** in the current language, but published in another language, we were displaying broken plugins because the content could not be found in the current language.

When a page extension plugin was pointing to a page that had **been published in the current language but later unpublished**, we were displaying the unpublished content because DjangoCMS does not take into account the publication status of content when it uses a fallback language (looks like a bug to me).

## Proposal

To fix this, I implemented language fallback on the page extension plugins, getting inspiration from the [DjangoCMS main view](https://github.com/django-cms/django-cms/blob/3.8.0/cms/views.py#L37) where pages are retrieved taking into account their language fallback.

I also took this opportunity to show plugins only if the page pointed by the plugin is published. This decision follows a complaint from our support team stating that:

> In draft, we want to see the page exactly how it will look when we press the publish button

We get around the above mentioned DjangoCMS bug by not displaying the plugin at all for a language that was published and later unpublished, even if it has a fallback language that is published. This is because in this case, DjangoCMS would not display the fallback language but the very content that was voluntarily unpublished... So this could be very annoying. Hiding the plugin completely in this language is also what was the user's intention when unpublishing it.
