### PR TITLE
✨(courses) use lang fallback to get page extension related via plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Pin Django to versions less than 3.2 which is not compatible with DjangoCMS
 - Fix pace computation when it is under an hour
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,22 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
-### Removed
+### Added
 
-- Creation date displayed on program glimpses
+- Add support for language fallback to get page extensions reversely related
+  to a page via a plugin
+
+### Changed
+
+- Retrieve LTI Consumer plugin context through an API endpoint
 
 ### Fixed
 
 - Fix pace computation when it is under an hour
 
-### Changed
+### Removed
 
-- Retrieve LTI Consumer plugin context through an API endpoint
+- Creation date displayed on program glimpses
 
 ## [2.3.3] - 2021-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add support for language fallback on search indexes
 - Add support for language fallback to get page extensions directly and
   reversely related to a page via a plugin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Add support for language fallback to get page extensions reversely related
-  to a page via a plugin
+- Add support for language fallback to get page extensions directly and
+  reversely related to a page via a plugin
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- On draft pages, show page extension plugins targeting draft pages
 - Retrieve LTI Consumer plugin context through an API endpoint
 
 ### Fixed

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 include_package_data = True
 install_requires =
     arrow # pyup: ignore
-    Django # pyup: ignore
+    Django<3.2 # pyup: ignore
     dj-pagination # pyup: ignore
     django-cms>=3.8.0 # pyup: ignore
     django-parler>=2.0.1 # pyup: ignore

--- a/src/richie/apps/courses/cms_plugins.py
+++ b/src/richie/apps/courses/cms_plugins.py
@@ -8,7 +8,7 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
 from richie.apps.core.defaults import PLUGINS_GROUP
