### PR TITLE
🔍️(i18n) add "hreflang" meta to avoid duplicates in search engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Add "hreflang" meta to all pages to avoid duplicates in search engines
+
+### Changed
+
 - Make related courses optional for program page
 
 ## [2.6.0] - 2021-05-03

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -22,6 +22,10 @@
             <meta name="theme-color" content="#ffffff">
             {% endblock meta_favicons %}
 
+            {% block meta_hreflang %}
+                {% language_chooser "richie/hreflang.html" %}
+            {% endblock meta_hreflang %}
+
             {% block meta_html %}
                 {% page_attribute "meta_description" as meta_description %}
                 {% if meta_description and meta_description != "None" %}<meta name="description" content="{% block meta-description %}{{ meta_description }}{% endblock %}">{% endif %}

--- a/src/richie/apps/core/templates/richie/hreflang.html
+++ b/src/richie/apps/core/templates/richie/hreflang.html
@@ -1,0 +1,6 @@
+{% load i18n menu_tags cms_tags %}
+{% if languages|length > 1 %}
+    {% for code, name in languages %}
+        <link rel="alternate" href="{% page_language_url code %}" hreflang="{{ code }}" />
+    {% endfor %}
+{% endif %}


### PR DESCRIPTION

## Purpose

I noticed that our pages where appearing twice in Google's search results, once per language. The good news is our SEO as skyrocketed, the bad news is we have duplicate content.

## Proposal

This is a well known problem solved by adding `hreflang` metas to all pages.

