### PR TITLE
🐛(plugins) fix LTI consumer plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix LTI consumer plugin (edit mode, manual config and update after create)
 - Fix an issue about text selection on search input on Firefox
 
 ## [2.2.0] - 2021-03-05

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -18,6 +18,3 @@ DJANGO_SOCIAL_AUTH_EDX_OIDC_SECRET=fakesecret
 DJANGO_SOCIAL_ERROR_REVERSE_ID=login-error
 
 DJANGO_RICHIE_COURSE_RUN_SYNC_SECRETS=shared secret
-
-#LTI Consumer plugin
-LTI_TEST_BASE_URL=http://localhost:8060/lti/videos/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}

--- a/src/richie/plugins/lti_consumer/cms_plugins.py
+++ b/src/richie/plugins/lti_consumer/cms_plugins.py
@@ -49,17 +49,10 @@ class LTIConsumerPlugin(CMSPluginBase):
 
         context = super().render(context, instance, placeholder)
         context["widget_props"] = json.dumps(
-            self.get_lti_consumer_widget_props(instance, edit=edit)
+            {
+                "url": instance.url,
+                "content_parameters": instance.get_content_parameters(edit=edit),
+                "automatic_resizing": instance.automatic_resizing,
+            }
         )
         return context
-
-    @staticmethod
-    def get_lti_consumer_widget_props(instance, edit=False):
-        """
-        Return all LTI consumer properties required by LTIConsumer React widget
-        """
-        return {
-            "url": instance.url,
-            "content_parameters": instance.content_parameters(edit=edit),
-            "automatic_resizing": instance.automatic_resizing,
-        }

--- a/src/richie/plugins/lti_consumer/defaults.py
+++ b/src/richie/plugins/lti_consumer/defaults.py
@@ -1,9 +1,10 @@
 """Default settings for Richie's LTI consumer plugin."""
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 STUDENT = "student"
 INSTRUCTOR = "instructor"
-PREDEFINED_LTI_PROVIDERS = [
+PREDEFINED_LTI_PROVIDERS = [(None, _("Custom provider configuration"))] + [
     (provider_key, provider.get("display_name", provider_key))
     for provider_key, provider in getattr(settings, "RICHIE_LTI_PROVIDERS", {}).items()
 ]

--- a/src/richie/plugins/lti_consumer/factories.py
+++ b/src/richie/plugins/lti_consumer/factories.py
@@ -1,7 +1,10 @@
 """
 LTIConsumer CMS plugin factories
 """
+from django.conf import settings
+
 import factory
+import factory.fuzzy
 
 from .models import LTIConsumer
 
@@ -14,7 +17,17 @@ class LTIConsumerFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = LTIConsumer
 
-    url = factory.Faker("url")
-    lti_provider_id = "lti_provider_test"
-    oauth_consumer_key = None
-    shared_secret = None
+    lti_provider_id = factory.fuzzy.FuzzyChoice(
+        getattr(settings, "RICHIE_LTI_PROVIDERS", {}).keys()
+    )
+
+    @factory.lazy_attribute
+    def url(self):
+        """Generates a random url in accordance with the LTI provider."""
+        if self.lti_provider_id:
+            # Let the "save" method generate by returning None
+            return None
+
+        return factory.Faker("url").evaluate(
+            None, None, {"locale": settings.LANGUAGE_CODE}
+        )

--- a/src/richie/plugins/lti_consumer/forms.py
+++ b/src/richie/plugins/lti_consumer/forms.py
@@ -54,6 +54,10 @@ class LTIConsumerForm(forms.ModelForm):
                         'The url is not valid for this provider. It should start with "{:s}".'
                     ).format(base_url)
                     self.add_error("url", message)
+
+            # Reset credentials
+            self.cleaned_data["oauth_consumer_key"] = None
+            self.cleaned_data["shared_secret"] = None
         else:
             oauth_consumer_key = self.cleaned_data.get("oauth_consumer_key")
             shared_secret = self.cleaned_data.get("shared_secret")

