### PR TITLE
🚸(programs) remove date on program glimpse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Removed
+
+- Creation date displayed on program glimpses
+
 ### Fixed
 
 - Fix pace computation when it is under an hour

--- a/src/frontend/scss/objects/_program_glimpses.scss
+++ b/src/frontend/scss/objects/_program_glimpses.scss
@@ -92,23 +92,6 @@ $r-program-glimpse-gutter: 0.8rem !default;
     $absolute: false
   );
 
-  &__footer {
-    @include r-button-colors(r-theme-val(program-glimpse, footer), $apply-border: true);
-    display: flex;
-    padding: 0 0.5rem;
-    font-size: 0.8rem;
-    border-bottom-left-radius: $border-radius-lg;
-    border-bottom-right-radius: $border-radius-lg;
-  }
-
-  &__date {
-    @include sv-flex(1, 0, auto);
-    margin: 0;
-    padding: 0.75rem 0;
-    font-weight: bold;
-    line-height: 1.1;
-  }
-
   &:hover,
   &:focus {
     @if r-theme-val(program-glimpse, card-hover-border) {

--- a/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
@@ -25,11 +25,6 @@
                 {% show_placeholder "program_excerpt" program_page %}
             </p>
         </div>
-        <div class="program-glimpse__footer">
-            <p class="program-glimpse__date">
-                {{ program_page.creation_date|date:"DATE_FORMAT" }}
-            </p>
-        </div>
     </div>
 </a>
 {% endwith %}


### PR DESCRIPTION

## Purpose

The date displayed on the glimpse was the "creation_date" which is useless. 
The support team requested that it be removed.


## Proposal

Remove program glimpse footer with creation date.
