### PR TITLE
🐛(courses) hide unpublished pages from related objects on public page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Hide unpublished pages when getting related objects on a public page
 - Fix course and organization code fields normalization and validation
 - Fix search bug due to wrong ordering of char filters
 - Stop indexing unpublished categories

--- a/src/richie/apps/core/models.py
+++ b/src/richie/apps/core/models.py
@@ -265,6 +265,11 @@ class BasePageExtension(PageExtension):
             )
             selector = {bfs: page}
 
+        # For a public page, we must filter out page extensions that are not published
+        # in any language
+        if is_draft is False:
+            selector["extended_object__title_set__published"] = True
+
         page_extension_model = apps.get_model(
             app_label="courses", model_name=model_name
         )

--- a/tests/apps/courses/test_models_category.py
+++ b/tests/apps/courses/test_models_category.py
@@ -116,6 +116,8 @@ class CategoryModelsTestCase(TestCase):
         )
         self.assertEqual(child_category.get_meta_category(), meta_category)
 
+    # get_courses
+
     def test_models_category_get_courses_queries(self):
         """
         It should be possible to retrieve the list of related courses on the category instance.
@@ -456,6 +458,12 @@ class CategoryModelsTestCase(TestCase):
             list(category.public_extension.get_courses()), [course.public_extension]
         )
 
+        # If the course is unpublished, it should not be displayed on the public
+        # page anymore
+        course_page.unpublish("en")
+        self.assertEqual(list(category.get_courses()), [course])
+        self.assertEqual(list(category.public_extension.get_courses()), [])
+
     def test_models_category_get_courses_several_languages(self):
         """
         The courses should not be duplicated if they exist in several languages.
@@ -496,6 +504,8 @@ class CategoryModelsTestCase(TestCase):
         self.assertEqual(Course.objects.count(), 4)
         self.assertEqual(category.get_courses().count(), 1)
         self.assertEqual(category.public_extension.get_courses().count(), 1)
+
+    # get_blogposts
 
     def test_models_category_get_blogposts(self):
         """
@@ -855,6 +865,12 @@ class CategoryModelsTestCase(TestCase):
             [blog_post.public_extension],
         )
 
+        # If the blog post is unpublished, it should not be displayed on the public
+        # page anymore
+        blog_post_page.unpublish("en")
+        self.assertEqual(list(category.get_blogposts()), [blog_post])
+        self.assertEqual(list(category.public_extension.get_blogposts()), [])
+
     def test_models_category_get_blogposts_several_languages(self):
         """
         The blogposts should not be duplicated if they exist in several languages.
@@ -867,6 +883,8 @@ class CategoryModelsTestCase(TestCase):
         )
         self.assertEqual(BlogPost.objects.count(), 2)
         self.assertEqual(category.get_blogposts().count(), 1)
+
+    # get_organizations
 
     def test_models_category_get_organizations(self):
         """
@@ -1247,6 +1265,12 @@ class CategoryModelsTestCase(TestCase):
             [organization.public_extension],
         )
 
+        # If the organization is unpublished, it should not be displayed on the public
+        # page anymore
+        organization_page.unpublish("en")
+        self.assertEqual(list(category.get_organizations()), [organization])
+        self.assertEqual(list(category.public_extension.get_organizations()), [])
+
     def test_models_category_get_organizations_several_languages(self):
         """
         The organizations should not be duplicated if they exist in several languages.
@@ -1259,6 +1283,8 @@ class CategoryModelsTestCase(TestCase):
         )
         self.assertEqual(Organization.objects.count(), 2)
         self.assertEqual(category.get_organizations().count(), 1)
+
+    # get_persons
 
     def test_models_category_get_persons(self):
         """
@@ -1597,6 +1623,12 @@ class CategoryModelsTestCase(TestCase):
         self.assertEqual(
             list(category.public_extension.get_persons()), [person.public_extension]
         )
+
+        # If the person is unpublished, it should not be displayed on the public
+        # page anymore
+        person_page.unpublish("en")
+        self.assertEqual(list(category.get_persons()), [person])
+        self.assertEqual(list(category.public_extension.get_persons()), [])
 
     def test_models_category_get_persons_several_languages(self):
         """

--- a/tests/apps/courses/test_models_course.py
+++ b/tests/apps/courses/test_models_course.py
@@ -1178,6 +1178,12 @@ class CourseModelsTestCase(TestCase):
             list(course.public_extension.get_programs()), [program.public_extension]
         )
 
