### PR TITLE
🐛(courses) fix "pt_effort" string computation when effort is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix schema.org related "pt_effort" string computation when effort is not set
 - Use `$r-course-subheader-aside` to define subheader aside column width
 
 ## [2.8.1] - 2021-09-28

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -209,6 +209,9 @@ class Course(BasePageExtension):
     @property
     def pt_effort(self):
         """Return effort as a PT string for schema.org metadata."""
+        if not self.effort:
+            return ""
+
         (effort, effort_unit) = self.effort
         unit_letter = effort_unit[0].upper()
         return f"PT{effort:d}{unit_letter:s}"

--- a/tests/apps/courses/test_models_course.py
+++ b/tests/apps/courses/test_models_course.py
@@ -1347,6 +1347,11 @@ class CourseModelsTestCase(TestCase):
         course = Course.objects.create(extended_object=PageFactory())
         self.assertIsNone(course.effort)
 
+    def test_models_course_field_pt_effort_null(self):
+        """The "pt_effort" property should return an empty string if effort is not set"""
+        course = factories.CourseFactory(effort=None)
+        self.assertEqual(course.pt_effort, "")
+
     def test_models_course_field_pt_effort_1_hour(self):
         """The "pt_effort" property should return what schema.org metadata expects"""
         course = factories.CourseFactory(effort=[1, "hour"])


### PR DESCRIPTION
## Purpose

While computing the "pt_effort" string for schema.org's [timeRequired field](https://schema.org/timeRequired) on the course, we forgot to handle the case when the effort field is not set.

## Proposal

- [x] Return an empty string if the effort is not set on the course.
- [x] Add a test to secure this case 
