### PR TITLE
🐛(lti_consumer) retrieve context through an api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix pace computation when it is under an hour
 
+### Changed
+
+- Retrieve LTI Consumer plugin context through an API endpoint
+
 ## [2.3.3] - 2021-03-25
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,9 @@ $ make migrate
 
 ## Unreleased
 
+- An API endpoint has been created to retrieve the context of a LTI Consumer plugin.
+  You need to append this route to api routes in your `urls` configuration.
+
 ## 2.1.x to 2.2.x
 
 - A new `COURSE_RUN_SYNC_NO_UPDATE_FIELDS` setting has been added to `RICHIE_LMS_BACKENDS`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -17,7 +17,9 @@ $ make migrate
 ## Unreleased
 
 - An API endpoint has been created to retrieve the context of a LTI Consumer plugin.
-  You need to append this route to api routes in your `urls` configuration.
+  You need to append this route to api routes in your `urls` configuration. Furthermore
+  to optimize db accesses, if a cache called `memory_cache` is defined in `CACHES`,
+  the response will be cached for 9min 30s.
 
 ## 2.1.x to 2.2.x
 

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -14,6 +14,7 @@ from cms.sitemaps import CMSSitemap
 
 from richie.apps.courses.urls import urlpatterns as courses_urlpatterns
 from richie.apps.search.urls import urlpatterns as search_urlpatterns
+from richie.plugins.urls import urlpatterns as plugins_urlpatterns
 
 # For now, we use URLPathVersioning to be consistent with fonzie. Fonzie uses it
 # because DRF OpenAPI only supports URLPathVersioning for now.
