### PR TITLE
🚑(LTIConsumer) fix lti context cache duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add a new authentication backend `fonzie`
 
+### Fixed
+
+- Decrease LTI context API endpoint cache lifetime to 5 minutes
+
 ## [2.5.0] - 2021-04-21
 
 ### Added

--- a/src/richie/plugins/lti_consumer/api.py
+++ b/src/richie/plugins/lti_consumer/api.py
@@ -47,8 +47,8 @@ class LTIConsumerViewsSet(viewsets.GenericViewSet):
         }
 
         if cache is not None:
-            # Cache the response for 9 minutes 30 seconds,
-            # lti oauth credentials are stale after 10 minutes
-            cache.set(cache_key, response, 9.5 * 60)
+            # Cache the response for 5 minutes,
+            # lti oauth credentials are stale after this delay.
+            cache.set(cache_key, response, 5 * 60)
 
         return Response(response)

--- a/tests/plugins/lti_consumer/test_api.py
+++ b/tests/plugins/lti_consumer/test_api.py
@@ -80,7 +80,7 @@ class LtiConsumerPluginApiTestCase(TestCase):
     def test_lti_consumer_view_set_get_context_method_is_cached(self, mock_params):
         """
         If "memory_cache" is defined, get_context method is cached
-        for 9 minutes and 30 seconds to optimize db accesses without return
+        for 5 minutes to optimize db accesses without return
         stale oauth credentials.
         """
         placeholder = Placeholder.objects.create(slot="test")


### PR DESCRIPTION
## Purpose

Previously, API endpoint to get lti context was cached for 9.5 minutes which was too long.
So some users can retrieve a stale context.


## Proposal

- [x] Decrease the cache lifetime to 5 minutes.
