### PR TITLE
🐛(frontend) fix fullscreen layout on safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix course teaser layout issues on Safari
+
 ### Added
 
 - Documentation on connecting Richie with OpenEdX

--- a/src/frontend/js/components/LtiConsumer/_styles.scss
+++ b/src/frontend/js/components/LtiConsumer/_styles.scss
@@ -5,13 +5,11 @@
     iframe {
       position: absolute;
       height: 100%;
-      object-fit: contain;
-      object-position: center;
     }
   }
 
   & > .lti-consumer {
-    animation: fadeIn 600ms cubic-bezier(0.33, 1, 0.68, 1) forwards;
+    animation: fadeIn 600ms cubic-bezier(0.33, 1, 0.68, 1);
     background-color: #ffffff;
 
     & > form {

--- a/src/frontend/scss/components/_subheader.scss
+++ b/src/frontend/scss/components/_subheader.scss
@@ -165,10 +165,8 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
       padding-bottom: 56.25%; // Aspect ratio 16/9
 
       iframe {
-        position: absolute;
         height: 100%;
-        object-fit: contain;
-        object-position: center;
+        position: absolute;
       }
     }
 


### PR DESCRIPTION
## Purpose

On Safari, when user launches course teaser in fullscreen mode some DOM elements
appear on the top of the video. It was due to a bug with Safari related to the
animation fill mode applied to the teaser container.

![Screenshot-2021-06-29-at-11 54 18](https://user-images.githubusercontent.com/9265241/123969849-e094f380-d9b8-11eb-9b20-e435a97bf98c.jpg)

Also on Safari, a second layout bug has been found. An offset was applied to the iframe container when its content loaded.

<img width="796" alt="Capture d’écran 2021-06-30 à 15 38 38" src="https://user-images.githubusercontent.com/9265241/123970597-89dbe980-d9b9-11eb-8bb7-0e4842849cc9.png">

## Proposal

- [x] Remove `forwards` animation fill mode applied to `.lti-consumer` animation
- [x] Remove iframe offset which appears when its content loaded