@@ -28,7 +29,7 @@ urlpatterns = [
     path(r"sitemap.xml", sitemap, {"sitemaps": {"cmspages": CMSSitemap}}),
     re_path(
         r"api/{}/".format(API_PREFIX),
-        include([*courses_urlpatterns, *search_urlpatterns]),
+        include([*courses_urlpatterns, *search_urlpatterns, *plugins_urlpatterns]),
     ),
     path(r"oauth/", include("social_django.urls", namespace="social")),
     path(r"", include("filer.server.urls")),

--- a/src/frontend/js/components/LtiConsumer/_styles.scss
+++ b/src/frontend/js/components/LtiConsumer/_styles.scss
@@ -1,12 +1,16 @@
 .lti-consumer {
-  animation: fadeIn 400ms ease-out forwards;
+  animation: fadeIn 600ms cubic-bezier(0.33, 1, 0.68, 1) forwards;
   background-color: #ffffff;
+
+  & > form {
+    display: none;
+  }
 }
 @keyframes fadeIn {
   from {
-    background-color: #ffffff00;
+    opacity: 0;
   }
   to {
-    background-color: #ffffff;
+    opacity: 1;
   }
 }

--- a/src/frontend/js/types/LtiConsumer.ts
+++ b/src/frontend/js/types/LtiConsumer.ts
@@ -14,9 +14,12 @@ export interface LtiConsumerContentParameters {
   roles: string;
   user_id: string;
 }
-
-export interface LtiConsumer {
+export interface LtiConsumerContext {
   url: string;
   content_parameters: LtiConsumerContentParameters;
   automatic_resizing: boolean;
+}
+
+export interface LtiConsumerProps {
+  id: number;
 }

--- a/src/richie/plugins/lti_consumer/api.py
+++ b/src/richie/plugins/lti_consumer/api.py
@@ -1,0 +1,39 @@
+"""Declare API endpoints for LTI Consumer Plugin"""
+from django.shortcuts import get_object_or_404
+
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from . import models
+
+
+class LTIConsumerViewsSet(viewsets.GenericViewSet):
+    """Viewset for LTI Consumer Plugin"""
+
+    @action(methods=["get"], detail=True, url_path="context")
+    # pylint: disable=no-self-use,unused-argument,invalid-name
+    def get_context(self, request, version=None, pk=None):
+        """Process context data for the LTI Consumer Plugin.
+
+        Parameters:
+        - pk: the primary key of the LTI Consumer plugin to get context
+
+        Returns:
+        - response (JSON Object):
+            - url: the LTI resource url
+            - content_paramters: all generated parameters related to the lti provider
+            - automatic_resizing: boolean to control automatic resizing
+
+        """
+        plugin = get_object_or_404(models.LTIConsumer, pk=pk)
+
+        edit = request.toolbar and request.toolbar.edit_mode_active
+
+        return Response(
+            {
+                "url": plugin.url,
+                "content_parameters": plugin.get_content_parameters(edit=edit),
+                "automatic_resizing": plugin.automatic_resizing,
+            }
+        )

--- a/src/richie/plugins/lti_consumer/api.py
+++ b/src/richie/plugins/lti_consumer/api.py
@@ -1,4 +1,6 @@
 """Declare API endpoints for LTI Consumer Plugin"""
+from django.core.cache import caches
+from django.core.cache.backends.base import InvalidCacheBackendError
 from django.shortcuts import get_object_or_404
 
 from rest_framework import viewsets
@@ -26,14 +28,27 @@ class LTIConsumerViewsSet(viewsets.GenericViewSet):
             - automatic_resizing: boolean to control automatic resizing
 
         """
-        plugin = get_object_or_404(models.LTIConsumer, pk=pk)
-
         edit = request.toolbar and request.toolbar.edit_mode_active
+        cache_key = f"lti_consumer_plugin__pk_{pk}__edit_{edit}"
 
-        return Response(
-            {
-                "url": plugin.url,
-                "content_parameters": plugin.get_content_parameters(edit=edit),
-                "automatic_resizing": plugin.automatic_resizing,
-            }
-        )
+        try:
+            cache = caches["memory_cache"]
+            response = cache.get(cache_key)
+            if response is not None:
+                return Response(response)
+        except InvalidCacheBackendError:
+            cache = None
+
+        plugin = get_object_or_404(models.LTIConsumer, pk=pk)
+        response = {
+            "automatic_resizing": plugin.automatic_resizing,
+            "content_parameters": plugin.get_content_parameters(edit=edit),
+            "url": plugin.url,
+        }
+
+        if cache is not None:
+            # Cache the response for 9 minutes 30 seconds,
+            # lti oauth credentials are stale after 10 minutes
+            cache.set(cache_key, response, 9.5 * 60)
+
+        return Response(response)

--- a/src/richie/plugins/lti_consumer/cms_plugins.py
+++ b/src/richie/plugins/lti_consumer/cms_plugins.py
@@ -1,8 +1,6 @@
 """
 LTI consumer CMS plugin
 """
-import json
-
 from django.utils.translation import gettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
@@ -35,24 +33,3 @@ class LTIConsumerPlugin(CMSPluginBase):
         """
 
         js = ("lti_consumer/js/change_form.js",)
-
-    def render(self, context, instance, placeholder):
-        """
-        Build plugin context passed to its template to perform rendering
-        and pass edit mode
-        """
-        edit = (
-            "request" in context
-            and context["request"].toolbar
-            and context["request"].toolbar.edit_mode_active
-        )
-
-        context = super().render(context, instance, placeholder)
-        context["widget_props"] = json.dumps(
-            {
-                "url": instance.url,
-                "content_parameters": instance.get_content_parameters(edit=edit),
-                "automatic_resizing": instance.automatic_resizing,
-            }
-        )
-        return context

--- a/src/richie/plugins/lti_consumer/models.py
+++ b/src/richie/plugins/lti_consumer/models.py
@@ -21,6 +21,8 @@ class LTIConsumer(CMSPlugin):
     LTI consumer plugin model.
     """
 
+    RESOURCE_NAME = "lti-consumer"
+
     url = models.URLField(
         verbose_name=_("LTI url"),
         help_text=_(

--- a/src/richie/plugins/lti_consumer/templates/richie/lti_consumer/lti_consumer.html
+++ b/src/richie/plugins/lti_consumer/templates/richie/lti_consumer/lti_consumer.html
@@ -1,5 +1,5 @@
 <div
   class="richie-react richie-react--lti-consumer aspect-ratio"
   style="{{ instance.inline_ratio_css_padding_bottom }}"
-  data-props='{{ widget_props }}'
+  data-props='{"id":{{ instance.pk }}}'
 ></div>

--- a/src/richie/plugins/lti_consumer/urls.py
+++ b/src/richie/plugins/lti_consumer/urls.py
@@ -1,0 +1,17 @@
+"""LTI Consumer plugin URLs configuration."""
+
+from django.urls import include, path
+
+from rest_framework.routers import DefaultRouter
+
+from . import models
+from .api import LTIConsumerViewsSet
+
+router = DefaultRouter()
+router.register(
+    models.LTIConsumer.RESOURCE_NAME,
+    LTIConsumerViewsSet,
+    basename="lti-consumer",
+)
+
+url_patterns = [path("", include(router.urls))]

--- a/src/richie/plugins/urls.py
+++ b/src/richie/plugins/urls.py
@@ -1,0 +1,9 @@
+"""
+Plugins urls
+"""
+
+from django.urls import include, path
+
+from richie.plugins.lti_consumer.urls import url_patterns as lti_consumer_url_patterns
+
+urlpatterns = [path("plugins/", include([*lti_consumer_url_patterns]))]

--- a/tests/plugins/lti_consumer/test_api.py
+++ b/tests/plugins/lti_consumer/test_api.py
@@ -5,11 +5,15 @@ Tests for LTI Consumer plugin api
 import json
 from unittest import mock
 
-from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
+from django.test.utils import override_settings
 
 from cms.api import add_plugin
 from cms.models import Placeholder
+from cms.toolbar.toolbar import CMSToolbar
 
+from richie.plugins.lti_consumer.api import LTIConsumerViewsSet
 from richie.plugins.lti_consumer.cms_plugins import LTIConsumerPlugin
 from richie.plugins.lti_consumer.factories import LTIConsumerFactory
 from richie.plugins.lti_consumer.models import LTIConsumer
@@ -57,3 +61,52 @@ class LtiConsumerPluginApiTestCase(TestCase):
             "/api/v1.0/plugins/lti-consumer/15003/context/", follow=True
         )
         self.assertEqual(response.status_code, 404)
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django_redis.cache.RedisCache",
+                "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
+                "OPTIONS": {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
+            },
+            "memory_cache": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+        }
+    )
+    @mock.patch.object(
+        LTIConsumer, "get_content_parameters", return_value="test_content"
+    )
+    def test_lti_consumer_view_set_get_context_method_is_cached(self, mock_params):
+        """
+        If "memory_cache" is defined, get_context method is cached
+        for 9 minutes and 30 seconds to optimize db accesses without return
+        stale oauth credentials.
+        """
+        placeholder = Placeholder.objects.create(slot="test")
+
+        lti_consumer = LTIConsumerFactory()
+        model_instance = add_plugin(
+            placeholder,
+            LTIConsumerPlugin,
+            "en",
+            url=lti_consumer.url,
+            lti_provider_id=lti_consumer.lti_provider_id,
+        )
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        request.session = {}
+        request.toolbar = CMSToolbar(request)
+        view_set = LTIConsumerViewsSet()
+
+        with self.assertNumQueries(1):
+            view_set.get_context(request, "v1.0", model_instance.pk)
+
+        mock_params.assert_called_once()
+
+        mock_params.reset_mock()
+
+        with self.assertNumQueries(0):
+            view_set.get_context(request, "v1.0", model_instance.pk)
+
+        mock_params.assert_not_called()

--- a/tests/plugins/lti_consumer/test_api.py
+++ b/tests/plugins/lti_consumer/test_api.py
@@ -1,0 +1,59 @@
+"""
+Tests for LTI Consumer plugin api
+"""
+
+import json
+from unittest import mock
+
+from django.test import TestCase
+
+from cms.api import add_plugin
+from cms.models import Placeholder
+
+from richie.plugins.lti_consumer.cms_plugins import LTIConsumerPlugin
+from richie.plugins.lti_consumer.factories import LTIConsumerFactory
+from richie.plugins.lti_consumer.models import LTIConsumer
+
+
+class LtiConsumerPluginApiTestCase(TestCase):
+    """Tests requests on LTI Consumer plugin API endpoints."""
+
+    @mock.patch.object(
+        LTIConsumer, "get_content_parameters", return_value="test_content"
+    )
+    def test_lti_consumer_api_get_context(self, mock_params):
+        """
+        Instianciating this plugin and make a request to its API endpoint
+        to get context
+        """
+        placeholder = Placeholder.objects.create(slot="test")
+
+        lti_consumer = LTIConsumerFactory()
+        model_instance = add_plugin(
+            placeholder,
+            LTIConsumerPlugin,
+            "en",
+            url=lti_consumer.url,
+            lti_provider_id=lti_consumer.lti_provider_id,
+        )
+
+        response = self.client.get(
+            f"/api/v1.0/plugins/lti-consumer/{model_instance.pk}/context/"
+        )
+        content = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(content["url"], lti_consumer.url)
+        self.assertEqual(content["automatic_resizing"], lti_consumer.automatic_resizing)
+        self.assertEqual(content["content_parameters"], "test_content")
+        mock_params.assert_called_once()
+
+    def test_lti_consumer_api_get_context_to_unknown_placeholder(self):
+        """
+        Making a context API request to an unknown plugin instance should return
+        a 404 error response.
+        """
+        response = self.client.get(
+            "/api/v1.0/plugins/lti-consumer/15003/context/", follow=True
+        )
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Purpose

When the page is cached, LTI Consumer plugin embedded could contain stale oauth parameters that cause authentication failure to the LTI service. To keep a relevant cache duration on our CMS pages, we decided to retrieve the LTI Consumer context through an API endpoint.


## Proposal
- [x] Add an API endpoint to retrieve fresh LTI Consumer context
