### PR TITLE
Feat/add fonzie authentication backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Add a new authentication backend `fonzie`
+
 ## [2.5.0] - 2021-04-21
 
 ### Added

--- a/src/frontend/js/types/User.ts
+++ b/src/frontend/js/types/User.ts
@@ -1,9 +1,10 @@
 export interface User {
+  access_token?: string;
   full_name?: string;
-  username: string;
   urls: {
     key: string;
     label: string;
     action: string | (() => void);
   }[];
+  username: string;
 }

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -37,30 +37,35 @@ export interface APICourseSearchResponse {
   objects: Course[];
 }
 
-export interface ApiImplementation {
-  user: {
-    me: () => Promise<Nullable<User>>;
-    login: () => void;
-    register: () => void;
-    logout: () => Promise<void>;
-  };
-  enrollment: {
-    get: (url: string, user: Nullable<User>) => Promise<Nullable<Enrollment>>;
-    isEnrolled: (url: string, user: Nullable<User>) => Promise<boolean>;
-    set: (url: string, user: User) => Promise<boolean>;
-  };
+export interface APIAuthentication {
+  login: () => void;
+  logout: () => Promise<void>;
+  me: () => Promise<Nullable<User>>;
+  register: () => void;
+}
+
+export interface APIEnrollment {
+  get: (url: string, user: Nullable<User>) => Promise<Nullable<Enrollment>>;
+  isEnrolled: (url: string, user: Nullable<User>) => Promise<boolean>;
+  set: (url: string, user: User) => Promise<boolean>;
+}
+
+export interface APILms {
+  user: APIAuthentication;
+  enrollment: APIEnrollment;
 }
 
 export interface ApiOptions {
   routes: {
-    [Model: string]: {
-      [Method: string]: string;
+    [key: string]: {
+      [key: string]: string;
     };
   };
 }
 
 export enum ApiBackend {
   BASE = 'base',
+  FONZIE = 'fonzie',
   OPENEDX_DOGWOOD = 'openedx-dogwood',
   OPENEDX_HAWTHORN = 'openedx-hawthorn',
 }

--- a/src/frontend/js/utils/api/authentication.ts
+++ b/src/frontend/js/utils/api/authentication.ts
@@ -8,12 +8,13 @@
 import { handle } from 'utils/errors/handle';
 import { AuthenticationBackend } from 'types/commonDataProps';
 import { Nullable } from 'utils/types';
-import { ApiImplementation, ApiBackend } from 'types/api';
+import { APIAuthentication, ApiBackend } from 'types/api';
 import BaseApiInterface from './lms/base';
 import OpenEdxDogwoodApiInterface from './lms/openedx-dogwood';
 import OpenEdxHawthornApiInterface from './lms/openedx-hawthorn';
+import OpenEdxFonzieApiInterface from './lms/openedx-fonzie';
 
-const AuthenticationAPIHandler = (): Nullable<ApiImplementation['user']> => {
+const AuthenticationAPIHandler = (): Nullable<APIAuthentication> => {
   const AUTHENTICATION: AuthenticationBackend = (window as any).__richie_frontend_context__?.context
     ?.authentication;
   if (!AUTHENTICATION) return null;
@@ -25,6 +26,8 @@ const AuthenticationAPIHandler = (): Nullable<ApiImplementation['user']> => {
       return OpenEdxDogwoodApiInterface(AUTHENTICATION).user;
     case ApiBackend.OPENEDX_HAWTHORN:
       return OpenEdxHawthornApiInterface(AUTHENTICATION).user;
+    case ApiBackend.FONZIE:
+      return OpenEdxFonzieApiInterface(AUTHENTICATION).user;
     default:
       handle(new Error(`No Authentication Backend found for ${AUTHENTICATION.backend}.`));
       return null;

--- a/src/frontend/js/utils/api/lms/base.ts
+++ b/src/frontend/js/utils/api/lms/base.ts
@@ -1,10 +1,10 @@
 import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
 import { Nullable, Maybe } from 'utils/types';
 import { User } from 'types/User';
-import { ApiImplementation } from 'types/api';
+import { APILms } from 'types/api';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
-const API = (APIConf: LMSBackend | AuthenticationBackend): ApiImplementation => {
+const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
   const extractCourseIdFromUrl = (url: string): Maybe<Nullable<string>> => {
     const matches = url.match((APIConf as LMSBackend).course_regexp);
     return matches && matches[1] ? matches[1] : null;

--- a/src/frontend/js/utils/api/lms/index.ts
+++ b/src/frontend/js/utils/api/lms/index.ts
@@ -1,6 +1,6 @@
 import { CommonDataProps } from 'types/commonDataProps';
 import { handle } from 'utils/errors/handle';
-import { ApiImplementation, ApiBackend } from 'types/api';
+import { APILms, ApiBackend } from 'types/api';
 import BaseApiInterface from './base';
 import OpenEdxDogwoodApiInterface from './openedx-dogwood';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
@@ -15,7 +15,7 @@ const selectAPIWithUrl = (url: string) => {
   return API;
 };
 
-const LmsAPIHandler = (url: string): ApiImplementation => {
+const LmsAPIHandler = (url: string): APILms => {
   const api = selectAPIWithUrl(url);
 
   switch (api?.backend) {

--- a/src/frontend/js/utils/api/lms/openedx-fonzie.ts
+++ b/src/frontend/js/utils/api/lms/openedx-fonzie.ts
@@ -4,11 +4,14 @@ import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
 /**
  *
- * OpenEdX Dogwood API Implementation
+ * OpenEdX completed by Fonzie API Implementation
  *
  * This implementation inherits from Hawthorn implementation.
- * The `user.me` method has to be overriden since `/user/v1/me` route does not
- * exist in OpenEdX Dogwood & Eucalyptus Rest API.
+ * The `user.me` method has to be overriden to retrieve user information from
+ * fonzie API to retrieve a JWT Token
+ *
+ * Related resources:
+ * https://github.com/openfun/fonzie/pull/24
  *
  */
 
@@ -16,7 +19,7 @@ const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
   const ApiOptions = {
     routes: {
       user: {
-        me: '/api/mobile/v0.5/my_user_info',
+        me: '/api/v1.0/user/me',
       },
     },
   };

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie';
 import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
 import { Maybe, Nullable } from 'utils/types';
 import { User } from 'types/User';
-import { ApiImplementation, ApiOptions } from 'types/api';
+import { APILms, ApiOptions } from 'types/api';
 import { location } from 'utils/indirection/window';
 import { handle } from 'utils/errors/handle';
 import { EDX_CSRF_TOKEN_COOKIE_NAME } from 'settings';
@@ -16,10 +16,7 @@ import { EDX_CSRF_TOKEN_COOKIE_NAME } from 'settings';
  *
  */
 
-const API = (
-  APIConf: AuthenticationBackend | LMSBackend,
-  options?: ApiOptions,
-): ApiImplementation => {
+const API = (APIConf: AuthenticationBackend | LMSBackend, options?: ApiOptions): APILms => {
   const extractCourseIdFromUrl = (url: string): Maybe<Nullable<string>> => {
     const matches = url.match((APIConf as LMSBackend).course_regexp);
     return matches && matches[1] ? matches[1] : null;


### PR DESCRIPTION
## Purpose

As a first step to integrate Richie to Joanie, we have to retrieve a JWT Token from the identity provider (currently openedx).
To retrieve authenticated user information with a signed jwt token, we added an
API route to OpenEdX through Fonzie. So, we have to add the support of this new authentication backend from Richie.


## Proposal

- [x] Add fonzie authentication backend
