### PR TITLE
🐛(search) avoid KeyError when a course is indexed with no titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixed
 
+- Avoid KeyError when an object is indexed with no titles
 - Add missing rel noopener noreferer on target blank links
 - Order blogposts by descending publication date within
   (person|category)_detail template

--- a/src/richie/apps/search/filter_definitions/courses.py
+++ b/src/richie/apps/search/filter_definitions/courses.py
@@ -180,7 +180,7 @@ class IndexableFilterDefinition(TermsQueryMixin, BaseFilterDefinition):
         # pylint: disable=unexpected-keyword-arg
         search_query_response = ES_CLIENT.search(
             # We only need the titles to get the i18n names
-            _source=["title.*"],
+            _source=["title"],
             index=indexer.index_name,
             doc_type=indexer.document_type,
             body={

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -62,7 +62,7 @@ class CategoriesIndexer:
         "logo",
         "nb_children",
         "path",
-        "title.*",
+        "title",
     ]
 
     @classmethod

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -212,7 +212,7 @@ class CoursesIndexer:
         "icon",
         "organization_highlighted",
         "organizations",
-        "title.*",
+        "title",
     ]
     form = CourseSearchForm
 

--- a/src/richie/apps/search/indexers/organizations.py
+++ b/src/richie/apps/search/indexers/organizations.py
@@ -47,7 +47,7 @@ class OrganizationsIndexer:
         },
     }
     scripts = {}
-    display_fields = ["absolute_url", "logo", "title.*"]
+    display_fields = ["absolute_url", "logo", "title"]
 
     @classmethod
     def get_es_document_for_organization(cls, organization, index=None, action="index"):

--- a/src/richie/apps/search/indexers/persons.py
+++ b/src/richie/apps/search/indexers/persons.py
@@ -51,7 +51,7 @@ class PersonsIndexer:
         },
     }
     scripts = {}
-    display_fields = ["absolute_url", "portrait", "title.*"]
+    display_fields = ["absolute_url", "portrait", "title"]
 
     @classmethod
     def get_es_document_for_person(cls, person, index=None, action="index"):

--- a/tests/apps/search/test_query_categories.py
+++ b/tests/apps/search/test_query_categories.py
@@ -30,7 +30,7 @@ class CategoriesQueryTestCase(TestCase):
     Test search queries on categories.
     """
 
-    def execute_query(self, kind, querystring=""):
+    def execute_query(self, kind, categories=None, querystring=""):
         """
         Not a test.
         This method is doing the heavy lifting for the tests in this class: create and fill the
@@ -68,7 +68,7 @@ class CategoriesQueryTestCase(TestCase):
                 "path": category["id"],
                 **category,
             }
-            for category in CATEGORIES
+            for category in categories or CATEGORIES
         ]
         bulk(actions=actions, chunk_size=500, client=ES_CLIENT)
         indices_client.refresh()
@@ -149,6 +149,45 @@ class CategoriesQueryTestCase(TestCase):
                         "path": "8312",
                         "title": "Literature",
                     }
+                ],
+            },
+        )
+
+    def test_query_categories_empty_content(self, *_):
+        """
+        Make sure no 500 error is raised if an empty category is indexed.
+        """
+        content = self.execute_query(
+            kind="subjects",
+            categories=[
+                {
+                    "id": "1234",
+                    "absolute_url": {},
+                    "description": {},
+                    "icon": {},
+                    "is_meta": False,
+                    "logo": {},
+                    "nb_children": 0,
+                    "path": "1234",
+                    "kind": "subjects",
+                    "title": {},
+                }
+            ],
+        )
+        self.assertEqual(
+            content,
+            {
+                "meta": {"count": 1, "offset": 0, "total_count": 1},
+                "objects": [
+                    {
+                        "id": "1234",
+                        "icon": None,
+                        "is_meta": False,
+                        "logo": None,
+                        "nb_children": 0,
+                        "path": "1234",
+                        "title": None,
+                    },
                 ],
             },
         )

--- a/tests/apps/search/test_query_courses_edge_cases.py
+++ b/tests/apps/search/test_query_courses_edge_cases.py
@@ -285,3 +285,34 @@ class EdgeCasesCoursesQueryTestCase(TestCase):
         result_ids = [o["id"] for o in content["objects"]]
         for index in range(3):
             self.assertEqual(str(index) in result_ids, index != hidden_id)
+
+    def test_query_courses_no_title(self, *_):
+        """
+        A course that has no title should not make the search fail with a 500 KeyError.
+        """
+        self.prepare_index(
+            [
+                {
+                    "absolute_url": {},
+                    "categories": [],
+                    "course_runs": [],
+                    "cover_image": {},
+                    "duration": {},
+                    "effort": {},
+                    "icon": {},
+                    "id": "xyz",
+                    "is_new": False,
+                    "is_listed": True,
+                    "organizations": [],
+                    "organizations_names": {},
+                    "title": {},
+                }
+            ]
+        )
+
+        response = self.client.get("/api/v1.0/courses/")
+        self.assertEqual(response.status_code, 200)
+
+        content = json.loads(response.content)
+        self.assertEqual(len(content["objects"]), 1)
+        self.assertEqual(content["objects"][0]["id"], "xyz")

--- a/tests/apps/search/test_viewsets_categories.py
+++ b/tests/apps/search/test_viewsets_categories.py
@@ -139,7 +139,7 @@ class CategoriesViewsetsTestCase(TestCase):
                 "logo",
                 "nb_children",
                 "path",
-                "title.*",
+                "title",
             ],
             body={
                 "query": {

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -296,7 +296,7 @@ class CoursesViewsetsTestCase(CMSTestCase):
                 "icon",
                 "organization_highlighted",
                 "organizations",
-                "title.*",
+                "title",
             ],
             body={
                 "aggs": {"some": "aggs"},

--- a/tests/apps/search/test_viewsets_organizations.py
+++ b/tests/apps/search/test_viewsets_organizations.py
@@ -96,7 +96,7 @@ class OrganizationsViewsetsTestCase(TestCase):
         )
         # The ES connector was called with a query that matches the client's request
         mock_search.assert_called_with(
-            _source=["absolute_url", "logo", "title.*"],
+            _source=["absolute_url", "logo", "title"],
             body={
                 "query": {
                     "bool": {

--- a/tests/apps/search/test_viewsets_persons.py
+++ b/tests/apps/search/test_viewsets_persons.py
@@ -104,7 +104,7 @@ class PersonsViewSetTestCase(TestCase):
         )
         # The ES connector was called with a query that matches the client's request
         mock_search.assert_called_with(
-            _source=["absolute_url", "portrait", "title.*"],
+            _source=["absolute_url", "portrait", "title"],
             body={
                 "query": {
                     "bool": {


### PR DESCRIPTION


## Purpose

A course should not get indexed with no titles, but if it does, querying the API should not raise a 500 error.

## Proposal

- Fix source fields definition to include the `title` field even if it's an empty dict.

