### PR TITLE
🐛(search) fix search template meta block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix meta header "alternate" href value to avoid duplicates in search engine
+- Fix search template meta block like missing favicon and open graph metas
 
 ## [2.8.0] - 2021-09-17
 

--- a/src/richie/apps/search/templates/search/search.html
+++ b/src/richie/apps/search/templates/search/search.html
@@ -3,6 +3,7 @@
 {% get_current_language as LANGUAGE_CODE %}
 
 {% block meta %}
+  {{ block.super }}
   {% if CDN_DOMAIN %}
   <meta name="public-path" value="{{ CDN_DOMAIN }}" />
   {% endif %}


### PR DESCRIPTION
The favicon and open graph metas weren't being added to the search page.