-from richie.apps.core.models import get_public_page_with_fallbacks
+from richie.apps.core.models import get_relevant_page_with_fallbacks
 
 from .forms import LicencePluginForm
 from .models import (
@@ -38,7 +38,7 @@ class OrganizationPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         """Populate and return the context for rendering."""
-        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
+        target_page = get_relevant_page_with_fallbacks(context, instance)
         context.update(
             {
                 "instance": instance,
@@ -68,7 +68,7 @@ class OrganizationsByCategoryPlugin(CMSPluginBase):
         Add to context a query of all the organizations linked to the target category or one of
         its descendants via a category plugin on the organization detail page.
         """
-        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
+        target_page = get_relevant_page_with_fallbacks(context, instance)
         organizations = target_page.category.get_organizations() if target_page else []
         context.update(
             {
@@ -96,7 +96,7 @@ class CategoryPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         """Populate and return the context for rendering."""
-        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
+        target_page = get_relevant_page_with_fallbacks(context, instance)
         context.update(
             {
                 "category_variant": instance.variant or context.get("category_variant"),
@@ -124,7 +124,7 @@ class CoursePlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         """Populate and return the context for rendering."""
-        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
+        target_page = get_relevant_page_with_fallbacks(context, instance)
         context.update(
             {
                 "instance": instance,
@@ -150,7 +150,7 @@ class PersonPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         """Populate and return the context for rendering."""
-        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
+        target_page = get_relevant_page_with_fallbacks(context, instance)
         context.update(
             {
                 "instance": instance,
@@ -198,7 +198,7 @@ class BlogPostPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         """Populate and return the context for rendering."""
-        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
+        target_page = get_relevant_page_with_fallbacks(context, instance)
         context.update(
             {
                 "blogpost_variant": instance.variant or context.get("blogpost_variant"),
@@ -224,7 +224,7 @@ class ProgramPlugin(CMSPluginBase):
 
     def render(self, context, instance, placeholder):
         """Populate and return the context for rendering."""
-        target_page = get_public_page_with_fallbacks(instance.page, context["request"])
+        target_page = get_relevant_page_with_fallbacks(context, instance)
         context.update(
             {
                 "instance": instance,

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -8,7 +8,7 @@ from datetime import MAXYEAR, datetime
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Prefetch, Q
+from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone, translation
 from django.utils.functional import cached_property, lazy
@@ -17,7 +17,7 @@ from django.utils.translation import gettext_lazy as _
 import pytz
 from cms.constants import PUBLISHER_STATE_DIRTY
 from cms.extensions.extension_pool import extension_pool
-from cms.models import Page, PagePermission, Title
+from cms.models import Page, PagePermission
 from cms.models.pluginmodel import CMSPlugin
 from filer.fields.image import FilerImageField
 from filer.models import FolderPermission
@@ -32,7 +32,6 @@ from .. import defaults
 from .category import Category
 from .organization import Organization
 from .person import Person
-from .program import Program
 from .role import PageRole
 
 MAX_DATE = datetime(MAXYEAR, 12, 31, tzinfo=pytz.utc)
@@ -585,33 +584,7 @@ class Course(BasePageExtension):
         Return a query to get the programs related to this course ie for which a plugin for
         this course is linked to the program page via any placeholder.
         """
-        is_draft = self.extended_object.publisher_is_draft
-        course = self if is_draft else self.draft_extension
-        language = language or translation.get_language()
-
-        bfs = (
-            "extended_object__placeholders__cmsplugin__courses_coursepluginmodel__page"
-        )
-        filter_dict = {
-            "extended_object__publisher_is_draft": is_draft,
-            "extended_object__placeholders__cmsplugin__language": language,
-            bfs: course.extended_object,
-        }
-
-        # pylint: disable=no-member
-        return (
-            Program.objects.filter(**filter_dict)
-            .select_related("extended_object")
-            .prefetch_related(
-                Prefetch(
-                    "extended_object__title_set",
-                    to_attr="prefetched_titles",
-                    queryset=Title.objects.filter(language=language),
-                )
-            )
-            .order_by("extended_object__node__path")
-            .distinct()
-        )
+        return self.get_reverse_related_page_extensions("program", language=language)
 
     @property
     def state(self):

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -156,9 +156,9 @@ class Organization(BasePageExtension):
         Return a query to get the courses related to this organization ie for which a plugin for
         this organization is linked to the course page via any placeholder.
         """
-        return self.get_reverse_related_page_extensions("course", language=language).filter(
-            extended_object__node__parent__cms_pages__course__isnull=True
-        )
+        return self.get_reverse_related_page_extensions(
+            "course", language=language
+        ).filter(extended_object__node__parent__cms_pages__course__isnull=True)
 
     def get_persons(self, language=None):
         """

--- a/src/richie/apps/courses/models/person.py
+++ b/src/richie/apps/courses/models/person.py
@@ -1,15 +1,11 @@
 """
 Declare and configure the model for the person application
 """
-from django.apps import apps
 from django.db import models
-from django.db.models import Prefetch
-from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 
 from cms.api import Page
 from cms.extensions.extension_pool import extension_pool
-from cms.models import Title
 from cms.models.pluginmodel import CMSPlugin
 
 from ...core.models import BasePageExtension
@@ -51,34 +47,8 @@ class Person(BasePageExtension):
         Return a query to get the courses related to this person ie for which a plugin for
         this person is linked to the course page via any placeholder.
         """
-        is_draft = self.extended_object.publisher_is_draft
-        person = self if is_draft else self.draft_extension
-        language = language or translation.get_language()
-
-        bfs = (
-            "extended_object__placeholders__cmsplugin__courses_personpluginmodel__page"
-        )
-        filter_dict = {
-            "extended_object__node__parent__cms_pages__course__isnull": True,  # exclude snapshots
-            "extended_object__publisher_is_draft": is_draft,
-            "extended_object__placeholders__cmsplugin__language": language,
-            bfs: person.extended_object,
-        }
-
-        course_model = apps.get_model(app_label="courses", model_name="course")
-        # pylint: disable=no-member
-        return (
-            course_model.objects.filter(**filter_dict)
-            .select_related("extended_object")
-            .prefetch_related(
-                Prefetch(
-                    "extended_object__title_set",
-                    to_attr="prefetched_titles",
-                    queryset=Title.objects.filter(language=language),
-                )
-            )
-            .order_by("extended_object__node__path")
-            .distinct()
+        return self.get_reverse_related_page_extensions("course", language=language).filter(
+            extended_object__node__parent__cms_pages__course__isnull=True
         )
 
     def get_blogposts(self, language=None):
@@ -86,33 +56,7 @@ class Person(BasePageExtension):
         Return a query to get the blogposts this person wrote ie for which a
         plugin for this person is linked to the blogpost page via any placeholder.
         """
-        is_draft = self.extended_object.publisher_is_draft
-        person = self if is_draft else self.draft_extension
-        language = language or translation.get_language()
-
-        bfs = (
-            "extended_object__placeholders__cmsplugin__courses_personpluginmodel__page"
-        )
-        filter_dict = {
-            "extended_object__publisher_is_draft": is_draft,
-            "extended_object__placeholders__cmsplugin__language": language,
-            bfs: person.extended_object,
-        }
-
-        blogpost_model = apps.get_model(app_label="courses", model_name="blogpost")
-        # pylint: disable=no-member
-        return (
-            blogpost_model.objects.filter(**filter_dict)
-            .select_related("extended_object")
-            .prefetch_related(
-                Prefetch(
-                    "extended_object__title_set",
-                    to_attr="prefetched_titles",
-                    queryset=Title.objects.filter(language=language),
-                )
-            )
-            .distinct()
-        )
+        return self.get_reverse_related_page_extensions("blogpost", language=language)
 
 
 class PersonPluginModel(CMSPlugin):

--- a/src/richie/apps/courses/models/person.py
+++ b/src/richie/apps/courses/models/person.py
@@ -47,9 +47,9 @@ class Person(BasePageExtension):
         Return a query to get the courses related to this person ie for which a plugin for
         this person is linked to the course page via any placeholder.
         """
-        return self.get_reverse_related_page_extensions("course", language=language).filter(
-            extended_object__node__parent__cms_pages__course__isnull=True
-        )
+        return self.get_reverse_related_page_extensions(
+            "course", language=language
+        ).filter(extended_object__node__parent__cms_pages__course__isnull=True)
 
     def get_blogposts(self, language=None):
         """

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -99,9 +99,7 @@
                         <section class="course-glimpse-list">
                             <h2 class="category-detail__title">{% trans "Related courses" %}</h2>
                             {% for course in page_obj.object_list %}
-                                {% if course.extended_object.publisher_is_draft or course.check_publication %}
-                                    {% include "courses/cms/fragment_course_glimpse.html" %}
-                                {% endif %}
+                                {% include "courses/cms/fragment_course_glimpse.html" %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
                                 {% paginate using "richie/pagination.html" %}
@@ -133,9 +131,7 @@
                         <section class="organization-glimpse-list">
                             <h2 class="category-detail__title">{% trans "Related organizations" %}</h2>
                             {% for organization in page_obj.object_list %}
-                                {% if organization.extended_object.publisher_is_draft or organization.check_publication %}
-                                    {% include "courses/cms/fragment_organization_glimpse.html" %}
-                                {% endif %}
+                                {% include "courses/cms/fragment_organization_glimpse.html" %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
                                 {% paginate using "richie/pagination.html" %}
@@ -154,9 +150,7 @@
                         <section class="blogpost-glimpse-list">
                             <h2 class="category-detail__title">{% trans "Related blogposts" %}</h2>
                             {% for blogpost in page_obj.object_list %}
-                                {% if blogpost.extended_object.publisher_is_draft or blogpost.check_publication %}
-                                    {% include "courses/cms/fragment_blogpost_glimpse.html" %}
-                                {% endif %}
+                                {% include "courses/cms/fragment_blogpost_glimpse.html" %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
                                 {% paginate using "richie/pagination.html" %}
@@ -175,9 +169,7 @@
                         <section class="person-glimpse-list">
                             <h2 class="category-detail__title">{% trans "Related persons" %}</h2>
                             {% for person in page_obj.object_list %}
-                                {% if person.extended_object.publisher_is_draft or person.check_publication %}
-                                    {% include "courses/cms/fragment_person_glimpse.html" %}
-                                {% endif %}
+                                {% include "courses/cms/fragment_person_glimpse.html" %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
                                 {% paginate using "richie/pagination.html" %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -34,14 +34,14 @@
                     <div class="category-badge-list">
                         <div class="category-badge-list__container">
                         {% with category_variant="badge" %}
-                        {% placeholder "course_icons" %}
-                        {% placeholder "course_categories" or %}
-                            {% if current_page.publisher_is_draft and current_page|is_empty_placeholder:"course_icons" %}
-                            <span class="category-badge-list__empty">
-                                {% trans "No associated categories" %}
-                            </span>
-                            {% endif %}
-                        {% endplaceholder %}
+                            {% placeholder "course_icons" %}
+                            {% placeholder "course_categories" or %}
+                                {% if current_page.publisher_is_draft and current_page|is_empty_placeholder:"course_icons" %}
+                                <span class="category-badge-list__empty">
+                                    {% trans "No associated categories" %}
+                                </span>
+                                {% endif %}
+                            {% endplaceholder %}
                         {% endwith %}
                         </div>
                     </div>

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -132,9 +132,7 @@
                     {% block main_organization %}
                     {% with main_organization=course.get_main_organization %}
                         {% if main_organization %}
-                            {% if main_organization.check_publication is True %}
-                                {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
-                            {% endif %}
+                            {% include "courses/cms/fragment_organization_main_logo.html" with organization=main_organization.public_extension %}
                         {% else %}
                             {% include "courses/cms/fragment_organization_main_logo.html" with organization=None %}
                         {% endif %}
@@ -365,9 +363,7 @@
                                 </h2>
                                 <div class="section__items section__items--programs">
                                     {% for program in page_obj.object_list %}
-                                        {% if program.extended_object.publisher_is_draft or program.check_publication %}
-                                            {% include "courses/cms/fragment_program_glimpse.html" with program=program %}
-                                        {% endif %}
+                                        {% include "courses/cms/fragment_program_glimpse.html" with program=program %}
                                     {% endfor %}
                                 </div>
                                 {% if paginator.num_pages > 1 %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -2,8 +2,7 @@
 {% comment %}Obviously, the context template variable "course" is required and must be a Course page extension{% endcomment %}
 
 {% with course_page=course.extended_object course_state=course.state main_org_title=course.get_main_organization.extended_object.get_title course_variant=course_variant|default:'glimpse' %}
-<a class="course-{{ course_variant }}{% if course_page.publisher_is_draft is True %} course-{{ course_variant }}--draft{% endif %}"
-    href="{{ course_page.get_absolute_url }}">
+<a class="course-{{ course_variant }}{% if course_page.publisher_is_draft is True %} course-{{ course_variant }}--draft{% endif %}" href="{{ course_page.get_absolute_url }}">
     <div class="course-{{ course_variant }}__media">
         {% get_page_plugins "course_cover" course_page as cover_plugins or %}
             <p class="course-{{ course_variant }}--empty">{% trans "Cover" %}</p>

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -88,7 +88,7 @@
                     <section class="course-glimpse-list">
                         <h2 class="organization-detail__title">{% trans "Related courses" %}</h2>
                         {% for course in page_obj.object_list %}
-                                {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
+                            {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
                         {% endfor %}
                         {% if paginator.num_pages > 1 %}
                             {% paginate using "richie/pagination.html" %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -88,9 +88,7 @@
                     <section class="course-glimpse-list">
                         <h2 class="organization-detail__title">{% trans "Related courses" %}</h2>
                         {% for course in page_obj.object_list %}
-                            {% if course.check_publication %}
                                 {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
-                            {% endif %}
                         {% endfor %}
                         {% if paginator.num_pages > 1 %}
                             {% paginate using "richie/pagination.html" %}
@@ -116,11 +114,9 @@
                     <section class="person-glimpse-list">
                         <h2 class="organization-detail__title">{% trans "Related persons" %}</h2>
                         {% for person in page_obj.object_list %}
-                            {% if person.extended_object.publisher_is_draft or person.check_publication %}
-                                {% with header_level=3 %}
-                                    {% include "courses/cms/fragment_person_glimpse.html" with person=person %}
-                                {% endwith %}
-                            {% endif %}
+                            {% with header_level=3 %}
+                                {% include "courses/cms/fragment_person_glimpse.html" with person=person %}
+                            {% endwith %}
                         {% endfor %}
                         {% if paginator.num_pages > 1 %}
                             {% paginate using "richie/pagination.html" %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -112,9 +112,7 @@
                         <section class="course-glimpse-list">
                             <h2 class="person-detail__title">{% trans "Courses" %}</h2>
                             {% for course in page_obj.object_list %}
-                                {% if course.extended_object.publisher_is_draft or course.check_publication %}
-                                    {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
-                                {% endif %}
+                                {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
                                 {% paginate using "richie/pagination.html" %}
@@ -140,9 +138,7 @@
                         <section class="blogpost-glimpse-list">
                             <h2 class="person-detail__title">{% trans "Blogposts" %}</h2>
                             {% for blogpost in page_obj.object_list %}
-                                {% if blogpost.extended_object.publisher_is_draft or blogpost.check_publication %}
-                                    {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=blogpost %}
-                                {% endif %}
+                                {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=blogpost %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
                                 {% paginate using "richie/pagination.html" %}

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -120,8 +120,8 @@ class CategoriesIndexer:
             "_op_type": action,
             "_type": cls.document_type,
             "absolute_url": {
-                language: category.extended_object.get_absolute_url(language)
-                for language in titles.keys()
+                lang: category.extended_object.get_absolute_url(lang)
+                for lang, _ in settings.LANGUAGES
             },
             "complete": {
                 language: slice_string_for_completion(title)

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -561,8 +561,8 @@ class CoursesIndexer:
             "_op_type": action,
             "_type": cls.document_type,
             "absolute_url": {
-                language: course.extended_object.get_absolute_url(language)
-                for language in titles.keys()
+                lang: course.extended_object.get_absolute_url(lang)
+                for lang, _ in settings.LANGUAGES
             },
             "categories": [page.category.get_es_id() for page in category_pages],
             # Index the names of categories to surface them in full text searches

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -86,8 +86,8 @@ class OrganizationsIndexer:
             "_op_type": action,
             "_type": cls.document_type,
             "absolute_url": {
-                language: organization.extended_object.get_absolute_url(language)
-                for language in titles.keys()
+                lang: organization.extended_object.get_absolute_url(lang)
+                for lang, _ in settings.LANGUAGES
             },
             "complete": {
                 language: slice_string_for_completion(title)

--- a/src/richie/apps/search/indexers/persons.py
+++ b/src/richie/apps/search/indexers/persons.py
@@ -88,8 +88,8 @@ class PersonsIndexer:
             "_op_type": action,
             "_type": cls.document_type,
             "absolute_url": {
-                language: person.extended_object.get_absolute_url(language)
-                for language in titles.keys()
+                lang: person.extended_object.get_absolute_url(lang)
+                for lang, _ in settings.LANGUAGES
             },
             "bio": {language: " ".join(st) for language, st in bio.items()},
             "complete": {

--- a/tests/apps/courses/test_api_course_run_sync_edx.py
+++ b/tests/apps/courses/test_api_course_run_sync_edx.py
@@ -10,13 +10,13 @@ from django.conf import settings
 from django.test import override_settings
 
 from cms.constants import PUBLISHER_STATE_DEFAULT, PUBLISHER_STATE_DIRTY
-from cms.models import Page
+from cms.models import Page, Title
 from cms.signals import post_publish
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.courses.factories import CourseFactory, CourseRunFactory
 from richie.apps.courses.lms.edx import SyncCourseRunSerializer
-from richie.apps.courses.models import Course, CourseRun, Title
+from richie.apps.courses.models import Course, CourseRun
 
 
 @mock.patch.object(post_publish, "send", wraps=post_publish.send)

--- a/tests/apps/courses/test_models_course.py
+++ b/tests/apps/courses/test_models_course.py
@@ -292,6 +292,78 @@ class CourseModelsTestCase(TestCase):
         with translation.override("en"):
             self.assertEqual(list(course.get_categories()), [category_en])
 
+    @override_settings(
+        LANGUAGES=(("en", "en"), ("fr", "fr"), ("de", "de")),
+        CMS_LANGUAGES={
+            "default": {
+                "public": True,
+                "hide_untranslated": False,
+                "redirect_on_fallback": False,
+                "fallbacks": ["en", "fr", "de"],
+            }
+        },
+    )
+    def test_models_course_get_categories_language_fallback(self):
+        """
+        The `get_categories` method should return categories linked to a course by
+        a plugin in fallback language by order of falling back.
+        """
+        category1, category2, category3 = factories.CategoryFactory.create_batch(
+            3, should_publish=True
+        )
+        course = factories.CourseFactory(should_publish=True)
+        placeholder = course.extended_object.placeholders.get(slot="course_team")
+
+        # Plugin lookups should fallback up to the second priority language
+        add_plugin(
+            language="de",
+            placeholder=placeholder,
+            plugin_type="CategoryPlugin",
+            **{"page": category1.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_categories()), [category1])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_categories()), [category1])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_categories()), [category1])
+
+        # Plugin lookups should fallback to the first priority language if available
+        # and ignore the second priority language unless it is the current language
+        add_plugin(
+            language="fr",
+            placeholder=placeholder,
+            plugin_type="CategoryPlugin",
+            **{"page": category2.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_categories()), [category2])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_categories()), [category2])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_categories()), [category1])
+
+        # Reverse plugin lookups should stick to the current language if available and
+        # ignore plugins on fallback languages
+        add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="CategoryPlugin",
+            **{"page": category3.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_categories()), [category3])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_categories()), [category2])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_categories()), [category1])
+
     def test_models_course_get_categories_other_placeholders(self):
         """
         The `get_categories` method should return all categories linked to a course via a plugin
@@ -358,7 +430,7 @@ class CourseModelsTestCase(TestCase):
             list(course.public_extension.get_organizations()), published_organizations
         )
 
-    def test_models_course_get_organizations_language(self):
+    def test_models_course_get_organizations_language_current(self):
         """
         The `get_organizations` method should only return organizations linked to a course by
         a plugin in the current language.
@@ -389,6 +461,82 @@ class CourseModelsTestCase(TestCase):
 
         with translation.override("en"):
             self.assertEqual(list(course.get_organizations()), [organization_en])
+
+    @override_settings(
+        LANGUAGES=(("en", "en"), ("fr", "fr"), ("de", "de")),
+        CMS_LANGUAGES={
+            "default": {
+                "public": True,
+                "hide_untranslated": False,
+                "redirect_on_fallback": False,
+                "fallbacks": ["en", "fr", "de"],
+            }
+        },
+    )
+    def test_models_course_get_organizations_language_fallback(self):
+        """
+        The `get_organizations` method should return organizations linked to a course by
+        a plugin in fallback language by order of falling back.
+        """
+        (
+            organization1,
+            organization2,
+            organization3,
+        ) = factories.OrganizationFactory.create_batch(3, should_publish=True)
+        course = factories.CourseFactory(should_publish=True)
+        placeholder = course.extended_object.placeholders.get(
+            slot="course_organizations"
+        )
+
+        # Plugin lookups should fallback up to the second priority language
+        add_plugin(
+            language="de",
+            placeholder=placeholder,
+            plugin_type="OrganizationPlugin",
+            **{"page": organization1.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_organizations()), [organization1])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_organizations()), [organization1])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_organizations()), [organization1])
+
+        # Plugin lookups should fallback to the first priority language if available
+        # and ignore the second priority language unless it is the current language
+        add_plugin(
+            language="fr",
+            placeholder=placeholder,
+            plugin_type="OrganizationPlugin",
+            **{"page": organization2.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_organizations()), [organization2])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_organizations()), [organization2])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_organizations()), [organization1])
+
+        # Reverse plugin lookups should stick to the current language if available and
+        # ignore plugins on fallback languages
+        add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="OrganizationPlugin",
+            **{"page": organization3.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_organizations()), [organization3])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_organizations()), [organization2])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_organizations()), [organization1])
 
     def test_models_course_get_organizations_other_placeholders(self):
         """
@@ -520,6 +668,78 @@ class CourseModelsTestCase(TestCase):
 
         with translation.override("en"):
             self.assertEqual(list(course.get_persons()), [person_en])
+
+    @override_settings(
+        LANGUAGES=(("en", "en"), ("fr", "fr"), ("de", "de")),
+        CMS_LANGUAGES={
+            "default": {
+                "public": True,
+                "hide_untranslated": False,
+                "redirect_on_fallback": False,
+                "fallbacks": ["en", "fr", "de"],
+            }
+        },
+    )
+    def test_models_course_get_persons_language_fallback(self):
+        """
+        The `get_persons` method should return persons linked to a course by
+        a plugin in fallback language by order of falling back.
+        """
+        person1, person2, person3 = factories.PersonFactory.create_batch(
+            3, should_publish=True
+        )
+        course = factories.CourseFactory(should_publish=True)
+        placeholder = course.extended_object.placeholders.get(slot="course_team")
+
+        # Plugin lookups should fallback up to the second priority language
+        add_plugin(
+            language="de",
+            placeholder=placeholder,
+            plugin_type="PersonPlugin",
+            **{"page": person1.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_persons()), [person1])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_persons()), [person1])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_persons()), [person1])
+
+        # Plugin lookups should fallback to the first priority language if available
+        # and ignore the second priority language unless it is the current language
+        add_plugin(
+            language="fr",
+            placeholder=placeholder,
+            plugin_type="PersonPlugin",
+            **{"page": person2.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_persons()), [person2])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_persons()), [person2])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_persons()), [person1])
+
+        # Reverse plugin lookups should stick to the current language if available and
+        # ignore plugins on fallback languages
+        add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="PersonPlugin",
+            **{"page": person3.extended_object},
+        )
+        with translation.override("en"):
+            self.assertEqual(list(course.get_persons()), [person3])
+
+        with translation.override("fr"):
+            self.assertEqual(list(course.get_persons()), [person2])
+
+        with translation.override("de"):
+            self.assertEqual(list(course.get_persons()), [person1])
 
     def test_models_course_get_persons_other_placeholders(self):
         """

