### PR TITLE
Add a topbar branding block to easily switch logos and images

### DIFF
--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -74,7 +74,9 @@
                         <button class="topbar__hamburger"
                                 data-target="main-menu" aria-label="menu" aria-expanded="false">&#8801;</button>
                         <a href="/">
+                        {% block topbar_branding %}
                             <img src="{% static "richie/images/logo.png" %}" class="topbar__logo" alt="{{ SITE.name }}">
+                        {% endblock topbar_branding %}
                         </a>
                     </div>
                     <div class="topbar__menu">


### PR DESCRIPTION
Adding a `topbar_branding` block allows us to easily switch and change properties on the site logo `<img>`. In specific cases, it allows users to place inline svg logos.