### PR TITLE
🐛(website) force deploy Docusaurus website

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,8 +743,6 @@ jobs:
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
-        environment:
-          FORCE_DEPLOY: true
     working_directory: ~/fun
     steps:
       - checkout
@@ -754,7 +752,7 @@ jobs:
             git config --global user.email "funmoocbot@users.noreply.github.com"
             git config --global user.name "FUN MOOC Bot"
             echo "machine github.com login funmoocbot password ${GH_TOKEN}" > ~/.netrc
-            cd ./website && yarn install && GIT_USER=funmoocbot yarn run publish-gh-pages
+            cd ./website && yarn install && GIT_USER=funmoocbot CI_PULL_REQUEST=false CIRCLE_PULL_REQUEST=false yarn run publish-gh-pages
 
 workflows:
   version: 2


### PR DESCRIPTION
## Purpose

Docusaurus only deploys the website if the `CI_PULL_REQUEST` and `CIRCLE_PULL_REQUEST` environment variables are both null. This is apparently not the case anymore in CircleCI on a build of the master branch.

## Proposal

We have to force it on the command. We can not force deployment with the `FORCE_DEPLOY` environment
variable because it was not released in Docusaurus v1.