--- a/tests/apps/courses/test_templates_blogpost_detail.py
+++ b/tests/apps/courses/test_templates_blogpost_detail.py
@@ -105,11 +105,17 @@ class DetailBlogPostCMSTestCase(CMSTestCase):
             ),
             html=True,
         )
-        self.assertNotContains(
+        self.assertContains(
             response,
-            category.extended_object.get_title(),
+            (
+                '<a class="category-tag category-tag--draft" '
+                'href="{:s}"><span class="category-tag__title">{:s}</span></a>'
+            ).format(
+                category.extended_object.get_absolute_url(),
+                category.extended_object.get_title(),
+            ),
+            html=True,
         )
-
         self.assertContains(
             response,
             '<p class="blogpost-detail__pubdate">Not published yet</p>',

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -260,10 +260,17 @@ class OrganizationCMSTestCase(CMSTestCase):
             ),
             html=True,
         )
-        # The not published category should not be on the page
-        self.assertNotContains(
+        # The not published category should be on the page
+        self.assertContains(
             response,
-            not_published_category.extended_object.get_title(),
+            (
+                '<a class="category-tag category-tag--draft" href="{:s}">'
+                '<span class="category-tag__title">{:s}</span></a>'
+            ).format(
+                not_published_category.extended_object.get_absolute_url(),
+                not_published_category.extended_object.get_title(),
+            ),
+            html=True,
         )
         # The modified draft category should not be leaked
         self.assertNotContains(response, "modified category")
@@ -275,8 +282,8 @@ class OrganizationCMSTestCase(CMSTestCase):
             html=True,
         )
 