--- a/src/richie/plugins/lti_consumer/models.py
+++ b/src/richie/plugins/lti_consumer/models.py
@@ -47,14 +47,16 @@ class LTIConsumer(CMSPlugin):
         - context_id from current site domain
         - url if predefined provider is used
         """
-        if not self.id:
-            if self.lti_provider and not self.url:
-                if self.lti_provider.get("is_base_url_regex"):
-                    self.url = "{:s}".format(
-                        exrex.getone(self.lti_provider.get("base_url", "")),
-                    )
-                else:
-                    self.url = self.lti_provider.get("base_url", "")
+        lti_provider = self.lti_provider
+
+        if lti_provider and not self.url:
+            is_regex = lti_provider.get("is_base_url_regex")
+            base_url = lti_provider.get("base_url", "")
+            if is_regex:
+                self.url = "{:s}".format(exrex.getone(base_url))
+            else:
+                self.url = base_url
+
         super().save(*args, **kwargs)
 
     @property
@@ -87,62 +89,58 @@ class LTIConsumer(CMSPlugin):
         """
         return f"padding-bottom: {self.inline_ratio * 100}%"
 
-    def auth_parameters(self, edit=False):
+    def get_resource_link_id(self):
+        """Use the plugin id as resource_link_id field."""
+        return str(self.id)
+
+    def get_content_parameters(self, edit=False):
         """
-        Builds required parameters for LTI authentication
+        Convenient wrapper to authorize and return required parameters
+        for LTI content consumption
         """
         role = INSTRUCTOR if edit else STUDENT
         site = get_current_site()
