### PR TITLE
🐛(course) fix pace computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix pace computation when it is under an hour
+
 ## [2.3.3] - 2021-03-25
 
 ### Fixed

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -559,7 +559,7 @@ class Course(BasePageExtension):
         if pace_hours == 0:
             resolution = 15 if pace_minutes > 15 else 5
             return _("~{pace:d} {effort_unit!s}/{duration_unit!s}").format(
-                pace=round(pace / resolution) * resolution
+                pace=round(pace_minutes / resolution) * resolution
                 or 5,  # Display at least 5 minutes
                 effort_unit=time_units[defaults.MINUTE][1],
                 duration_unit=time_units[pace_reference_unit][0],

--- a/tests/apps/courses/test_models_course.py
+++ b/tests/apps/courses/test_models_course.py
@@ -1111,6 +1111,9 @@ class CourseModelsTestCase(TestCase):
         course = factories.CourseFactory(duration=[7, "day"], effort=[350, "minute"])
         self.assertEqual(course.get_pace_display(), "~45 minutes/day")
 
+        course = factories.CourseFactory(duration=[7, "day"], effort=[4, "hour"])
+        self.assertEqual(course.get_pace_display(), "~30 minutes/day")
+
     def test_models_course_get_pace_display_with_not_a_full_hour_pace(self):
         """
         If pace is not a full hour, a label with hour


### PR DESCRIPTION
## Purpose

When effort unit was hour and pace was under an hour, computation was wrong.

![Bug](https://trello-attachments.s3.amazonaws.com/6062fe71dce8175ad1894276/612x236/ba28762ec197ef2e023506e812e10561/Capture_2_-_NOTOK.png)

## Proposal

- [x] Fix computation for this case
