### PR TITLE
📝(UPGRADE) add missing instruction from 2.7.x to 2.8.x

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,17 @@ $ make migrate
 
 - A new scss variable has been added `$r-course-subheader-aside`. If you have overridden
   `_variables.scss` file, you have to define this variable.
+- Add a new entry to your `urls.py` declarations for the `robot.txt` file so
+  that the `sitemap.xml` file is found without the need to register it in each
+  crawler administration panel:
+  ```python
+    path(
+        "robots.txt",
+        TemplateView.as_view(
+            template_name="richie/robots.html", content_type="text/plain"
+        ),
+    )
+  ```
 
 ## 2.4.x to 2.5.x
 


### PR DESCRIPTION
## Purpose

We forgot to add an instruction about the new `robots.txt` path.

## Proposal

Add instruction:

```python
    path(
        "robots.txt",
        TemplateView.as_view(
            template_name="richie/robots.html", content_type="text/plain"
        ),
    )
```