-        # The not published course should not be on the page
-        self.assertNotContains(
+        # The not published course should be on the page
+        self.assertContains(
             response,
             not_published_course.extended_object.get_title(),
         )

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -226,12 +226,26 @@ class PersonCMSTestCase(CMSTestCase):
             html=True,
         )
         # The not published category should not be on the page
-        self.assertNotContains(
+        self.assertContains(
             response,
-            not_published_category.extended_object.get_title(),
+            (
+                '<a class="category-badge category-badge--draft" href="{:s}">'
+                '<span class="category-badge__title">{:s}</span></a>'
+            ).format(
+                not_published_category.extended_object.get_absolute_url(),
+                not_published_category.extended_object.get_title(),
+            ),
+            html=True,
         )
 
         # The published organization should be on the page in its published version
+        self.assertContains(
+            response,
+            '<a class="organization-glimpse" '
+            'href="{:s}"'.format(
+                published_organization.extended_object.get_absolute_url()
+            ),
+        )
         self.assertContains(
             response,
             '<div class="organization-glimpse__title">{:s}</div>'.format(
@@ -239,10 +253,20 @@ class PersonCMSTestCase(CMSTestCase):
             ),
             html=True,
         )
-
         # The not published organization should not be on the page
-        self.assertNotContains(
-            response, not_published_organization.extended_object.get_title()
+        self.assertContains(
+            response,
+            '<a class="organization-glimpse organization-glimpse--draft" '
+            'href="{:s}"'.format(
+                not_published_organization.extended_object.get_absolute_url()
+            ),
+        )
+        self.assertContains(
+            response,
+            '<div class="organization-glimpse__title">{:s}</div>'.format(
+                not_published_organization.extended_object.get_title()
+            ),
+            html=True,
         )
 
         self.assertNotContains(response, "modified")

--- a/tests/apps/search/test_indexers_categories.py
+++ b/tests/apps/search/test_indexers_categories.py
@@ -141,6 +141,42 @@ class CategoriesIndexersTestCase(TestCase):
             ],
         )
 
