### PR TITLE
🔍️(SEO) add course cover to og image meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix course teaser layout issues on Safari
+- Added the course cover image using 1200x630 size for the open graph og:image meta
 
 ### Added
 

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -11,6 +11,19 @@
 {% endblock meta_index_rules %}
 
 
+{% block meta_opengraph_image %}
+    {% get_placeholder_plugins "course_cover" as plugins or %}
+        {{ block.super }}
+    {% endget_placeholder_plugins %}
+    {% blockplugin plugins.0 %}
+        {% thumbnail instance.picture 1200x630 crop upscale subject_location=instance.picture.subject_location as thumb %}
+        <meta property="og:image" content="{{ request.scheme }}:{% if CDN_DOMAIN is not defined %}//{{ request.get_host }}{% endif %}{{ thumb.url }}">
+        <meta property="og:image:width" content="{{ thumb.width }}">
+        <meta property="og:image:height" content="{{ thumb.height }}">
+    {% endblockplugin %}
+{% endblock meta_opengraph_image %}
+
+
 {% block meta_opengraph_contextuals %}
     <meta property="og:title" content="{{ current_page.get_title|truncatechars:65 }}">
     <meta property="og:url" content="{{ SITE.web_url }}{{ current_page.get_absolute_url }}">

--- a/tests/apps/courses/test_open_graph_course.py
+++ b/tests/apps/courses/test_open_graph_course.py
@@ -1,0 +1,52 @@
+"""
+Test suite for the Open Graph for course pages
+"""
+import re
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.courses.factories import CourseFactory
+
+
+class CourseOpenGraphTestCase(CMSTestCase):
+    """Testing a course page open graph meta content values"""
+
+    def setUp(self) -> None:
+        self.cover_file_name = "cover.jpg"
+        course = CourseFactory(
+            page_title="Introduction to Programming",
+            code="IntroProg",
+            page_languages=["en", "fr"],
+            fill_cover={
+                "original_filename": self.cover_file_name,
+            },
+        )
+        self.course_page = course.extended_object
+        self.course_page.publish("en")
+
+    def test_open_graph_course_meta_og_image(self):
+        url = self.course_page.get_absolute_url(language="en")
+        response = self.client.get(url)
+        response_content = response.content.decode("UTF-8")
+
+        match = re.search("<meta[^>]+og:image[^>]+>", response_content)
+        html_meta_og_image = match.group(0)
+        self.assertIn(self.cover_file_name, html_meta_og_image)
+
+    def test_open_graph_course_meta_og_image_width(self):
+        url = self.course_page.get_absolute_url(language="en")
+        response = self.client.get(url)
+        response_content = response.content.decode("UTF-8")
+
+        match = re.search("<meta[^>]+og:image:width[^>]+>", response_content)
+        html_meta_og_image = match.group(0)
+        self.assertIn("1200", html_meta_og_image)
+
+    def test_open_graph_course_meta_og_image_height(self):
+        url = self.course_page.get_absolute_url(language="en")
+        response = self.client.get(url)
+        response_content = response.content.decode("UTF-8")
+
+        match = re.search("<meta[^>]+og:image:height[^>]+>", response_content)
+        html_meta_og_image = match.group(0)
+        self.assertIn("630", html_meta_og_image)


### PR DESCRIPTION
Added the course cover image using 1200x630 size for the open graph og:image meta
