### PR TITLE
♻️(search) stop relying on MPTT paths to define search filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Set a proper default value to `DJANGO_SECRET_KEY` in `Base` configuration
+- Update search filters to stop relying on CMS pages MPTT paths
 
 ### Fixed
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -538,7 +538,20 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
             "OPTIONS": values.DictValue(
                 {}, environ_name="CACHE_DEFAULT_OPTIONS", environ_prefix=None
             ),
-        }
+        },
+        "search": {
+            "BACKEND": values.Value(
+                "django.core.cache.backends.locmem.LocMemCache",
+                environ_name="SEARCH_CACHE_BACKEND",
+                environ_prefix=None,
+            ),
+            "LOCATION": values.Value(
+                "search_cache",
+                environ_name="SEARCH_CACHE_NAME",
+                environ_prefix=None,
+            ),
+            "TIMEOUT": 60,
+        },
     }
 
     # For more details about CMS_CACHE_DURATION, see :
@@ -623,7 +636,12 @@ class Test(Base):
             "BACKEND": "django_redis.cache.RedisCache",
             "LOCATION": "mymaster/redis-sentinel:26379,redis-sentinel:26379/0",
             "OPTIONS": {"CLIENT_CLASS": "richie.apps.core.cache.SentinelClient"},
-        }
+        },
+        "search": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "search_cache",
+            "TIMEOUT": 60,
+        },
     }
 
     RICHIE_LMS_BACKENDS = [

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -84,7 +84,7 @@ FILTERS_CONFIGURATION = [
         },
     ),
     (
-        "richie.apps.search.filter_definitions.IndexableMPTTFilterDefinition",
+        "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
         {
             "human_name": _("Subjects"),
             "is_autocompletable": True,
@@ -97,7 +97,7 @@ FILTERS_CONFIGURATION = [
         },
     ),
     (
-        "richie.apps.search.filter_definitions.IndexableMPTTFilterDefinition",
+        "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
         {
             "human_name": _("Levels"),
             "is_autocompletable": True,
@@ -110,7 +110,7 @@ FILTERS_CONFIGURATION = [
         },
     ),
     (
-        "richie.apps.search.filter_definitions.IndexableMPTTFilterDefinition",
+        "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
         {
             "human_name": _("Organizations"),
             "is_autocompletable": True,

--- a/src/richie/apps/search/filter_definitions/__init__.py
+++ b/src/richie/apps/search/filter_definitions/__init__.py
@@ -8,7 +8,7 @@ from .base import NestingWrapper  # noqa
 from .courses import (  # noqa
     AvailabilityFilterDefinition,
     IndexableFilterDefinition,
-    IndexableMPTTFilterDefinition,
+    IndexableHierarchicalFilterDefinition,
     LanguagesFilterDefinition,
     StaticChoicesFilterDefinition,
 )

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -1,203 +1,35 @@
 """Integration tests for actual search results and their ordering."""
 # pylint: disable=too-many-lines
-import json
 import random
 from unittest import mock
 
+from django.core.cache import caches
 from django.test import TestCase
 
 import arrow
+from cms.models import Page
 
-from richie.apps.courses.factories import CategoryFactory, OrganizationFactory
+from richie.apps.courses.factories import (
+    CategoryFactory,
+    OrganizationFactory,
+    PersonFactory,
+)
 from richie.apps.search import ES_CLIENT, ES_INDICES_CLIENT
 from richie.apps.search.elasticsearch import bulk_compat
-from richie.apps.search.filter_definitions import FILTERS, IndexableFilterDefinition
+from richie.apps.search.filter_definitions import FILTERS
 from richie.apps.search.filter_definitions.courses import ALL_LANGUAGES_DICT
+from richie.apps.search.indexers.categories import CategoriesIndexer
 from richie.apps.search.indexers.courses import CoursesIndexer
+from richie.apps.search.indexers.organizations import OrganizationsIndexer
+from richie.apps.search.indexers.persons import PersonsIndexer
 from richie.apps.search.text_indexing import ANALYSIS_SETTINGS
-
-COURSES = [
-    {
-        "categories": ["P-00010001", "P-00010002", "L-000100010001", "L-00020001"],
-        "categories_names": {"en": ["Artificial intelligence", "Autumn", "Wilderness"]},
-        "code": "001abc",
-        "description": {
-            "en": (
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec egestas "
-                "lectus. Cras eget lobortis eros. Suspendisse hendrerit dictum ex, eget pharetra. "
-                "Pellentesque habitant morbi tristique senectus et netus et malesuada fames "
-                "ac turpis egestas. Integer ut eleifend massa."
-            )
-        },
-        "introduction": {"en": "Polarized non-volatile structure"},
-        "is_new": True,
-        "is_listed": True,
-        "organization_highlighted": {"en": "Org 311"},
-        "organizations": ["P-00030001", "P-00030004", "L-000300010001"],
-        "organizations_names": {"en": ["Org 31", "Org 34", "Org 311"]},
-        "persons": ["2"],
-        "persons_names": {"en": ["Mikhaïl Boulgakov"]},
-        "title": {"en": "Artificial intelligence for mushroom picking"},
-    },
-    {
-        "categories": ["P-00010001", "P-00010003", "L-000100010002", "L-00020003"],
-        "categories_names": {"en": ["Martial arts?", "Autumn"]},
-        "code": "002lmn",
-        "description": {
-            "en": (
-                "Artisanally-sourced clicks neque. erat volutpat. Nulla at laoreet. "
-                "Finibus viverra tortor et pulvinar. In placerat interdum arcu, ac ullamcorper "
-                "augue. Nam sed semper velit. Praesent orci nulla, malesuada nec commodo at, "
-                "lobortis eget justo."
-            )
-        },
-        "introduction": {"en": "De-engineered demand-driven success"},
-        "is_new": True,
-        "is_listed": True,
-        "organization_highlighted": {"en": "Org 33"},
-        "organizations": ["P-00030001", "P-00030003", "L-000300010002"],
-        "organizations_names": {"en": ["Org 31", "Org 33", "Org 312"]},
-        "persons": [],
-        "persons_names": {},
-        "title": {"en": "Click-farms: managing the autumn harvest"},
-    },
-    {
-        "categories": ["P-00010002", "P-00010003", "L-000100020001", "L-00020001"],
-        "categories_names": {"en": ["Artificial intelligence", "Water", "Wilderness"]},
-        "code": "003rst",
-        "description": {
-            "en": (
-                "Cursus honorum finite que non luctus ante. Etiam accumsan vulputate magna non "
-                "sollicitudin. Aliquam molestie est finibus elit scelerisque laoreet. Maecenas "
-                "porttitor cursus cursus. Nam pellentesque eget neque quis tincidunt. Fusce sem "
-                "ipsum, dignissim at augue."
-            )
-        },
-        "introduction": {"en": "Up-sized value-added project"},
-        "is_new": False,
-        "is_listed": True,
-        "organization_highlighted": {"en": "Org 321"},
-        "organizations": ["P-00030002", "P-00030003", "L-000300020001"],
-        "organizations_names": {"en": ["Org 32", "Org 33", "Org 321"]},
-        "persons": [],
-        "persons_names": {},
-        "title": {"en": "Building a data lake out of mountain springs"},
-    },
-    {
-        "categories": ["P-00010002", "P-00010004", "L-000100020002", "L-00020002"],
-        "categories_names": {"en": ["Martial arts?", "Water"]},
-        "code": "004xyz",
-        "description": {
-            "en": (
-                "Nullam ornare finibus sollicitudin. Aliquam nisl leo, vestibulum a turpis quis, "
-                "convallis tincidunt sem. Aliquam eleifend tellus vitae neque sagittis rutrum. "
-                "Artificial vulputate neque placerat, commodo quam gravida, maximus lectus."
-            )
-        },
-        "introduction": {"en": "Innovative encompassing extranet"},
-        "is_new": False,
-        "is_listed": True,
-        "organization_highlighted": {"en": "Org 34"},
-        "organizations": ["P-00030002", "P-00030004", "L-000300020002"],
-        "organizations_names": {"en": ["Org 32", "Org 34", "Org 322"]},
-        "persons": ["2"],
-        "persons_names": {"en": ["Mikhaïl Boulgakov"]},
-        "title": {"en": "Kung-fu moves for cloud infrastructure security"},
-    },
-]
-INDEXABLE_IDS = {
-    id: f"#{id:s}"
-    for course in COURSES
-    for id in course["categories"] + course["organizations"] + course["persons"]
-}
-COURSE_RUNS = {
-    "A": {
-        # A) ongoing course, next open course to end enrollment
-        "start": arrow.utcnow().shift(days=-5).datetime,
-        "end": arrow.utcnow().shift(days=+120).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=-15).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=+5).datetime,
-        "languages": ["fr"],
-    },
-    "B": {
-        # B) ongoing course, can still be enrolled in for longer than A)
-        "start": arrow.utcnow().shift(days=-15).datetime,
-        "end": arrow.utcnow().shift(days=+105).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=-30).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=+15).datetime,
-        "languages": ["en"],
-    },
-    "C": {
-        # C) not started yet, first upcoming course to start
-        "start": arrow.utcnow().shift(days=+15).datetime,
-        "end": arrow.utcnow().shift(days=+150).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=-30).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=+30).datetime,
-        "languages": ["en"],
-    },
-    "D": {
-        # D) already finished course but enrollment still open
-        "start": arrow.utcnow().shift(days=-80).datetime,
-        "end": arrow.utcnow().shift(days=-15).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=-100).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=+15).datetime,
-        "languages": ["en"],
-    },
-    "E": {
-        # E) not started yet, will start after the other upcoming course
-        "start": arrow.utcnow().shift(days=+45).datetime,
-        "end": arrow.utcnow().shift(days=+120).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=+30).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=+60).datetime,
-        "languages": ["fr", "de"],
-    },
-    "F": {
-        # F) ongoing course, most recent to end enrollment
-        "start": arrow.utcnow().shift(days=-90).datetime,
-        "end": arrow.utcnow().shift(days=+15).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=-120).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=-30).datetime,
-        "languages": ["en"],
-    },
-    "G": {
-        # G) ongoing course, enrollment has been over for the longest
-        "start": arrow.utcnow().shift(days=-75).datetime,
-        "end": arrow.utcnow().shift(days=+30).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=-100).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=-45).datetime,
-        "languages": ["fr"],
-    },
-    "H": {
-        # H) already finished course; it finished more recently than I)
-        "start": arrow.utcnow().shift(days=-80).datetime,
-        "end": arrow.utcnow().shift(days=-15).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=-100).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=-60).datetime,
-        "languages": ["en"],
-    },
-    "I": {
-        # I) the course that has been over for the longest
-        "start": arrow.utcnow().shift(days=-120).datetime,
-        "end": arrow.utcnow().shift(days=-30).datetime,
-        "enrollment_start": arrow.utcnow().shift(days=-150).datetime,
-        "enrollment_end": arrow.utcnow().shift(days=-90).datetime,
-        "languages": ["en", "de"],
-    },
-}
 
 
 # pylint: disable=too-many-public-methods
 @mock.patch.dict(  # Reduce the number of languages
     ALL_LANGUAGES_DICT,
-    {
-        language: f"#{language:s}"
-        for cr in COURSE_RUNS.values()
-        for language in cr["languages"]
-    },
+    {"fr": "#fr", "en": "#en", "de": "#de"},
     clear=True,
-)
-@mock.patch.object(  # Avoid having to build the categories and organizations indices
-    IndexableFilterDefinition, "get_i18n_names", return_value=INDEXABLE_IDS
 )
 @mock.patch.object(  # Avoid messing up the development Elasticsearch index
     CoursesIndexer,
@@ -211,6 +43,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
     works as expected.
     """
 
+    def __init__(self, *args, **kwargs):
+        self.persons = None
+        self.course_runs = None
+        super().__init__(*args, **kwargs)
+
     def setUp(self):
         """Reset indexable filters cache before each test so the context is as expected."""
         super().setUp()
@@ -223,7 +60,8 @@ class CourseRunsCoursesQueryTestCase(TestCase):
 
     @staticmethod
     def reset_filter_definitions_cache():
-        """Reset indexable filters cache on the `base_page` field."""
+        """Reset indexable filters cache on the `base_page` and `aggs_include` fields."""
+        caches["search"].clear()
         for filter_name in ["levels", "subjects", "organizations"]:
             # pylint: disable=protected-access
             FILTERS[filter_name]._base_page = None
@@ -237,9 +75,19 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             - levels page path: 0002
             - organizations page path: 0003
         """
-        CategoryFactory(page_reverse_id="subjects", should_publish=True)
-        CategoryFactory(page_reverse_id="levels", should_publish=True)
-        OrganizationFactory(page_reverse_id="organizations", should_publish=True)
+        return {
+            "subjects": CategoryFactory(
+                page_reverse_id="subjects", page_title="Subjects", should_publish=True
+            ),
+            "levels": CategoryFactory(
+                page_reverse_id="levels", page_title="Levels", should_publish=True
+            ),
+            "organizations": OrganizationFactory(
+                page_reverse_id="organizations",
+                page_title="Organizations",
+                should_publish=True,
+            ),
+        }
 
     @staticmethod
     def get_expected_courses(courses_definition, course_run_ids):
@@ -272,18 +120,288 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         # > [1, 3, 0]
         return list(list(zip(*sorted_courses))[0])
 
-    def execute_query(self, querystring="", suite=None):
+    def prepare_indices(self, suite=None):
         """
         Not a test.
         This method is doing the heavy lifting for the tests in this class:
+        - create relevant objects that will be linked with courses,
         - generate a set of courses randomly associated to our "interesting" course runs,
-        - prepare the Elasticsearch index,
-        - execute the query.
+        - prepare the Elasticsearch index.
         """
+        filter_pages = self.create_filter_pages()
+
+        top_subjects = [
+            # 00010001 through 00010004
+            CategoryFactory(
+                page_parent=filter_pages["subjects"].extended_object,
+                page_title=f"Subject #{i}",
+                should_publish=True,
+            )
+            for i in range(0, 4)
+        ]
+
+        subject_0_children = [
+            # 000100010001 and 000100010002
+            CategoryFactory(
+                page_parent=top_subjects[0].extended_object,
+                page_title=f"Subject #0 Child #{i}",
+                should_publish=True,
+            )
+            for i in range(0, 2)
+        ]
+
+        subject_1_children = [
+            # 000100020001 and 000100020002
+            CategoryFactory(
+                page_parent=top_subjects[1].extended_object,
+                page_title=f"Subject #1 Child #{i}",
+                should_publish=True,
+            )
+            for i in range(0, 2)
+        ]
+
+        levels = [
+            # 00020001 through 00020003
+            CategoryFactory(
+                page_parent=filter_pages["levels"].extended_object,
+                page_title=f"Level #{i}",
+                should_publish=True,
+            )
+            for i in range(0, 3)
+        ]
+
+        top_organizations = [
+            # 00030001 through 00030004
+            OrganizationFactory(
+                page_parent=filter_pages["organizations"].extended_object,
+                page_title=f"Organization #{i}",
+                should_publish=True,
+            )
+            for i in range(0, 4)
+        ]
+
+        organization_0_children = [
+            # 000300010001 and 000300010002
+            OrganizationFactory(
+                page_parent=top_organizations[0].extended_object,
+                page_title=f"Organization #0 Child #{i}",
+                should_publish=True,
+            )
+            for i in range(0, 2)
+        ]
+
+        organization_1_children = [
+            # 000300020001 and 000300020002
+            OrganizationFactory(
+                page_parent=top_organizations[1].extended_object,
+                page_title=f"Organization #1 Child #{i}",
+                should_publish=True,
+            )
+            for i in range(0, 2)
+        ]
+
+        self.persons = [
+            PersonFactory(
+                page_title="Mikhaïl Boulgakov",
+                should_publish=True,
+            )
+        ]
+
+        # NB: Indexed human names do not match the actual titles for the pages.
+        # This makes it simpler to run full-text searches and check their results.
+        courses = [
+            {
+                "categories": [
+                    "P-00010001",
+                    "P-00010002",
+                    "L-000100010001",
+                    "L-00020001",
+                ],
+                "categories_names": {
+                    "en": ["Artificial intelligence", "Autumn", "Wilderness"]
+                },
+                "code": "001abc",
+                "description": {
+                    "en": (
+                        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam nec "
+                        "egestas lectus. Cras eget lobortis eros. Suspendisse hendrerit dictum "
+                        "ex, eget pharetra. Pellentesque habitant morbi tristique senectus et "
+                        "netus et malesuada fames ac turpis egestas. Integer ut eleifend massa."
+                    )
+                },
+                "introduction": {"en": "Polarized non-volatile structure"},
+                "is_new": True,
+                "is_listed": True,
+                "organization_highlighted": {"en": "Org 311"},
+                "organizations": ["P-00030001", "L-00030004", "L-000300010001"],
+                "organizations_names": {"en": ["Org 31", "Org 34", "Org 311"]},
+                "persons": [self.persons[0].extended_object_id],
+                "persons_names": {"en": ["Mikhaïl Boulgakov"]},
+                "title": {"en": "Artificial intelligence for mushroom picking"},
+            },
+            {
+                "categories": [
+                    "P-00010001",
+                    "L-00010003",
+                    "L-000100010002",
+                    "L-00020003",
+                ],
+                "categories_names": {"en": ["Martial arts?", "Autumn"]},
+                "code": "002lmn",
+                "description": {
+                    "en": (
+                        "Artisanally-sourced clicks neque. erat volutpat. Nulla at laoreet. "
+                        "Finibus viverra tortor et pulvinar. In placerat interdum arcu, ac "
+                        "ullamcorper augue. Nam sed semper velit. Praesent orci nulla, malesuada "
+                        "nec commodo at, lobortis eget justo."
+                    )
+                },
+                "introduction": {"en": "De-engineered demand-driven success"},
+                "is_new": True,
+                "is_listed": True,
+                "organization_highlighted": {"en": "Org 33"},
+                "organizations": ["P-00030001", "L-00030003", "L-000300010002"],
+                "organizations_names": {"en": ["Org 31", "Org 33", "Org 312"]},
+                "persons": [],
+                "persons_names": {},
+                "title": {"en": "Click-farms: managing the autumn harvest"},
+            },
+            {
+                "categories": [
+                    "P-00010002",
+                    "L-00010003",
+                    "L-000100020001",
+                    "L-00020001",
+                ],
+                "categories_names": {
+                    "en": ["Artificial intelligence", "Water", "Wilderness"]
+                },
+                "code": "003rst",
+                "description": {
+                    "en": (
+                        "Cursus honorum finite que non luctus ante. Etiam accumsan vulputate "
+                        "magna non sollicitudin. Aliquam molestie est finibus elit scelerisque "
+                        "laoreet. Maecenas porttitor cursus cursus. Nam pellentesque eget neque "
+                        "quis tincidunt. Fusce sem ipsum, dignissim at augue."
+                    )
+                },
+                "introduction": {"en": "Up-sized value-added project"},
+                "is_new": False,
+                "is_listed": True,
+                "organization_highlighted": {"en": "Org 321"},
+                "organizations": ["P-00030002", "L-00030003", "L-000300020001"],
+                "organizations_names": {"en": ["Org 32", "Org 33", "Org 321"]},
+                "persons": [],
+                "persons_names": {},
+                "title": {"en": "Building a data lake out of mountain springs"},
+            },
+            {
+                "categories": [
+                    "P-00010002",
+                    "L-00010004",
+                    "L-000100020002",
+                    "L-00020002",
+                ],
+                "categories_names": {"en": ["Martial arts?", "Water"]},
+                "code": "004xyz",
+                "description": {
+                    "en": (
+                        "Nullam ornare finibus sollicitudin. Aliquam nisl leo, vestibulum a "
+                        "turpis quis, convallis tincidunt sem. Aliquam eleifend tellus vitae "
+                        "neque sagittis rutrum. Artificial vulputate neque placerat, commodo "
+                        "quam gravida, maximus lectus."
+                    )
+                },
+                "introduction": {"en": "Innovative encompassing extranet"},
+                "is_new": False,
+                "is_listed": True,
+                "organization_highlighted": {"en": "Org 34"},
+                "organizations": ["P-00030002", "L-00030004", "L-000300020002"],
+                "organizations_names": {"en": ["Org 32", "Org 34", "Org 322"]},
+                "persons": [self.persons[0].extended_object_id],
+                "persons_names": {"en": ["Mikhaïl Boulgakov"]},
+                "title": {"en": "Kung-fu moves for cloud infrastructure security"},
+            },
+        ]
+        self.course_runs = {
+            "A": {
+                # A) ongoing course, next open course to end enrollment
+                "start": arrow.utcnow().shift(days=-5).datetime,
+                "end": arrow.utcnow().shift(days=+120).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=-15).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=+5).datetime,
+                "languages": ["fr"],
+            },
+            "B": {
+                # B) ongoing course, can still be enrolled in for longer than A)
+                "start": arrow.utcnow().shift(days=-15).datetime,
+                "end": arrow.utcnow().shift(days=+105).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=-30).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=+15).datetime,
+                "languages": ["en"],
+            },
+            "C": {
+                # C) not started yet, first upcoming course to start
+                "start": arrow.utcnow().shift(days=+15).datetime,
+                "end": arrow.utcnow().shift(days=+150).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=-30).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=+30).datetime,
+                "languages": ["en"],
+            },
+            "D": {
+                # D) already finished course but enrollment still open
+                "start": arrow.utcnow().shift(days=-80).datetime,
+                "end": arrow.utcnow().shift(days=-15).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=-100).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=+15).datetime,
+                "languages": ["en"],
+            },
+            "E": {
+                # E) not started yet, will start after the other upcoming course
+                "start": arrow.utcnow().shift(days=+45).datetime,
+                "end": arrow.utcnow().shift(days=+120).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=+30).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=+60).datetime,
+                "languages": ["fr", "de"],
+            },
+            "F": {
+                # F) ongoing course, most recent to end enrollment
+                "start": arrow.utcnow().shift(days=-90).datetime,
+                "end": arrow.utcnow().shift(days=+15).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=-120).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=-30).datetime,
+                "languages": ["en"],
+            },
+            "G": {
+                # G) ongoing course, enrollment has been over for the longest
+                "start": arrow.utcnow().shift(days=-75).datetime,
+                "end": arrow.utcnow().shift(days=+30).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=-100).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=-45).datetime,
+                "languages": ["fr"],
+            },
+            "H": {
+                # H) already finished course; it finished more recently than I)
+                "start": arrow.utcnow().shift(days=-80).datetime,
+                "end": arrow.utcnow().shift(days=-15).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=-100).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=-60).datetime,
+                "languages": ["en"],
+            },
+            "I": {
+                # I) the course that has been over for the longest
+                "start": arrow.utcnow().shift(days=-120).datetime,
+                "end": arrow.utcnow().shift(days=-30).datetime,
+                "enrollment_start": arrow.utcnow().shift(days=-150).datetime,
+                "enrollment_end": arrow.utcnow().shift(days=-90).datetime,
+                "languages": ["en", "de"],
+            },
+        }
+
         # Shuffle and group our course runs to assign them randomly to 4 courses
         # For example: [["I", "E", "C"], ["D", "G"], ["B", "A"], ["H", "F"]]
         if not suite:
