### PR TITLE
🐛(courses) fix course run title and web analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix `useCache` hook when it has to encode UTF-16 characters to base 64.
 - Fix an issue related to css selector priority from r-scheme-colors mixins
 - Fix css classes related with course runs on the course detail page.
+- Fix error on course page when course run hasn't a title and the setting
+WEB_ANALYTICS_ID is enabled
 
 ## Changed
 

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -185,7 +185,7 @@ class WebAnalyticsContextProcessor:
         dimensions["course_runs_titles"] = [
             course_run.title
             for course_run in course_runs
-            if course_run is not None and course_run.title is not None
+            if course_run is not None and course_run.safe_title is not None
         ]
 
         dimensions["course_runs_resource_links"] = map(

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from datetime import MAXYEAR, datetime
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 from django.db.models import Q, Sum
 from django.urls import reverse
@@ -874,6 +874,16 @@ class CourseRun(TranslatableModel):
             # Get the course in the same version as the course run
             extended_object__publisher_is_draft=is_draft,
         ).distinct()[0]
+
+    @property
+    def safe_title(self):
+        """
+        Access the `title` translatable field from the `CourseRunTranslation` on a safe way.
+        """
+        try:
+            return self.title
+        except ObjectDoesNotExist:
+            return None
 
 
 class CourseRunTranslation(TranslatedFieldsModel):


### PR DESCRIPTION
Fixes #1484

Fix error on course page when course run hasn't a title and the setting WEB_ANALYTICS_ID is enabled.