### PR TITLE
Fix/lti consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Use a unique name to LTIConsumerPlugin iframes to allow several plugins on the
+- Fix iframeResizer on LTIConsumer component when several plugins are on the
   same page
 
 ## [2.6.0] - 2021-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Send username to LTI Consumer if user is logged in
 - Make related courses optional for program page
 
+### Fixed
+
+- Use a unique name to LTIConsumerPlugin iframes to allow several plugins on the
+  same page
+
 ## [2.6.0] - 2021-05-03
 
 ### Added

--- a/src/frontend/js/components/LtiConsumer/_styles.scss
+++ b/src/frontend/js/components/LtiConsumer/_styles.scss
@@ -1,9 +1,28 @@
-.lti-consumer {
-  animation: fadeIn 600ms cubic-bezier(0.33, 1, 0.68, 1) forwards;
-  background-color: #ffffff;
+.richie-react--lti-consumer {
+  &.aspect-ratio {
+    position: relative;
 
-  & > form {
-    display: none;
+    iframe {
+      position: absolute;
+      height: 100%;
+      object-fit: contain;
+      object-position: center;
+    }
+  }
+
+  & > .lti-consumer {
+    animation: fadeIn 600ms cubic-bezier(0.33, 1, 0.68, 1) forwards;
+    background-color: #ffffff;
+
+    & > form {
+      display: none;
+    }
+
+    & > iframe {
+      border: 0;
+      display: block;
+      width: 100%;
+    }
   }
 }
 @keyframes fadeIn {

--- a/src/frontend/js/components/LtiConsumer/index.tsx
+++ b/src/frontend/js/components/LtiConsumer/index.tsx
@@ -39,7 +39,7 @@ const LtiConsumer = ({ id }: LtiConsumerProps) => {
       if (context.automatic_resizing) {
         // Retrieve and inject current component container height to prevent flickering
         // and remove aspect-ratio trick which is not compatible with iframeResizer
-        const componentContainer = document.querySelector('.richie-react--lti-consumer');
+        const componentContainer = formRef.current?.closest('.richie-react--lti-consumer');
         iframeResizer({ minHeight: componentContainer?.clientHeight }, iframeRef.current!);
         componentContainer?.classList.remove('aspect-ratio');
         componentContainer?.attributes.removeNamedItem('style');

--- a/src/frontend/js/components/LtiConsumer/index.tsx
+++ b/src/frontend/js/components/LtiConsumer/index.tsx
@@ -52,12 +52,11 @@ const LtiConsumer = ({ id }: LtiConsumerProps) => {
   return (
     <div className="lti-consumer">
       <form
-        id="lti_form"
         ref={formRef}
         action={context.url}
         method="POST"
         encType="application/x-www-form-urlencoded"
-        target="lti_iframe"
+        target={`lti_iframe_${id}`}
       >
         {Object.entries(context.content_parameters).map(([name, value]) => (
           <input key={name} type="hidden" name={name} value={value} />
@@ -65,7 +64,7 @@ const LtiConsumer = ({ id }: LtiConsumerProps) => {
       </form>
       <iframe
         ref={iframeRef}
-        name="lti_iframe"
+        name={`lti_iframe_${id}`}
         title={context.url}
         src={context.url}
         allow="microphone *; camera *; midi *; geolocation *; encrypted-media *; fullscreen *"


### PR DESCRIPTION
## Purpose

LTIConsumerPlugin is not fit to be added several times on the same page. Moreover we have to support this use case.


## Proposal
We have to fix all problems related to LTIConsumerPlugin multi instance
- [x] Use a unique name for LTIConsumer iframe
- [x] Target properly component parent used to instantiate iframeResizer if needed
- [x] Move styles related to LTIConsumerPlugin out of `.subheader` element 
