### PR TITLE
📝(richie) add documentation to connect Richie with OpenEdX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Documentation on connecting Richie with OpenEdX
+
 ## [2.7.1] - 2021-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Among the features that `Richie` offers out of the box:
 
 ## Quick preview
 
-If you're just looking for a quick preview of `Richie`, you can take a look and have a tour of
+If you're looking for a quick preview of `Richie`, you can take a look and have a tour of
 `Richie` on our dedicated [demo site](https://demo.richie.education).
 
 It is connected back-to-back with a demo of OpenEdX running on

--- a/docs/api/course-run-synchronization-api.md
+++ b/docs/api/course-run-synchronization-api.md
@@ -1,0 +1,54 @@
+---
+id: course-run-synchronization-api
+title: Course run synchronization API
+sidebar_label: course run sync
+---
+
+API endpoint allowing remote systems to synchronize their course runs with a Richie instance.
+
+## Synchronization endpoint [/api/1.0/course-runs-sync]
+
+This documentation describes version "1.0" of this API endpoint.
+
+### Synchronize a course run [POST]
+
+It takes a JSON object containing the course run details:
+
+- resource_link: `https://lms.example.com/courses/course-v1:001+001+001/info` (string, required) -
+  url of the course syllabus on the LMS from which a unique course identifier can be extracted
+- start: `2018-02-01T06:00:00Z` (string, optional) - ISO 8601 date, when this session of the
+  course starts
+- end: `2018-02-28T06:00:00Z` (string, optional) - ISO 8601 date, when this session of the course
+  ends
+- enrollment_start: `2018-01-01T06:00:00Z` (string, optional) - ISO 8601 date, when enrollment
+  for this session of the course starts
+- enrollment_end: `2018-01-31T06:00:00Z` (string, optional) - ISO 8601 date, when enrollment for
+  this session of the course ends
+- languages: ['fr', 'en'] (array[string], required) - ISO 639-1 code (2 letters) for the course's
+  languages
+
+
++ Request (application/json)
+    + Headers
+        + Authorization: `SIG-HMAC-SHA256 xxxxxxx` (string, required) - Authorization header
+            containing the digest of the utf-8 encoded json representation of the submitted data
+            for the given secret key and SHA256 digest algorithm (see [synchronizing-course-runs]
+            for an example).
+    + Body
+
+            {
+                "resource_link": "https://lms.example.com/courses/course-v1:001+001+001/info",
+                "start": "2021-02-01T00:00:00Z",
+                "end": "2021-02-31T23:59:59Z",
+                "enrollment_start": "2021-01-01T00:00:00Z",
+                "enrollment_end": "2021-01-31T23:59:59Z",
+                "languages": ["en", "fr"]
+            }
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+                "success": True
+            }

