### PR TITLE
🐛(lti_consumer) fix permissions granting institutor role more carefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix permissions on the LTI consumer plugin when granting institutor role
 - Allow configuring the inline ratio and auto-resizing for manually-defined
   LTIConsumerPlugin instances
 - Use a unique name to LTIConsumerPlugin iframes to allow several plugins on the

--- a/tests/plugins/lti_consumer/test_api.py
+++ b/tests/plugins/lti_consumer/test_api.py
@@ -7,20 +7,23 @@ import random
 from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory
 from django.test.utils import override_settings
 
 from cms.api import add_plugin
-from cms.models import Placeholder
+from cms.models import PagePermission, Placeholder
+from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.toolbar import CMSToolbar
 
+from richie.apps.core.factories import UserFactory
+from richie.apps.core.helpers import create_i18n_page
 from richie.plugins.lti_consumer.api import LTIConsumerViewsSet
 from richie.plugins.lti_consumer.cms_plugins import LTIConsumerPlugin
 from richie.plugins.lti_consumer.factories import LTIConsumerFactory
 from richie.plugins.lti_consumer.models import LTIConsumer
 
 
-class LtiConsumerPluginApiTestCase(TestCase):
+class LtiConsumerPluginApiTestCase(CMSTestCase):
     """Tests requests on LTI Consumer plugin API endpoints."""
 
     @mock.patch.object(
@@ -31,7 +34,8 @@ class LtiConsumerPluginApiTestCase(TestCase):
         Instianciating this plugin and make a request to its API endpoint
         to get context
         """
-        placeholder = Placeholder.objects.create(slot="test")
+        page = create_i18n_page("A page")
+        placeholder = page.placeholders.get(slot="maincontent")
 
         lti_consumer = LTIConsumerFactory()
         model_instance = add_plugin(
@@ -51,7 +55,107 @@ class LtiConsumerPluginApiTestCase(TestCase):
         self.assertIn(content["url"], lti_consumer.url)
         self.assertTrue(content["is_automatic_resizing"])
         self.assertEqual(content["content_parameters"], "test_content")
-        mock_params.assert_called_once()
+        mock_params.assert_called_once_with(edit=False)
+
+    @mock.patch.object(
+        LTIConsumer, "get_content_parameters", return_value="test_content"
+    )
+    def test_lti_consumer_api_get_context_edit_all_permissions(self, mock_params):
+        """
+        A query with a user in edition mode and with all permissions required to change
+        the plugin should get the instructor role.
+        """
+        user = UserFactory()
+        page = create_i18n_page("A page")
+        placeholder = page.placeholders.get(slot="maincontent")
+
+        lti_consumer = LTIConsumerFactory()
+        model_instance = add_plugin(
+            placeholder,
+            LTIConsumerPlugin,
+            "en",
+            url=lti_consumer.url,
+            lti_provider_id=lti_consumer.lti_provider_id,
+        )
+
+        # Add all necessary model and object level permissions
+        self.add_permission(user, "change_lticonsumer")
+        self.add_permission(user, "change_page")
+        PagePermission.objects.create(
+            page=placeholder.page,
+            user=user,
+            can_add=False,
+            can_change=True,
+            can_delete=False,
+            can_publish=False,
+            can_move_page=False,
+        )
+
+        request = RequestFactory().get(
+            f"/api/v1.0/plugins/lti-consumer/{model_instance.pk}/context/"
+        )
+        request.user = user
+        request.session = {}
+        request.toolbar = CMSToolbar(request)
+        request.toolbar.edit_mode_active = True
+        view_set = LTIConsumerViewsSet()
+
+        response = view_set.get_context(request, "v1.0", model_instance.pk)
+        self.assertEqual(response.status_code, 200)
+
+        mock_params.assert_called_once_with(edit=True)
+
+    @mock.patch.object(
+        LTIConsumer, "get_content_parameters", return_value="test_content"
+    )
+    def test_lti_consumer_api_get_context_edit_missing_permissions(self, mock_params):
+        """
+        A query with a user in edition mode but with missing permissions to change
+        the plugin should not get the instructor role.
+        """
+        user = UserFactory()
+        page = create_i18n_page("A page")
+        placeholder = page.placeholders.get(slot="maincontent")
+
+        lti_consumer = LTIConsumerFactory()
+        model_instance = add_plugin(
+            placeholder,
+            LTIConsumerPlugin,
+            "en",
+            url=lti_consumer.url,
+            lti_provider_id=lti_consumer.lti_provider_id,
+        )
+
+        # Add all necessary model and object level permissions except one
+        skip = random.choice(range(3))
+        if skip != 0:
+            self.add_permission(user, "change_lticonsumer")
+        if skip != 1:
+            self.add_permission(user, "change_page")
+        if skip != 2:
+            PagePermission.objects.create(
+                page=placeholder.page,
+                user=user,
+                can_add=False,
+                can_change=True,
+                can_delete=False,
+                can_publish=False,
+                can_move_page=False,
+            )
+
+        request = RequestFactory().get(
+            f"/api/v1.0/plugins/lti-consumer/{model_instance.pk}/context/"
+        )
+        request.user = user
+        request.session = {}
+        request.toolbar = CMSToolbar(request)
+        request.toolbar.edit_mode_active = True
+        view_set = LTIConsumerViewsSet()
+
+        response = view_set.get_context(request, "v1.0", model_instance.pk)
+        self.assertEqual(response.status_code, 200)
+
+        mock_params.assert_called_once_with(edit=False)
 
     @mock.patch.object(
         LTIConsumer, "get_content_parameters", return_value="test_content"
@@ -63,7 +167,8 @@ class LtiConsumerPluginApiTestCase(TestCase):
         The "is_automatic_resizing" parameter should default to True if it is not set
         in the provider configuration.
         """
-        placeholder = Placeholder.objects.create(slot="test")
+        page = create_i18n_page("A page")
+        placeholder = page.placeholders.get(slot="maincontent")
 
         lti_consumer = LTIConsumerFactory()
         model_instance = add_plugin(
@@ -110,7 +215,8 @@ class LtiConsumerPluginApiTestCase(TestCase):
         The "is_automatic_resizing" parameter should default to the value set in the
         plugin model instance.
         """
-        placeholder = Placeholder.objects.create(slot="test")
+        page = create_i18n_page("A page")
+        placeholder = page.placeholders.get(slot="maincontent")
 
         is_automatic = random.choice([True, False])
         model_instance = add_plugin(
@@ -155,7 +261,7 @@ class LtiConsumerPluginApiTestCase(TestCase):
     @mock.patch.object(
         LTIConsumer, "get_content_parameters", return_value="test_content"
     )
-    def test_lti_consumer_view_set_get_context_method_is_cached(self, mock_params):
+    def test_lti_consumer_api_get_context_method_is_cached(self, mock_params):
         """
         If "memory_cache" is defined, get_context method is cached
         for 5 minutes to optimize db accesses without return
@@ -180,7 +286,7 @@ class LtiConsumerPluginApiTestCase(TestCase):
         with self.assertNumQueries(1):
             view_set.get_context(request, "v1.0", model_instance.pk)
 
-        mock_params.assert_called_once()
+        mock_params.assert_called_once_with(edit=False)
 
         mock_params.reset_mock()
 

--- a/tests/plugins/lti_consumer/test_models.py
+++ b/tests/plugins/lti_consumer/test_models.py
@@ -45,7 +45,7 @@ class LTIConsumerModelsTestCase(TestCase):
         )
 
     def test_lti_consumer_models_inline_ratio_max(self):
-        """The "inline_ratio" field should not accept values bigger than 1"""
+        """The "inline_ratio" field should not accept values bigger than 10"""
         instance = LTIConsumerFactory(inline_ratio=10.01)
 
         with self.assertRaises(ValidationError) as context:


### PR DESCRIPTION
## Purpose

We noticed that when a Marsha LTI consumer plugin is created, all editors on the site can update it regardless of the permissions they have to update this specific page and plugin.

## Proposal

We were granting the LTI `instructor` role as soon as edit mode was on. 
We propose to check plugin update permissions before granting this role and add tests to secure it.

