### PR TITLE
🐛(search) lazily retrieve es version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Set a proper default value to `DJANGO_SECRET_KEY` in `Base` configuration
+
 ### Fixed
 
 - Fix meta header "alternate" href value to avoid duplicates in search engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Lazily retrieve elasticsearch server version
 - Fix meta header "alternate" href value to avoid duplicates in search engine
 - Fix search template meta block like missing favicon and open graph metas
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -139,7 +139,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
 
     # Security
     ALLOWED_HOSTS = []
-    SECRET_KEY = values.Value(None)
+    SECRET_KEY = values.Value("ThisIsAnExampleKeyForDevPurposeOnly")
     # System check reference:
     # https://docs.djangoproject.com/en/2.2/ref/checks/#security
     SILENCED_SYSTEM_CHECKS = values.ListValue(
@@ -648,13 +648,15 @@ class ContinuousIntegration(Test):
 class Production(Base):
     """Production environment settings
 
-    You must define the DJANGO_ALLOWED_HOSTS environment variable in Production
-    configuration (and derived configurations):
+    You must define the DJANGO_ALLOWED_HOSTS and DJANGO_SECRET_KEY environment
+    variables in Production configuration (and derived configurations):
 
     DJANGO_ALLOWED_HOSTS="foo.com,foo.fr"
+    DJANGO_SECRET_KEY="your-secret-key"
     """
 
     # Security
+    SECRET_KEY = values.SecretValue()
     ALLOWED_HOSTS = values.ListValue(None)
     CSRF_COOKIE_SECURE = True
     SECURE_BROWSER_XSS_FILTER = True

--- a/tests/apps/search/test_elasticsearch_compat_layer.py
+++ b/tests/apps/search/test_elasticsearch_compat_layer.py
@@ -1,18 +1,43 @@
 """Tests for the ElasticSearch compatibility layer."""
 from unittest import mock
 
+from django.conf import settings
 from django.test import TestCase
 
-from richie.apps.search import ES_CLIENT, ES_INDICES_CLIENT
-from richie.apps.search.elasticsearch import bulk_compat
+from richie.apps.search.elasticsearch import (
+    ElasticsearchClientCompat7to6,
+    ElasticsearchIndicesClientCompat7to6,
+    bulk_compat,
+)
 from richie.apps.search.indexers.categories import CategoriesIndexer
 from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
+from richie.apps.search.utils.indexers import slice_string_for_completion
 
 CATEGORIES = [
-    {"id": "8312", "kind": "subjects", "title": {"en": "Literature"}},
-    {"id": "8399", "kind": "subjects", "title": {"en": "Science for beginners"}},
-    {"id": "8421", "kind": "levels", "title": {"en": "Bégînnêr"}},
-    {"id": "8476", "kind": "levels", "title": {"en": "Expert"}},
+    {
+        "id": "8312",
+        "kind": "subjects",
+        "title": {"en": "Literature"},
+        "complete": {"en": slice_string_for_completion("Literature")},
+    },
+    {
+        "id": "8399",
+        "kind": "subjects",
+        "title": {"en": "Science for beginners"},
+        "complete": {"en": slice_string_for_completion("Science for beginners")},
+    },
+    {
+        "id": "8421",
+        "kind": "levels",
+        "title": {"en": "Bégînnêr"},
+        "complete": {"en": slice_string_for_completion("Bégînnêr")},
+    },
+    {
+        "id": "8476",
+        "kind": "levels",
+        "title": {"en": "Expert"},
+        "complete": {"en": slice_string_for_completion("Expert")},
+    },
 ]
 
 
@@ -22,48 +47,77 @@ class ElasticSearchCompatLayerTestCase(TestCase):
     different versions of ElasticSearch.
     """
 
-    @mock.patch(
-        "elasticsearch.Elasticsearch.info",
-        return_value={"should not be called": "the value is cached"},
+    @mock.patch.object(
+        CategoriesIndexer,
+        "index_name",
+        new_callable=mock.PropertyMock,
+        return_value="test_categories",
     )
-    def test_cache_version_information(self, mock_es_info):
+    def test_cache_version_information(self, *_):
         """
-        Make sure we only ever make the info() call once even if we use more than
-        one ElasticSearch API endpoint.
+        Make sure we only ever make the info() call once by instance
+        even if we use more than one ElasticSearch API endpoint.
         """
 
-        # Perform a bunch of ES actions, from index management all the way to searches
-        ES_INDICES_CLIENT.delete(index="_all")
-        ES_INDICES_CLIENT.create(index="test_categories")
-        ES_INDICES_CLIENT.close(index="test_categories")
-        ES_INDICES_CLIENT.put_settings(body=ANALYSIS_SETTINGS, index="test_categories")
-        ES_INDICES_CLIENT.open(index="test_categories")
-        ES_INDICES_CLIENT.put_mapping(
-            body=CategoriesIndexer.mapping, index="test_categories"
+        # - Use a fresh ES client instance to be sure that __es_version__ has
+        #   not been called yet
+        es_client = ElasticsearchClientCompat7to6(
+            [getattr(settings, "RICHIE_ES_HOST", "elasticsearch")]
         )
+        es_indices_client = ElasticsearchIndicesClientCompat7to6(es_client)
 
-        actions = [
-            {
-                "_id": category["id"],
-                "_index": "test_categories",
-                "_op_type": "create",
-                "absolute_url": {"en": "en/url"},
-                "description": {"en": "en/description"},
-                "icon": {"en": "en/icon"},
-                "is_meta": False,
-                "logo": {"en": "en/logo"},
-                "nb_children": 0,
-                "path": category["id"],
-                "title_raw": category["title"],
-                **category,
-            }
-            for category in CATEGORIES
-        ]
-        bulk_compat(actions=actions, chunk_size=500, client=ES_CLIENT)
-        ES_INDICES_CLIENT.refresh()
+        with mock.patch(
+            "elasticsearch.Elasticsearch.info", wraps=es_client.info
+        ) as mock_es_info:
+            with mock.patch("richie.apps.search.ES_CLIENT", es_client):
+                with mock.patch(
+                    "richie.apps.search.ES_INDICES_CLIENT", es_indices_client
+                ):
+                    # Perform a bunch of ES actions, from index management all the way to searches
 
-        self.client.get("/api/v1.0/subjects/")
-        self.client.get("/api/v1.0/levels/")
-        self.client.get("/api/v1.0/subjects/8312/")
+                    es_indices_client.delete(index="_all")
+                    es_indices_client.create(index="test_categories")
+                    es_indices_client.close(index="test_categories")
+                    es_indices_client.put_settings(
+                        body=ANALYSIS_SETTINGS, index="test_categories"
+                    )
+                    es_indices_client.open(index="test_categories")
+                    es_indices_client.put_mapping(
+                        body=CategoriesIndexer.mapping, index="test_categories"
+                    )
 
-        mock_es_info.assert_not_called()
+                    actions = [
+                        {
+                            "_id": category["id"],
+                            "_index": "test_categories",
+                            "_op_type": "create",
+                            "absolute_url": {"en": "en/url"},
+                            "description": {"en": "en/description"},
+                            "icon": {"en": "en/icon"},
+                            "is_meta": False,
+                            "logo": {"en": "en/logo"},
+                            "nb_children": 0,
+                            "path": category["id"],
+                            "title_raw": category["title"],
+                            **category,
+                        }
+                        for category in CATEGORIES
+                    ]
+                    bulk_compat(actions=actions, chunk_size=500, client=es_client)
+                    es_indices_client.refresh()
+
+                    self.client.get("/api/v1.0/subjets/")
+                    self.client.get("/api/v1.0/levels/")
+                    self.client.get("/api/v1.0/subjets/8312")
+
+                    mock_es_info.assert_called_once()
+                    mock_es_info.reset_mock()
+
+                    # - Autocomplete checks the es_version,
+                    #   info() should not be triggered again
+                    self.client.get("/api/v1.0/subjects/autocomplete/?query=Lit")
+                    self.client.get("/api/v1.0/levels/autocomplete/?query=Expert")
+                    self.client.get("/api/v1.0/subjects/autocomplete/?query=Sci")
+                    self.client.get("/api/v1.0/levels/autocomplete/?query=Bég")
+
+                    mock_es_info.assert_not_called()


### PR DESCRIPTION
## Purpose

Retrieve the elasticsearch server version on initialization could creates bug in contexts where elasticsearch host is not accessible. e.g: during a docker build if we run a manage command, an elasticsearch client is initiliazed and build
failed due to a ConnectionError. So a workaround is to lazily retrieve the elasticsearch version the first time we need to know the version then reuse the value.


## Proposal

- [x] Retrieve `ElasticsearchClientCompat7to6.__es_version__` only when it is needed and cache the result
