### PR TITLE
🐛(Search) fix filter pane quality issues on handheld devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Order blogposts by descending publication date within
   (person|category)_detail template
+- Fix filter pane quality issues on handheld devices
 - Fix small quality issues on the course search filters modal
 
 ## [2.4.0] - 2021-04-07

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -14,7 +14,11 @@ let mockMatches = false;
 jest.mock('utils/indirection/window', () => ({
   history: { pushState: jest.fn() },
   location: { search: '' },
-  matchMedia: () => ({ matches: mockMatches }),
+  matchMedia: () => ({
+    matches: mockMatches,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  }),
   scroll: jest.fn(),
 }));
 

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -7,9 +7,10 @@ import { SearchFiltersPane } from 'components/SearchFiltersPane';
 import { Spinner } from 'components/Spinner';
 import { useCourseSearch } from 'data/useCourseSearch';
 import { useCourseSearchParams, CourseSearchParamsAction } from 'data/useCourseSearchParams';
+import useMatchMedia from 'utils/useMatchMedia';
 import { RequestStatus } from 'types/api';
 import { CommonDataProps } from 'types/commonDataProps';
-import { matchMedia, scroll } from 'utils/indirection/window';
+import { scroll } from 'utils/indirection/window';
 
 const messages = defineMessages({
   errorMessage: {
@@ -40,7 +41,7 @@ const Search = ({ context }: CommonDataProps) => {
   const { courseSearchParams, lastDispatchActions } = useCourseSearchParams();
   const courseSearchResponse = useCourseSearch(courseSearchParams);
 
-  const alwaysShowFilters = matchMedia('(min-width: 992px)').matches;
+  const alwaysShowFilters = useMatchMedia('(min-width: 992px)');
   const [showFilters, setShowFilters] = useState(false);
 
   const [referenceId] = useState(`control-${Math.random()}`);

--- a/src/frontend/scss/components/_subheader.scss
+++ b/src/frontend/scss/components/_subheader.scss
@@ -6,6 +6,8 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
 .subheader {
   $subheader-selector: &;
   @include r-scheme-colors(r-theme-val(subheader, base));
+  position: relative;
+  z-index: 100;
 
   // Top level base container to include possible main background and basic
   // spacing

--- a/src/frontend/scss/components/templates/search/_search.scss
+++ b/src/frontend/scss/components/templates/search/_search.scss
@@ -47,6 +47,7 @@ $r-search-filters-width: 15rem !default;
     position: absolute;
     left: 0;
     max-width: 85vw;
+    padding: 0 2rem 1rem 2rem;
     transform: translateX(-100.1%);
     transition: ease-in-out 0.5s;
 
@@ -56,6 +57,7 @@ $r-search-filters-width: 15rem !default;
       left: auto;
       flex-basis: $r-search-filters-width;
       max-width: $r-search-filters-width;
+      padding: 0;
       transform: none;
     }
 
@@ -84,7 +86,6 @@ $r-search-filters-width: 15rem !default;
   }
 
   &__results {
-    position: relative;
     flex-grow: 1;
     flex-shrink: 0;
     flex-basis: 100%;


### PR DESCRIPTION
## Purpose

1. The button to open/close filter pane did not (dis)appear on window resize
2. There was quality issues on the search filter pane on handheld devices


## Proposal

- [x] useMatchMedia hook to show/hide button on window resize
- [x] fix filter pane quality issues


![Capture d’écran 2021-04-15 à 16 22 24-squashed-squashed](https://user-images.githubusercontent.com/9265241/114886512-df1b4c80-9e07-11eb-863e-74fdcd0e906a.jpg)
![Capture d’écran 2021-04-15 à 16 21 55-squashed-squashed](https://user-images.githubusercontent.com/9265241/114886518-e0e51000-9e07-11eb-8772-4be7342bf58d.jpg)
