### PR TITLE
🐛(website) use falsy IS_PULL_REQUEST values to force docs to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -748,11 +748,13 @@ jobs:
       - checkout
       - run:
           name: Deploying to GitHub Pages
+          # NB: pass falsy values for the PULL REQUEST environment variables to make sure the
+          # deployment is not cancelled by Docusaurus based on incorrect values provide by Circle CI.
           command: |
             git config --global user.email "funmoocbot@users.noreply.github.com"
             git config --global user.name "FUN MOOC Bot"
             echo "machine github.com login funmoocbot password ${GH_TOKEN}" > ~/.netrc
-            cd ./website && yarn install && GIT_USER=funmoocbot CI_PULL_REQUEST=false CIRCLE_PULL_REQUEST=false yarn run publish-gh-pages
+            cd ./website && yarn install && GIT_USER=funmoocbot CI_PULL_REQUEST="" CIRCLE_PULL_REQUEST="" yarn run publish-gh-pages
 
 workflows:
   version: 2


### PR DESCRIPTION
## Purpose

We previously used false as a value to force deployments of our docs regardless of the (incorrect) values provided by the
Circle CI environment. 

## Proposal

As environment variables are always strings, "false" is actually a truthy value. Use an empty string instead to we do provide a falsy value.