### PR TITLE
💄(frontend) make scheme svg color more easily overridable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix an issue related to css selector priority from r-scheme-colors mixins
+
 ## [2.8.2] - 2021-10-05
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,7 @@ $ make migrate
 
 ## 2.7.x to 2.8.x
 
+- `.no-scheme-fill` css class util has been removed.
 - `IndexableMPTTFilterDefinition` class was renamed to `IndexableHierarchicalFilterDefinition`.
   If your project defines custom filter definitions in the `RICHIE_FILTERS_CONFIGURATION`
   setting, you need to make sure you don't point to the old class name.

--- a/src/frontend/scss/components/templates/richie/glimpse/_glimpse.scss
+++ b/src/frontend/scss/components/templates/richie/glimpse/_glimpse.scss
@@ -275,7 +275,7 @@ $r-glimpse-gutter: 0.4rem !default;
     font-style: italic;
     text-indent: 2.3rem;
 
-    svg {
+    .icon {
       position: absolute;
       top: 0;
       left: 0.1rem;

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -162,7 +162,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     line-height: 1.1rem;
     margin-bottom: 0;
 
-    svg {
+    .icon {
       @include sv-flex(1, 0, 1.4rem);
       width: 1.4rem;
       height: 0.9rem;
@@ -191,7 +191,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     font-size: 0.9rem;
     line-height: 1.1;
 
-    svg {
+    .icon {
       @include sv-flex(1, 0, 1.4rem);
       width: 1.4rem;
       height: 0.9rem;
@@ -261,11 +261,11 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     font-weight: $font-weight-bold;
     line-height: 1.1;
 
-    svg {
+    .icon {
       @include sv-flex(1, 0, 1.4rem);
-      width: 1.4rem;
       height: 1.3rem;
       margin-right: 0.5rem;
+      width: 1.4rem;
     }
   }
 }

--- a/src/frontend/scss/tools/_colors.scss
+++ b/src/frontend/scss/tools/_colors.scss
@@ -83,7 +83,7 @@
 ///       color: #000000;
 ///       background: #ffffff;
 ///
-///       svg:not(.no-scheme-fill){
+///       svg {
 ///           fill: #000000;
 ///       }
 ///
@@ -146,9 +146,8 @@
     color: $font-color;
   }
 
-  // Fill svg color but not for elements with ".no-scheme-fill" class
   @if $apply-svg and $svg-color {
-    svg:not(.no-scheme-fill) {
+    svg {
       fill: $svg-color;
     }
   }
@@ -226,9 +225,9 @@
     color: $font-color;
   }
 
-  // Fill svg color but not for ".no-scheme-fill" class
   @if $svg-color {
-    svg:not(.no-scheme-fill) {
+    svg,
+    .icon {
       fill: $svg-color;
     }
   }

--- a/src/frontend/scss/tools/_detail.scss
+++ b/src/frontend/scss/tools/_detail.scss
@@ -23,20 +23,20 @@
 
   // Thin top divider line
   @if r-theme-val(block-schemes, divider) {
-    &#{$sel} + #{$sel}--divider {
+    & + #{$sel}--divider {
       border-top: $onepixel solid r-theme-val(block-schemes, divider);
     }
   }
 
   // Implement background variant modifiers
   @each $name, $scheme in r-theme-val(block-schemes, variants) {
-    &#{$sel}--#{$name} {
+    &--#{$name} {
       @include r-scheme-colors($scheme);
     }
   }
 
   // Some specific responsives adjustments for the 'waves' section
-  &#{$sel}--waves {
+  &--waves {
     padding-top: 3vw;
     @include media-breakpoint-up(lg) {
       padding-top: 3vw;
@@ -52,7 +52,7 @@
   }
 
   @if r-theme-val(block-schemes, alt-arc) {
-    &#{$sel}--arc {
+    &--arc {
       padding-bottom: 0 !important;
 
       &::after {
@@ -70,7 +70,7 @@
   }
 
   @if r-theme-val(block-schemes, alt-curve) {
-    &#{$sel}--curve {
+    &--curve {
       padding-top: 0 !important;
 
       &::before {

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_quote.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_quote.html
@@ -28,7 +28,7 @@
 
 {% if instance.content %}
 <div class="glimpse-{{ glimpse_variant }}__content">
-    <svg role="img">
+    <svg class="icon" role="img">
         <use href="#icon-quote" />
     </svg>
     {{ instance.content|linebreaks }}


### PR DESCRIPTION
## Purpose

If the selected scheme has a `svg-color` property, `r-scheme-colors` applied this color to all svg children of the selected element. Coupled with the use of `detail-block` mixin, in some case, the css selector in charge to style svg had a too high priority selector and we were unable to change svg color from a lower level. So we decide to enlight as possible selector in charge to apply svg-color, to do that we refactor `detail-block` and `r-scheme-colors` mixins.


## Proposal

- [x] Enlight as possible selector in charge to apply svg-color 
- [x] Check this modification has no wrong side-effect.
