### PR TITLE
🔍️(seo) fix alternate meta href value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix meta header "alternate" href value to avoid duplicates in search engine
+
 ## [2.8.0] - 2021-09-17
 
 ### Added

--- a/src/richie/apps/core/templates/richie/hreflang.html
+++ b/src/richie/apps/core/templates/richie/hreflang.html
@@ -1,6 +1,6 @@
 {% load i18n menu_tags cms_tags %}
 {% if languages|length > 1 %}
     {% for code, name in languages %}
-        <link rel="alternate" href="{% page_language_url code %}" hreflang="{{ code }}" />
+        <link rel="alternate" href="{{ SITE.web_url }}{% page_language_url code %}" hreflang="{{ code }}" />
     {% endfor %}
 {% endif %}

--- a/tests/apps/core/test_pages.py
+++ b/tests/apps/core/test_pages.py
@@ -59,11 +59,14 @@ class PagesTests(CMSTestCase):
             response = self.client.get(page.get_absolute_url(language))
             self.assertEqual(200, response.status_code)
             self.assertIn(
-                '<link rel="alternate" href="/fr-ca/un-deux/" hreflang="fr-ca" />',
+                (
+                    '<link rel="alternate" href="http://example.com/fr-ca/un-deux/" '
+                    'hreflang="fr-ca" />'
+                ),
                 response.rendered_content,
             )
             self.assertIn(
-                '<link rel="alternate" href="/es/uno-dos/" hreflang="es" />',
+                '<link rel="alternate" href="http://example.com/es/uno-dos/" hreflang="es" />',
                 response.rendered_content,
             )
 

--- a/tests/apps/courses/test_templates_course_detail_rdfa.py
+++ b/tests/apps/courses/test_templates_course_detail_rdfa.py
@@ -290,7 +290,7 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
             (
                 subject,
                 URIRef("https://schema.org/alternate"),
-                URIRef("/en/very-interesting-course/"),
+                URIRef("http://example.com/en/very-interesting-course/"),
             )
             in graph
         )
@@ -298,7 +298,7 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
             (
                 subject,
                 URIRef("https://schema.org/alternate"),
-                URIRef("/fr/very-interesting-course/"),
+                URIRef("http://example.com/fr/very-interesting-course/"),
             )
             in graph
         )


### PR DESCRIPTION
Fix the href value of alternate meta, so we could have a better SEO.

Related with issue #1393 
Executed the suggestion change of @sveetch and fixed the tests.

