### PR TITLE
🐛(SEO) fix opengraph og:image meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix open graph og:image meta when static files are on a CDN
 - Fix course teaser layout issues on Safari
 
 ### Added

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -1,4 +1,4 @@
-{% load i18n cms_tags menu_tags rfc_5646_locale static sekizai_tags %}
+{% load i18n cms_tags menu_tags rfc_5646_locale static sekizai_tags full_static_tags %}
 <!doctype html>
 <html lang="{{ LANGUAGE_CODE|rfc_5646_locale }}">
     <head>
@@ -44,7 +44,7 @@
                 {% comment %}Since we are not able yet to get relevant image contextually for each content kind, we
                 keep the logo as the ressource image for all{% endcomment %}
                 {% block meta_opengraph_image %}
-                    <meta property="og:image" content="{{ SITE.web_url }}{% static "richie/images/logo.png" %}">
+                    <meta property="og:image" content="{% fullstatic "richie/images/logo.png" %}">
                 {% endblock meta_opengraph_image %}
                 {% block meta_opengraph_contextuals %}
                     <meta property="og:title" content="{{ SITE.name }}">

--- a/src/richie/apps/core/templatetags/full_static_tags.py
+++ b/src/richie/apps/core/templatetags/full_static_tags.py
@@ -1,0 +1,24 @@
+"""
+Add full URL to a static Django file.
+https://stackoverflow.com/a/47336360
+"""
+
+from django import template
+from django.templatetags import static
+
+# pylint: disable=invalid-name
+register = template.Library()
+
+
+class FullStaticNode(static.StaticNode):
+    """
+    Generate absolute full URL to a static file.
+    """
+    def url(self, context):
+        request = context['request']
+        return request.build_absolute_uri(super().url(context))
+
+
+@register.tag('fullstatic')
+def do_static(parser, token):
+    return FullStaticNode.handle_token(parser, token)

--- a/tests/apps/core/test_templatetags_full_static_tags.py
+++ b/tests/apps/core/test_templatetags_full_static_tags.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for the template tags of the full static tags.
+"""
+from django.template import Context, Template
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+
+class FullStaticTagsTemplateTagsTestCase(TestCase):
+    """
+    Unit test suite to validate the behavior of the `full_static_tags` template tag.
+    """
+
+    def test_templatetags_full_static_tags(self):
+        "The full_static_tags template tag retrieves the full URL for a registered static asset"
+        request = RequestFactory().get('/')
+        out = Template(
+            "{% load full_static_tags %}"
+            "{% fullstatic 'richie/images/logo.png' %}"
+         ).render(Context({"request": request}))
+        self.assertEqual(out, "http://testserver/static/richie/images/logo.png")


### PR DESCRIPTION
The **og:image** head meta need to have an absolute URL.

Currently on [demo](https://demo.richie.education/en/) we have this value http://edx.richie.education//dpaz9rouqy0e2.cloudfront.net/static/richie/images/logo.bc96dea393cb.png when a social network scraps the page it won't found the image because the URL is bad formed. 

Richie is prefixing the `og:image` meta content value with the site name. But when static assets of the richie site is behind a CDN the URL of the og:image has an incorrect value.