### PR TITLE
Fix/frontend issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Clean built frontend files before each build
+- Remove use of regexp group for JS_COURSE_REGEX setting
 
 ## [2.4.0] - 2021-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1161,6 +1161,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     by Richie.
 - Translations are loaded dynamically in frontend application,
 - Optimized frontend build in our official Docker image.
+- Debounce search requests
 
 ### Fixed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,10 @@ $ make migrate
 
 ## Unreleased
 
+- Named capturing group regex are still considered experimental in Javascript and may cause trouble
+  with old browsers, so we decided to remove this feature from Richie and use indexed capturing
+  group instead. As a consequence, you should update your `JS_COURSE_REGEX` setting to remove
+  the `course_id`named group.
 - Frontend JS is now generated into a dedicated `build` folder inside `static/js`. So if you need
   these scripts in templates, you have to update the script tag src to new destination.
   `static/js/index.js` becomes `static/js/build/index.js`

--- a/docs/lms-connection.md
+++ b/docs/lms-connection.md
@@ -23,7 +23,7 @@ RICHIE_LMS_BACKENDS=[
         "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
         "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
         "JS_BACKEND": "openedx-hawthorn",
-        "JS_COURSE_REGEX": r"^.*/course/(?<course_id>[0-9]*)$",
+        "JS_COURSE_REGEX": r"^.*/course/(.*)$",
     },
 ]
 ```

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -543,7 +543,9 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
 
     # For more details about CMS_CACHE_DURATION, see :
     # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations
-    CMS_CACHE_DURATIONS = values.DictValue({"menus": 0, "content": 0, "permissions": 0})
+    CMS_CACHE_DURATIONS = values.DictValue(
+        {"menus": 3600, "content": 60, "permissions": 3600}
+    )
 
     # Sessions
     SESSION_ENGINE = values.Value("django.contrib.sessions.backends.db")

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -298,7 +298,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 "base", environ_name="EDX_JS_BACKEND", environ_prefix=None
             ),
             "JS_COURSE_REGEX": values.Value(
-                r"^.*/courses/(?<course_id>.*)/course/?$",
+                r"^.*/courses/(.*)/course/?$",
                 environ_name="EDX_JS_COURSE_REGEX",
                 environ_prefix=None,
             ),
@@ -543,9 +543,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
 
     # For more details about CMS_CACHE_DURATION, see :
     # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations
-    CMS_CACHE_DURATIONS = values.DictValue(
-        {"menus": 3600, "content": 60, "permissions": 3600}
-    )
+    CMS_CACHE_DURATIONS = values.DictValue({"menus": 0, "content": 0, "permissions": 0})
 
     # Sessions
     SESSION_ENGINE = values.Value("django.contrib.sessions.backends.db")
@@ -621,7 +619,7 @@ class Test(Base):
             "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
             "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
             "JS_BACKEND": "base",
-            "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
+            "JS_COURSE_REGEX": r"^.*/courses/(.*)/course/?$",
         }
     ]
 

--- a/src/frontend/js/common/searchFields/index.tsx
+++ b/src/frontend/js/common/searchFields/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import debounce from 'lodash-es/debounce';
 
 import { StaticFilterDefinitions } from 'types/filters';
 import {
@@ -32,7 +33,7 @@ export const renderSuggestion: SearchAutosuggestProps['renderSuggestion'] = (sug
  * @param setSuggestions The suggestion setter method for the component using our helper.
  * @param incomingValue The current value of the search suggest form field.
  */
-export const onSuggestionsFetchRequested = async (
+const onSuggestionsFetchRequested = async (
   filters: StaticFilterDefinitions,
   setSuggestions: (suggestions: SearchSuggestionSection[]) => void,
   incomingValue: string,
@@ -61,6 +62,10 @@ export const onSuggestionsFetchRequested = async (
     sections.filter((section) => !!section!.values.length),
   );
 };
+
+export const onSuggestionsFetchRequestedDebounced = debounce(onSuggestionsFetchRequested, 200, {
+  maxWait: 1000,
+});
 
 /**
  * Helper to pick out the relevant filter for a suggestion from the general filters object.

--- a/src/frontend/js/components/RootSearchSuggestField/index.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.tsx
@@ -6,7 +6,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import {
   getRelevantFilter,
   getSuggestionValue,
-  onSuggestionsFetchRequested,
+  onSuggestionsFetchRequestedDebounced,
   renderSuggestion,
 } from 'common/searchFields';
 import { SearchInput } from 'components/SearchInput';
@@ -130,7 +130,7 @@ const RootSearchSuggestField = ({
       multiSection={true}
       onSuggestionsClearRequested={() => setSuggestions([])}
       onSuggestionsFetchRequested={async ({ value: incomingValue }) =>
-        onSuggestionsFetchRequested(await getFilters(), setSuggestions, incomingValue)
+        onSuggestionsFetchRequestedDebounced(await getFilters(), setSuggestions, incomingValue)
       }
       onSuggestionHighlighted={({ suggestion }) => setHasHighlightedSuggestion(!!suggestion)}
       onSuggestionSelected={onSuggestionSelected}

--- a/src/frontend/js/data/useCourseSearchParams/index.ts
+++ b/src/frontend/js/data/useCourseSearchParams/index.ts
@@ -1,7 +1,7 @@
 import { parse, stringify } from 'query-string';
-import { useContext, useEffect } from 'react';
+import { useEffect } from 'react';
 
-import { HistoryContext } from 'data/useHistory';
+import { useHistory } from 'data/useHistory';
 import { API_LIST_DEFAULT_PARAMS } from 'settings';
 import { APIListRequestParams } from 'types/api';
 import { FilterDefinition } from 'types/filters';
@@ -95,7 +95,7 @@ const courseSearchParamsReducer = (
 export const useCourseSearchParams = (): CourseSearchParamsState => {
   // Grab HistoryContext so we can be kept updated when other parts of the component tree use pushState
   // to change the user search through the query string.
-  const [historyEntry, pushState, replaceState] = useContext(HistoryContext);
+  const [historyEntry, pushState, replaceState] = useHistory();
 
   // HistoryEntry.state includes parse query strings, which if we're on a search page should be course search params
   const courseSearchParams: APIListRequestParams = historyEntry.state.data.params;

--- a/src/frontend/js/utils/api/lms/base.ts
+++ b/src/frontend/js/utils/api/lms/base.ts
@@ -5,8 +5,10 @@ import { ApiImplementation } from 'types/api';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
 const API = (APIConf: LMSBackend | AuthenticationBackend): ApiImplementation => {
-  const extractCourseIdFromUrl = (url: string): Maybe<Nullable<string>> =>
-    url.match((APIConf as LMSBackend).course_regexp)?.groups?.course_id;
+  const extractCourseIdFromUrl = (url: string): Maybe<Nullable<string>> => {
+    const matches = url.match((APIConf as LMSBackend).course_regexp);
+    return matches && matches[1] ? matches[1] : null;
+  };
 
   return {
     user: OpenEdxHawthornApiInterface(APIConf).user,

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
@@ -20,8 +20,10 @@ const API = (
   APIConf: AuthenticationBackend | LMSBackend,
   options?: ApiOptions,
 ): ApiImplementation => {
-  const extractCourseIdFromUrl = (url: string): Maybe<Nullable<string>> =>
-    url.match((APIConf as LMSBackend).course_regexp)?.groups?.course_id;
+  const extractCourseIdFromUrl = (url: string): Maybe<Nullable<string>> => {
+    const matches = url.match((APIConf as LMSBackend).course_regexp);
+    return matches && matches[1] ? matches[1] : null;
+  };
 
   const ROUTES = {
     user: {

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -3129,20 +3129,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001154:
-  version "1.0.30001154"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz#f3bbc245ce55e4c1cd20fa731b097880181a7f17"
-  integrity sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org==
-
-caniuse-lite@^1.0.30001166:
-  version "1.0.30001170"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
-  integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
-
-caniuse-lite@^1.0.30001181:
-  version "1.0.30001192"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz#b848ebc0ab230cf313d194a4775a30155d50ae40"
-  integrity sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==
+caniuse-lite@^1.0.30001154, caniuse-lite@^1.0.30001166, caniuse-lite@^1.0.30001181:
+  version "1.0.30001214"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz"
+  integrity sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Purpose

1. Old browsers does not support group regexp. So enrollment widget does not work on these browsers.
https://sentry.io/organizations/gip-fun-mooc/issues/2337189525/?environment=production&project=1454000&query=is%3Aunresolved

2. There are too much request to the search api endpoint.
From our search components, autocomplete and search queries are immediately fired on each user inputs that is too much. We have to debounce these requests. (The debounce was in place on SuggestField but did not work properly).

## Proposal

- [x] Remove use of group regexp from frontend
- [x] Debounce search requests
