### PR TITLE
🐛(courses) reverse 401 and 403 errors in course run sync webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Reverse 401 and 403 errors in course run synchronization webhook
 - Fix missing persons search index update on publish/unpublish
 - Delete object from search indices when its page is unpublished
 - Fix section on blogpost detail page which was breaking the flow for children

--- a/src/richie/apps/courses/api.py
+++ b/src/richie/apps/courses/api.py
@@ -99,7 +99,7 @@ def course_runs_sync(request, version):
     # It then enables us to do updates and change the secret without incurring downtime.
     authorization_header = request.headers.get("Authorization")
     if not authorization_header:
-        return Response("Missing authentication.", status=401)
+        return Response("Missing authentication.", status=403)
 
     signature_is_valid = any(
         authorization_header
@@ -114,7 +114,7 @@ def course_runs_sync(request, version):
     )
 
     if not signature_is_valid:
-        return Response("Invalid authentication.", status=403)
+        return Response("Invalid authentication.", status=401)
 
     # Select LMS from resource link
     resource_link = request.data.get("resource_link")

--- a/tests/apps/courses/test_api_course_run_sync_edx.py
+++ b/tests/apps/courses/test_api_course_run_sync_edx.py
@@ -40,7 +40,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             "/api/v1.0/course-runs-sync", data, content_type="application/json"
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(json.loads(response.content), "Missing authentication.")
         self.assertEqual(CourseRun.objects.count(), 0)
         self.assertEqual(Course.objects.count(), 0)
@@ -65,7 +65,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             HTTP_AUTHORIZATION=("invalid authorization"),
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(json.loads(response.content), "Invalid authentication.")
         self.assertEqual(CourseRun.objects.count(), 0)
         self.assertEqual(Course.objects.count(), 0)


### PR DESCRIPTION
## Purpose

We mixed up both error codes:
- if there is no token, the user is anonymous and is not allowed to access the resource => 403
- if the token is invalid, the user can't be authenticated => 401

## Proposal

Reverse error codes and update tests.
