### PR TITLE
👷(ci) stop using docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,8 @@ jobs:
       - checkout
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-      # Activate docker-in-docker (with layers caching enabled)
+      # Activate docker-in-docker
       - setup_remote_docker:
-          docker_layer_caching: true
           version: 19.03.13
 
       # Login to Docker Hub with encrypted credentials stored as secret


### PR DESCRIPTION
## Purpose

Docker layer caching is a paid-for feature that @openfun does not have access to as part of their open source Circle CI plan. It is currently blocking some of our CI jobs.

## Proposal 

We need to remove it from our CI definition to allow our CI workflows to run.
