### PR TITLE
🐛(search) delete object from search indices when a page is unpublished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix missing persons search index update on publish/unpublish
 - Delete object from search indices when its page is unpublished
 - Fix section on blogpost detail page which was breaking the flow for children
 - Hide unpublished pages when getting related objects on a public page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Delete object from search indices when its page is unpublished
 - Fix section on blogpost detail page which was breaking the flow for children
 - Hide unpublished pages when getting related objects on a public page
 - Fix course and organization code fields normalization and validation

--- a/src/richie/apps/search/apps.py
+++ b/src/richie/apps/search/apps.py
@@ -11,8 +11,11 @@ class SearchConfig(AppConfig):
     # pylint: disable=import-outside-toplevel
     def ready(self):
         """Register signals to update the Elasticsearch indices."""
-        from cms.signals import post_publish
+        from cms.signals import post_publish, post_unpublish
 
-        from .signals import on_page_publish
+        from .signals import on_page_published, on_page_unpublished
 
-        post_publish.connect(on_page_publish, dispatch_uid="search_post_publish")
+        post_publish.connect(on_page_published, dispatch_uid="search_post_publish")
+        post_unpublish.connect(
+            on_page_unpublished, dispatch_uid="search_post_unpublish"
+        )

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -607,7 +607,8 @@ class CoursesIndexer:
                 language: " ".join(st) for language, st in introductions.items()
             },
             "is_new": len(course_runs) == 1,
-            "is_listed": course.is_listed,
+            # If titles is an empty dict, it means the course is not published in any language:
+            "is_listed": bool(course.is_listed and titles),
             # Pick the highlighted organization from the organizations QuerySet to benefit from
             # the prefetch of related title sets
             "organization_highlighted": {

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -21,7 +21,7 @@ from richie.apps.search.index_manager import (
     regenerate_indices,
     store_es_scripts,
 )
-from richie.apps.search.signals import update_course
+from richie.apps.search.signals import apply_es_action_to_course
 
 
 class IndexManagerTestCase(TestCase):
@@ -313,7 +313,7 @@ class IndexManagerTestCase(TestCase):
         # Create a course and trigger a signal to index it. This will create a
         # broken "richie_test_courses" index
         course = CourseFactory(should_publish=True)
-        update_course(course.extended_object, "en")
+        apply_es_action_to_course(course.extended_object, "index", "en")
         self.assertIsNotNone(indices_client.get("richie_test_courses"))
 
         # Call our `regenerate_indices command`

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -729,6 +729,26 @@ class CoursesIndexersTestCase(TestCase):
             course_document["persons_names"], {"en": ["Brian"], "fr": ["François"]}
         )
 
+    def test_indexers_courses_get_es_document_for_course_not_published(self):
+        """
+        A course indexed with no published title shoud not be listed.
+        """
+        course = CourseFactory(
+            page_title={"en": "a course", "fr": "un cours"}, should_publish=True
+        )
+
+        course_document = CoursesIndexer.get_es_document_for_course(course)
+        self.assertTrue(course_document["is_listed"])
+
+        # Only after unpublishing all languages, the course stops being listed
+        course.extended_object.unpublish("en")
+        course_document = CoursesIndexer.get_es_document_for_course(course)
+        self.assertTrue(course_document["is_listed"])
+
+        course.extended_object.unpublish("fr")
+        course_document = CoursesIndexer.get_es_document_for_course(course)
+        self.assertFalse(course_document["is_listed"])
+
     # format_es_object_for_api
 
     def test_indexers_courses_format_es_object_for_api(self):


### PR DESCRIPTION
## Purpose

When a page was published in a new version, we were updating it in our search indices, but we forgot to do the same upon unpublishing a page in a language

As a result, some hidden pages were remaining in the search engine until the next complete reindexation.

## Proposal

- [x] Add a signal "post_unpublish"
- [x] On unpublishing a page, check if it is still published in a language:
    * [x] If yes, reindex it to take into account the fact that a language was newly hidden
    * [x] if no, delete it from the index
- [x] Add missing signal and update methods for `person` pages

