### PR TITLE
🐛(search) fix search bug due to wrong ordering of char filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix search bug due to wrong ordering of char filters
 - Stop indexing unpublished categories
 - Repatriate within our codebase the deprecated bootstrap mixin
   make-container-max-widths

--- a/src/richie/apps/search/text_indexing.py
+++ b/src/richie/apps/search/text_indexing.py
@@ -97,10 +97,10 @@ ANALYSIS_SETTINGS = {
                 "tokenizer": "standard",
                 "filter": [
                     "english_possessive_stemmer",
+                    "asciifolding",
                     "lowercase",
                     "english_stop",
                     "english_stemmer",
-                    "asciifolding",
                 ],
             },
             "english_trigram": {
@@ -108,10 +108,10 @@ ANALYSIS_SETTINGS = {
                 "tokenizer": "trigram",
                 "filter": [
                     "english_possessive_stemmer",
+                    "asciifolding",
                     "lowercase",
                     "english_stop",
                     "english_stemmer",
-                    "asciifolding",
                 ],
             },
             "french": {
@@ -119,10 +119,10 @@ ANALYSIS_SETTINGS = {
                 "tokenizer": "standard",
                 "filter": [
                     "french_elision",
+                    "asciifolding",
                     "lowercase",
                     "french_stop",
                     "french_stemmer",
-                    "asciifolding",
                 ],
             },
             "french_trigram": {
@@ -130,10 +130,10 @@ ANALYSIS_SETTINGS = {
                 "tokenizer": "trigram",
                 "filter": [
                     "french_elision",
+                    "asciifolding",
                     "lowercase",
                     "french_stop",
                     "french_stemmer",
-                    "asciifolding",
                 ],
             },
             "simple_diacritics_insensitive": {


### PR DESCRIPTION
### Purpose

We noticed that courses with the word "`électricité`" could not be found with a search query lacking accents: "`electricite`".

### Proposal

The problem was due to a wrong ordering of filters. We were stemming before doing the ascii folding. As a result:

- "`électricité`" was indexed as "`electr`"
- searching "`électricité`" was analyzed as "`electr`" => result found :smiley: 
- searching "`electricite`" was analylzed as "`electricit`" => result not found :thinking: 

I changed the order of the char filters in our custom analyzers and added tests to secure the fix.

Fixes https://github.com/openfun/richie/issues/1347