### PR TITLE
⚡️(courses) cache getting course runs dict from the course models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Cache getting the course runs dictionary from the course model
 - Take fallback languages into account in page extension plugins
 - Load components lazily in Root component
 

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -11,7 +11,7 @@ from django.db import models
 from django.db.models import Prefetch, Q
 from django.urls import reverse
 from django.utils import timezone, translation
-from django.utils.functional import lazy
+from django.utils.functional import cached_property, lazy
 from django.utils.translation import gettext_lazy as _
 
 import pytz
@@ -484,7 +484,8 @@ class Course(BasePageExtension):
             direct_course__extended_object__publisher_is_draft=is_draft,
         ).order_by("-start")
 
-    def get_course_runs_dict(self):
+    @cached_property
+    def course_runs_dict(self):
         """Returns a dict of course runs grouped by their state."""
         course_runs_dict = {
             i: [] for i in range(len(CourseState.STATE_CALLS_TO_ACTION))

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -281,7 +281,7 @@
 
             {% block runs %}
                 <div class="course-detail__aside">
-                    {% with runs_dict=course.get_course_runs_dict %}
+                    {% with runs_dict=course.course_runs_dict %}
                         {% block runs_open %}
                             <div class="course-detail__row course-detail__runs course-detail__runs--open">
                                 <h2 class="course-detail__title">


### PR DESCRIPTION
## Purpose

On one of our sites, we want to display the first open course run in the top header of the course syllabus, and only the remaining ones in the side column.

## Proposal

This will is done via overridding template blocks in [richie site factory](https://github.com/openfun/richie-site-factory) and we will need to call the method "get_course_runs_dict" several times in the template.

This method being very costly, it is a good idea to first make sure that it is cached on the instance: make it a cached property.
