### PR TITLE
Frontend/extend window interface

### DIFF
--- a/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
@@ -34,7 +34,7 @@ describe('<CourseRunEnrollment />', () => {
       ],
     })
     .generate();
-  (window as any).__richie_frontend_context__ = { context: contextProps };
+  window.__richie_frontend_context__ = { context: contextProps };
   const CourseRunEnrollment = require('.').default;
   const { SessionProvider } = require('data/useSession');
 

--- a/src/frontend/js/components/Root/index.spec.tsx
+++ b/src/frontend/js/components/Root/index.spec.tsx
@@ -16,7 +16,7 @@ jest.mock('components/RootSearchSuggestField', () => ({
 }));
 
 describe('<Root />', () => {
-  (window as any).__richie_frontend_context__ = {
+  window.__richie_frontend_context__ = {
     context: ContextFactory({ authentication: undefined }).generate(),
   };
   const { Root } = require('.');

--- a/src/frontend/js/components/Root/index.tsx
+++ b/src/frontend/js/components/Root/index.tsx
@@ -78,7 +78,7 @@ export const Root = ({ richieReactSpots }: RootProps) => {
 
       // Add context to props if they do not already include it
       if (!props.context) {
-        props.context = (window as any).__richie_frontend_context__.context;
+        props.context = window.__richie_frontend_context__.context;
       }
 
       return ReactDOM.createPortal(<Component {...props} />, element);

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -478,14 +478,14 @@ describe('components/SearchSuggestField', () => {
     fireEvent.focus(field);
 
     fireEvent.change(field, { target: { value: 'ri' } });
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => expect(history.pushState).not.toHaveBeenCalled());
 
     fireEvent.change(field, { target: { value: 'ric' } });
     act(() => {
       // run all pending timers (debounce) to update courseSearchParams
       jest.runOnlyPendingTimers();
     });
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(history.pushState).toHaveBeenCalledTimes(1));
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -499,12 +499,12 @@ describe('components/SearchSuggestField', () => {
     );
 
     fireEvent.change(field, { target: { value: 'rich data driven' } });
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(history.pushState).toHaveBeenCalledTimes(1));
     act(() => {
       // run all pending timers (debounce) to update courseSearchParams
       jest.runOnlyPendingTimers();
     });
-    expect(history.pushState).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(history.pushState).toHaveBeenCalledTimes(2));
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -518,12 +518,12 @@ describe('components/SearchSuggestField', () => {
     );
 
     fireEvent.change(field, { target: { value: '' } });
-    expect(history.pushState).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(history.pushState).toHaveBeenCalledTimes(2));
     act(() => {
       // run all pending timers (debounce) to update courseSearchParams
       jest.runOnlyPendingTimers();
     });
-    expect(history.pushState).toHaveBeenCalledTimes(3);
+    await waitFor(() => expect(history.pushState).toHaveBeenCalledTimes(3));
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -561,13 +561,13 @@ describe('components/SearchSuggestField', () => {
     fireEvent.focus(field);
 
     fireEvent.change(field, { target: { value: 'ri' } });
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => expect(history.pushState).not.toHaveBeenCalled());
 
     fireEvent.change(field, { target: { value: 'ri ' } });
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => expect(history.pushState).not.toHaveBeenCalled());
 
     fireEvent.change(field, { target: { value: ' ri' } });
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => expect(history.pushState).not.toHaveBeenCalled());
 
     fireEvent.change(field, { target: { value: 'ric' } });
     act(() => {
@@ -575,7 +575,7 @@ describe('components/SearchSuggestField', () => {
       jest.runOnlyPendingTimers();
     });
 
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(history.pushState).toHaveBeenCalledTimes(1));
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',
@@ -625,13 +625,13 @@ describe('components/SearchSuggestField', () => {
     fireEvent.change(field, { target: { value: 'orga' } });
 
     // As user typing is debounced, history.pushState is not fired immediately
-    expect(history.pushState).not.toHaveBeenCalled();
+    await waitFor(() => expect(history.pushState).not.toHaveBeenCalled());
 
     act(() => {
       // run all pending timers (debounce) to update courseSearchParams
       jest.runOnlyPendingTimers();
     });
-    expect(history.pushState).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(history.pushState).toHaveBeenCalledTimes(1));
     expect(history.pushState).toHaveBeenLastCalledWith(
       {
         name: 'courseSearch',

--- a/src/frontend/js/components/UserLogin/index.spec.tsx
+++ b/src/frontend/js/components/UserLogin/index.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('utils/indirection/window', () => ({
 
 describe('<UserLogin />', () => {
   const contextProps = ContextFactory().generate();
-  (window as any).__richie_frontend_context__ = { context: contextProps };
+  window.__richie_frontend_context__ = { context: contextProps };
   const UserLogin = require('.').default;
   const { SessionProvider } = require('data/useSession');
 

--- a/src/frontend/js/data/useSession/index.spec.tsx
+++ b/src/frontend/js/data/useSession/index.spec.tsx
@@ -10,7 +10,7 @@ import { SessionContext } from '.';
 
 describe('useSession', () => {
   const context = ContextFactory().generate();
-  (window as any).__richie_frontend_context__ = { context };
+  window.__richie_frontend_context__ = { context };
   const {
     SessionProvider,
     useSession,

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -106,4 +106,4 @@ async function render() {
 document.addEventListener('DOMContentLoaded', render);
 
 // In some case, you would like to render Richie components manually
-(window as any).__RICHIE__ = Object.create({ render });
+window.__RICHIE__ = Object.create({ render });

--- a/src/frontend/js/types/globals.d.ts
+++ b/src/frontend/js/types/globals.d.ts
@@ -1,1 +1,9 @@
-declare const RICHIE_VERSION: string;
+import { CommonDataProps } from 'types/commonDataProps';
+
+declare global {
+  const RICHIE_VERSION: string;
+  interface Window {
+    __richie_frontend_context__: CommonDataProps;
+    __RICHIE__: () => Promise<void>;
+  }
+}

--- a/src/frontend/js/utils/api/authentication.ts
+++ b/src/frontend/js/utils/api/authentication.ts
@@ -15,8 +15,8 @@ import OpenEdxHawthornApiInterface from './lms/openedx-hawthorn';
 import OpenEdxFonzieApiInterface from './lms/openedx-fonzie';
 
 const AuthenticationAPIHandler = (): Nullable<APIAuthentication> => {
-  const AUTHENTICATION: AuthenticationBackend = (window as any).__richie_frontend_context__?.context
-    ?.authentication;
+  const AUTHENTICATION: AuthenticationBackend =
+    window.__richie_frontend_context__?.context?.authentication;
   if (!AUTHENTICATION) return null;
 
   switch (AUTHENTICATION.backend) {

--- a/src/frontend/js/utils/api/lms/base.spec.ts
+++ b/src/frontend/js/utils/api/lms/base.spec.ts
@@ -11,7 +11,7 @@ describe('Base API', () => {
       },
     ],
   }).generate();
-  (window as any).__richie_frontend_context__ = { context };
+  window.__richie_frontend_context__ = { context };
   const { default: API } = require('./base');
   const LMSConf = context.lms_backends[0];
   const BaseAPI = API(LMSConf);

--- a/src/frontend/js/utils/api/lms/index.spec.ts
+++ b/src/frontend/js/utils/api/lms/index.spec.ts
@@ -1,4 +1,5 @@
 import { ApiBackend } from 'types/api';
+import { ContextFactory } from 'utils/test/factories';
 
 import { handle } from 'utils/errors/handle';
 
@@ -6,23 +7,21 @@ const mockHandle: jest.Mock<typeof handle> = handle as any;
 jest.mock('utils/errors/handle');
 
 describe('API LMS', () => {
-  (window as any).__richie_frontend_context__ = {
-    context: {
-      lms_backends: [
-        {
-          backend: ApiBackend.BASE,
-          endpoint: 'https://demo.endpoint/api',
-          course_regexp: /.*base.org\/.*/,
-        },
-        {
-          backend: ApiBackend.OPENEDX_HAWTHORN,
-          endpoint: 'https://edx.endpoint/api',
-          course_regexp: /.*edx.org\/.*/,
-        },
-      ],
-      environment: 'test',
-    },
-  };
+  const context = ContextFactory({
+    lms_backends: [
+      {
+        backend: ApiBackend.BASE,
+        endpoint: 'https://demo.endpoint/api',
+        course_regexp: '.*base.org/.*',
+      },
+      {
+        backend: ApiBackend.OPENEDX_HAWTHORN,
+        endpoint: 'https://edx.endpoint/api',
+        course_regexp: '.*edx.org/.*',
+      },
+    ],
+  }).generate();
+  window.__richie_frontend_context__ = { context };
 
   const { default: LMSHandler } = require('./index');
 

--- a/src/frontend/js/utils/api/lms/index.ts
+++ b/src/frontend/js/utils/api/lms/index.ts
@@ -5,7 +5,7 @@ import BaseApiInterface from './base';
 import OpenEdxDogwoodApiInterface from './openedx-dogwood';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
-const context: CommonDataProps['context'] = (window as any).__richie_frontend_context__?.context;
+const context: CommonDataProps['context'] = window.__richie_frontend_context__?.context;
 if (!context) throw new Error('No context frontend context available');
 
 const LMS_BACKENDS = context.lms_backends;

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
@@ -22,7 +22,7 @@ describe('OpenEdX Hawthorn API', () => {
       },
     ],
   }).generate();
-  (window as any).__richie_frontend_context__ = { context };
+  window.__richie_frontend_context__ = { context };
   const { default: API } = require('./openedx-hawthorn');
   const LMSConf = context.lms_backends[0];
   const HawthornApi = API(LMSConf);

--- a/src/frontend/js/utils/errors/handle.spec.ts
+++ b/src/frontend/js/utils/errors/handle.spec.ts
@@ -7,7 +7,7 @@ import { ContextFactory } from 'utils/test/factories';
 jest.mock('@sentry/browser');
 
 describe('handle', () => {
-  (window as any).__richie_frontend_context__ = {
+  window.__richie_frontend_context__ = {
     context: ContextFactory({
       sentry_dsn: 'https://sentry.local.test',
     }).generate(),

--- a/src/frontend/js/utils/errors/handle.ts
+++ b/src/frontend/js/utils/errors/handle.ts
@@ -1,9 +1,6 @@
 import * as Sentry from '@sentry/browser';
 
-import { CommonDataProps } from 'types/commonDataProps';
-
-const context: CommonDataProps['context'] = (window as any).__richie_frontend_context__?.context;
-
+const context = window.__richie_frontend_context__?.context;
 if (context?.sentry_dsn) {
   Sentry.init({
     dsn: context.sentry_dsn,


### PR DESCRIPTION
## Purpose

Within window objects we add two custom properties:
- `__richie_frontend_context__`
- `__RICHIE__`

As Typescript do not know that window object contains those properties, currently we are using `(window as any)` syntax which is a little ugly.

## Proposal

- [x] Declare custom properties added to window through global interface.
