### PR TITLE
🐛(frontend) fix quality issues with <SearchFilterGroupModal />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add portuguese translations
 
+## Fixed
+
+- Fix small quality issues on the course search filters modal
+
 ## [2.4.0] - 2021-04-07
 
 ### Added

--- a/src/frontend/js/components/SearchFilterGroupModal/_styles.scss
+++ b/src/frontend/js/components/SearchFilterGroupModal/_styles.scss
@@ -70,10 +70,12 @@
     background: r-theme-val(search-filters-group-modal, close-background);
     border: none;
     border-top: 1px solid r-theme-val(search-filters-group-modal, close-border);
+    margin-top: -1px; // Avoid having a double border when the button overlaps with a list item
   }
 
   &__overlay {
-    z-index: 10; // Make sure the overlay is above any random 0-1-2 z-indexes in content
+    // Make sure the overlay is above any random 0-1-2 z-indexes in content and 200 z-index to the top bar
+    z-index: 300;
     position: fixed;
     top: 0;
     left: 0;
@@ -93,6 +95,27 @@
 
     &:hover {
       color: r-theme-val(search-filters-group-modal, button-color);
+    }
+  }
+}
+
+body.has-search-filter-group-modal {
+  overflow: hidden;
+
+  /*
+   * Flex children in a fixed/absolute container breaks Safari.
+   * Use a specific, admittedly hacky media query to target it with a special layout
+   * that solves the issue on that browser.
+   */
+  @media not all and (min-resolution: 0.001dpcm) {
+    @media all {
+      .search-filter-group-modal {
+        overflow: hidden;
+      }
+
+      .search-filter-group-modal__form__values {
+        overflow: auto;
+      }
     }
   }
 }

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { defineMessages, FormattedMessage, MessageDescriptor } from 'react-intl';
+import { defineMessages, FormattedMessage, MessageDescriptor, useIntl } from 'react-intl';
 import ReactModal from 'react-modal';
 
 import { fetchList } from 'data/getResourceList';
@@ -24,6 +24,16 @@ const messages = defineMessages({
     description:
       'Error message when the search for more filter value fails in the search filters modal.',
     id: 'components.SearchFilterGroupModal.error',
+  },
+  inputLabel: {
+    defaultMessage: 'Search for filters to add',
+    description: 'Accessible label for the search input in the search filter modal.',
+    id: 'components.SearchFilterGroupModal.inputLabel',
+  },
+  inputPlaceholder: {
+    defaultMessage: 'Search in { filterName }',
+    description: 'Placeholder message for the search input in the search filter modal.',
+    id: 'components.SearchFilterGroupModal.inputPlaceholder',
   },
   modalTitle: {
     defaultMessage: 'Add filters for {filterName}',
@@ -53,6 +63,8 @@ if (!isTestEnv) {
 }
 
 export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) => {
+  const intl = useIntl();
+
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [values, setValues] = useState([] as FilterValue[]);
   const [query, setQuery] = useState('');
@@ -124,12 +136,14 @@ export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) 
             <FormattedMessage {...messages.modalTitle} values={{ filterName: filter.human_name }} />
           </legend>
           <input
-            aria-label="Search for filters to add"
+            aria-label={intl.formatMessage(messages.inputLabel)}
             className="search-filter-group-modal__form__input"
             onChange={(event) => {
               setQuery(event.target.value);
             }}
-            placeholder={`Search in ${filter.human_name}`}
+            placeholder={intl.formatMessage(messages.inputPlaceholder, {
+              filterName: filter.human_name,
+            })}
           />
           {error ? (
             <div className="search-filter-group-modal__form__error">


### PR DESCRIPTION
## Purpose

There were several issues on `<SearchFilterGroupModal />`, which we're fixing here:

- placeholder and label for the search input were not localized;
<img width="1458" alt="Capture d’écran 2021-04-14 à 11 31 02" src="https://user-images.githubusercontent.com/1932937/114710682-4fee3600-9d2e-11eb-8910-2188586e2c8e.png">

- close button created a double border as it overlapped with a list item;
<img width="1458" alt="Capture d’écran 2021-04-14 à 11 31 11" src="https://user-images.githubusercontent.com/1932937/114710738-5da3bb80-9d2e-11eb-9139-c46918796f8d.png">

- positioning for the close button was broken in Safari;
<img width="1458" alt="Capture d’écran 2021-04-14 à 14 34 41" src="https://user-images.githubusercontent.com/1932937/114710969-ad828280-9d2e-11eb-931d-6de470c41cb1.png">

- document body kept scrolling even as the modal was opened.


## Proposal

For Safari I moved the scrolling container to the list of items as opposed to the whole modal. I also had to inject the Safari "hack" directly into the DOM as sass does not recognize it as valid CSS.

There's also another issue which I did not address: color contrast for the placeholder is not accessible. There's the same problem on the main search menu. I think both should be addressed together, I was not sure how we want to fix this (white input background, different colors, etc.)