-            shuffled_runs = random.sample(list(COURSE_RUNS), len(COURSE_RUNS))
+            shuffled_runs = random.sample(list(self.course_runs), len(self.course_runs))
             suite = [shuffled_runs[i::4] for i in range(4)]
 
         # Associate groups of course runs to each course
@@ -293,12 +411,43 @@ class CourseRunsCoursesQueryTestCase(TestCase):
 
         # Delete any existing indices so we get a clean slate
         ES_INDICES_CLIENT.delete(index="_all")
+
+        # Create an index for our categories
+        ES_INDICES_CLIENT.create(index="richie_categories")
+        ES_INDICES_CLIENT.close(index="richie_categories")
+        ES_INDICES_CLIENT.put_settings(
+            body=ANALYSIS_SETTINGS, index="richie_categories"
+        )
+        ES_INDICES_CLIENT.open(index="richie_categories")
+        ES_INDICES_CLIENT.put_mapping(
+            body=CategoriesIndexer.mapping, index="richie_categories"
+        )
+
+        # Create an index for our organizations
+        ES_INDICES_CLIENT.create(index="richie_organizations")
+        ES_INDICES_CLIENT.close(index="richie_organizations")
+        ES_INDICES_CLIENT.put_settings(
+            body=ANALYSIS_SETTINGS, index="richie_organizations"
+        )
+        ES_INDICES_CLIENT.open(index="richie_organizations")
+        ES_INDICES_CLIENT.put_mapping(
+            body=OrganizationsIndexer.mapping, index="richie_organizations"
+        )
+
+        # Create an index for our persons
+        ES_INDICES_CLIENT.create(index="richie_persons")
+        ES_INDICES_CLIENT.close(index="richie_persons")
+        ES_INDICES_CLIENT.put_settings(body=ANALYSIS_SETTINGS, index="richie_persons")
+        ES_INDICES_CLIENT.open(index="richie_persons")
+        ES_INDICES_CLIENT.put_mapping(
+            body=PersonsIndexer.mapping, index="richie_persons"
+        )
+
         # Create an index we'll use to test the ES features
         ES_INDICES_CLIENT.create(index="test_courses")
         ES_INDICES_CLIENT.close(index="test_courses")
         ES_INDICES_CLIENT.put_settings(body=ANALYSIS_SETTINGS, index="test_courses")
         ES_INDICES_CLIENT.open(index="test_courses")
