### PR TITLE
🐛(docs) work around broken check for docs deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,6 +743,8 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
+        environment:
+          FORCE_DEPLOY: true
     working_directory: ~/fun
     steps:
       - checkout


### PR DESCRIPTION
## Purpose

Docusaurus-publish checks if it is running on a Pull Request by looking at the relevant environment variables as provided by
Circle CI. However, one of those is deprecated and we suspect it contains an incorrect value, where Docusaurus concludes it is running on a PR when it is actually just running on master.

## Proposal

Hopefully this will be solved in a later version of Docusaurus, and/or Circle CI will provide correct values in their environment variables.

In the meantime, since we manage when we deploy our docs on our own (by only running the job on master), we can just use FORCE_DEPLOY to disregard the check and always deploy when our CI deployment job is running.
