### PR TITLE
⬆️(cms) upgrade DjangoCMS to version 3.9.0 and Django to version 3.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Documentation on connecting Richie with OpenEdX
+
+### Changed
+
+- Upgrade to DjangoCMS 3.9.0 (and subsequently to Django 3.2.6)
+
 ### Fixed
 
 - Repatriate within our codebase the deprecated bootstrap mixin
   make-container-max-widths
 - Fix course teaser layout issues on Safari
-
-### Added
-
-- Documentation on connecting Richie with OpenEdX
 
 ## [2.7.1] - 2021-06-08
 

--- a/renovate.json
+++ b/renovate.json
@@ -24,8 +24,6 @@
         "dj-pagination",
         "django-cms",
         "django-parler",
-        "django-treebeard",
-        "Django",
         "djangocms-file",
         "djangocms-googlemap",
         "djangocms-link",

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,9 +30,9 @@ include_package_data = True
 # renovate.json file at the root of this repository
 install_requires =
     arrow
-    Django<3.2
+    Django
     dj-pagination
-    django-cms>=3.8.0
+    django-cms>=3.9.0
     django-parler>=2.0.1
     djangocms-file
     djangocms-googlemap
@@ -45,7 +45,7 @@ install_requires =
     social-auth-core[openidconnect]==3.2.0
     social-auth-app-django==3.1.0
     django-redis>=4.11.0
-    django-treebeard==4.4
+    django-treebeard
     exrex==0.10.5
 package_dir =
     =src


### PR DESCRIPTION

## Purpose

[DjangoCMS 3.9.0](https://github.com/django-cms/django-cms/releases/tag/3.9.0) was released on June 29, 2021. We want to upgrade Richie to this version of DjangoCMS.

## Proposal

- [x] Bump DjangoCMS to version 3.9.0.
- [x] Remove dependency constraints on Django and treebeard, now that DjangoCMS has fixed dependency issues with these packages' latest versions.