### PR TITLE
✨(courses) optional limit max archived course runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add setting to limit the number of archived course runs displayed by
+  default on a course detail page.
 - Add timing function variables
 - Add a `outline` variant to button
 - Create a `shadowed-box` mixin

--- a/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -230,4 +230,17 @@
       color: r-theme-val(course-detail, license-label-color);
     }
   }
+
+  &__view-more-runs {
+    text-decoration: none;
+    background-color: transparent;
+    color: r-theme-val(course-detail, view-more-runs-color);
+    border: 0;
+    padding: 0;
+    margin-top: 1rem;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/src/frontend/scss/settings/_colors.scss
+++ b/src/frontend/scss/settings/_colors.scss
@@ -514,6 +514,7 @@ $r-theme: (
     plan-title-color: r-color('firebrick6'),
     license-label-color: r-color('denim'),
     checkmark-list-decoration: url('../../richie/images/components/checkmark.svg'),
+    view-more-runs-color: r-color('firebrick6'),
   ),
   organization-detail: (
     banner-empty-background: r-color('smoke'),

--- a/src/frontend/scss/tools/_utils.scss
+++ b/src/frontend/scss/tools/_utils.scss
@@ -17,3 +17,8 @@
   margin: $margin;
   padding: $padding;
 }
+
+// Helper class to hide elements.
+.is-hidden {
+  display: none;
+}

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -10,6 +10,7 @@ from django.http.request import HttpRequest
 from django.middleware.csrf import get_token
 from django.utils.translation import get_language_from_request
 
+from richie.apps.courses.defaults import RICHIE_MAX_ARCHIVED_COURSE_RUNS
 from richie.apps.courses.models import Organization
 
 from . import defaults
@@ -107,6 +108,11 @@ def site_metas(request: HttpRequest):
         context[
             "RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT"
         ] = settings.RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT
+
+    context["RICHIE_MAX_ARCHIVED_COURSE_RUNS"] = getattr(
+        settings, "RICHIE_MAX_ARCHIVED_COURSE_RUNS", RICHIE_MAX_ARCHIVED_COURSE_RUNS
+    )
+
     return context
 
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -229,6 +229,12 @@
                 initializeAccordions();
                 initializeHamburgerMenu();
             });
+
+            function toggleClass(elements, clazz) {
+                for (let element of elements) {
+                    element.classList.toggle(clazz);
+                }
+            }
         </script>
         {% if request.toolbar and request.toolbar.edit_mode_active %}
         {# When edit mode is active, we have to refresh js scripts after saving modifications #}

--- a/src/richie/apps/courses/defaults.py
+++ b/src/richie/apps/courses/defaults.py
@@ -343,3 +343,7 @@ EFFORT_UNITS = {
     MINUTE: TIME_UNITS[MINUTE],
     HOUR: TIME_UNITS[HOUR],
 }
+
+# Maximum number of archived course runs displayed by default on course detail page.
+# The additional runs can be viewed by clicking on `View more` link.
+RICHIE_MAX_ARCHIVED_COURSE_RUNS = 10

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -358,7 +358,7 @@
                                 <h3 class="course-detail__title">
                                     {% trans "Archived" context "Archived course runs (plural)" %}
                                 </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.6 %}