-
         # Use the default courses mapping from the Indexer
         ES_INDICES_CLIENT.put_mapping(body=CoursesIndexer.mapping, index="test_courses")
         # Add the sorting script
@@ -309,39 +458,55 @@ class CourseRunsCoursesQueryTestCase(TestCase):
 
         # Actually insert our courses in the index
         now = arrow.utcnow()
-        actions = [
-            {
-                "_id": course_id,
-                "_index": "test_courses",
-                "_op_type": "create",
-                # The sorting algorithm assumes that course runs are sorted by decreasing
-                # end date in order to limit the number of iterations and courses with a
-                # lot of archived courses.
-                "absolute_url": {"en": "url"},
-                "cover_image": {"en": "cover_image.jpg"},
-                "duration": {"en": "N/A"},
-                "effort": {"en": "N/A"},
-                "icon": {"en": "icon.jpg"},
-                "title": {"en": "title"},
-                **COURSES[course_id],
-                "course_runs": sorted(
-                    [
-                        # Each course randomly gets course runs (thanks to above shuffle)
-                        COURSE_RUNS[course_run_id]
-                        for course_run_id in course_run_ids
-                    ],
-                    key=lambda o: now - o["end"],
-                ),
-            }
-            for course_id, course_run_ids in courses_definition
-        ]
+        actions = (
+            [
+                CategoriesIndexer.get_es_document_for_category(category)
+                for category in top_subjects
+                + subject_0_children
+                + subject_1_children
+                + levels
+            ]
+            + [
+                OrganizationsIndexer.get_es_document_for_organization(organization)
+                for organization in top_organizations
+                + organization_0_children
+                + organization_1_children
+            ]
+            + [
+                PersonsIndexer.get_es_document_for_person(person)
+                for person in self.persons
+            ]
+            + [
+                {
+                    "_id": course_id,
+                    "_index": "test_courses",
+                    "_op_type": "create",
+                    # The sorting algorithm assumes that course runs are sorted by decreasing
+                    # end date in order to limit the number of iterations and courses with a
+                    # lot of archived courses.
+                    "absolute_url": {"en": "url"},
+                    "cover_image": {"en": "cover_image.jpg"},
+                    "duration": {"en": "N/A"},
+                    "effort": {"en": "N/A"},
+                    "icon": {"en": "icon.jpg"},
+                    "title": {"en": "title"},
+                    **courses[course_id],
+                    "course_runs": sorted(
+                        [
+                            # Each course randomly gets course runs (thanks to above shuffle)
+                            self.course_runs[course_run_id]
+                            for course_run_id in course_run_ids
+                        ],
+                        key=lambda o: now - o["end"],
+                    ),
+                }
+                for course_id, course_run_ids in courses_definition
+            ]
+        )
         bulk_compat(actions=actions, chunk_size=500, client=ES_CLIENT)
         ES_INDICES_CLIENT.refresh()
 
