### PR TITLE
🐛(base) fix initializeAccordions compatibility issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   (person|category)_detail template
 - Fix filter pane quality issues on handheld devices
 - Fix small quality issues on the course search filters modal
+- Fix initializeAccordions compatibility issue
 
 ### Changed
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -192,8 +192,15 @@
                 if ($accordionItems.length > 0) {
                     $accordionItems.forEach(function(itemObject, itemIndex) {
                         itemObject.addEventListener('click', function () {
-                            itemObject.closest('li').toggleAttribute('data-accordion-active');
-                            itemObject.toggleAttribute('data-accordion-open');
+                            var $closestLi = itemObject.closest('li');
+
+                            $closestLi.hasAttribute('data-accordion-active')
+                                ? $closestLi.removeAttribute('data-accordion-active')
+                                : $closestLi.setAttribute('data-accordion-active', true);
+
+                            itemObject.hasAttribute('data-accordion-open')
+                                ? itemObject.removeAttribute('data-accordion-open')
+                                : itemObject.setAttribute('data-accordion-open', true);
                         });
                     });
                 }


### PR DESCRIPTION
## Purpose

initializeAccordions used js `toggleAttribute` methods which [is not supported on old browsers](https://caniuse.com/?search=toggleAttribute). Sentry reports us that several users still use old browser versions. As accordions are not usable for this user, we have to fix it by using supported methods.

https://sentry.io/organizations/gip-fun-mooc/issues/2337198788/events/5a4bfa3cb94048b287982d58c4e985a1/events/?environment=production&project=1454000


## Proposal

- [x] Replace `toggleAttribute` by other method well supported.
