### PR TITLE
✨(blogposts) sort related blog posts by their publication date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Sort related blogposts by their publication date (latest comes first)
 - Upgrade to DjangoCMS 3.9.0 (and subsequently to Django 3.2.6)
 
 ### Fixed

--- a/src/richie/apps/courses/models/blog.py
+++ b/src/richie/apps/courses/models/blog.py
@@ -71,7 +71,7 @@ class BlogPost(BasePageExtension):
             .exclude(id=self.id)
             .select_related("extended_object")
             .distinct()
-            .order_by("extended_object__node__path")
+            .order_by("-extended_object__publication_date")
         )
 
 


### PR DESCRIPTION

## Purpose

When displaying related blogposts on a blogpost's detail page, we were sorting by the related blogposts' "path" (same order as in  the pages tree).

We were waiting for user feedback which requested to sort them by their publication date (the latest coming first).

## Proposal

Sort related blogposts by their publication date and add a test to secure this behavior.
