### PR TITLE
🔥(frontend) remove JestMockOf

### DIFF
--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -6,7 +6,6 @@ import { IntlProvider } from 'react-intl';
 import { fetchList } from 'data/getResourceList';
 import { History, HistoryContext } from 'data/useHistory';
 import { APIListRequestParams } from 'types/api';
-import { JestMockOf } from 'utils/types';
 
 import { SearchFilterValueParent } from '.';
 
@@ -14,7 +13,7 @@ jest.mock('data/getResourceList', () => ({
   fetchList: jest.fn(),
 }));
 
-const mockFetchList: JestMockOf<typeof fetchList> = fetchList as any;
+const mockFetchList: jest.MockedFunction<typeof fetchList> = fetchList as any;
 
 describe('<SearchFilterValueParent />', () => {
   const historyPushState = jest.fn();

--- a/src/frontend/js/data/useCourseSearch/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearch/index.spec.tsx
@@ -3,13 +3,12 @@ import React from 'react';
 
 import { fetchList } from 'data/getResourceList';
 import { APIListRequestParams } from 'types/api';
-import { JestMockOf } from 'utils/types';
 import { useCourseSearch } from '.';
 
 jest.mock('data/getResourceList', () => ({
   fetchList: jest.fn(),
 }));
-const mockFetchList = fetchList as JestMockOf<typeof fetchList>;
+const mockFetchList = fetchList as jest.MockedFunction<typeof fetchList>;
 
 describe('data/useCourseSearch', () => {
   // Build a helper component with an out-of-scope function to let us reach our Hook from

--- a/src/frontend/js/utils/types.ts
+++ b/src/frontend/js/utils/types.ts
@@ -1,5 +1,3 @@
-export type JestMockOf<T extends (...args: any[]) => any> = jest.Mock<ReturnType<T>, Parameters<T>>;
-
 export type Maybe<T> = T | undefined;
 
 export type Nullable<T> = T | null;


### PR DESCRIPTION
## Purpose

Since @types/jest 24.9.0, `MockedFunction` type is available. So we can remove our own type JestMockOf and use the official MockedFunction type.


## Proposal

- [x] Replace `JestMockOf` by `MockedFunction` type
