### PR TITLE
New blocks for branding customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add enrollment count to course run and to course page
+- Add blocks on header and footer for branding overrides
 
 ### Fixed
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -80,7 +80,9 @@
                             <button class="topbar__hamburger"
                                     data-target="main-menu" aria-label="menu" aria-expanded="false">&#8801;</button>
                             <a href="/" title="{% trans "Go to homepage" %}" rel="home" accesskey="h">
+                            {% block branding_topbar %}
                                 <img src="{% static "richie/images/logo.png" %}" class="topbar__logo" alt="{{ SITE.name }}">
+                            {% endblock branding_topbar %}
                             </a>
                         </div>
                         <div class="topbar__menu">
@@ -141,7 +143,9 @@
                         </div>
                         <div class="body-footer__brand">
                             <a href="/">
+                            {% block branding_footer %}
                                 <img src="{% static "richie/images/logo-alt.png" %}" alt="">
+                            {% endblock branding_footer %}
                             </a>
                         </div>
                         <div class="body-footer__insert">


### PR DESCRIPTION
## Proposal

Adding new Blocks to the header and the footer will allow us to override the `<img>` element and switch it up for a `<svg>` inline or any other element to be used as site branding.