+        # If the program is unpublished, it should not be displayed on the public
+        # page anymore
+        program_page.unpublish("en")
+        self.assertEqual(list(course.get_programs()), [program])
+        self.assertEqual(list(course.public_extension.get_programs()), [])
+
     def test_models_course_get_programs_several_languages(self):
         """
         The programs should not be duplicated if they exist in several languages.

--- a/tests/apps/courses/test_models_organization.py
+++ b/tests/apps/courses/test_models_organization.py
@@ -215,6 +215,8 @@ class OrganizationModelsTestCase(TestCase):
         self.assertIsNone(organization.create_page_role())
         self.assertFalse(organization.extended_object.roles.exists())
 
+    # get_courses
+
     def test_models_organization_get_courses(self):
         """
         It should be possible to retrieve the list of related courses on the organization instance.
@@ -484,6 +486,12 @@ class OrganizationModelsTestCase(TestCase):
             list(organization.public_extension.get_courses()), [course.public_extension]
         )
 
+        # If the course is unpublished, it should not be displayed on the public
+        # page anymore
+        course_page.unpublish("en")
+        self.assertEqual(list(organization.get_courses()), [course])
+        self.assertEqual(list(organization.public_extension.get_courses()), [])
+
     def test_models_organization_get_courses_several_languages(self):
         """
         The courses should not be duplicated if they exist in several languages.
@@ -526,6 +534,8 @@ class OrganizationModelsTestCase(TestCase):
         self.assertEqual(Course.objects.count(), 4)
         self.assertEqual(organization.get_courses().count(), 1)
         self.assertEqual(organization.public_extension.get_courses().count(), 1)
+
+    # get_persons
 
     def test_models_organization_get_persons(self):
         """
@@ -793,6 +803,12 @@ class OrganizationModelsTestCase(TestCase):
         self.assertEqual(
             list(organization.public_extension.get_persons()), [person.public_extension]
         )
+
+        # If the person is unpublished, it should not be displayed on the public
+        # page anymore
+        person_page.unpublish("en")
+        self.assertEqual(list(organization.get_persons()), [person])
+        self.assertEqual(list(organization.public_extension.get_persons()), [])
 
     def test_models_organization_get_persons_several_languages(self):
         """

--- a/tests/apps/courses/test_models_person.py
+++ b/tests/apps/courses/test_models_person.py
@@ -30,6 +30,8 @@ class PersonModelsTestCase(TestCase):
         with self.assertNumQueries(2):
             self.assertEqual(str(person), "Person: Page of Lady Louise Dupont")
 
+    # get_courses
+
     def test_models_person_get_courses(self):
         """
         It should be possible to retrieve the list of related courses on the person instance.
@@ -288,6 +290,12 @@ class PersonModelsTestCase(TestCase):
             list(person.public_extension.get_courses()), [course.public_extension]
         )
 
+        # If the course is unpublished, it should not be displayed on the public
+        # page anymore
+        course_page.unpublish("en")
+        self.assertEqual(list(person.get_courses()), [course])
+        self.assertEqual(list(person.public_extension.get_courses()), [])
+
     def test_models_person_get_courses_several_languages(self):
         """
         The courses should not be duplicated if they exist in several languages.
@@ -326,6 +334,8 @@ class PersonModelsTestCase(TestCase):
         self.assertEqual(Course.objects.count(), 4)
         self.assertEqual(person.get_courses().count(), 1)
         self.assertEqual(person.public_extension.get_courses().count(), 1)
+
+    # get_blogposts
 
     def test_models_person_get_blogposts(self):
         """
@@ -582,6 +592,12 @@ class PersonModelsTestCase(TestCase):
         self.assertEqual(
             list(person.public_extension.get_blogposts()), [blog_post.public_extension]
         )
+
+        # If the blog post is unpublished, it should not be displayed on the public
+        # page anymore
+        blog_post_page.unpublish("en")
+        self.assertEqual(list(person.get_blogposts()), [blog_post])
+        self.assertEqual(list(person.public_extension.get_blogposts()), [])
 
     def test_models_person_get_blogposts_several_languages(self):
         """


### PR DESCRIPTION
## Purpose 

When getting related objects on a public page, we excluded related objects that were not published but forgot to exclude objects that had been published and later unpublished.

## Proposal

- [x] Add filtering clause to filter out unpublished objects when getting related objects for a public page
- [x] Add tests to secure behavior
