### PR TITLE
🔧(docker) use a custom name for the app service on default network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,9 @@ services:
       - env.d/development/${DEV_ENV_FILE:-dev}
       - env.d/development/${DB_HOST:-postgresql}
     networks:
-      - default
+      default:
+        aliases:
+          - app-service
     volumes:
       - .:/app
       - ./data/static:/data/static

--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -1,5 +1,5 @@
 upstream richie-backend {
-  server app:8000 fail_timeout=0;
+  server app-service:8000 fail_timeout=0;
 }
 
 server {


### PR DESCRIPTION
## Purpose

Joanie, Richie and OpenEdX have to run over the same network. But both Richie and Joanie have a service called `app`. From Richie, `nginx` create a reverse proxy resolving urls with the domain `app`. If Joanie is run before Richie, the nginx service use the Joanie app service. To avoid this issue, we could add a network alias to the richie `app` service.

Related to https://github.com/openfun/joanie/pull/26

## Proposal

- [x] Update docker app service networks
- [x] Update nginx conf to use the network app service alias name
