### PR TITLE
💄(program) make related courses optional for program page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+- Make related courses optional for program page
+
 ## [2.6.0] - 2021-05-03
 
 ### Added

--- a/src/richie/apps/courses/templates/courses/cms/program_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_detail.html
@@ -54,14 +54,15 @@
         </div>
     </div>
 
-
-    <div class="program-detail__courses program-detail__block">
-        <div class="program-detail__row">
-            <section class="course-glimpse-list">
-                <h2 class="program-detail__title">{% trans "Related courses" %}</h2>
-                {% placeholder "program_courses" %}
-            </section>
+    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"program_courses" %}
+        <div class="program-detail__courses program-detail__block">
+            <div class="program-detail__row">
+                <section class="course-glimpse-list">
+                    <h2 class="program-detail__title">{% trans "Related courses" %}</h2>
+                    {% placeholder "program_courses" %}
+                </section>
+            </div>
         </div>
-    </div>
+    {% endif %}
 </div>
 {% endspaceless %}{% endblock content %}

--- a/tests/apps/courses/test_templates_program_detail.py
+++ b/tests/apps/courses/test_templates_program_detail.py
@@ -129,3 +129,32 @@ class ProgramCMSTestCase(CMSTestCase):
         )
         # The unpublished course should not be present on the page
         self.assertNotContains(response, courses[3].extended_object.get_title())
+
+    def test_templates_program_detail_cms_no_course(self):
+        """
+        Validate that a program without course doesn't show the course section
+        on a published program page but does on the draft program page
+        """
+        program = ProgramFactory(
+            page_title="Preums",
+            fill_cover=True,
+            fill_excerpt=True,
+            fill_body=True,
+        )
+        page = program.extended_object
+
+        # Publish the program and ensure the content is absent
+        page.publish("en")
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+        self.assertNotContains(
+            response, '<div class="program-detail__courses program-detail__block">'
+        )
+
+        # The content should be visible as draft to the staff user
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        response = self.client.get(url)
+        self.assertContains(
+            response, '<div class="program-detail__courses program-detail__block">'
+        )


### PR DESCRIPTION
## Purpose

To be able to present programs that won't have or doesn't yet have courses
ready to be presented.

## Proposal

Add an if statement to check for course presence