+    def test_indexers_categories_get_es_documents_language_fallback(self):
+        """Absolute urls should be computed as expected with language fallback."""
+        # Our meta category and its page
+        meta = CategoryFactory(
+            page_parent=create_i18n_page({"fr": "Catégories"}, published=True),
+            page_reverse_id="subjects",
+            page_title={"en": "Subjects", "fr": "Sujets"},
+            fill_icon=True,
+            fill_logo=True,
+            should_publish=True,
+        )
+        category1 = CategoryFactory(
+            page_parent=meta.extended_object,
+            page_title={"fr": "ma première thématique"},
+            fill_icon=True,
+            fill_logo=True,
+            should_publish=True,
+        )
+        CategoryFactory(
+            page_parent=category1.extended_object,
+            page_title={"fr": "ma deuxième thématic"},
+            should_publish=True,
+        )
+
+        self.assertEqual(
+            list(
+                CategoriesIndexer.get_es_documents(
+                    index="some_index", action="some_action"
+                )
+            )[0]["absolute_url"],
+            {
+                "en": "/en/categories/sujets/ma-premiere-thematique/ma-deuxieme-thematic/",
+                "fr": "/fr/categories/sujets/ma-premiere-thematique/ma-deuxieme-thematic/",
+            },
+        )
+
     def test_indexers_categories_format_es_object_for_api(self):
         """
         Make sure format_es_object_for_api returns a properly formatted category.

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -299,7 +299,10 @@ class CoursesIndexersTestCase(TestCase):
                     "_index": "some_index",
                     "_op_type": "some_action",
                     "_type": "course",
-                    "absolute_url": {"en": "/en/enhanced-incremental-circuit/"},
+                    "absolute_url": {
+                        "en": "/en/enhanced-incremental-circuit/",
+                        "fr": "/fr/enhanced-incremental-circuit/",
+                    },
                     "categories": [],
                     "categories_names": {},
                     "complete": {
@@ -486,6 +489,22 @@ class CoursesIndexersTestCase(TestCase):
         self.assertEqual(
             indexed_courses[0]["icon"],
             {"en": {"color": "#654321", "title": category.extended_object.get_title()}},
+        )
+
+    def test_indexers_courses_get_es_documents_language_fallback(self):
+        """Absolute urls should be computed as expected with language fallback."""
+        CourseFactory(should_publish=True, page_title={"fr": "un titre court français"})
+
+        indexed_courses = list(
+            CoursesIndexer.get_es_documents(index="some_index", action="some_action")
+        )
+
+        self.assertEqual(
+            indexed_courses[0]["absolute_url"],
+            {
+                "en": "/en/un-titre-court-francais/",
+                "fr": "/fr/un-titre-court-francais/",
+            },
         )
 
     def test_indexers_courses_format_es_object_for_api(self):

--- a/tests/apps/search/test_indexers_organizations.py
+++ b/tests/apps/search/test_indexers_organizations.py
@@ -121,6 +121,28 @@ class OrganizationsIndexersTestCase(TestCase):
             ],
         )
 
+    def test_indexers_organizations_get_es_documents_language_fallback(self):
+        """Absolute urls should be computed as expected with language fallback."""
+        OrganizationFactory(
+            page_title={
+                "fr": "ma première organisation",
+            },
+            should_publish=True,
+        )
+        indexed_organizations = list(
+            OrganizationsIndexer.get_es_documents(
+                index="some_index", action="some_action"
+            )
+        )
+
+        self.assertEqual(
+            indexed_organizations[0]["absolute_url"],
+            {
+                "en": "/en/ma-premiere-organisation/",
+                "fr": "/fr/ma-premiere-organisation/",
+            },
+        )
+
     def test_indexers_organizations_format_es_object_for_api(self):
         """
         Make sure format_es_object_for_api returns a properly formatted organization

