### PR TITLE
🔧(renovate) use openfun preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,8 @@
 {
-  "commitMessageAction": "update",
-  "commitMessagePrefix": "⬆️(dependencies)",
-  "commitMessageTopic": "{{depName}}",
-  "enabledManagers": ["npm", "setup-cfg"],
-  "extends": ["config:base"],
-  "labels": ["dependencies"],
-  "prConcurrentLimit": 2,
-  "prCreation": "not-pending",
-  "prHourlyLimit": 1,
-  "rebaseWhen": "behind-base-branch",
-  "semanticCommits": "disabled",
-  "separateMajorMinor": false,
-  "updateNotScheduled": true,
+  "extends": [
+    "github>openfun/renovate-configuration"
+  ],
   "packageRules": [
-    {
-      "groupName": "npm dependencies",
-      "matchManagers": ["npm"],
-      "schedule": ["before 7am on monday"],
-      "matchPackagePatterns": ["*"]
-    },
-    {
-      "groupName": "python dependencies",
-      "matchManagers": ["setup-cfg"],
-      "schedule": ["before 7am on monday"],
-      "matchPackagePatterns": ["*"]
-    },
     {
       "enabled": false,
       "groupName": "ignored python dependencies",


### PR DESCRIPTION
## Purpose

In order to homegenize dependency management, we created a global  renovate preset which is in charge to upgrade js and python dependencies on our repositories. So on Richie, we have to update our renovate configuration to use
this new preset.


## Proposal

- [x] Upgrade renovate configuration to use the [openfun preset](https://github.com/openfun/renovate-configuration/)
