### PR TITLE
🧐(search) boost title field for a better search experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Boost course title field by a factor of 20 (empirical) for fulltext queries
 - Sort related blogposts by their publication date (latest comes first)
 - Upgrade to DjangoCMS 3.9.0 (and subsequently to Django 3.2.6)
 

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -172,7 +172,7 @@ class CourseSearchForm(SearchForm):
                                 "fields": [
                                     "description.*",
                                     "introduction.*",
-                                    "title.*",
+                                    "title.*^20",
                                     f"categories_names.*^{related_content_boost}",
                                     f"organizations_names.*^{related_content_boost}",
                                     f"persons_names.*^{related_content_boost}",

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -227,7 +227,7 @@ class CourseSearchFormTestCase(TestCase):
                                 "fields": [
                                     "description.*",
                                     "introduction.*",
-                                    "title.*",
+                                    "title.*^20",
                                     "categories_names.*^0.05",
                                     "organizations_names.*^0.05",
                                     "persons_names.*^0.05",


### PR DESCRIPTION
## Purpose

When the query we type matches the title of a course that is not open, it may appear after some open courses with titles that don't match as good. 

## Proposal

Users expect to see the titles that match their query first.
