### PR TITLE
🐛(blogposts) fix section on blogpost detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix section on blogpost detail page which was breaking the flow for children
 - Hide unpublished pages when getting related objects on a public page
 - Fix course and organization code fields normalization and validation
 - Fix search bug due to wrong ordering of char filters

--- a/src/frontend/scss/components/templates/courses/cms/_blogpost_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_blogpost_detail.scss
@@ -272,37 +272,4 @@
       border-radius: $border-radius-lg;
     }
   }
-
-  // Neutralize and change sub section behaviors to display as an headline
-  // element
-  .section {
-    width: 100%;
-    margin: 0 !important;
-    padding: 0.5rem 0 !important;
-    font-size: 1rem;
-    color: r-theme-val(blogpost-detail, headline-color);
-    @if r-theme-val(blogpost-detail, headline-border) {
-      border-top: 0.625rem solid r-theme-val(blogpost-detail, headline-border);
-    }
-
-    &__row {
-      margin: 0 !important;
-      padding: 0 !important;
-    }
-
-    &__title {
-      @include font-size($h4-font-size);
-      margin: 0 0 0.5rem 0;
-      padding: 0;
-      color: r-theme-val(blogpost-detail, headline-title-color);
-      line-height: 1.4;
-      text-align: left;
-    }
-
-    &__items {
-      display: block;
-      margin: 0 !important;
-      padding: 0 !important;
-    }
-  }
 }


### PR DESCRIPTION
### Purpose

On blogpost pages, an apparently useless override on the section styles was breaking the flow.

As a result, adding several glimpses in a section was displaying them on several lines.

### Proposal

- [x] Remove css style overrides for sections on the blogpost detail page

### Screenshots

#### Before

<img src="https://user-images.githubusercontent.com/1427165/129347470-808539ca-18b9-4f50-8c3f-b9b347c7bc5e.png" width="500"/>

#### After
<img src="https://user-images.githubusercontent.com/1427165/129347403-c73d11fe-278e-4a93-b4a9-0bd6a0877acd.png" width="350"/>
