### PR TITLE
🐛(backend) escape frontend_context characters for use in javascript s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Escape FRONTEND_CONTEXT characters for use in Javascript string
 - Reverse 401 and 403 errors in course run synchronization webhook
 - Fix missing persons search index update on publish/unpublish
 - Delete object from search indices when its page is unpublished

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -160,7 +160,7 @@
 
         {% render_block "js" %}
         <script>
-            window.__richie_frontend_context__ = JSON.parse('{{ FRONTEND_CONTEXT|safe }}');
+            window.__richie_frontend_context__ = JSON.parse('{{ FRONTEND_CONTEXT|escapejs|safe }}');
         </script>
         <script src="{% static 'richie/js/build/index.js' %}"></script>
         <script>

--- a/tests/apps/core/test_authentication_delegation.py
+++ b/tests/apps/core/test_authentication_delegation.py
@@ -28,8 +28,9 @@ class UserMenuTests(CMSTestCase):
     )
     def test_user_menu_with_profile_urls(self):
         """
-        user menu should render correctly
-        and includes formatted profile_urls
+        User menu should render correctly and includes formatted profile_urls.
+        Characters should be escaped with the `escapejs` template tag to prevent
+        an issue when this variable contains unescaped characters for javascript (e.g: '\').
         """
         page = create_page(
             title="Home",
@@ -47,7 +48,10 @@ class UserMenuTests(CMSTestCase):
         self.assertIsNotNone(re.search(pattern, str(response.content)))
         self.assertContains(
             response,
-            r'"authentication": {{"endpoint": "{}", "backend": "{}"}}'.format(
+            (
+                r"\u0022authentication\u0022: "
+                r"{{\u0022endpoint\u0022: \u0022{}\u0022, \u0022backend\u0022: \u0022{}\u0022}}"
+            ).format(
                 "https://richie.education:9999",
                 "richie.apps.courses.lms.base.BaseLMSBackend",
             ),


### PR DESCRIPTION
## Purpose

`FRONTEND_CONTEXT` could contains some characters that's need to be escaped for use in javascript string. For example, if this variable contains some regexp string, they can contain unescaped back slash characters that raise an error when JSON.parse try to parse this string.

Related issue: #1440

## Proposal

- [x] Escape `FRONTEND_CONTEXT` characters for use in javascript string
