### PR TITLE
✨(blogposts) add language fallback to get_related_blogposts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Add support for language fallback on "get_related_blogposts"
 - Add portuguese translations
 
 ## Fixed

--- a/tests/apps/courses/test_models_blogpost.py
+++ b/tests/apps/courses/test_models_blogpost.py
@@ -2,6 +2,8 @@
 Unit tests for the BlogPost model
 """
 from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import translation
 
 from cms.api import add_plugin, create_page
 
@@ -49,16 +51,16 @@ class BlogPostModelsTestCase(TestCase):
         self._attach_category(blogpost3.public_extension, category)
 
         # Draft blogposts
-        with self.assertNumQueries(1):
-            self.assertEqual(list(blogpost1.get_related_blogposts()), [blogpost2])
-        with self.assertNumQueries(1):
-            self.assertEqual(list(blogpost2.get_related_blogposts()), [blogpost1])
-        # 2 queries because blogpost3 page fields were not retrieved when attaching categories
         with self.assertNumQueries(2):
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [blogpost2])
+        with self.assertNumQueries(2):
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [blogpost1])
+        # 3 queries because blogpost3 page fields were not retrieved when attaching categories
+        with self.assertNumQueries(3):
             self.assertFalse(blogpost3.get_related_blogposts().exists())
 
         blogpost1_public = blogpost1.public_extension
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             self.assertEqual(
                 list(blogpost1_public.get_related_blogposts()),
                 [blogpost3.public_extension],
@@ -66,14 +68,108 @@ class BlogPostModelsTestCase(TestCase):
 
         # Public blogposts
         blogpost2_public = blogpost2.public_extension
-        # 2 queries because blogpost2.public_extension page fields were not retrieved when
+        # 3 queries because blogpost2.public_extension page fields were not retrieved when
         # attaching categories
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             self.assertFalse(blogpost2_public.get_related_blogposts().exists())
 
         blogpost3_public = blogpost3.public_extension
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             self.assertEqual(
                 list(blogpost3_public.get_related_blogposts()),
                 [blogpost1.public_extension],
             )
+
+    @override_settings(
+        CMS_LANGUAGES={
+            "default": {
+                "public": True,
+                "hide_untranslated": False,
+                "redirect_on_fallback": False,
+                "fallbacks": ["en", "fr", "de"],
+            }
+        }
+    )
+    # pylint: disable=too-many-statements
+    def test_models_blogpost_get_related_blogposts_language_fallback(self):
+        """
+        Validate that the related blogposts lookup works as expected with language fallback.
+        """
+        category1, category2, category3 = CategoryFactory.create_batch(
+            3, should_publish=True
+        )
+        blogpost, blogpost1, blogpost2, blogpost3 = BlogPostFactory.create_batch(
+            4, should_publish=True
+        )
+        ph_blogpost = blogpost.extended_object.placeholders.get(slot="categories")
+        ph_blogpost1 = blogpost1.extended_object.placeholders.get(slot="categories")
+        ph_blogpost2 = blogpost2.extended_object.placeholders.get(slot="categories")
+        ph_blogpost3 = blogpost3.extended_object.placeholders.get(slot="categories")
+
+        # Related blogpost lookup should fallback up to the second priority language
+        add_plugin(ph_blogpost, "CategoryPlugin", "de", page=category1.extended_object)
+        add_plugin(ph_blogpost1, "CategoryPlugin", "de", page=category1.extended_object)
+
+        with translation.override("en"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost1])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [blogpost])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [])
+
+        with translation.override("fr"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost1])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [blogpost])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [])
+
+        with translation.override("de"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost1])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [blogpost])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [])
+
+        # Reverse plugin lookups should fallback to the first priority language if available
+        # and ignore the second priority language unless it is the current language
+        add_plugin(ph_blogpost, "CategoryPlugin", "fr", page=category2.extended_object)
+        add_plugin(ph_blogpost2, "CategoryPlugin", "fr", page=category2.extended_object)
+
+        with translation.override("en"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost2])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [blogpost])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [])
+
+        with translation.override("fr"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost2])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [blogpost])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [])
+
+        with translation.override("de"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost1])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [blogpost])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [])
+
+        # Reverse plugin lookups should stick to the current language if available and
+        # ignore plugins on fallback languages
+        add_plugin(ph_blogpost, "CategoryPlugin", "en", page=category3.extended_object)
+        add_plugin(ph_blogpost3, "CategoryPlugin", "en", page=category3.extended_object)
+
+        with translation.override("en"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost3])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [blogpost])
+
+        with translation.override("fr"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost2])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [blogpost])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [])
+
+        with translation.override("de"):
+            self.assertEqual(list(blogpost.get_related_blogposts()), [blogpost1])
+            self.assertEqual(list(blogpost1.get_related_blogposts()), [blogpost])
+            self.assertEqual(list(blogpost2.get_related_blogposts()), [])
+            self.assertEqual(list(blogpost3.get_related_blogposts()), [])


### PR DESCRIPTION
### Purpose

The `get_related_blogposts` method on the blogpost model does not take into account language fallbacks.

## Proposal

Refactor the `get_related_blogposts` method on the blogpost model to take into account language fallbacks.
Write a test to secure this behavior.