### PR TITLE
🐛(search) fix indexing unpublished categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Stop indexing unpublished categories
 - Repatriate within our codebase the deprecated bootstrap mixin
   make-container-max-widths
 - Fix course teaser layout issues on Safari

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -363,7 +363,7 @@ class Course(BasePageExtension):
             Category, CategoryPluginModel, language=language
         )
 
-    def get_root_to_leaf_category_pages(self):
+    def get_root_to_leaf_public_category_pages(self):
         """
         Build a query retrieving all pages linked to this course's categories or one of their
         ancestors excluding the meta category itself.
@@ -375,7 +375,9 @@ class Course(BasePageExtension):
         category_query = self.get_categories()
 
         # 1. We want the pages directly related to a category of the course
-        page_query = Page.objects.filter(publisher_draft__category__in=category_query)
+        page_query = Page.objects.filter(
+            publisher_draft__category__in=category_query, title_set__published=True
+        )
         # 2. We want the pages related to one of the ancestors of the categories of the course
         for category in category_query.select_related(
             "public_extension__extended_object"
@@ -386,7 +388,8 @@ class Course(BasePageExtension):
             # Don't include the meta category as it materializes a "filter bank" and not a
             # search option
             page_query = page_query | ancestor_query.filter(
-                node__parent__cms_pages__category__isnull=False
+                node__parent__cms_pages__category__isnull=False,
+                title_set__published=True,
             )
         return page_query.distinct()
 

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -490,7 +490,7 @@ class CoursesIndexer:
         # Prepare categories, making sure we get title information for categories
         # in the same query
         category_pages = (
-            course.get_root_to_leaf_category_pages()
+            course.get_root_to_leaf_public_category_pages()
             .select_related("node")
             .prefetch_related(
                 Prefetch(

--- a/tests/apps/courses/test_models_course.py
+++ b/tests/apps/courses/test_models_course.py
@@ -1143,7 +1143,7 @@ class CourseModelsTestCase(TestCase):
         self.assertEqual(Program.objects.count(), 2)
         self.assertEqual(course.get_programs().count(), 1)
 
-    def test_models_course_get_root_to_leaf_category_pages_leaf(self):
+    def test_models_course_get_root_to_leaf_public_category_pages_leaf(self):
         """
         A course linked to a leaf category, in a nested category tree, should be associated
         with all the category's ancestors.
@@ -1166,9 +1166,11 @@ class CourseModelsTestCase(TestCase):
             parent_category.public_extension.extended_object,
             leaf_category.public_extension.extended_object,
         ]
-        self.assertEqual(expected_pages, list(course.get_root_to_leaf_category_pages()))
+        self.assertEqual(
+            expected_pages, list(course.get_root_to_leaf_public_category_pages())
+        )
 
-    def test_models_course_get_root_to_leaf_category_pages_parent(self):
+    def test_models_course_get_root_to_leaf_public_category_pages_parent(self):
         """
         A course linked to a parent category, in a nested category tree, should be associated
         with all the category's ancestors, but not we the child.
@@ -1188,9 +1190,11 @@ class CourseModelsTestCase(TestCase):
         )
 
         expected_pages = [parent_category.public_extension.extended_object]
-        self.assertEqual(expected_pages, list(course.get_root_to_leaf_category_pages()))
+        self.assertEqual(
+            expected_pages, list(course.get_root_to_leaf_public_category_pages())
+        )
 
-    def test_models_course_get_root_to_leaf_category_pages_duplicate(self):
+    def test_models_course_get_root_to_leaf_public_category_pages_duplicate(self):
         """
         If the course is linked to several categories, the ancestor categories should not get
         duplicated.
@@ -1217,7 +1221,9 @@ class CourseModelsTestCase(TestCase):
             leaf_category1.public_extension.extended_object,
             leaf_category2.public_extension.extended_object,
         ]
-        self.assertEqual(expected_pages, list(course.get_root_to_leaf_category_pages()))
+        self.assertEqual(
+            expected_pages, list(course.get_root_to_leaf_public_category_pages())
+        )
 
     # Fields: effort
 

--- a/tests/apps/search/test_indexers_organizations.py
+++ b/tests/apps/search/test_indexers_organizations.py
@@ -121,6 +121,20 @@ class OrganizationsIndexersTestCase(TestCase):
             ],
         )
 
+    def test_indexers_organizations_get_es_documents_unpublished(self):
+        """Unpublished organizations should not be indexed"""
+        OrganizationFactory()
+
+        # The unpublished organization should not get indexed
+        self.assertEqual(
+            list(
+                OrganizationsIndexer.get_es_documents(
+                    index="some_index", action="some_action"
+                )
+            ),
+            [],
+        )
+
     def test_indexers_organizations_get_es_documents_language_fallback(self):
         """Absolute urls should be computed as expected with language fallback."""
         OrganizationFactory(

--- a/tests/apps/search/test_indexers_persons.py
+++ b/tests/apps/search/test_indexers_persons.py
@@ -96,6 +96,20 @@ class PersonsIndexersTestCase(TestCase):
             ],
         )
 
+    def test_indexers_persons_get_es_documents_unpublished(self):
+        """Unpublished persons should not be indexed"""
+        PersonFactory()
+
+        # The unpublished person should not get indexed
+        self.assertEqual(
+            list(
+                PersonsIndexer.get_es_documents(
+                    index="some_index", action="some_action"
+                )
+            ),
+            [],
+        )
+
     def test_indexers_persons_get_es_documents_language_fallback(self):
         """Absolute urls should be computed as expected with language fallback."""
         PersonFactory(


### PR DESCRIPTION
## Purpose

Unpublished categories were not indexed in the "categories" index but they were listed in the course document of the
"courses" index.

## Proposal

- [x] Add filter condition to exclude unpublished categories
- [x] Add tests to secure fix

Fixes #704