### PR TITLE
🐛(search) handle too-short query strings in <Search />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add blocks on header and footer for branding overrides
 - Add organization logo to course glimpse
 
-### Changed
+### Fixed
+
+- Fix an error when a user typed a short search query in the header or home
+- Fix an issue related to css selector priority from r-scheme-colors mixins
+- Fix css classes related with course runs on the course detail page.
+
+## Changed
 
 - Update course search API to remove MPTT regexes as query params and replace
   them with arrays or strings.

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -68,6 +68,60 @@ describe('<Search />', () => {
     });
   });
 
+  it('shows the results and a warning message when there is a text query that is too short', async () => {
+    // Note: this can happen when loading <Search /> with a short text query already in the query string
+    fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', {
+      // NB: query is absent from API request query string
+      meta: {
+        total_count: 200,
+      },
+      objects: [
+        {
+          absolute_url: '/en/courses/vision-oriented-systemic-implementation/',
+          cover_image: {
+            sizes: '300px',
+            src: '/some/image.jpg',
+            srcset: '/some/image.jpg *',
+          },
+          duration: '2 days',
+          effort: '425 minutes',
+          icon: null,
+          introduction: 'Politics some never so various mean. American society long building.',
+          title: 'Vision-oriented systemic implementation',
+          id: '346',
+          categories: ['40', '46', '60', '104'],
+          code: '00027',
+          organization_highlighted: 'Object-based analyzing time-frame',
+          organizations: ['170', '186', '190'],
+          state: {
+            priority: 3,
+            datetime: '2022-04-30T18:45:31Z',
+            call_to_action: null,
+            text: 'starting on',
+          },
+        },
+      ],
+    });
+
+    render(
+      <IntlProvider locale="en">
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0', query: 'vi' })}>
+          <Search context={contextProps} />
+        </HistoryContext.Provider>
+      </IntlProvider>,
+    );
+
+    // Wait for search results to be loaded
+    await waitFor(() => {
+      expect(screen.queryByText('Loading search results...')).toBeNull();
+    });
+
+    screen.getByText('Vision-oriented systemic implementation');
+    screen.getByText((content) =>
+      content.startsWith('Text search requires at least 3 characters.'),
+    );
+  });
+
   it('shows an error message when it fails to get the results', async () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', 500);
 

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -35,11 +35,22 @@ const messages = defineMessages({
     description: 'Accessibility text for the spinner while search results are being loaded',
     id: 'components.Search.spinnerText',
   },
+  textQueryLengthWarning: {
+    defaultMessage: `Text search requires at least 3 characters. { query } is not long enough to search.
+Search results will not be affected by this query.`,
+    description:
+      'Warning message in search results when the text query is not long enough to be used.',
+    id: 'components.Search.textQueryLengthWarning',
+  },
 });
 
 const Search = ({ context }: CommonDataProps) => {
   const { courseSearchParams, lastDispatchActions } = useCourseSearchParams();
-  const courseSearchResponse = useCourseSearch(courseSearchParams);
+  const { query, ...courseSearchParamsWithoutQuery } = courseSearchParams;
+
+  const courseSearchResponse = useCourseSearch(
+    query && query.length < 3 ? courseSearchParamsWithoutQuery : courseSearchParams,
+  );
 
   const alwaysShowFilters = useMatchMedia('(min-width: 992px)');
   const [showFilters, setShowFilters] = useState(false);
@@ -108,6 +119,16 @@ const Search = ({ context }: CommonDataProps) => {
       <div className="search__results">
         {courseSearchResponse && courseSearchResponse.status === RequestStatus.SUCCESS ? (
           <React.Fragment>
+            {query && query.length < 3 ? (
+              <div className="banner banner--rounded banner--warning">
+                <p className="banner__message">
+                  <FormattedMessage
+                    {...messages.textQueryLengthWarning}
+                    values={{ query: <b>&quot;{query}&quot;</b> }}
+                  />
+                </p>
+              </div>
+            ) : null}
             <CourseGlimpseList
               context={context}
               courses={courseSearchResponse.content.objects}

--- a/src/frontend/js/data/useCourseSearch/index.ts
+++ b/src/frontend/js/data/useCourseSearch/index.ts
@@ -1,3 +1,4 @@
+import { stringify } from 'query-string';
 import { useState } from 'react';
 
 import { APIListRequestParams } from 'types/api';
@@ -12,7 +13,7 @@ export const useCourseSearch = (searchParams: APIListRequestParams) => {
   useAsyncEffect(async () => {
     const response = await fetchList('courses', searchParams);
     setCourseSearchResponse(response);
-  }, [searchParams]);
+  }, [stringify(searchParams)]);
 
   return courseSearchResponse;
 };


### PR DESCRIPTION
## Purpose

When the user makes use of our <Search /> UI, if they type a textual query that is too short to be used to search, we manage it by not triggering a search, which users understand as a nudge to keep typing.

There are cases, however, when a user can land on the course search page with a too-short query string in the URL, such as when they typed that short query string in the search bar in the homepage or in the header.

Right now we're just showing an unhelpful error message.

Closes #1373 

## Proposal

We would rather display search results that do not make use of their short query, as we would have done if they just typed 2 characters in the search view directly.

Unlike that case however, we need to warn them that their query was ignored as the interface did not give them a hint by its ongoing state while they were typing said query.

EDIT: changed screenshot to banner warning:
![Screenshot 2021-10-28 at 14-41-55 Courses](https://user-images.githubusercontent.com/1932937/139257326-36ace32b-5c02-406d-8a90-4b978bdd620b.png)

