### PR TITLE
🔧(renovate) fix ignored python dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,8 +23,13 @@
       "groupName": "python dependencies",
       "matchManagers": ["setup-cfg"],
       "schedule": ["before 7am on monday"],
-      "matchPackagePatterns": ["*"],
-      "excludePackageNames": [
+      "matchPackagePatterns": ["*"]
+    },
+    {
+      "enabled": false,
+      "groupName": "ignored python dependencies",
+      "matchManagers": ["setup-cfg"],
+      "matchPackageNames": [
         "arrow",
         "dj-pagination",
         "django-cms",

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 include_package_data = True
 # When you install a new package, if you do not want our renovate bot checks
 # updates for it, please add the exact name of the package within
-# `excludePackageNames` (in the "python dependencies" group) within
+# `matchPackageNames` (in the "ignored python dependencies" group) within
 # renovate.json file at the root of this repository
 install_requires =
     arrow


### PR DESCRIPTION
## Purpose

Following renovate configuration update, instead of ignore dependencies listed in
`excludePackageNames`, Renovate creates a dedicated PR for each of these dependencies.
So to renovate really ignores update of these dependencies we have to create
a dedicated packageRule

Furthermore with this syntax, it's easier to create a generic preset for all our repositories.

## Proposal

- [x] Add `ignored python dependencies` package rule