-        response = self.client.get(f"/api/v1.0/courses/?{querystring:s}")
-        self.assertEqual(response.status_code, 200)
-
-        return courses_definition, json.loads(response.content)
+        return courses_definition
 
     def test_query_courses_match_all_general(self, *_):
         """
@@ -350,12 +515,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         the two course runs in german end-up on the same course (in this case the facet count
         should be 1. See next test).
         """
-        self.create_filter_pages()
-        _, content = self.execute_query(
-            suite=[["A", "E"], ["H", "G"], ["B", "I"], ["C", "F"]]
-        )
+        self.prepare_indices(suite=[["A", "E"], ["H", "G"], ["B", "I"], ["C", "F"]])
+        response = self.client.get("/api/v1.0/courses/")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            content,
+            response.json(),
             {
                 "meta": {"count": 4, "offset": 0, "total_count": 4},
                 "objects": [
@@ -375,11 +539,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "icon": "icon.jpg",
                         "introduction": "Polarized non-volatile structure",
                         "organization_highlighted": "Org 311",
-                        "organizations": ["P-00030001", "P-00030004", "L-000300010001"],
+                        "organizations": ["P-00030001", "L-00030004", "L-000300010001"],
                         "state": {
                             "priority": 0,
                             "call_to_action": "enroll now",
-                            "datetime": COURSE_RUNS["A"]["enrollment_end"]
+                            "datetime": self.course_runs["A"]["enrollment_end"]
                             .isoformat()
                             .replace("+00:00", "Z"),
                             "text": "closing on",
@@ -391,7 +555,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "absolute_url": "url",
                         "categories": [
                             "P-00010002",
-                            "P-00010003",
+                            "L-00010003",
                             "L-000100020001",
                             "L-00020001",
                         ],
@@ -402,10 +566,10 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "icon": "icon.jpg",
                         "introduction": "Up-sized value-added project",
                         "organization_highlighted": "Org 321",
-                        "organizations": ["P-00030002", "P-00030003", "L-000300020001"],
+                        "organizations": ["P-00030002", "L-00030003", "L-000300020001"],
                         "state": {
                             "priority": 0,
-                            "datetime": COURSE_RUNS["B"]["enrollment_end"]
+                            "datetime": self.course_runs["B"]["enrollment_end"]
                             .isoformat()
                             .replace("+00:00", "Z"),
                             "call_to_action": "enroll now",
@@ -418,7 +582,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "absolute_url": "url",
                         "categories": [
                             "P-00010002",
-                            "P-00010004",
+                            "L-00010004",
                             "L-000100020002",
                             "L-00020002",
                         ],
@@ -429,10 +593,10 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "icon": "icon.jpg",
                         "introduction": "Innovative encompassing extranet",
                         "organization_highlighted": "Org 34",
-                        "organizations": ["P-00030002", "P-00030004", "L-000300020002"],
+                        "organizations": ["P-00030002", "L-00030004", "L-000300020002"],
                         "state": {
                             "priority": 1,
-                            "datetime": COURSE_RUNS["C"]["start"]
+                            "datetime": self.course_runs["C"]["start"]
                             .isoformat()
                             .replace("+00:00", "Z"),
                             "call_to_action": "enroll now",
@@ -445,7 +609,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "absolute_url": "url",
                         "categories": [
                             "P-00010001",
-                            "P-00010003",
+                            "L-00010003",
                             "L-000100010002",
                             "L-00020003",
                         ],
@@ -456,7 +620,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "icon": "icon.jpg",
                         "introduction": "De-engineered demand-driven success",
                         "organization_highlighted": "Org 33",
-                        "organizations": ["P-00030001", "P-00030003", "L-000300010002"],
+                        "organizations": ["P-00030001", "L-00030003", "L-000300010002"],
                         "state": {
                             "priority": 5,
                             "datetime": None,
@@ -518,17 +682,17 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "values": [
                             {
                                 "count": 2,
-                                "human_name": "#L-00020001",
+                                "human_name": "Level #0",
                                 "key": "L-00020001",
                             },
                             {
                                 "count": 1,
-                                "human_name": "#L-00020002",
+                                "human_name": "Level #1",
                                 "key": "L-00020002",
                             },
                             {
                                 "count": 1,
-                                "human_name": "#L-00020003",
+                                "human_name": "Level #2",
                                 "key": "L-00020003",
                             },
                         ],
@@ -558,23 +722,23 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "values": [
                             {
                                 "count": 2,
-                                "human_name": "#P-00030001",
+                                "human_name": "Organization #0",
                                 "key": "P-00030001",
                             },
                             {
                                 "count": 2,
-                                "human_name": "#P-00030002",
+                                "human_name": "Organization #1",
                                 "key": "P-00030002",
                             },
                             {
                                 "count": 2,
-                                "human_name": "#P-00030003",
-                                "key": "P-00030003",
+                                "human_name": "Organization #2",
+                                "key": "L-00030003",
                             },
                             {
                                 "count": 2,
-                                "human_name": "#P-00030004",
-                                "key": "P-00030004",
+                                "human_name": "Organization #3",
+                                "key": "L-00030004",
                             },
                         ],
                     },
@@ -587,7 +751,13 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "is_searchable": True,
                         "name": "persons",
                         "position": 5,
-                        "values": [{"count": 2, "human_name": "#2", "key": "2"}],
+                        "values": [
+                            {
+                                "count": 2,
+                                "human_name": "Mikhaïl Boulgakov",
+                                "key": f"{self.persons[0].extended_object_id}",
+                            }
+                        ],
                     },
                     "subjects": {
                         "base_path": "0001",
@@ -601,23 +771,23 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "values": [
                             {
                                 "count": 3,
-                                "human_name": "#P-00010002",
+                                "human_name": "Subject #1",
                                 "key": "P-00010002",
                             },
                             {
                                 "count": 2,
-                                "human_name": "#P-00010001",
+                                "human_name": "Subject #0",
                                 "key": "P-00010001",
                             },
                             {
                                 "count": 2,
-                                "human_name": "#P-00010003",
-                                "key": "P-00010003",
+                                "human_name": "Subject #2",
+                                "key": "L-00010003",
                             },
                             {
                                 "count": 1,
-                                "human_name": "#P-00010004",
-                                "key": "P-00010004",
+                                "human_name": "Subject #3",
+                                "key": "L-00010004",
                             },
                         ],
                     },
@@ -633,15 +803,15 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         - D/H course runs grouped under the same course:
           => 1 german course instead of 2
         """
-        _, content = self.execute_query(
-            suite=[["A", "B"], ["H", "C"], ["E", "I"], ["G", "F"]]
-        )
+        self.prepare_indices(suite=[["A", "B"], ["H", "C"], ["E", "I"], ["G", "F"]])
+        response = self.client.get("/api/v1.0/courses/")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((o["state"] for o in content["objects"])),
+            list((o["state"] for o in response.json()["objects"])),
             [
                 {
                     "call_to_action": "enroll now",
-                    "datetime": COURSE_RUNS["A"]["enrollment_end"]
+                    "datetime": self.course_runs["A"]["enrollment_end"]
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "priority": 0,
@@ -649,7 +819,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 },
                 {
                     "call_to_action": "enroll now",
-                    "datetime": COURSE_RUNS["C"]["start"]
+                    "datetime": self.course_runs["C"]["start"]
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "priority": 1,
@@ -657,7 +827,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 },
                 {
                     "call_to_action": None,
-                    "datetime": COURSE_RUNS["E"]["start"]
+                    "datetime": self.course_runs["E"]["start"]
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "priority": 3,
@@ -672,7 +842,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             ],
         )
         self.assertEqual(
-            content["filters"]["languages"]["values"],
+            response.json()["filters"]["languages"]["values"],
             [
                 {"count": 4, "human_name": "#en", "key": "en"},
                 {"count": 3, "human_name": "#fr", "key": "fr"},
@@ -680,7 +850,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             ],
         )
         self.assertEqual(
-            content["filters"]["availability"]["values"],
+            response.json()["filters"]["availability"]["values"],
             [
                 {"count": 2, "human_name": "Open for enrollment", "key": "open"},
                 {"count": 2, "human_name": "Coming soon", "key": "coming_soon"},
@@ -693,9 +863,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering and sorting open courses.
         """
-        courses_definition, content = self.execute_query("availability=open")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?availability=open")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
+            list((int(c["id"]) for c in response.json()["objects"])),
             self.get_expected_courses(courses_definition, ["A", "B", "C", "D"]),
         )
 
@@ -703,17 +875,21 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         The scope can be limited to objects via the querystring.
         """
-        _courses_definition, content = self.execute_query("scope=objects")
-        self.assertEqual(len(content["objects"]), 4)
-        self.assertFalse("filters" in content)
+        self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?scope=objects")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["objects"]), 4)
+        self.assertFalse("filters" in response.json())
 
     def test_query_courses_match_all_scope_filters(self, *_):
         """
         The scope can be limited to filters via the querystring.
         """
-        _courses_definition, content = self.execute_query("scope=filters")
-        self.assertEqual(len(content["filters"]), 7)
-        self.assertFalse("objects" in content)
+        self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?scope=filters")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()["filters"]), 7)
+        self.assertFalse("objects" in response.json())
 
     def test_query_courses_course_runs_filter_availability_facets(self, *_):
         """
@@ -723,16 +899,15 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         runs with the same language (resp. availability) get grouped under the same
         course.
         """
-        self.create_filter_pages()
-        _, content = self.execute_query(
-            "availability=open", suite=[["A", "B"], ["H", "C"], ["E", "I"], ["G", "F"]]
-        )
+        self.prepare_indices(suite=[["A", "B"], ["H", "C"], ["E", "I"], ["G", "F"]])
+        response = self.client.get("/api/v1.0/courses/?availability=open")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((o["state"] for o in content["objects"])),
+            list((o["state"] for o in response.json()["objects"])),
             [
                 {
                     "call_to_action": "enroll now",
-                    "datetime": COURSE_RUNS["A"]["enrollment_end"]
+                    "datetime": self.course_runs["A"]["enrollment_end"]
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "priority": 0,
@@ -740,7 +915,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 },
                 {
                     "call_to_action": "enroll now",
-                    "datetime": COURSE_RUNS["C"]["start"]
+                    "datetime": self.course_runs["C"]["start"]
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "priority": 1,
@@ -749,14 +924,14 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             ],
         )
         self.assertEqual(
-            content["filters"]["languages"]["values"],
+            response.json()["filters"]["languages"]["values"],
             [
                 {"count": 2, "human_name": "#en", "key": "en"},
                 {"count": 1, "human_name": "#fr", "key": "fr"},
             ],
         )
         self.assertEqual(
-            content["filters"]["availability"]["values"],
+            response.json()["filters"]["availability"]["values"],
             [
                 {"count": 2, "human_name": "Open for enrollment", "key": "open"},
                 {"count": 2, "human_name": "Coming soon", "key": "coming_soon"},
@@ -765,29 +940,29 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             ],
         )
         self.assertEqual(
-            content["filters"]["subjects"]["values"],
+            response.json()["filters"]["subjects"]["values"],
             [
-                {"count": 2, "human_name": "#P-00010001", "key": "P-00010001"},
-                {"count": 1, "human_name": "#P-00010002", "key": "P-00010002"},
-                {"count": 1, "human_name": "#P-00010003", "key": "P-00010003"},
-                {"count": 0, "human_name": "#P-00010004", "key": "P-00010004"},
+                {"count": 2, "human_name": "Subject #0", "key": "P-00010001"},
+                {"count": 1, "human_name": "Subject #1", "key": "P-00010002"},
+                {"count": 1, "human_name": "Subject #2", "key": "L-00010003"},
+                {"count": 0, "human_name": "Subject #3", "key": "L-00010004"},
             ],
         )
         self.assertEqual(
-            content["filters"]["levels"]["values"],
+            response.json()["filters"]["levels"]["values"],
             [
-                {"count": 1, "human_name": "#L-00020001", "key": "L-00020001"},
-                {"count": 1, "human_name": "#L-00020003", "key": "L-00020003"},
-                {"count": 0, "human_name": "#L-00020002", "key": "L-00020002"},
+                {"count": 1, "human_name": "Level #0", "key": "L-00020001"},
+                {"count": 1, "human_name": "Level #2", "key": "L-00020003"},
+                {"count": 0, "human_name": "Level #1", "key": "L-00020002"},
             ],
         )
         self.assertEqual(
-            content["filters"]["organizations"]["values"],
+            response.json()["filters"]["organizations"]["values"],
             [
-                {"count": 2, "human_name": "#P-00030001", "key": "P-00030001"},
-                {"count": 1, "human_name": "#P-00030003", "key": "P-00030003"},
-                {"count": 1, "human_name": "#P-00030004", "key": "P-00030004"},
-                {"count": 0, "human_name": "#P-00030002", "key": "P-00030002"},
+                {"count": 2, "human_name": "Organization #0", "key": "P-00030001"},
+                {"count": 1, "human_name": "Organization #2", "key": "L-00030003"},
+                {"count": 1, "human_name": "Organization #3", "key": "L-00030004"},
+                {"count": 0, "human_name": "Organization #1", "key": "P-00030002"},
             ],
         )
 
@@ -795,9 +970,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering and sorting ongoing courses.
         """
-        courses_definition, content = self.execute_query("availability=ongoing")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?availability=ongoing")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
+            list((int(c["id"]) for c in response.json()["objects"])),
             self.get_expected_courses(courses_definition, ["A", "B", "F", "G"]),
         )
 
@@ -805,9 +982,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering and sorting coming soon courses.
         """
-        courses_definition, content = self.execute_query("availability=coming_soon")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?availability=coming_soon")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
+            list((int(c["id"]) for c in response.json()["objects"])),
             self.get_expected_courses(courses_definition, ["C", "E"]),
         )
 
@@ -815,9 +994,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering and sorting archived courses.
         """
-        courses_definition, content = self.execute_query("availability=archived")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?availability=archived")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
+            list((int(c["id"]) for c in response.json()["objects"])),
             self.get_expected_courses(courses_definition, ["D", "H", "I"]),
         )
 
@@ -825,9 +1006,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering and sorting courses in one language.
         """
-        courses_definition, content = self.execute_query("languages=fr")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?languages=fr")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
+            list((int(c["id"]) for c in response.json()["objects"])),
             self.get_expected_courses(courses_definition, ["A", "E", "G"]),
         )
 
@@ -839,16 +1022,15 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         runs with the same language (resp. availability) get grouped under the same
         course.
         """
-        self.create_filter_pages()
-        _, content = self.execute_query(
-            "languages=fr", suite=[["A", "B"], ["H", "D"], ["E", "I"], ["G", "F"]]
-        )
+        self.prepare_indices(suite=[["A", "B"], ["H", "D"], ["E", "I"], ["G", "F"]])
+        response = self.client.get("/api/v1.0/courses/?languages=fr")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((o["state"] for o in content["objects"])),
+            list((o["state"] for o in response.json()["objects"])),
             [
                 {
                     "call_to_action": "enroll now",
-                    "datetime": COURSE_RUNS["A"]["enrollment_end"]
+                    "datetime": self.course_runs["A"]["enrollment_end"]
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "priority": 0,
@@ -856,7 +1038,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                 },
                 {
                     "call_to_action": None,
-                    "datetime": COURSE_RUNS["E"]["start"]
+                    "datetime": self.course_runs["E"]["start"]
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "priority": 3,
@@ -871,7 +1053,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             ],
         )
         self.assertEqual(
-            content["filters"]["languages"]["values"],
+            response.json()["filters"]["languages"]["values"],
             [
                 {"count": 4, "human_name": "#en", "key": "en"},
                 {"count": 3, "human_name": "#fr", "key": "fr"},
@@ -879,7 +1061,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             ],
         )
         self.assertEqual(
-            content["filters"]["availability"]["values"],
+            response.json()["filters"]["availability"]["values"],
             [
                 {"count": 1, "human_name": "Open for enrollment", "key": "open"},
                 {"count": 1, "human_name": "Coming soon", "key": "coming_soon"},
@@ -890,29 +1072,29 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         # A, E and G course runs are in French
         # So only courses 0, 2 and 3 are selected
         self.assertEqual(
-            content["filters"]["subjects"]["values"],
+            response.json()["filters"]["subjects"]["values"],
             [
-                {"count": 3, "human_name": "#P-00010002", "key": "P-00010002"},
-                {"count": 1, "human_name": "#P-00010001", "key": "P-00010001"},
-                {"count": 1, "human_name": "#P-00010003", "key": "P-00010003"},
-                {"count": 1, "human_name": "#P-00010004", "key": "P-00010004"},
+                {"count": 3, "human_name": "Subject #1", "key": "P-00010002"},
+                {"count": 1, "human_name": "Subject #0", "key": "P-00010001"},
+                {"count": 1, "human_name": "Subject #2", "key": "L-00010003"},
+                {"count": 1, "human_name": "Subject #3", "key": "L-00010004"},
             ],
         )
         self.assertEqual(
-            content["filters"]["levels"]["values"],
+            response.json()["filters"]["levels"]["values"],
             [
-                {"count": 2, "human_name": "#L-00020001", "key": "L-00020001"},
-                {"count": 1, "human_name": "#L-00020002", "key": "L-00020002"},
-                {"count": 0, "human_name": "#L-00020003", "key": "L-00020003"},
+                {"count": 2, "human_name": "Level #0", "key": "L-00020001"},
+                {"count": 1, "human_name": "Level #1", "key": "L-00020002"},
+                {"count": 0, "human_name": "Level #2", "key": "L-00020003"},
             ],
         )
         self.assertEqual(
-            content["filters"]["organizations"]["values"],
+            response.json()["filters"]["organizations"]["values"],
             [
-                {"count": 2, "human_name": "#P-00030002", "key": "P-00030002"},
-                {"count": 2, "human_name": "#P-00030004", "key": "P-00030004"},
-                {"count": 1, "human_name": "#P-00030001", "key": "P-00030001"},
-                {"count": 1, "human_name": "#P-00030003", "key": "P-00030003"},
+                {"count": 2, "human_name": "Organization #1", "key": "P-00030002"},
+                {"count": 2, "human_name": "Organization #3", "key": "L-00030004"},
+                {"count": 1, "human_name": "Organization #0", "key": "P-00030001"},
+                {"count": 1, "human_name": "Organization #2", "key": "L-00030003"},
             ],
         )
 
@@ -920,9 +1102,11 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering and sorting courses in several languages.
         """
-        courses_definition, content = self.execute_query("languages=fr&languages=de")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?languages=fr&languages=de")
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
+            list((int(c["id"]) for c in response.json()["objects"])),
             self.get_expected_courses(courses_definition, ["A", "E", "G", "I"]),
         )
 
@@ -930,11 +1114,13 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering and sorting courses on an availability AND a language.
         """
-        courses_definition, content = self.execute_query(
-            "availability=ongoing&languages=en"
+        courses_definition = self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?availability=ongoing&languages=en"
         )
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
+            list((int(c["id"]) for c in response.json()["objects"])),
             self.get_expected_courses(courses_definition, ["B", "F"]),
         )
 
@@ -946,17 +1132,19 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         runs with the same language (resp. availability) get grouped under the same
         course.
         """
-        self.create_filter_pages()
-        _, content = self.execute_query(
-            "availability=ongoing&languages=en",
+        self.prepare_indices(
             suite=[["A", "B"], ["H", "C"], ["E", "I"], ["G", "F"]],
         )
+        response = self.client.get(
+            "/api/v1.0/courses/?availability=ongoing&languages=en"
+        )
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            list((o["state"] for o in content["objects"])),
+            list((o["state"] for o in response.json()["objects"])),
             [
                 {
                     "call_to_action": "enroll now",
-                    "datetime": COURSE_RUNS["B"]["enrollment_end"]
+                    "datetime": self.course_runs["B"]["enrollment_end"]
                     .isoformat()
                     .replace("+00:00", "Z"),
                     "priority": 0,
@@ -971,14 +1159,14 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             ],
         )
         self.assertEqual(
-            content["filters"]["languages"]["values"],
+            response.json()["filters"]["languages"]["values"],
             [
                 {"count": 2, "human_name": "#en", "key": "en"},
                 {"count": 2, "human_name": "#fr", "key": "fr"},
             ],
         )
         self.assertEqual(
-            content["filters"]["availability"]["values"],
+            response.json()["filters"]["availability"]["values"],
             [
                 {"count": 2, "human_name": "Open for enrollment", "key": "open"},
                 {"count": 1, "human_name": "Coming soon", "key": "coming_soon"},
@@ -989,29 +1177,29 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         # Only the B and E course runs are on-going and in English
         # So only courses 0 and 3 are selected
         self.assertEqual(
-            content["filters"]["subjects"]["values"],
+            response.json()["filters"]["subjects"]["values"],
             [
-                {"count": 2, "human_name": "#P-00010002", "key": "P-00010002"},
-                {"count": 1, "human_name": "#P-00010001", "key": "P-00010001"},
-                {"count": 1, "human_name": "#P-00010004", "key": "P-00010004"},
-                {"count": 0, "human_name": "#P-00010003", "key": "P-00010003"},
+                {"count": 2, "human_name": "Subject #1", "key": "P-00010002"},
+                {"count": 1, "human_name": "Subject #0", "key": "P-00010001"},
+                {"count": 1, "human_name": "Subject #3", "key": "L-00010004"},
+                {"count": 0, "human_name": "Subject #2", "key": "L-00010003"},
             ],
         )
         self.assertEqual(
-            content["filters"]["levels"]["values"],
+            response.json()["filters"]["levels"]["values"],
             [
-                {"count": 1, "human_name": "#L-00020001", "key": "L-00020001"},
-                {"count": 1, "human_name": "#L-00020002", "key": "L-00020002"},
-                {"count": 0, "human_name": "#L-00020003", "key": "L-00020003"},
+                {"count": 1, "human_name": "Level #0", "key": "L-00020001"},
+                {"count": 1, "human_name": "Level #1", "key": "L-00020002"},
+                {"count": 0, "human_name": "Level #2", "key": "L-00020003"},
             ],
         )
         self.assertEqual(
-            content["filters"]["organizations"]["values"],
+            response.json()["filters"]["organizations"]["values"],
             [
-                {"count": 2, "human_name": "#P-00030004", "key": "P-00030004"},
-                {"count": 1, "human_name": "#P-00030001", "key": "P-00030001"},
-                {"count": 1, "human_name": "#P-00030002", "key": "P-00030002"},
-                {"count": 0, "human_name": "#P-00030003", "key": "P-00030003"},
+                {"count": 2, "human_name": "Organization #3", "key": "L-00030004"},
+                {"count": 1, "human_name": "Organization #0", "key": "P-00030001"},
+                {"count": 1, "human_name": "Organization #1", "key": "P-00030002"},
+                {"count": 0, "human_name": "Organization #2", "key": "L-00030003"},
             ],
         )
 
@@ -1019,35 +1207,38 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering new courses.
         """
-        courses_definition, content = self.execute_query("new=new")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?new=new")
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are new:
         courses_definition = filter(lambda c: c[0] in [0, 1], courses_definition)
 
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
 
     def test_query_courses_filter_organization(self, *_):
         """
         Battle test filtering by an organization.
         """
-        self.create_filter_pages()
-        courses_definition, content = self.execute_query("organizations=P-00030002")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?organizations=P-00030002")
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are linked to organization 00030002:
         courses_definition = filter(lambda c: c[0] in [2, 3], courses_definition)
 
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
         self.assertEqual(
-            content["filters"]["organizations"]["values"],
+            response.json()["filters"]["organizations"]["values"],
             [
-                {"count": 2, "human_name": "#P-00030001", "key": "P-00030001"},
-                {"count": 2, "human_name": "#P-00030002", "key": "P-00030002"},
-                {"count": 2, "human_name": "#P-00030003", "key": "P-00030003"},
-                {"count": 2, "human_name": "#P-00030004", "key": "P-00030004"},
+                {"count": 2, "human_name": "Organization #0", "key": "P-00030001"},
+                {"count": 2, "human_name": "Organization #1", "key": "P-00030002"},
+                {"count": 2, "human_name": "Organization #2", "key": "L-00030003"},
+                {"count": 2, "human_name": "Organization #3", "key": "L-00030004"},
             ],
         )
 
@@ -1055,15 +1246,17 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering by multiple organizations.
         """
-        courses_definition, content = self.execute_query(
-            "organizations=P-00030002&organizations=L-000300010001"
+        courses_definition = self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?organizations=P-00030002&organizations=L-000300010001"
         )
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are linked to organizations 00030002 or 000300010001:
         courses_definition = filter(lambda c: c[0] in [0, 2, 3], courses_definition)
 
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
 
     def test_query_courses_filter_organization_include(self, *_):
@@ -1071,16 +1264,24 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         It should be possible to limit faceting on an organization to specific values by
         passing a regex in the querystring.
         """
-        self.create_filter_pages()
-        _courses_definition, content = self.execute_query(
-            "organizations_include=.*-00030001.{4}"
+        self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?organizations_include=.*-00030001.{4}"
         )
-
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            content["filters"]["organizations"]["values"],
+            response.json()["filters"]["organizations"]["values"],
             [
-                {"count": 1, "human_name": "#L-000300010001", "key": "L-000300010001"},
-                {"count": 1, "human_name": "#L-000300010002", "key": "L-000300010002"},
+                {
+                    "count": 1,
+                    "human_name": "Organization #0 Child #0",
+                    "key": "L-000300010001",
+                },
+                {
+                    "count": 1,
+                    "human_name": "Organization #0 Child #1",
+                    "key": "L-000300010002",
+                },
             ],
         )
 
@@ -1088,28 +1289,32 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering by a subject.
         """
-        courses_definition, content = self.execute_query("subjects=P-00010001")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?subjects=P-00010001")
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are linked to subject 2:
         courses_definition = filter(lambda c: c[0] in [0, 1], courses_definition)
 
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
 
     def test_query_courses_filter_multiple_subjects(self, *_):
         """
         Battle test filtering by multiple subjects.
         """
-        courses_definition, content = self.execute_query(
-            "subjects=P-00010001&subjects=P-00010004"
+        courses_definition = self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?subjects=P-00010001&subjects=L-00010004"
         )
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are linked to subjects 1 or 4:
         courses_definition = filter(lambda c: c[0] in [0, 1, 3], courses_definition)
 
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
 
     def test_query_courses_filter_subject_include(self, *_):
@@ -1117,16 +1322,24 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         It should be possible to limit faceting on a subject to specific values by
         passing a regex in the querystring.
         """
-        self.create_filter_pages()
-        _courses_definition, content = self.execute_query(
-            "subjects_include=.*-00010001.{4}"
+        self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?subjects_include=.*-00010001.{4}"
         )
-
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            content["filters"]["subjects"]["values"],
+            response.json()["filters"]["subjects"]["values"],
             [
-                {"count": 1, "human_name": "#L-000100010001", "key": "L-000100010001"},
-                {"count": 1, "human_name": "#L-000100010002", "key": "L-000100010002"},
+                {
+                    "count": 1,
+                    "human_name": "Subject #0 Child #0",
+                    "key": "L-000100010001",
+                },
+                {
+                    "count": 1,
+                    "human_name": "Subject #0 Child #1",
+                    "key": "L-000100010002",
+                },
             ],
         )
 