--- a/tests/apps/search/test_indexers_persons.py
+++ b/tests/apps/search/test_indexers_persons.py
@@ -96,6 +96,26 @@ class PersonsIndexersTestCase(TestCase):
             ],
         )
 
+    def test_indexers_persons_get_es_documents_language_fallback(self):
+        """Absolute urls should be computed as expected with language fallback."""
+        PersonFactory(
+            page_title={
+                "fr": "ma première personne",
+            },
+            should_publish=True,
+        )
+        indexed_persons = list(
+            PersonsIndexer.get_es_documents(index="some_index", action="some_action")
+        )
+
+        self.assertEqual(
+            indexed_persons[0]["absolute_url"],
+            {
+                "en": "/en/ma-premiere-personne/",
+                "fr": "/fr/ma-premiere-personne/",
+            },
+        )
+
     def test_indexers_persons_format_es_object_for_api(self):
         """
         Make sure format_es_object_for_api returns a properly formatted person


### PR DESCRIPTION
## Purpose

When we rely on page extension plugins added in a language, to display on other languages via fallbacks, the reverse relation was broken.

For example: organizations added to the course page in english. They were displayed on the course's french page but the course did not display on the organization's french page.

## Proposal

Refactor the getter method to take into account fallback languages.
I took the opportunity to factorize the method ad added tests to secure the new behavior.
