### PR TITLE
🐛(frontend) fix lti consumer issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix layout issue on LTI consumer resizing
+
+### Added
+
+- Allow fullscreen within LTI consumer iframe
+
 ## [2.3.1] - 2021-03-24
 
 ### Fixed

--- a/src/frontend/js/components/LtiConsumer/index.tsx
+++ b/src/frontend/js/components/LtiConsumer/index.tsx
@@ -16,10 +16,7 @@ const LtiConsumer = ({
       // Retrieve and inject current component container height to prevent flickering
       // and remove aspect-ratio trick which is not compatible with iframeResizer
       const componentContainer = document.querySelector('.richie-react--lti-consumer');
-      iframeResizer(
-        { sizeWidth: true, minHeight: componentContainer?.clientHeight },
-        iframeRef.current!,
-      );
+      iframeResizer({ minHeight: componentContainer?.clientHeight }, iframeRef.current!);
       componentContainer?.classList.remove('aspect-ratio');
       componentContainer?.attributes.removeNamedItem('style');
     }
@@ -45,7 +42,8 @@ const LtiConsumer = ({
         name="lti_iframe"
         title={url}
         src={url}
-        allow="microphone *; camera *; midi *; geolocation *; encrypted-media *"
+        allow="microphone *; camera *; midi *; geolocation *; encrypted-media *; fullscreen *"
+        allowFullScreen
       />
     </div>
   );


### PR DESCRIPTION
## Purpose

When iframeResizer was enabled, it enforced iframe content width and leads to layout issue on small screens.
Furthermore, option to allow fullscreen was missing.


## Proposal

- [x] Add attributes to allow use of fullscren within LTI Consumer iframe
- [x] Do not use `sizeWidth` iframeResizer options