--- a/docs/displaying-connection-status.md
+++ b/docs/displaying-connection-status.md
@@ -1,0 +1,127 @@
+---
+id: displaying-connection-status
+title: Displaying OpenEdX connection status in Richie
+sidebar_label: Displaying connection status
+---
+
+This guide explains how to configure Richie and OpenEdX to share the OpenEdX connection status
+and display profile information for the logged-in user in Richie.
+
+In Richie, the only users that are actually authenticated on the DjangoCMS instance producing the
+site, are editors and staff users. Your instructors and learners will not have user accounts on
+Richie, but authentication is delegated to a remote service that can be OpenEdX, KeyCloack, or
+your own centralized identity management service.
+
+In the following, we will explain how to use OpenEdX as your authentication delegation service.
+
+## Prerequisites
+
+Richie will need to make CORS requests to the OpenEdX instance. As a consequence, you need to
+activate CORS requests on your OpenEdX instance:
+
+```python
+FEATURES = {
+    ...
+    "ENABLE_CORS_HEADERS": True,
+}
+```
+
+Then, make sure the following settings are set as follows on your OpenEdX instance:
+
+```python
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_INSECURE = False
+CORS_ORIGIN_ALLOW_ALL = False
+CORS_ORIGIN_WHITELIST: ["richie.example.com"]  # The domain on which Richie is hosted
+```
+
+## Allow redirects
+
+When Richie sends the user to the OpenEdX instance for authentication, and wants OpenEdX to
+redirect the user back to Richie after a successful login or signup, it prefixes the path with
+`/richie`. Adding the following rule to your Nginx server (or equivalent) and replacing the
+richie host by yours will allow this redirect to follow through to your Richie instance:
+
+```
+rewrite ^/richie/(.*)$ https://richie.example.com/$1 permanent;
+```
+
+## Configure authentication delegation
+
+Now, on your Richie instance, you need to configure the service to which Richie will delegate
+authentication using the `RICHIE_AUTHENTICATION_DELEGATION` setting:
+
+```python
+RICHIE_AUTHENTICATION_DELEGATION = {
+    "BASE_URL": "https://lms.example.com",
+    "BACKEND": "openedx-hawthorn",
+    "PROFILE_URLS": {
+        "dashboard": {
+            "label": _("Dashboard"),
+            "href": "{base_url:s}/dashboard",
+        },
+    },
+}
+```
+
+The following should help you understand how to configure this setting:
+
+### BASE_URL
+
+The base url on which the OpenEdX instance is hosted. This is used to construct the complete url
+of the login/signup pages to which the frontend application will send the user for authentication.
+
+- Type: string
+- Required: Yes
+- Value: for example https://lms.example.com
+
+
+### BACKEND
+
+The name of the ReactJS backend to use for the targeted LMS.
+
+- Type: string
+- Required: Yes
+- Value: Richie ships with the following Javascript backends:
+    + `openedx-dogwood`: backend for OpenEdX versions equal to `dogwood` or `eucalyptus`
+    + `openedx-hawthorn`: backend for OpenEdX versions equal to `hawthorn` or higher
+    + `openedx-fonzie`: backend for OpenEdX via [Fonzie](https://github.com/openfun/fonzie)
+        (extra user info and JWT tokens)
+    + `base`: fake backend for development purposes
+
+
+### PROFILE_URLS
+
+Mapping definition of custom links presented to the logged-in user as a dropdown menu when he/she
+clicks on his/her username in Richie's page header.
+
+Links order will be respected to build the dropdown menu.
+
+- Type: dictionary
+- Required: No
+- Value: For example, to emulate the links proposed in OpenEdX, you can configure this setting
+  as follows:
+
+    ```python
+        {
+            "dashboard": {
+                "label": _("Dashboard"),
+                "href": "{base_url:s}/dashboard",
+            },
+            "profile": {
+                "label": _("Profile"),
+                "href": "{base_url:s}/u/(username)",
+            },
+            "account": {
+                "label": _("Account"),
+                "href": "{base_url:s}/account/settings",
+            }
+        }
+    ```
+
+    The `base_url` variable is used as a Python format parameter and will be replaced by the value
+    set for the above authentication delegation `BASE_URL` setting.
+
+    If you need to bind user data into a url, wrap the property between brackets. For example, the
+    link configured above for the profile page `{base_url:s}/u/(username)` would point to
+    `https://lms.example.com/u/johndoe` for a user carrying the username `johndoe`.

--- a/docs/lms-backends.md
+++ b/docs/lms-backends.md
@@ -1,0 +1,159 @@
+---
+id: lms-backends
+title: Configuring LMS Backends
+sidebar_label: LMS Backends
+---
+
+Richie can be connected to one or more OpenEdX Learning Management Systems (LMS) for a seamless
+experience between browsing the course catalog on Richie, enrolling to a course and following the
+course itself on the LMS.
+
+It is possible to do the same with Moodle or any other LMS exposing an enrollment API, at the
+cost of writing a custom LMS handler backend.
+
+## Prerequisites
+
+This connection requires that Richie and OpenEdX be hosted on sibling domains i.e. domains that
+are both subdomains of the same root domain, e.g. `richie.example.com` and `lms.example.com`.
+
+OpenEdX will need to generate a CORS CSRF Cookie and this cookie is flagged as secure, which
+implies that we are not able to use it without SSL connections.
+
+As a consequence, you need to configure your OpenEdX instance as follows:
+
+```python
+FEATURES = {
+    ...
+    "ENABLE_CORS_HEADERS": True,
+    "ENABLE_CROSS_DOMAIN_CSRF_COOKIE": True,
+}
+
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_INSECURE = False
+CORS_ORIGIN_WHITELIST: ["richie.example.com"]  # The domain on which Richie is hosted
+
+CROSS_DOMAIN_CSRF_COOKIE_DOMAIN = ".example.com"  # The parent domain shared by Richie and OpenEdX
+CROSS_DOMAIN_CSRF_COOKIE_NAME: "edx_csrf_token"
+SESSION_COOKIE_NAME: "edx_session"
+```
+
+## Configuring the LMS handler
+
+The `LMSHandler` utility acts as a proxy that routes queries to the correct LMS backend API,
+based on a regex match on the URL of the course. It is configured via the `RICHIE_LMS_BACKENDS`
+setting. As an example, here is how it would be configured to connect to an Ironwood OpenEdX
+instance hosted on `https://lms.example.com`:
+
+```python
+RICHIE_LMS_BACKENDS=[
+    {
+        "BASE_URL": "https://lms.example.com",
+        # Django
+        "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+        "COURSE_REGEX": r"^https://lms\.example\.com/courses/(?P<course_id>.*)/course/?$",
+        # ReactJS
+        "JS_BACKEND": "openedx-hawthorn",
+        "JS_COURSE_REGEX": r"^https://lms\.example\.com/courses/(.*)/course/?$",
+        # Course runs synchronization
+        "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
+        "DEFAULT_COURSE_RUN_SYNC_MODE": "sync_to_public",
+    },
+]
+```
+
+The following should help you understand how to configure this setting:
+
+### BASE_URL
+
+The base url on which the OpenEdX instance is hosted. This is used to construct the complete url
+of the API endpoint on which the enrollment request is made by Richie's frontend application.
+
+- Type: string
+- Required: Yes
+- Value: for example https://lms.example.com
+
+
+### BACKEND
+
+The path to a Python class serving as LMS backend for the targeted LMS.
+
+- Type: string
+- Required: Yes
+- Value: Richie ships with the following Python backends (custom backends can be written to fit
+  another specific LMS):
+    + `richie.apps.courses.lms.edx.EdXLMSBackend`: backend for OpenEdX
+    + `richie.apps.courses.lms.base.BaseLMSBackend`: fake backend for development purposes
+
+
+### COURSE_REGEX
+
+A Python regex that should match the course syllabus urls of the targeted LMS and return a
+`course_id` named group on the id of the course extracted from these urls.
+
+- Type: string
+- Required: Yes
+- Value: for example `^.*/courses/(?P<course_id>.*)/course/?$`
+
+
+### JS_BACKEND
+
+The name of the ReactJS backend to use for the targeted LMS.
+
+- Type: string
+- Required: Yes
+- Value: Richie ships with the following Javascript backends (custom backends can be written to
+  fit another specific LMS):
+    + `openedx-dogwood`: backend for OpenEdX versions equal to `dogwood` or `eucalyptus`
+    + `openedx-hawthorn`: backend for OpenEdX versions equal to `hawthorn` or higher
+    + `openedx-fonzie`: backend for OpenEdX via [Fonzie](https://github.com/openfun/fonzie)
+        (extra user info and JWT tokens)
+    + `base`: fake backend for development purposes
+
+### JS_COURSE_REGEX
+
+A Javascript regex that should match the course syllabus urls of the targeted LMS and return an
+unnamed group on the id of the course extracted from these urls.
+
+- Type: string
+- Required: Yes
+- Value: for example `^.*/courses/(.*)/course/?$`
+
+### DEFAULT_COURSE_RUN_SYNC_MODE
+
+When a course run is created, this setting is used to set the value of the `sync_mode` field.
+This value defines how the course runs synchronization script will impact this course run after
+creation.
+
+- Type: enum(string)
+- Required: No
+- Value: possible values are `manual`, `sync_to_draft` and `sync_to_public`
+    + `manual`: this course run is ignored by the course runs synchronization script
+    + `sync_to_draft`: only the draft version of this course run is synchronized. A manual
+        publication is necessary for the update to be visible on the public site.
+    + `sync_to_public`: the public version of this course run is updated by the synchronization
+        script. As a results, updates are directly visible on the public site without further
+        publication by a staff user in Richie.
+
+### COURSE_RUN_SYNC_NO_UPDATE_FIELDS
+
+A list of fields that must only be set the first time a course run is synchronized. During this
+first synchronization, a new course run is created in Richie and all fields sent to the API
+endpoint via the payload are set on the object. For subsequent synchronization calls, the fields
+listed in this setting are ignored and not synchronized. This can be used to allow modifying some
+fields manually in Richie regardless of what OpenEdX sends after an initial value is set.
+
+Note that this setting is only effective for course runs with the `sync_mode` field set to a
+value other then `manual`.
+
+- Type: enum(string)
+- Required: No
+- Value: for example ["languages"]
+
+
+## Technical support
+
+If you encounter an issue with this documentation or the backends included in Richie, please
+[open an issue on our repository](https://github.com/openfun/richie/issues).
+
+If you need a custom backend, you can [submit a PR](https://github.com/openfun/richie/pulls) or
+[open an issue](https://github.com/openfun/richie/issues) and we will consider adding it.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,7 +4,7 @@ title: Getting started with Richie
 sidebar_label: Quick start
 ---
 
-If you're just looking for a quick preview of `Richie`, you can take a look and have a tour of `Richie` on our dedicated [demo site](https://demo.richie.education).
+If you're looking for a quick preview of `Richie`, you can take a look and have a tour of `Richie` on our dedicated [demo site](https://demo.richie.education).
 
 Login/password are `admin`/`admin`. The database is regularly flushed.
 
@@ -69,25 +69,18 @@ You can create a basic demo site by running:
     $ make demo-site
 
 Note that if you don't create the demo site and start from a blank CMS, you will get some errors
-requesting you to create some required root pages. So it is easier as a first approach to test the
-CMS with the demo site.
+requesting you to create some required root pages. So it is easier as a first approach to test the CMS with the demo site.
 
 You should be able to view the site at [localhost:8070](http://localhost:8070)
 
-### Basic - Connecting Richie to OpenEdx
+## Connecting Richie to an LMS
 
-This project is pre-configured to connect with an OpenEdx instance started with
-[OpenEdx Docker](https://github.com/openfun/openedx-docker], which provides a ready to use
-docker-compose stack of OpenEdx in several flavors. Head over to
-[OpenEdx Docker README](https://github.com/openfun/openedx-docker#readme) for instructions on how
-to bootstrap an instance.
+It is possible to use Richie as a catalogue aggregating courses from one or more LMS
+without any specific connection. In this case, each course run in the catalogue points to
+a course on the LMS, and the LMS points back to the catalogue to browse courses.
 
-Just start apps with `make run`.
+This approach is used for example on https://www.fun-campus.fr or https://catalogue.edulib.org.
 
-Richie should respond on `http://localhost:8070` and OpenEdx on `http://localhost:8073`.
-
-### Advanced - Connecting Richie to OpenEdx
-
-If you want users to enroll on courses in OpenEdx directly from Richie via API calls, you should
-read [the advanced guide](lms-connection.md#connecting-richie-and-openedx-over-tls) to connect
-Richie to OpenEdx over TLS.
+For a seamless user experience, it is possible to connect a Richie instance to an OpenEdX instance
+(or some other LMS like Moodle at the cost of minor adaptations), in several ways that we explain in
+the [LMS connection guide](lms-connection).

--- a/docs/synchronizing-course-runs.md
+++ b/docs/synchronizing-course-runs.md
@@ -1,0 +1,121 @@
+---
+id: synchronizing-course-runs
+title: Synchronizing course runs between Richie and OpenEdX
+sidebar_label: Synchronizing course runs
+---
+
+Richie can receive automatic course runs updates on a dedicated API endpoint.
+
+## Configure a shared secret
+
+In order to activate the course run synchronization API endpoint, you first need to configure the
+`RICHIE_COURSE_RUN_SYNC_SECRETS` setting with one or more secrets:
+
+```python
+RICHIE_COURSE_RUN_SYNC_SECRETS = ["SharedSecret", "OtherSharedSecret"]
+```
+
+This setting collects several secrets in order to allow rotating them without any downtime. Any
+of the secrets listed in this setting can be used to sign your queries. 
+
+Your secret should be shared with the LMS or distant system that needs to synchronize its course
+runs with the Richie instance. Richie will try the declared secrets one by one until it finds
+one that matches the signature sent by the remote system.
+
+## Configure LMS backends
+
+You then need to configure the LMS handler via the `RICHIE_LMS_BACKENDS` setting as explained
+in our [guide on configuring LMS backends](lms-backends#configuring-the-lms-handler). This is
+required if you want Richie to create a new course run automatically and associate it with the
+right course when the resource link submitted to the course run synchronization API endpoint is
+unknown to Richie.
+
+Each course run can be set to react differently to a synchronization request, thanks to the 
+`sync_mode` field. This field can be set to one of the following values:
+
++ `manual`: this course run is ignored by the course runs synchronization script. In this case,
+    the course run can only be edited manually using the DjangoCMS frontend editing.
++ `sync_to_draft`: only the draft version of this course run is synchronized. A manual
+    publication is necessary for the update to be visible on the public site.
++ `sync_to_public`: the public version of this course run is updated by the synchronization
+    script. As a results, updates are directly visible on the public site without further
+    publication by a staff user in Richie.
+
+A [DEFAULT_COURSE_RUN_SYNC_MODE parameter](lms-backends#default_course_run_sync_mode) in the 
+`RICHIE_LMS_BACKENDS` setting, defines what default value is used for new course runs.
+
+## Make a synchronization query
+
+You can refer to the [documentation of the course run synchronization API][sync-api] for details
+on the query expected by this endpoint.
+
+We also share here our sample code to call this synchronization endpoint from OpenEdX. This code
+should run on the `post_publish` signal emitted by the OpenEdX `cms` application each time a
+course run is modified and published.
+
+Given a `COURSE_HOOK` setting defined as follows in your OpenEdX instance:
+
+```python
+COURSE_HOOK = {
+    "secret": "SharedSecret",
+    "url": "https://richie.example.com/api/v1.0/course-runs-sync/",
+}
+```
+
+The code for the synchronization function in OpenEdX could look like this:
+
+```python
+import hashlib
+import hmac
+import json
+
+from django.conf import settings
+
+from microsite_configuration import microsite
+import requests
+from xmodule.modulestore.django import modulestore
+
+
+def update_course(course_key, *args, **kwargs):
+    """Synchronize an OpenEdX course, identified by its course key, with a Richie instance."""
+    course = modulestore().get_course(course_key)
+    edxapp_domain = microsite.get_value("site_domain", settings.LMS_BASE)
+
+    data = {
+        "resource_link": "https://{:s}/courses/{!s}/info".format(
+            edxapp_domain, course_key
+        ),
+        "start": course.start and course.start.isoformat(),
+        "end": course.end and course.end.isoformat(),
+        "enrollment_start": course.enrollment_start and course.enrollment_start.isoformat(),
+        "enrollment_end": course.enrollment_end and course.enrollment_end.isoformat(),
+        "languages": [course.language or settings.LANGUAGE_CODE],
+    }
+
+    signature = hmac.new(
+        setting.COURSE_HOOK["secret"].encode("utf-8"),
+        msg=json.dumps(data).encode("utf-8"),
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+
+    response = requests.post(
+        setting.COURSE_HOOK["url"],
+        json=data,
+        headers={"Authorization": "SIG-HMAC-SHA256 {:s}".format(signature)},
+    )
+```
+
+Thanks to the signal emitted in OpenEdX, this function can then be triggered each time a course
+is modified and published:
+
+```python
+from django.dispatch import receiver
+from xmodule.modulestore.django import SignalHandler
+
+
+@receiver(SignalHandler.course_published, dispatch_uid='update_course_on_publish')
+def update_course_on_publish(sender, course_key, **kwargs):
+    update_course(course_key)
+```
+
+[sync-api]: api/course-run-synchronization-api

--- a/docs/tls-connection.md
+++ b/docs/tls-connection.md
@@ -1,0 +1,106 @@
+---
+id: tls-connection
+title: Connecting Richie and OpenEdX over TLS for development
+sidebar_label: TLS connection for development
+---
+
+## Purpose
+
+By default in the docker-compose environment for development, Richie is hosted on `localhost:8070`
+and uses a fake LMS backend (`base.BaseLMSBackend`) as you can see if you check the
+`RICHIE_LMS_BACKENDS` setting in `env.d/development`.
+
+This base backend uses session storage to fake enrollments to course runs.
+
+If you want to test real enrollments to an OpenEdX instance hosted on an external domain, OpenEdX
+will need to generate a CORS CSRF Cookie. This cookie is flagged as secure, which implies that
+we are not able to use it without SSL connections.
+
+So if you need to use the OpenEdx API to Create, Update or Delete data from Richie, you have to
+enable SSL on Richie and OpenEdx on your development environment, which requires a little bit more 
+configuration. Below, we explain how to serve OpenEdx and Richie over SSL.
+
+## Run OpenEdx and Richie on sibling domains
+
+Richie and OpenEdx must be on sibling domains ie domains that both are subdomains of the same
+parent domain, because sharing secure Cookies on `localhost` or unrelated domains is blocked.
+To do that, you have to edit your hosts file (_.e.g_ `/etc/hosts` on a \*NIX system) to alias a
+domain `local.dev` with two subdomains `richie` and `edx` pointing to `localhost`:
+
+```
+# /etc/hosts
+127.0.0.1 richie.local.dev
+127.0.0.1 edx.local.dev
+```
+
+Once this has been done, the OpenEdx app should respond on http://edx.local.dev:8073
+and Richie should respond on http://richie.local.dev:8070. The Richie application should now be
+able to make CORS XHR requests to the OpenEdX application.
+
+## Enable TLS
+
+If you want to develop with OpenEdx as LMS backend of the Richie application (see the
+`RICHIE_LMS_BACKENDS` setting), you need to enable TLS for your development servers.
+Both Richie and OpenEdx use Nginx as reverse proxy which eases the SSL setup.
+
+### 1. Install mkcert and its Certificate Authority
+
+First you will need to install mkcert and its Certificate Authority.
+[mkcert](https://mkcert.org/) is a little util to ease local certificate generation.
+
+#### a. Install `mkcert` on your local machine
+
+- [Read the doc](https://github.com/FiloSottile/mkcert)
+- Linux users who do not want to use linuxbrew : [read this article](https://www.prado.lt/how-to-create-locally-trusted-ssl-certificates-in-local-development-environment-on-linux-with-mkcert).
+
+#### b. Install Mkcert Certificate Authority
+
+`mkcert -install`
+
+> If you do not want to use mkcert, you can generate [CA and certificate with openssl](https://www.freecodecamp.org/news/how-to-get-https-working-on-your-local-development-environment-in-5-minutes-7af615770eec/).
+> You will have to put your certificate and its key in the `docker/files/etc/nginx/ssl` directory
+> and respectively name them `richie.local.dev.pem` and `richie.local.dev.key`.
+
+### 2. On Richie
+
+Then, to setup the SSL configuration with mkcert, run our helper script:
+
+```bash
+$ bin/setup-ssl
+```
+
+> If you do not want to use mkcert, read the instructions above to generate a Richie certificate,
+> and run the helper script with the `--no-cert` option:
+
+```bash
+bin/setup-ssl --no-cert
+```
+
+### 3. On OpenEdx
+
+In the same way, you also have to enable SSL in OpenEdx, by updating the Nginx configuration.
+Read how to [enable SSL on OpenEdx][ssl].
+
+Once this has been done, the OpenEdx app should respond on https://edx.local.dev:8073
+and Richie should respond on https://richie.local.dev:8070. The richie application should be able
+to share cookies with the OpenEdx application to allow CORS CSRF Protected XHR requests.
+
+### 4. Start Richie and OpenEdx over SSL
+
+Now, the OpenEdx application should respond on https://edx.local.dev:8073, and Richie
+on https://richie.local.dev:8070 without browser warning about the certificate validity.
+
+You need to follow these steps once. The next time you want to use SSL, you can run the following
+command on both the Richie and OpenEdX projects:
+
+```bash
+$ make run-ssl
+```
+
+Of course, you can still run apps without ssl by using:
+
+```bash
+$ make run
+```
+
+[ssl]: https://github.com/openfun/openedx-docker/blob/master/docs/richie-configuration.md#richie-configuration

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -290,9 +290,6 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_name="EDX_COURSE_REGEX",
                 environ_prefix=None,
             ),
-            # Synchronization
-            "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
-            "DEFAULT_COURSE_RUN_SYNC_MODE": "sync_to_public",
             # React frontend
             "JS_BACKEND": values.Value(
                 "base", environ_name="EDX_JS_BACKEND", environ_prefix=None
@@ -302,6 +299,9 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_name="EDX_JS_COURSE_REGEX",
                 environ_prefix=None,
             ),
+            # Course runs synchronization
+            "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
+            "DEFAULT_COURSE_RUN_SYNC_MODE": "sync_to_public",
         }
     ]
     RICHIE_COURSE_RUN_SYNC_SECRETS = values.ListValue([])

--- a/website/versioned_docs/version-2.0.0/lms-connection.md
+++ b/website/versioned_docs/version-2.0.0/lms-connection.md
@@ -78,7 +78,7 @@ to make CORS XHR requests.
 If you want to develop with OpenEdx as `RICHIE_LMS_BACKENDS` of Richie, you need to enable TLS for your
 development servers. Both Richie and OpenEdx use Nginx as reverse proxy that ease the SSL setup.
 
-##### 1. Install mkcert ans its Certificate Authority
+##### 1. Install mkcert and its Certificate Authority
 
 First you will need to install mkcert and its Certificate Authority.
 [mkcert](https://mkcert.org/) is a little util to ease local certificate generation.

--- a/website/versioned_docs/version-2.0.1/lms-connection.md
+++ b/website/versioned_docs/version-2.0.1/lms-connection.md
@@ -77,7 +77,7 @@ to make CORS XHR requests.
 If you want to develop with OpenEdx as `RICHIE_LMS_BACKENDS` of Richie, you need to enable TLS for your
 development servers. Both Richie and OpenEdx use Nginx as reverse proxy that ease the SSL setup.
 
-##### 1. Install mkcert ans its Certificate Authority
+##### 1. Install mkcert and its Certificate Authority
 
 First you will need to install mkcert and its Certificate Authority.
 [mkcert](https://mkcert.org/) is a little util to ease local certificate generation.

--- a/website/versioned_docs/version-2.5.0/lms-connection.md
+++ b/website/versioned_docs/version-2.5.0/lms-connection.md
@@ -77,7 +77,7 @@ to make CORS XHR requests.
 If you want to develop with OpenEdx as `RICHIE_LMS_BACKENDS` of Richie, you need to enable TLS for your
 development servers. Both Richie and OpenEdx use Nginx as reverse proxy that ease the SSL setup.
 
-##### 1. Install mkcert ans its Certificate Authority
+##### 1. Install mkcert and its Certificate Authority
 
 First you will need to install mkcert and its Certificate Authority.
 [mkcert](https://mkcert.org/) is a little util to ease local certificate generation.


### PR DESCRIPTION
## Purpose

The documentation on how to connect Richie and OpenEdX was only targetting the development environment and many users requested a more complete documentation on how Richie can be connected to OpenEdX in production.

## Proposal

I tried to structure my explanations in 4 separate features:

- Displaying the OpenEdX connection status and user profile information in Richie,
- Enrolling to a course run on OpenEdX without leaving Richie,
- Synchronizing course runs automatically in the Richie catalog each time they are modified in OpenEdX,
- Joanie, enrollment management on steroids.
 
To view the documentation site as it will look after this PR, pull the branch, `cd` into the `website` directory and run:

```bash
yarn start
```

Then head over to the documentation site on `localhost:3000` and select the `master` version to see the latest changes.
