### PR TITLE
🩹(tests) remove error message when a test fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Prevent logout action to be called twice
+- Remove error message related with cache when any test fails
 
 ## [2.9.1] - 2021-11-03
 

--- a/src/richie/apps/core/cache.py
+++ b/src/richie/apps/core/cache.py
@@ -155,7 +155,7 @@ class LimitBrowserCacheTTLHeaders(MiddlewareMixin):
         Rewrite the "Cache-control" and "Expires headers" in the response
         if needed.
         """
-        max_ttl = getattr(settings, "MAX_BROWSER_CACHE_TTL", None)
+        max_ttl = getattr(settings, "MAX_BROWSER_CACHE_TTL", 600)
         if max_ttl:
             try:
                 max_ttl = int(max_ttl)


### PR DESCRIPTION
Remove error message related with cache when any test fails.
When any test fails locally, any test shows this annoying error. 
This pull request removes that message.

```
-------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------
ERROR    richie.apps.core.cache:cache.py:163 int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```