### PR TITLE
Refactor/react query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add a new authentication backend `fonzie`
+- Add react-query to manage API requests and local data store
 
 ### Changed
 

--- a/src/frontend/js/components/Root/index.spec.tsx
+++ b/src/frontend/js/components/Root/index.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { IntlProvider } from 'react-intl';
 
 import { findByText, render } from '@testing-library/react';
@@ -13,6 +13,11 @@ jest.mock('components/RootSearchSuggestField', () => ({
   __esModule: true,
   default: ({ exampleProp }: { exampleProp: string }) =>
     `root search suggest field component rendered with ${exampleProp}`,
+}));
+
+jest.mock('data/useSession', () => ({
+  __esModule: true,
+  SessionProvider: (props: PropsWithChildren<any>) => props.children,
 }));
 
 describe('<Root />', () => {
@@ -73,7 +78,7 @@ describe('<Root />', () => {
     // Render the root component, passing our real element and our bogus one
     render(
       <IntlProvider locale="en">
-        <Root richieReactSpots={[userLoginContainer, userFeedbackContainer]} />
+        <Root richieReactSpots={[userFeedbackContainer, userLoginContainer]} />
       </IntlProvider>,
     );
 

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { QueryClientProvider } from 'react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { stringify } from 'query-string';
@@ -6,6 +7,7 @@ import { IntlProvider } from 'react-intl';
 
 import { History, HistoryContext } from 'data/useHistory';
 import * as mockWindow from 'utils/indirection/window';
+import createQueryClient from 'utils/react-query/createQueryClient';
 import { ContextFactory } from 'utils/test/factories';
 import { CommonDataProps } from 'types/commonDataProps';
 import Search from '.';
@@ -34,10 +36,11 @@ describe('<Search />', () => {
     historyPushState,
     historyReplaceState,
   ];
-
+  const queryClient = createQueryClient();
   const contextProps: CommonDataProps['context'] = ContextFactory().generate();
 
-  beforeEach(() => {
+  afterEach(() => {
+    queryClient.clear();
     fetchMock.restore();
     jest.resetAllMocks();
   });
@@ -51,11 +54,13 @@ describe('<Search />', () => {
     });
 
     render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByText('Loading search results...').parentElement).toHaveAttribute(
@@ -72,11 +77,13 @@ describe('<Search />', () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', 500);
 
     render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByText('Loading search results...').parentElement).toHaveAttribute(
@@ -100,11 +107,13 @@ describe('<Search />', () => {
 
     mockMatches = true;
     const { container } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     await waitFor(() => {
@@ -127,11 +136,13 @@ describe('<Search />', () => {
 
     mockMatches = false;
     const { container } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     await waitFor(() => {
@@ -189,17 +200,19 @@ describe('<Search />', () => {
       });
 
       render(
-        <IntlProvider locale="en">
-          <HistoryContext.Provider
-            value={makeHistoryOf({
-              limit: '20',
-              offset: '0',
-              lastDispatchActions: [{ type: 'FILTER_RESET' }],
-            })}
-          >
-            <Search context={contextProps} />
-          </HistoryContext.Provider>
-        </IntlProvider>,
+        <QueryClientProvider client={queryClient}>
+          <IntlProvider locale="en">
+            <HistoryContext.Provider
+              value={makeHistoryOf({
+                limit: '20',
+                offset: '0',
+                lastDispatchActions: [{ type: 'FILTER_RESET' }],
+              })}
+            >
+              <Search context={contextProps} />
+            </HistoryContext.Provider>
+          </IntlProvider>
+        </QueryClientProvider>,
       );
     });
 
@@ -219,17 +232,19 @@ describe('<Search />', () => {
       });
 
       render(
-        <IntlProvider locale="en">
-          <HistoryContext.Provider
-            value={makeHistoryOf({
-              limit: '20',
-              offset: '0',
-              lastDispatchActions: [{ type: 'QUERY_UPDATE' }],
-            })}
-          >
-            <Search context={contextProps} />
-          </HistoryContext.Provider>
-        </IntlProvider>,
+        <QueryClientProvider client={queryClient}>
+          <IntlProvider locale="en">
+            <HistoryContext.Provider
+              value={makeHistoryOf({
+                limit: '20',
+                offset: '0',
+                lastDispatchActions: [{ type: 'QUERY_UPDATE' }],
+              })}
+            >
+              <Search context={contextProps} />
+            </HistoryContext.Provider>
+          </IntlProvider>
+        </QueryClientProvider>,
       );
     });
 

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -39,7 +39,7 @@ const messages = defineMessages({
 
 const Search = ({ context }: CommonDataProps) => {
   const { courseSearchParams, lastDispatchActions } = useCourseSearchParams();
-  const courseSearchResponse = useCourseSearch(courseSearchParams);
+  const { data: courseSearchResponse } = useCourseSearch(courseSearchParams);
 
   const alwaysShowFilters = useMatchMedia('(min-width: 992px)');
   const [showFilters, setShowFilters] = useState(false);

--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -2,10 +2,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
+import { QueryClientProvider } from 'react-query';
 
 import { fetchList } from 'data/getResourceList';
 import { History, HistoryContext } from 'data/useHistory';
-import { APIListRequestParams } from 'types/api';
+import { APIListRequestParams, RequestStatus } from 'types/api';
+import createQueryClient from 'utils/react-query/createQueryClient';
 
 import { SearchFilterValueParent } from '.';
 
@@ -27,32 +29,38 @@ describe('<SearchFilterValueParent />', () => {
     historyPushState,
     historyReplaceState,
   ];
+  const queryClient = createQueryClient();
 
-  afterEach(jest.resetAllMocks);
+  afterEach(() => {
+    queryClient.clear();
+    jest.resetAllMocks();
+  });
 
   it('renders the parent filter value and a button to show the children', () => {
     const { getByLabelText, queryByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '00010002',
-              has_more_values: false,
-              human_name: 'Subjects',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'subjects',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 12,
-              human_name: 'Literature',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '00010002',
+                has_more_values: false,
+                human_name: 'Subjects',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'subjects',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 12,
+                human_name: 'Literature',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     getByLabelText((content) => content.startsWith('Literature'));
@@ -66,6 +74,7 @@ describe('<SearchFilterValueParent />', () => {
 
   it('shows the children when one of them is active', async () => {
     mockFetchList.mockResolvedValue({
+      status: RequestStatus.SUCCESS,
       content: {
         filters: {
           subjects: {
@@ -88,27 +97,29 @@ describe('<SearchFilterValueParent />', () => {
 
     // Helper to get the React element with the expected params
     const getElement = (params: APIListRequestParams) => (
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf(params)}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '00010002',
-              has_more_values: false,
-              human_name: 'Subjects',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'subjects',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 12,
-              human_name: 'Literature',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf(params)}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '00010002',
+                has_more_values: false,
+                human_name: 'Subjects',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'subjects',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 12,
+                human_name: 'Literature',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>
     );
     const { getByLabelText, queryByLabelText, rerender } = render(
       getElement({ limit: '999', offset: '0', subjects: [] }),
@@ -133,6 +144,7 @@ describe('<SearchFilterValueParent />', () => {
 
   it('hides/shows the children when the user clicks on the toggle button', async () => {
     mockFetchList.mockResolvedValue({
+      status: RequestStatus.SUCCESS,
       content: {
         filters: {
           subjects: {
@@ -154,33 +166,35 @@ describe('<SearchFilterValueParent />', () => {
     } as any);
 
     const { getByLabelText, queryByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({
-            limit: '999',
-            offset: '0',
-            subjects: ['L-000400050004'],
-          })}
-        >
-          <SearchFilterValueParent
-            filter={{
-              base_path: '00010002',
-              has_more_values: false,
-              human_name: 'Subjects',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'subjects',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 12,
-              human_name: 'Literature',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider
+            value={makeHistoryOf({
+              limit: '999',
+              offset: '0',
+              subjects: ['L-000400050004'],
+            })}
+          >
+            <SearchFilterValueParent
+              filter={{
+                base_path: '00010002',
+                has_more_values: false,
+                human_name: 'Subjects',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'subjects',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 12,
+                human_name: 'Literature',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     getByLabelText((content) => content.startsWith('Literature'));
@@ -232,27 +246,29 @@ describe('<SearchFilterValueParent />', () => {
 
   it('shows the parent filter value itself as inactive when it is not in the search params', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 217,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 217,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     // The filter value is displayed with its facet count
@@ -265,27 +281,29 @@ describe('<SearchFilterValueParent />', () => {
 
   it('disables the parent value when its count is 0', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 0,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 0,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     // The filter shows its active state
@@ -296,33 +314,35 @@ describe('<SearchFilterValueParent />', () => {
   });
   it('shows the parent filter value itself as active when it is in the search params', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({
-            filter_name: 'P-00040005',
-            limit: '999',
-            offset: '0',
-          })}
-        >
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 218,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider
+            value={makeHistoryOf({
+              filter_name: 'P-00040005',
+              limit: '999',
+              offset: '0',
+            })}
+          >
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 218,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     const checkbox = getByLabelText((content) => content.startsWith('Human name'));
@@ -333,27 +353,29 @@ describe('<SearchFilterValueParent />', () => {
 
   it('dispatches a FILTER_ADD action on filter click if it was not active', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 217,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 217,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     fireEvent.click(getByLabelText((content) => content.startsWith('Human name')));
@@ -372,33 +394,35 @@ describe('<SearchFilterValueParent />', () => {
 
   it('dispatches a FILTER_REMOVE action on filter click if it was active', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({
-            filter_name: 'P-00040005',
-            limit: '999',
-            offset: '0',
-          })}
-        >
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 217,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider
+            value={makeHistoryOf({
+              filter_name: 'P-00040005',
+              limit: '999',
+              offset: '0',
+            })}
+          >
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 217,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     fireEvent.click(getByLabelText((content) => content.startsWith('Human name')));

--- a/src/frontend/js/components/UserLogin/index.spec.tsx
+++ b/src/frontend/js/components/UserLogin/index.spec.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
+import faker from 'faker';
+import { QueryClientProvider } from 'react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { IntlProvider } from 'react-intl';
-
-import { ContextFactory } from 'utils/test/factories';
-import { SESSION_CACHE_KEY } from 'settings';
-import faker from 'faker';
-import { Deferred } from 'utils/test/deferred';
 import { act } from 'react-dom/test-utils';
+
+import { ContextFactory, PersistedClientFactory, QueryStateFactory } from 'utils/test/factories';
+import { Deferred } from 'utils/test/deferred';
+import createQueryClient from 'utils/react-query/createQueryClient';
+import { REACT_QUERY_SETTINGS } from 'settings';
 
 jest.mock('utils/errors/handle', () => ({
   handle: jest.fn(),
@@ -31,11 +33,10 @@ describe('<UserLogin />', () => {
   const initializeUser = () => {
     const username = faker.internet.userName();
     sessionStorage.setItem(
-      SESSION_CACHE_KEY,
-      btoa(
-        JSON.stringify({
-          value: { username },
-          expiredAt: Date.now() + 60_0000,
+      REACT_QUERY_SETTINGS.cacheStorage.key,
+      JSON.stringify(
+        PersistedClientFactory({
+          queries: [QueryStateFactory('user', { data: { username } })],
         }),
       ),
     );
@@ -50,13 +51,17 @@ describe('<UserLogin />', () => {
   it('gets and renders the user name and a dropdown containing a logout link', async () => {
     const username = initializeUser();
 
-    const { getByText, queryByText } = render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <UserLogin context={contextProps} />
-        </SessionProvider>
-      </IntlProvider>,
-    );
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <UserLogin context={contextProps} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
 
     const button = screen.getByRole('button', {
       name: `Access to your profile settings ${username}`,
@@ -64,9 +69,9 @@ describe('<UserLogin />', () => {
 
     userEvent.click(button);
 
-    getByText(username);
-    getByText('Log out');
-    expect(queryByText('Loading login status...')).toBeNull();
+    screen.getByText(username);
+    screen.getByText('Log out');
+    expect(screen.queryByText('Loading login status...')).toBeNull();
   });
 
   it('renders signup/login buttons when the user is not logged in', async () => {
@@ -74,11 +79,13 @@ describe('<UserLogin />', () => {
     fetchMock.get('https://endpoint.test/api/user/v1/me', loginDeferred.promise);
 
     const { getByText, queryByText } = render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <UserLogin context={contextProps} />
-        </SessionProvider>
-      </IntlProvider>,
+      <QueryClientProvider client={createQueryClient({ persistor: true })}>
+        <IntlProvider locale="en">
+          <SessionProvider>
+            <UserLogin context={contextProps} />
+          </SessionProvider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     await act(async () => {
@@ -90,20 +97,24 @@ describe('<UserLogin />', () => {
     expect(queryByText('Loading login status...')).toBeNull();
   });
 
-  it('should renders profile urls and bind user info if needed', () => {
+  it('should renders profile urls and bind user info if needed', async () => {
     const username = initializeUser();
     const profileUrls = {
       settings: { label: 'Settings', action: 'https://auth.local.test/settings' },
       account: { label: 'Account', action: 'https://auth.local.test/u/(username)' },
     };
 
-    const { getByText, getByRole } = render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <UserLogin context={contextProps} profileUrls={profileUrls} />
-        </SessionProvider>
-      </IntlProvider>,
-    );
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <UserLogin context={contextProps} profileUrls={profileUrls} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
 
     const button = screen.getByRole('button', {
       name: `Access to your profile settings ${username}`,
@@ -111,9 +122,9 @@ describe('<UserLogin />', () => {
 
     userEvent.click(button);
 
-    getByText(username);
-    const settingsLink = getByRole('link', { name: 'Settings' });
-    const accountLink = getByRole('link', { name: 'Account' });
+    screen.getByText(username);
+    const settingsLink = screen.getByRole('link', { name: 'Settings' });
+    const accountLink = screen.getByRole('link', { name: 'Account' });
     expect(settingsLink.getAttribute('href')).toEqual('https://auth.local.test/settings');
     expect(accountLink.getAttribute('href')).toEqual(`https://auth.local.test/u/${username}`);
   });

--- a/src/frontend/js/components/UserMenu/DesktopUserMenu.tsx
+++ b/src/frontend/js/components/UserMenu/DesktopUserMenu.tsx
@@ -65,7 +65,6 @@ export const DesktopUserMenu: React.FC<UserMenuProps> = ({ user }) => {
                 <button
                   className={`selector__list__link
                   ${highlightedIndex === index ? 'selector__list__link--highlighted' : ''}`}
-                  onClick={link.action}
                 >
                   {link.label}
                 </button>

--- a/src/frontend/js/components/UserMenu/index.spec.tsx
+++ b/src/frontend/js/components/UserMenu/index.spec.tsx
@@ -7,6 +7,8 @@ import { UserMenu } from '.';
 /* Enforce to use DesktopUserMenu by default */
 let mockMatches = true;
 
+const logout = jest.fn();
+
 const props = {
   user: {
     username: 'John Doe',
@@ -14,7 +16,7 @@ const props = {
       {
         key: 'logout',
         label: 'Log out',
-        action: '/logout',
+        action: logout,
       },
       {
         key: 'profile',
@@ -39,6 +41,8 @@ jest.mock('utils/indirection/window', () => ({
 }));
 
 describe('<UserMenu />', () => {
+  afterEach(() => jest.resetAllMocks());
+
   it('renders a dropdown with links matching the data passed to the "link" prop', async () => {
     render(
       <IntlProvider locale="en">
@@ -54,7 +58,11 @@ describe('<UserMenu />', () => {
 
     screen.getByRole('link', { name: 'Profile' });
     screen.getByRole('link', { name: 'My Dashboard' });
-    screen.getByRole('link', { name: 'Log out' });
+    const logoutButton = screen.getByRole('button', { name: 'Log out' });
+
+    userEvent.click(logoutButton);
+
+    expect(logout).toHaveBeenCalledTimes(1);
   });
 
   it('renders a list of links matching the data passed to the "link" prop on Mobile/Tablet', async () => {
@@ -70,6 +78,10 @@ describe('<UserMenu />', () => {
     screen.getByRole('heading', { name: 'John Doe' });
     screen.getByRole('link', { name: 'Profile' });
     screen.getByRole('link', { name: 'My Dashboard' });
-    screen.getByRole('link', { name: 'Log out' });
+    const logoutButton = screen.getByRole('button', { name: 'Log out' });
+
+    userEvent.click(logoutButton);
+
+    expect(logout).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/frontend/js/data/useCourseSearch/index.ts
+++ b/src/frontend/js/data/useCourseSearch/index.ts
@@ -1,18 +1,24 @@
-import { useState } from 'react';
+import { UseQueryOptions, useQuery } from 'react-query';
 
 import { APIListRequestParams } from 'types/api';
-import { Nullable } from 'types/utils';
-import { useAsyncEffect } from 'utils/useAsyncEffect';
 import { fetchList, FetchListResponse } from '../getResourceList';
 
-export const useCourseSearch = (searchParams: APIListRequestParams) => {
-  const [courseSearchResponse, setCourseSearchResponse] =
-    useState<Nullable<FetchListResponse>>(null);
-
-  useAsyncEffect(async () => {
-    const response = await fetchList('courses', searchParams);
-    setCourseSearchResponse(response);
-  }, [searchParams]);
-
-  return courseSearchResponse;
+export const useCourseSearch = (
+  searchParams: APIListRequestParams,
+  queryOptions: UseQueryOptions<
+    FetchListResponse,
+    unknown,
+    FetchListResponse,
+    (string | APIListRequestParams)[]
+  > = {},
+) => {
+  const queryKey = ['courses', searchParams];
+  return useQuery<FetchListResponse, unknown, FetchListResponse, (string | APIListRequestParams)[]>(
+    queryKey,
+    async () => fetchList('courses', searchParams),
+    {
+      keepPreviousData: true,
+      ...queryOptions,
+    },
+  );
 };

--- a/src/frontend/js/data/useEnrollment/index.spec.tsx
+++ b/src/frontend/js/data/useEnrollment/index.spec.tsx
@@ -10,7 +10,7 @@ import { CourseRun } from 'types';
 import { Deferred } from 'utils/test/deferred';
 import { REACT_QUERY_SETTINGS } from 'settings';
 import * as factories from 'utils/test/factories';
-import createQueryClient from 'utils/api/queryClient';
+import createQueryClient from 'utils/react-query/createQueryClient';
 
 describe('useEnrollment', () => {
   const endpoint = 'https://endpoint.test';

--- a/src/frontend/js/data/useEnrollment/index.spec.tsx
+++ b/src/frontend/js/data/useEnrollment/index.spec.tsx
@@ -1,0 +1,111 @@
+import { act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook } from '@testing-library/react-hooks';
+import faker from 'faker';
+import fetchMock from 'fetch-mock';
+import React from 'react';
+import { APIBackend } from 'types/api';
+import { CommonDataProps } from 'types/commonDataProps';
+import { CourseRun } from 'types';
+import { Deferred } from 'utils/test/deferred';
+import { REACT_QUERY_SETTINGS } from 'settings';
+import * as factories from 'utils/test/factories';
+import createQueryClient from 'utils/api/queryClient';
+
+describe('useEnrollment', () => {
+  const endpoint = 'https://endpoint.test';
+  const contextProps: CommonDataProps['context'] = factories
+    .ContextFactory({
+      authentication: {
+        backend: APIBackend.OPENEDX_HAWTHORN,
+        endpoint,
+      },
+      lms_backends: [
+        {
+          backend: APIBackend.OPENEDX_HAWTHORN,
+          course_regexp: '(.*)',
+          endpoint,
+        },
+      ],
+    })
+    .generate();
+  (window as any).__richie_frontend_context__ = { context: contextProps };
+  const { SessionProvider } = require('data/useSession');
+  const { default: useEnrollment } = require('.');
+  const wrapper = ({ client, children }: React.PropsWithChildren<{ client: QueryClient }>) => (
+    <QueryClientProvider client={client}>
+      <SessionProvider>{children}</SessionProvider>
+    </QueryClientProvider>
+  );
+
+  const initializeUser = (loggedin = true) => {
+    const username = faker.internet.userName();
+    sessionStorage.setItem(
+      REACT_QUERY_SETTINGS.cacheStorage.key,
+      JSON.stringify(
+        factories.PersistedClientFactory({
+          queries: [factories.QueryStateFactory('user', { data: loggedin ? { username } : null })],
+        }),
+      ),
+    );
+    return loggedin ? username : null;
+  };
+
+  afterEach(() => {
+    sessionStorage.clear();
+    fetchMock.restore();
+  });
+
+  it('does not make request when user is not authenticated', async () => {
+    const username = initializeUser(false);
+    const courseRun: CourseRun = factories.CourseRunFactory.generate();
+
+    fetchMock.get(
+      `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
+      401,
+    );
+
+    let client: QueryClient;
+    await waitFor(() => {
+      client = createQueryClient({ persistor: true });
+    });
+
+    const { result } = renderHook(() => useEnrollment(courseRun.resource_link), {
+      wrapper,
+      initialProps: { client: client! },
+    });
+
+    expect(fetchMock.called()).toBeFalsy();
+    expect(result.current.enrollment).toBeUndefined();
+    expect(result.current.enrollmentIsActive).toBeUndefined();
+  });
+
+  it('retrieves enrollment when user is authenticated', async () => {
+    const username = initializeUser();
+    const courseRun: CourseRun = factories.CourseRunFactory.generate();
+    let client: QueryClient;
+    await waitFor(() => {
+      client = createQueryClient({ persistor: true });
+    });
+
+    const enrollmentResponse = { title: courseRun.id, is_active: faker.datatype.boolean() };
+    const enrollementDefered = new Deferred();
+    fetchMock.get(
+      `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
+      enrollementDefered.promise,
+    );
+
+    const { result } = renderHook(() => useEnrollment(courseRun.resource_link), {
+      wrapper,
+      initialProps: { client: client! },
+    });
+
+    await act(async () => {
+      enrollementDefered.resolve(enrollmentResponse);
+    });
+
+    expect(fetchMock.called()).toBeTruthy();
+    expect(result.current.enrollment).toStrictEqual(enrollmentResponse);
+    expect(result.current.enrollmentIsActive).toStrictEqual(enrollmentResponse.is_active);
+  });
+});

--- a/src/frontend/js/data/useEnrollment/index.ts
+++ b/src/frontend/js/data/useEnrollment/index.ts
@@ -1,0 +1,38 @@
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import CourseEnrollmentAPI from 'utils/api/courseEnrollment';
+import { useSession } from 'data/useSession';
+
+const useEnrollment = (resourceLink: string) => {
+  const { user } = useSession();
+  const queryKey = ['enrollment', resourceLink];
+  const queryClient = useQueryClient();
+  const EnrollmentAPI = CourseEnrollmentAPI(resourceLink);
+
+  const { data: enrollment } = useQuery(queryKey, async () => EnrollmentAPI.get(user!), {
+    enabled: !!user,
+  });
+
+  const { data: isActive } = useQuery(
+    [...queryKey, 'is_active'],
+    async () => EnrollmentAPI.isEnrolled(enrollment),
+    {
+      // Enrollment is null if it has been fetched
+      enabled: enrollment !== undefined,
+    },
+  );
+
+  const { mutateAsync } = useMutation(() => EnrollmentAPI.set(user!), {
+    mutationKey: queryKey,
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKey, data);
+    },
+  });
+
+  return {
+    enrollment,
+    enrollmentIsActive: isActive,
+    setEnrollment: mutateAsync,
+  };
+};
+
+export default useEnrollment;

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -13,6 +13,8 @@ import 'core-js/modules/es.promise';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { IntlProvider } from 'react-intl';
+import { QueryClientProvider } from 'react-query';
+import createQueryClient from 'utils/react-query/createQueryClient';
 
 import { Root } from 'components/Root';
 import { handle } from 'utils/errors/handle';
@@ -93,11 +95,16 @@ async function render() {
     reactRoot.setAttribute('class', 'richie-react richie-react--root');
     document.body.append(reactRoot);
 
+    // React-query
+    const queryClient = createQueryClient({ logger: true, persistor: true });
+
     // Render the tree inside a shared `IntlProvider` so all components are able to access translated strings.
     ReactDOM.render(
-      <IntlProvider locale={locale} messages={translatedMessages}>
-        <Root richieReactSpots={richieReactSpots} />
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale={locale} messages={translatedMessages}>
+          <Root richieReactSpots={richieReactSpots} />
+        </IntlProvider>
+      </QueryClientProvider>,
       reactRoot,
     );
   }

--- a/src/frontend/js/settings.ts
+++ b/src/frontend/js/settings.ts
@@ -4,4 +4,19 @@ export const API_LIST_DEFAULT_PARAMS = {
 };
 
 export const EDX_CSRF_TOKEN_COOKIE_NAME = 'edx_csrf_token';
-export const SESSION_CACHE_KEY = 'richie_session';
+
+export const REACT_QUERY_SETTINGS = {
+  // Cache is garbage collected after this delay
+  cacheTime: 24 * 60 * 60 * 1000, // 24h in ms
+  // Data are considered as stale after this delay
+  staleTimes: {
+    default: 0, // Stale immediately
+    session: 15 * 60 * 1000, // 15 minutes in ms
+  },
+  cacheStorage: {
+    // The key used to persist cache within cache storage
+    key: 'RICHIE_PERSISTED_QUERIES',
+    // Cache storage throttle time
+    throttleTime: 500,
+  },
+};

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -46,7 +46,7 @@ export interface APIAuthentication {
 
 export interface APIEnrollment {
   get: (url: string, user: Nullable<User>) => Promise<Nullable<Enrollment>>;
-  isEnrolled: (url: string, user: Nullable<User>) => Promise<boolean>;
+  isEnrolled: (enrollment: Maybe<Nullable<Enrollment>>) => Promise<Maybe<boolean>>;
   set: (url: string, user: User) => Promise<boolean>;
 }
 

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -31,8 +31,24 @@ export interface CourseState {
   text: string;
 }
 
+export interface OpenEdXEnrollment {
+  created: Nullable<string>;
+  mode: 'audit' | 'honor' | 'verified';
+  is_active: boolean;
+  course_details: {
+    course_id: string;
+    course_name: string;
+    enrollment_start: Nullable<string>;
+    enrollment_end: Nullable<string>;
+    course_start: Nullable<string>;
+    course_end: Nullable<string>;
+    invite_only: boolean;
+  };
+  user: string;
+}
+
 /**
- * Use an empty type to make sure we do not depend on any LMS-specific fields
+ * Use an unknown type to make sure we do not depend on any LMS-specific fields
  * on enrollment objects, just use HTTP response codes.
  */
-export interface Enrollment {}
+export type Enrollment = unknown;

--- a/src/frontend/js/utils/api/courseEnrollment.ts
+++ b/src/frontend/js/utils/api/courseEnrollment.ts
@@ -1,19 +1,22 @@
 import { User } from 'types/User';
-import { Nullable } from 'types/utils';
+import { Enrollment } from 'types';
+import { Maybe, Nullable } from 'types/utils';
 import APIHandler from './lms';
 
-const EnrollmentApi = {
-  get: (url: string, user: Nullable<User>) => {
-    const LMS = APIHandler(url);
-    return LMS.enrollment.get(url, user);
-  },
-  isEnrolled: (url: string, user: Nullable<User>) => {
-    const LMS = APIHandler(url);
-    return LMS.enrollment.isEnrolled(url, user);
-  },
-  set: (url: string, user: User) => {
-    const LMS = APIHandler(url);
-    return LMS.enrollment.set(url, user);
-  },
+const EnrollmentApi = (resourceLink: string) => {
+  const LMS = APIHandler(resourceLink);
+
+  return {
+    get: async (user: Nullable<User>) => {
+      return LMS.enrollment.get(resourceLink, user);
+    },
+    isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) => {
+      return LMS.enrollment.isEnrolled(enrollment);
+    },
+    set: async (user: User) => {
+      return LMS.enrollment.set(resourceLink, user);
+    },
+  };
 };
+
 export default EnrollmentApi;

--- a/src/frontend/js/utils/api/lms/base.spec.ts
+++ b/src/frontend/js/utils/api/lms/base.spec.ts
@@ -50,10 +50,12 @@ describe('Base API', () => {
           username: 'johndoe',
         });
 
-        const response = await BaseAPI.enrollment.isEnrolled(
+        const enrollment = await BaseAPI.enrollment.get(
           'https://demo.endpoint/courses?course_id=af1987efz98:afe78',
           { username: 'johndoe' },
         );
+
+        const response = await BaseAPI.enrollment.isEnrolled(enrollment);
 
         expect(response).toBeTruthy();
       });

--- a/src/frontend/js/utils/api/lms/base.ts
+++ b/src/frontend/js/utils/api/lms/base.ts
@@ -2,6 +2,7 @@ import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
 import { Nullable, Maybe } from 'types/utils';
 import { User } from 'types/User';
 import { APILms } from 'types/api';
+import { Enrollment, OpenEdXEnrollment } from 'types';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
 const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
@@ -61,11 +62,8 @@ const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
           }
           resolve(null);
         }),
-      isEnrolled: async (url: string, user: Nullable<User>): Promise<boolean> =>
-        new Promise((resolve) => {
-          const courseId = extractCourseIdFromUrl(url);
-          resolve(Boolean(sessionStorage.getItem(`${user?.username}-${courseId}`)));
-        }),
+      isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) =>
+        new Promise((resolve) => resolve((enrollment as OpenEdXEnrollment)?.is_active)),
       set: (url: string, user: User): Promise<boolean> =>
         new Promise((resolve) => {
           const courseId = extractCourseIdFromUrl(url);

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
@@ -112,22 +112,15 @@ describe('OpenEdX Hawthorn API', () => {
 
       it('returns false if user is not enrolled', async () => {
         fetchMock.get(`${EDX_ENDPOINT}/api/enrollment/v1/enrollment/${username},${courseId}`, 200);
-        const response = await HawthornApi.enrollment.isEnrolled(
+
+        const enrollment = await HawthornApi.enrollment.get(
           `https://demo.endpoint/courses?course_id=${courseId}`,
           { username },
         );
 
-        expect(response).toBeFalsy();
-      });
+        const response = await HawthornApi.enrollment.isEnrolled(enrollment);
 
-      it('returns false if user is anonymous', async () => {
-        fetchMock.get(`${EDX_ENDPOINT}/api/enrollment/v1/enrollment/${username},${courseId}`, 401);
-        const response = await HawthornApi.enrollment.isEnrolled(
-          `https://demo.endpoint/courses?course_id=${courseId}`,
-          { username },
-        );
-
-        expect(response).toBeFalsy();
+        expect(response).toStrictEqual(false);
       });
     });
 

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
@@ -6,6 +6,7 @@ import { APILms, APIOptions } from 'types/api';
 import { location } from 'utils/indirection/window';
 import { handle } from 'utils/errors/handle';
 import { EDX_CSRF_TOKEN_COOKIE_NAME } from 'settings';
+import { Enrollment, OpenEdXEnrollment } from 'types';
 
 /**
  *
@@ -89,27 +90,8 @@ const API = (APIConf: AuthenticationBackend | LMSBackend, options?: APIOptions):
             return null;
           });
       },
-      isEnrolled: async (url: string, user?: Nullable<User>): Promise<boolean> => {
-        const courseId = extractCourseIdFromUrl(url);
-        const params = user ? `${user.username},${courseId}` : courseId;
-
-        return fetch(`${ROUTES.enrollment.isEnrolled}/${params}`, {
-          credentials: 'include',
-        })
-          .then((response) => {
-            if (response.ok) {
-              return response.headers.get('Content-Type') === 'application/json'
-                ? response.json()
-                : false;
-            }
-            if (response.status === 401 || response.status === 403) return false;
-            throw new Error(`[GET - Enrollment] > ${response.status} - ${response.statusText}`);
-          })
-          .then((response) => response.is_active || false)
-          .catch((error) => {
-            handle(error);
-            return false;
-          });
+      isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) => {
+        return new Promise((resolve) => resolve(!!(enrollment as OpenEdXEnrollment)?.is_active));
       },
       set: async (url: string, user: User): Promise<boolean> => {
         try {

--- a/src/frontend/js/utils/index.tsx
+++ b/src/frontend/js/utils/index.tsx
@@ -1,0 +1,1 @@
+export const noop = () => undefined;

--- a/src/frontend/js/utils/react-query/createQueryClient.ts
+++ b/src/frontend/js/utils/react-query/createQueryClient.ts
@@ -1,0 +1,50 @@
+import { createSessionStoragePersistor } from 'utils/react-query/createSessionStoragePersistor';
+import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
+import { QueryClient, setLogger } from 'react-query';
+import { CommonDataProps } from 'types/commonDataProps';
+import { handle } from 'utils/errors/handle';
+import { REACT_QUERY_SETTINGS } from 'settings';
+import { noop } from 'utils';
+
+interface QueryClientOptions {
+  logger?: boolean;
+  persistor?: boolean;
+}
+
+const createQueryClient = (options?: QueryClientOptions) => {
+  const context: CommonDataProps['context'] = (window as any)?.__richie_frontend_context__?.context;
+  const environment = context?.environment;
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        cacheTime: REACT_QUERY_SETTINGS.cacheTime,
+        refetchOnWindowFocus: false,
+        staleTime: REACT_QUERY_SETTINGS.staleTimes.default,
+      },
+    },
+  });
+
+  if (options?.logger) {
+    // Link react-query logger to our error handler
+    setLogger({
+      // eslint-disable-next-line no-console
+      log: environment === 'development' ? console.log : noop,
+      warn: environment === 'development' ? console.warn : noop,
+      error: handle,
+    });
+  }
+
+  if (options?.persistor) {
+    // Prepare react-query cache persistance
+    const localStoragePersistor = createSessionStoragePersistor();
+    persistQueryClient({
+      persistor: localStoragePersistor,
+      queryClient,
+    });
+  }
+
+  return queryClient;
+};
+
+export default createQueryClient;

--- a/src/frontend/js/utils/react-query/createSessionStoragePersistor/index.spec.ts
+++ b/src/frontend/js/utils/react-query/createSessionStoragePersistor/index.spec.ts
@@ -1,0 +1,118 @@
+import faker from 'faker';
+import { createSessionStoragePersistor } from 'utils/react-query/createSessionStoragePersistor';
+import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
+import { QueryClient } from 'react-query';
+import { ContextFactory, PersistedClientFactory, QueryStateFactory } from 'utils/test/factories';
+import { REACT_QUERY_SETTINGS } from 'settings';
+import { act } from 'react-dom/test-utils';
+
+describe('createSessionStoragePersistor', () => {
+  const context = ContextFactory().generate();
+  (window as any).__richie_frontend_context__ = { context };
+  const createQueryClient = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          cacheTime: 5 * 60 * 1000, // 5 minutes
+          staleTime: 2 * 60 * 1000, // 2 minutes
+        },
+      },
+    });
+    persistQueryClient({
+      persistor: createSessionStoragePersistor(),
+      queryClient,
+      maxAge: 2 * 60 * 1000,
+    });
+    return queryClient;
+  };
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    jest.clearAllTimers();
+  });
+
+  it('persists state into sessionStorage', async () => {
+    const username = faker.internet.userName();
+
+    await act(async () => {
+      queryClient = createQueryClient();
+    });
+
+    queryClient.setQueryData('user', { username });
+
+    let cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    expect(cacheString).not.toBeNull();
+    let client = JSON.parse(cacheString!);
+
+    // As persistClient is throttled, it has not been executed yet,
+    // so sessionStorage is not up to date
+    expect(client.clientState.queries).toHaveLength(0);
+
+    // advance timer by the throttle delay to execute persistClient
+    jest.advanceTimersByTime(REACT_QUERY_SETTINGS.cacheStorage.throttleTime);
+
+    // Now all data within sessionStorage are fresh
+    cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    client = JSON.parse(cacheString!);
+
+    expect(client.clientState.queries).toHaveLength(1);
+    expect(client.clientState.queries[0].queryKey).toEqual('user');
+    expect(client.clientState.queries[0].state.data).toStrictEqual({ username });
+  });
+
+  it('hydrates state', async () => {
+    const username = faker.internet.userName();
+
+    sessionStorage.setItem(
+      REACT_QUERY_SETTINGS.cacheStorage.key,
+      JSON.stringify(
+        PersistedClientFactory({
+          queries: [QueryStateFactory('user', { data: { username } })],
+        }),
+      ),
+    );
+
+    await act(async () => {
+      queryClient = createQueryClient();
+    });
+
+    const data = queryClient.getQueryData('user');
+
+    expect(data).toStrictEqual({ username });
+  });
+
+  it('is cleaned when cache has expired', async () => {
+    const username = faker.internet.userName();
+
+    await act(async () => {
+      queryClient = createQueryClient();
+    });
+
+    queryClient.setQueryData('user', { username });
+    jest.advanceTimersByTime(REACT_QUERY_SETTINGS.cacheStorage.throttleTime);
+
+    let cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    expect(cacheString).not.toBeNull();
+
+    const client = JSON.parse(cacheString!);
+    expect(client.clientState.queries).toHaveLength(1);
+    expect(client.clientState.queries[0].queryKey).toEqual('user');
+    expect(client.clientState.queries[0].state.data).toStrictEqual({ username });
+
+    // When sessionStorage has expired, persistClient cleans it through the
+    // removeClient method
+    jest.advanceTimersByTime(2 * 60 * 1000);
+
+    await act(async () => {
+      queryClient = createQueryClient();
+    });
+
+    cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    expect(cacheString).toBeNull();
+  });
+});

--- a/src/frontend/js/utils/react-query/createSessionStoragePersistor/index.ts
+++ b/src/frontend/js/utils/react-query/createSessionStoragePersistor/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Largely inspired by the createLocalStoragePersistor-experimental module
+ * included within react-query
+ *
+ * Just use sessionStorage instead of localStorage
+ */
+
+import { PersistedClient, Persistor } from 'react-query/persistQueryClient-experimental';
+import { throttle } from 'lodash-es';
+import { noop } from 'utils';
+import { REACT_QUERY_SETTINGS } from 'settings';
+
+interface CreateSessionStoragePersistorOptions {
+  localStorageKey?: string;
+  throttleTime?: number;
+}
+
+export function createSessionStoragePersistor({
+  localStorageKey = REACT_QUERY_SETTINGS.cacheStorage.key,
+  throttleTime = REACT_QUERY_SETTINGS.cacheStorage.throttleTime,
+}: CreateSessionStoragePersistorOptions = {}): Persistor {
+  if (typeof sessionStorage !== 'undefined') {
+    return {
+      persistClient: throttle((persistedClient) => {
+        sessionStorage.setItem(localStorageKey, JSON.stringify(persistedClient));
+      }, throttleTime),
+      restoreClient: () => {
+        const cacheString = sessionStorage.getItem(localStorageKey);
+
+        if (!cacheString) {
+          return;
+        }
+
+        return JSON.parse(cacheString) as PersistedClient;
+      },
+      removeClient: () => {
+        sessionStorage.removeItem(localStorageKey);
+      },
+    };
+  }
+
+  return {
+    persistClient: noop,
+    restoreClient: noop,
+    removeClient: noop,
+  };
+}

--- a/src/frontend/js/utils/test/factories.ts
+++ b/src/frontend/js/utils/test/factories.ts
@@ -1,6 +1,11 @@
 import { createSpec, derived, faker } from '@helpscout/helix';
 import { CommonDataProps } from 'types/commonDataProps';
 import { APIBackend } from 'types/api';
+import { DehydratedState } from 'react-query/types/hydration';
+import { QueryState } from 'react-query/types/core/query';
+import { MutationState } from 'react-query/types/core/mutation';
+import { PersistedClient } from 'react-query/types/persistQueryClient-experimental';
+import { MutationKey, QueryKey } from 'react-query';
 
 const CourseStateFactory = createSpec({
   priority: derived(() => Math.floor(Math.random() * 7)),
@@ -33,8 +38,8 @@ export const UserFactory = createSpec({
   username: faker.internet.userName(),
 });
 
-export const ContextFactory = (context: Partial<CommonDataProps['context']> = {}) => {
-  return createSpec({
+export const ContextFactory = (context: Partial<CommonDataProps['context']> = {}) =>
+  createSpec({
     auth_endpoint: 'https://endpoint.test',
     csrftoken: faker.random.alphaNumeric(64),
     environment: 'test',
@@ -53,4 +58,58 @@ export const ContextFactory = (context: Partial<CommonDataProps['context']> = {}
     sentry_dsn: null,
     ...context,
   });
-};
+
+interface PersistedClientFactoryOptions {
+  buster?: number;
+  mutations?: DehydratedState['mutations'];
+  queries?: DehydratedState['queries'];
+  timestamp?: number;
+}
+export const PersistedClientFactory = ({
+  buster,
+  mutations,
+  queries,
+  timestamp,
+}: PersistedClientFactoryOptions) =>
+  ({
+    timestamp: timestamp || Date.now(),
+    buster: buster || '',
+    clientState: {
+      mutations: mutations || [],
+      queries: queries || [],
+    },
+  } as PersistedClient);
+
+export const QueryStateFactory = (key: QueryKey, state: Partial<QueryState>) => ({
+  queryKey: key,
+  queryHash: Array.isArray(key) ? JSON.stringify(key) : `[${JSON.stringify(key)}]`,
+  state: {
+    data: undefined,
+    dataUpdateCount: 1,
+    dataUpdatedAt: Date.now(),
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    fetchFailureCount: 0,
+    fetchMeta: null,
+    isFetching: false,
+    isInvalidated: false,
+    isPaused: false,
+    status: 'success',
+    ...state,
+  } as QueryState,
+});
+
+export const MutationStateFactory = (key: MutationKey, state: Partial<MutationState> = {}) => ({
+  mutationKey: key,
+  state: {
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    isPaused: false,
+    status: 'success',
+    variables: undefined,
+    ...state,
+  } as MutationState,
+});

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -97,6 +97,7 @@
     "react-dom": "17.0.2",
     "react-intl": "5.17.7",
     "react-modal": "3.13.1",
+    "react-query": "3.16.0",
     "sass": "1.32.13",
     "source-map-loader": "2.0.1",
     "typescript": "4.2.4",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1298,6 +1298,13 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.13.10":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -3017,6 +3024,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -3081,6 +3093,19 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.5.3.tgz#c75c39d923ae8af6284a893bfdc8bd3996d2dd2d"
+  integrity sha512-OLOXfwReZa2AAAh9yOUyiALB3YxBe0QpThwwuyRHLgpl8bSznSDmV6Mz7LeBJg1VZsMcDcNMy7B53w12qHrIhQ==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.0.4"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -3693,6 +3718,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-node@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.5.tgz#9d270aa7eaa5af0b72c4c9d9b814e7f4ce738b79"
+  integrity sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -5752,6 +5782,11 @@ js-cookie@2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6137,6 +6172,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mdn-polyfills@5.20.0:
   version "5.20.0"
   resolved "https://registry.yarnpkg.com/mdn-polyfills/-/mdn-polyfills-5.20.0.tgz#ca8247edf20a4f60dec6804372229812b348260b"
@@ -6185,6 +6228,11 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.0.5"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.44.0:
   version "1.44.0"
@@ -6249,6 +6297,13 @@ ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -7024,6 +7079,15 @@ react-modal@3.13.1:
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 
+react-query@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.16.0.tgz#8de1556aabb3d200d0f8eeb74ce2b0b3dd0a0a51"
+  integrity sha512-YOvI8mO9WG+r4XsyJinjlDMiV5IewUWUcTv2J7z6bIP3KOFvgT6k6HM8vQouz4hPnme7Ktq9j5e7LarUqgJXFQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-themeable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
@@ -7180,6 +7244,11 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -7310,7 +7379,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -8208,6 +8277,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Purpose

[React Query](https://react-query.tanstack.com/) is a powerful tool to fetch, cache and update data without to have to manage any "global state". 
With Joanie, we will have to make several requests that `react-query` will greatly ease management. Furthermore in order to homogenize codebase, it is interesting to use react-query for existing queries. For example, we will able to manage session state and cache uniquely within `react-query`, we could also minimize number of requests by finetuning `react-query`cache precisely.

## Proposal

- [x] Install `react-query`
- [x] Refactor code to use `react-query` to make requests when its useful.
