### PR TITLE
💄(subheader) use a dedicated variable to set aside column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Use `$r-course-subheader-aside` to define subheader aside column width
+
 ## [2.8.1] - 2021-09-28
 
 ### Changed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,11 @@ $ make migrate
 
 ## Unreleased
 
+## 2.7.x to 2.8.x
+
+- A new scss variable has been added `$r-course-subheader-aside`. If you have overridden
+  `_variables.scss` file, you have to define this variable.
+
 ## 2.4.x to 2.5.x
 
 - Named capturing group regex are still considered experimental in Javascript and may cause trouble

--- a/src/frontend/scss/components/_subheader.scss
+++ b/src/frontend/scss/components/_subheader.scss
@@ -119,7 +119,7 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
   // Main subheader container alongside 'aside' container
   &__main {
     @include media-breakpoint-up(lg) {
-      @include sv-flex(1, 0, calc(100% - #{$r-course-aside}));
+      @include sv-flex(1, 0, calc(100% - #{$r-course-subheader-aside}));
       display: flex;
       justify-content: flex-start;
       align-content: flex-start;
@@ -142,7 +142,7 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
     text-align: center;
 
     @include media-breakpoint-up(lg) {
-      @include sv-flex(1, 0, $r-course-aside);
+      @include sv-flex(1, 0, $r-course-subheader-aside);
       padding: 3rem 1rem;
     }
   }

--- a/src/frontend/scss/settings/_variables.scss
+++ b/src/frontend/scss/settings/_variables.scss
@@ -159,5 +159,10 @@ $r-footer-logo-width-lg: 11.875rem;
 // template
 $r-course-aside: 35%;
 
+// Subheader aside column width in course detail. Unlike, $r-course-aside this
+// variable cannot be null. Otherwise to homegenize layout, it should have the
+// same value than $r-course-aside.
+$r-course-subheader-aside: 35%;
+
 // Course search page shared variables
 $r-search-filters-gutter: 0.2rem !default;


### PR DESCRIPTION
## Purpose

Previously, we used `$r-course-aside` variable to define both the course content aside column width and  the subheader aside column width. But in some use case, we want to define this variable to null to make `course__content` in full width. But we do not want this behavior for the `subheader` block. So we decided to use a dedicated variable to set the subheader aside column width.


## Proposal

- [x] Use `$r-course-subheader-aside` variable to set subheader aside column width
