### PR TITLE
🚸(blogposts) increase excerpt size limit to 240 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Increase blogpost excerpt size limit to 240 characters
 - Change organization icon on course glimpse to a building
 - Boost course title field by a factor of 20 (empirical) for fulltext queries
 - Sort related blogposts by their publication date (latest comes first)

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -442,7 +442,7 @@ DJANGOCMS_VIDEO_TEMPLATES = [("full-width", _("Full width"))]
 
 # Richie plugins
 
-RICHIE_PLAINTEXT_MAXLENGTH = {"course_introduction": 200, "bio": 150, "excerpt": 200}
+RICHIE_PLAINTEXT_MAXLENGTH = {"course_introduction": 200, "bio": 150, "excerpt": 240}
 
 RICHIE_SIMPLETEXT_CONFIGURATION = [
     {


### PR DESCRIPTION
## Purpose

The default size limit for a blogpost excerpt was a bit short.

## Proposal

Bump the default limit to 240 characters.