-        return {
-            "lti_message_type": self.lti_provider.get(
-                "display_name", self.lti_provider_id
-            ),
+
+        lti_parameters = {
+            "lti_message_type": "basic-lti-launch-request",
             "lti_version": "LTI-1p0",
-            "resource_link_id": str(self.id),
+            "resource_link_id": self.get_resource_link_id(),
             "context_id": site.domain,
             "user_id": "richie",
             "lis_person_contact_email_primary": "",
             "roles": role,
         }
 
-    def authorize(self):
-        """
-        Returns headers from LTI authentication
-        """
-        client = oauth1.Client(
-            client_key=self.lti_provider.get("oauth_consumer_key"),
-            client_secret=self.lti_provider.get("shared_secret"),
+        # Get credentials from the predefined LTI provider if any, or from the model otherwise
+        oauth_consumer_key = (
+            self.lti_provider.get("oauth_consumer_key", "")
+            if self.lti_provider_id
+            else self.oauth_consumer_key
         )
-
+        shared_secret = (
+            self.lti_provider.get("shared_secret", "")
+            if self.lti_provider_id
+            else self.shared_secret
+        )
+        client = oauth1.Client(
+            client_key=oauth_consumer_key, client_secret=shared_secret
+        )
         _uri, headers, _body = client.sign(
             self.url,
             http_method="POST",
-            body=self.auth_parameters(),
+            body=lti_parameters,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
-        return headers
 
-    def build_content_parameters(self, auth_headers, edit=False):
-        """
-        Builds required parameters for LTI content consumption
-        """
         oauth_dict = dict(
             param.strip().replace('"', "").split("=")
-            for param in auth_headers["Authorization"].split(",")
+            for param in headers["Authorization"].split(",")
         )
-        signature = oauth_dict["oauth_signature"]
-        oauth_dict["oauth_signature"] = unquote(signature)
+        oauth_dict["oauth_signature"] = unquote(oauth_dict["oauth_signature"])
         oauth_dict["oauth_nonce"] = oauth_dict.pop("OAuth oauth_nonce")
 
-        oauth_dict.update(self.auth_parameters(edit=edit))
+        oauth_dict.update(lti_parameters)
         return oauth_dict
-
-    def content_parameters(self, edit=False):
-        """
-        Convenient wrapper to authorize and return required parameters
-        for LTI content consumption
-        """
-        return self.build_content_parameters(self.authorize(), edit=edit)
 
     def __str__(self):
         return self.url

--- a/src/richie/plugins/lti_consumer/static/lti_consumer/js/change_form.js
+++ b/src/richie/plugins/lti_consumer/static/lti_consumer/js/change_form.js
@@ -1,6 +1,6 @@
 $(document).ready(() => {
   const $lti_provider_id = $("#id_lti_provider_id");
-  const $credentials_fields = $(".field-oauth_consumer_key, .field-shared_secret");
+  const $credentials_fields = $(".field-oauth_consumer_key, .field-form_shared_secret");
 
   const set_credentials_fields_visibility = () => {
     if ($lti_provider_id.val()) {

--- a/tests/plugins/lti_consumer/test_factories.py
+++ b/tests/plugins/lti_consumer/test_factories.py
@@ -1,7 +1,7 @@
 """
 Factory tests
 """
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from richie.plugins.lti_consumer.factories import LTIConsumerFactory
 
@@ -9,7 +9,23 @@ from richie.plugins.lti_consumer.factories import LTIConsumerFactory
 class LTIConsumerFactoriesTestCase(TestCase):
     """Tests for the LTIConsumer factory"""
 
-    def test_factories_lti_consumer_create_success(self):
-        """Factory creation success."""
+    @override_settings(
+        RICHIE_LTI_PROVIDERS={
+            "lti_provider_test": {
+                "base_url": "http://localhost:8060/lti/videos/",
+                "is_base_url_regex": False,
+            }
+        }
+    )
+    def test_factories_lti_consumer_create_with_lti_provider(self):
+        """
+        The url field should be computed by the model's "save" method if an
+        LTI provider is defined.
+        """
         lti_consumer = LTIConsumerFactory()
+        self.assertIn(lti_consumer.url, "http://localhost:8060/lti/videos/")
+
+    def test_factories_lti_consumer_create_without_lti_provider(self):
+        """The url field should be set to a random value for a custom provider."""
+        lti_consumer = LTIConsumerFactory(lti_provider_id=None)
         self.assertIsNotNone(lti_consumer.url)

--- a/tests/plugins/lti_consumer/test_forms.py
+++ b/tests/plugins/lti_consumer/test_forms.py
@@ -31,8 +31,11 @@ class LTIConsumerFormTestCase(TestCase):
         Verify LTI consumer form lists predefined providers
         """
         self.assertListEqual(
-            [("", "---------"), ("lti_provider_test", "LTI Provider Test Video")],
             LTIConsumerForm().fields["lti_provider_id"].widget.choices,
+            [
+                (None, "Custom provider configuration"),
+                ("lti_provider_test", "LTI Provider Test Video"),
+            ],
         )
 
     def test_forms_lti_consumer_clean_errors(self):


### PR DESCRIPTION
### Purpose

We experienced 3 bugs when trying to run the new LTI consumer plugin in production:
- The edit mode was not passed properly and made the signature wrong
- The "oauth_consumer_key" and "shared_secret" fields on the plugin were not taken into account
- The plugin was raising 500 errors when we tried to update it after creation

I improved the tests to fill the gaps and cover these cases.

## Proposal

- [x] Use standard "basic-lti-launch-request" value as LTI message type
- [x] The first bug was brought by multiple methods calling each other with arguments. One argument was forgotten and tests could not see it because some methods were mocked to test another one. I simplify building the LTI parameters by doing everything in one method.  It is still possible to test it by mocking only the `timestamp` and `nonce` higher in the oauth library.
- [x] Use the `oauth_consumer_key` and `shared_secret` fields when the value is defined
- [x] Make LTIConsumerFactory really random
- [x] Improve form and model cleaning methods so that they work when updating an existing plugin as well  
- [x] Improve the "--------" empty label on select box for predefined LTI providers to "Custom provider configuration"
- [x] Reset credentials on the `LTIConsumer` model when a predefined LTI provider is selected  