+                                {% include "courses/cms/fragment_course_runs_list.html" with max_course_runs=RICHIE_MAX_ARCHIVED_COURSE_RUNS course_runs=runs_dict.6%}
                             </div>
                         {% endif %}
                         {% endblock runs_archived %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_runs_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_runs_list.html
@@ -2,28 +2,33 @@
 
 {% spaceless %}
 {% if course_runs %}
-<ul class="course-detail__run-list">
-    {% for run in course_runs %}
-        {% render_model_block run %}
-            <li>
-                {% if course != run.direct_course %}
-                    <a href="{{ run.direct_course.extended_object.get_absolute_url }}">
-                {% endif %}
-                {% if run.title %}
-                    {% blocktrans with title=run.title|capfirst start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' %}
-                        {{ title }}, from {{ start }} to {{ end }}
-                    {% endblocktrans %}
-                {% else %}
-                    {% blocktrans with start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' %}
-                        From {{ start }} to {{ end }}
-                    {% endblocktrans %}
-                {% endif %}
-                {% if course != run.direct_course %}
-                    </a>
-                {% endif %}
-            </li>
-        {% endrender_model_block %}
-    {% endfor %}
-</ul>
+    <ul class="course-detail__run-list">
+        {% for run in course_runs %}
+            {% render_model_block run %}
+                <li{% if max_course_runs and max_course_runs < forloop.counter %} class="is-hidden"{% endif %}>
+                    {% if course != run.direct_course %}
+                        <a href="{{ run.direct_course.extended_object.get_absolute_url }}">
+                    {% endif %}
+                    {% if run.title %}
+                        {% blocktrans with title=run.title|capfirst start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' %}
+                            {{ title }}, from {{ start }} to {{ end }}
+                        {% endblocktrans %}
+                    {% else %}
+                        {% blocktrans with start=run.start|date:'DATE_FORMAT'|default:'...' end=run.end|date:'DATE_FORMAT'|default:'...' %}
+                            From {{ start }} to {{ end }}
+                        {% endblocktrans %}
+                    {% endif %}
+                    {% if course != run.direct_course %}
+                        </a>
+                    {% endif %}
+                </li>
+            {% endrender_model_block %}
+        {% endfor %}
+    </ul>
+    {% if max_course_runs and course_runs|length > max_course_runs %}
+        <button type="button" class="course-detail__view-more-runs" onclick="toggleClass(this.previousElementSibling.getElementsByClassName('is-hidden'), 'is-hidden'); toggleClass([this], 'is-hidden');">
+            {% trans "View more" %}
+        </button>
+    {% endif %}
 {% endif %}
 {% endspaceless %}

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -1231,3 +1231,39 @@ class RunsCourseCMSTestCase(CMSTestCase):
 
         # Without course license participation
         self.assertNotContains(response, "License for the course content")
+
+    @override_settings(RICHIE_MAX_ARCHIVED_COURSE_RUNS=3)
+    def test_templates_course_detail_view_richie_max_archived_course_runs(self):
+        """
+        Only the number of archived course runs defined by `RICHIE_MAX_ARCHIVED_COURSE_RUNS`
+        setting should be displayed.
+        """
+        course = CourseFactory()
+        for _ in range(5):
+            self.create_run_archived_closed(course).refresh_from_db()
+        course.extended_object.publish("en")
+        response = self.client.get(course.extended_object.get_absolute_url())
+
+        self.assertContains(
+            response,
+            '<li class="is-hidden">',
+            count=2,
+        )
+        self.assertContains(response, "course-detail__view-more-runs")
+
+    @override_settings(RICHIE_MAX_ARCHIVED_COURSE_RUNS=None)
+    def test_templates_course_detail_view_no_richie_max_archived_course_runs(self):
+        """
+        All course runs should be displayed when `RICHIE_MAX_ARCHIVED_COURSE_RUNS` setting is None
+        """
+        course = CourseFactory()
+        for _ in range(5):
+            self.create_run_archived_closed(course).refresh_from_db()
+        course.extended_object.publish("en")
+        response = self.client.get(course.extended_object.get_absolute_url())
+
+        self.assertNotContains(
+            response,
+            '<li class="is-hidden">',
+        )
+        self.assertNotContains(response, "course-detail__view-more-runs")


### PR DESCRIPTION
Limit the number of archived course runs displayed by default on a course detail page.

The additional runs can be viewed by clicking on `View more` link.

![image](https://user-images.githubusercontent.com/67018/139221620-2e22531f-ca54-4b4a-aae7-9e8a8998821e.png)

Then after clicking on _View more_ link it would show all the rest of the archived course runs.

![image](https://user-images.githubusercontent.com/67018/139221835-385d9707-4864-45db-88c1-92ef1bb486c6.png)

#1497 