@@ -1134,52 +1347,63 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         """
         Battle test filtering by a level.
         """
-        courses_definition, content = self.execute_query("levels=L-00020001")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?levels=L-00020001")
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are linked to level L-00020001:
         courses_definition = filter(lambda c: c[0] in [0, 2], courses_definition)
 
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
 
     def test_query_courses_filter_multiple_levels(self, *_):
         """
         Battle test filtering by multiple levels.
         """
-        courses_definition, content = self.execute_query(
-            "levels=L-00020001&levels=L-00020002"
+        courses_definition = self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?levels=L-00020001&levels=L-00020002"
         )
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are linked to levels L-00020001 or L-00020002:
         courses_definition = filter(lambda c: c[0] in [0, 2, 3], courses_definition)
 
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
 
     def test_query_courses_match_all_no_filter_pages(self, *_):
         """
         Running a query when indexable filter pages are absent should result in empty facets.
-        This behavior is because "include" defaults to the "^$" regex matching no values of the
-        term when a `reverse_id` is set but no corresponding page is found.
+        This behavior is because "include" for each filter definition defaults to the list of
+        children for the base page (the one whose reverse_id matches the filter settings).
+        If the base page does not exist, the filter is empty.
         """
-        _, content = self.execute_query()
-        self.assertEqual(content["filters"]["subjects"]["values"], [])
-        self.assertEqual(content["filters"]["levels"]["values"], [])
-        self.assertEqual(content["filters"]["organizations"]["values"], [])
+        self.prepare_indices()
+        for reverse_id in ["subjects", "levels", "organizations"]:
+            Page.objects.get(reverse_id=reverse_id, publisher_is_draft=False).delete()
+        response = self.client.get("/api/v1.0/courses/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["filters"]["subjects"]["values"], [])
+        self.assertEqual(response.json()["filters"]["levels"]["values"], [])
+        self.assertEqual(response.json()["filters"]["organizations"]["values"], [])
 
     def test_query_courses_by_related_person(self, *_):
         """
         Full-text search appropriately returns the list of courses that match a given
         related person name even through a text query.
         """
-        courses_definition, content = self.execute_query("query=boulgakov")
+        courses_definition = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?query=boulgakov")
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are linked to persons whose name contains "boulgakov"
         courses_definition = filter(lambda c: c[0] in [0, 3], courses_definition)
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
 
     def test_query_courses_text_language_analyzer_query(self, *_):
@@ -1188,51 +1412,71 @@ class CourseRunsCoursesQueryTestCase(TestCase):
         word through a language analyzer.
         The score of the text query impacts ordering.
         """
-        _courses_definition, content = self.execute_query(
-            "query=artificial",
+        self.prepare_indices(
             suite=[["B", "F", "I"], ["E", "C"], ["H", "G"], ["D", "A"]],
         )
+        response = self.client.get("/api/v1.0/courses/?query=artificial")
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that contain the word "artificial"
-        self.assertEqual(list((int(c["id"]) for c in content["objects"])), [0, 3, 2])
+        self.assertEqual(
+            list((int(c["id"]) for c in response.json()["objects"])), [0, 3, 2]
+        )
 
     def test_query_courses_text_language_analyzer_with_filter_category(self, *_):
         """
         Full-text search through the language analyzer combines with another filter.
         """
-        courses_definition, content = self.execute_query(
-            "query=artificial&subjects=P-00010001"
+        courses_definition = self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?query=artificial&subjects=P-00010001"
         )
+        self.assertEqual(response.status_code, 200)
         # Keep only the courses that are linked to category one and contain the word "artificial"
         courses_definition = filter(lambda c: c[0] in [0], courses_definition)
 
         self.assertEqual(
-            list((int(c["id"]) for c in content["objects"])),
-            self.get_expected_courses(courses_definition, list(COURSE_RUNS)),
+            list((int(c["id"]) for c in response.json()["objects"])),
+            self.get_expected_courses(courses_definition, list(self.course_runs)),
         )
 
     def test_query_courses_code_partial(self, *_):
         """Full-text search should match partial codes."""
+        self.prepare_indices()
         for query in ["3rs", "3rst", "03rst", "003rst"]:
-            _courses_definition, content = self.execute_query(f"query={query:s}")
-            self.assertEqual(list((int(c["id"]) for c in content["objects"])), [2])
+            response = self.client.get(f"/api/v1.0/courses/?query={query:s}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                list((int(c["id"]) for c in response.json()["objects"])), [2]
+            )
 
     def test_query_courses_code_fuzzy(self, *_):
         """Full-text search should match codes with automatic fuzziness."""
+        self.prepare_indices()
         # A Levenshtein distance of 1 matches even our shortest search queries (3 characters)
         for query in ["7rs", "3dst", "13rst", "003rsg"]:
-            _courses_definition, content = self.execute_query(f"query={query:s}")
-            self.assertEqual(list((int(c["id"]) for c in content["objects"])), [2])
+            response = self.client.get(f"/api/v1.0/courses/?query={query:s}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                list((int(c["id"]) for c in response.json()["objects"])), [2]
+            )
 
         # A Levenshtein distance of 2 matches only for search queries of at least 5 characters
         for query in ["7ds", "3det", "14rst"]:
-            _courses_definition, content = self.execute_query(f"query={query:s}")
-            self.assertEqual(list((int(c["id"]) for c in content["objects"])), [])
+            response = self.client.get(f"/api/v1.0/courses/?query={query:s}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                list((int(c["id"]) for c in response.json()["objects"])), []
+            )
 
-        _courses_definition, content = self.execute_query("query=003rfg")
-        self.assertEqual(list((int(c["id"]) for c in content["objects"])), [2])
+        response = self.client.get("/api/v1.0/courses/?query=003rfg")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list((int(c["id"]) for c in response.json()["objects"])), [2])
 
         # A Levenshtein distance of 3 doesn't match for search queries of 5 characters
         # (we could test for longer queries...)
         for query in ["7de", "3def", "14dst", "003efg"]:
-            _courses_definition, content = self.execute_query(f"query={query:s}")
-            self.assertEqual(list((int(c["id"]) for c in content["objects"])), [])
+            response = self.client.get(f"/api/v1.0/courses/?query={query:s}")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                list((int(c["id"]) for c in response.json()["objects"])), []
+            )


### PR DESCRIPTION
## Purpose

Task n°2 for #1415 

Filters based on the IndexableMPTTFilterDefinition, which are filters defined by a base page and for which a hierarchy of pages indexed in ES is the list of available filters, were using a regex filter that required the MPTT path of said filters to be used as IDs and indexed on courses.

## Proposal

We replaced the regexp with a (cached) database call to directly provide a list of children instead of an MPTT based regex. This will enable us to link filters with courses through proper IDs as filters do not rely on MPTT paths in their definition.
