### PR TITLE
Hide enrollment count when minimum is zero or none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Hide enrollment count by default until an explicit minimum is set
+
 ## [2.9.0] - 2021-10-27
 
 ### Added

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,8 @@ $ make migrate
 
 ## Unreleased
 
+## 2.8.x to 2.9.x
+
 - Add `django.contrib.humanize` to your installed apps.
   ```python
   INSTALLED_APPS = (
@@ -23,6 +25,10 @@ $ make migrate
       'django.contrib.humanize',
   )
   ```
+- If you want to activate the new feature showing the enrollment count on the course detail page,
+  set the `RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT` setting to a value greater than 0, to
+  specify the minimum number of enrollments for a course (accross all its sessions) starting from
+  which you want to show the enrollment count. It will display as: "1000 already enrolled!"
 
 ## 2.7.x to 2.8.x
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -580,7 +580,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
 
     # Minimum enrollment count value that would be shown on course detail page
     RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT = values.Value(
-        0,
+        5000,
         environ_name="RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT",
         environ_prefix=None,
     )

--- a/src/frontend/scss/components/_subheader.scss
+++ b/src/frontend/scss/components/_subheader.scss
@@ -137,7 +137,7 @@ $r-subheader-search-title-width: 19rem !default; // aligned on computed search r
     font-size: 1rem;
   }
 
-  &__enrollment_count {
+  &__enrollment-count {
     @include make-container();
     padding-left: 0;
     padding-right: 0;

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -111,19 +111,17 @@
                         {% endif %}
                     </div>
 
-                    <div class="subheader__enrollment_count">
-                        {% block enrollment_count %}
-                            {% with enrollment_count=course.course_runs_enrollment_count %}
-                                {% if enrollment_count > 0 and RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT is None or enrollment_count > 0 and enrollment_count >= RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT %}
-                                    <div>
-                                        {% blocktrans with count=enrollment_count|intcomma %}
-                                            {{ count }} already enrolled!
-                                        {% endblocktrans %}
-                                    </div>
-                                {% endif %}
-                            {% endwith %}
-                        {% endblock enrollment_count %}
-                    </div>
+                    {% block enrollment_count %}
+                        {% with enrollment_count=course.course_runs_enrollment_count %}
+                            {% if enrollment_count > 0 and RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT > 0 and enrollment_count >= RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT %}
+                                <div class="subheader__enrollment-count">
+                                    {% blocktrans with count=enrollment_count|intcomma %}
+                                        {{ count }} already enrolled!
+                                    {% endblocktrans %}
+                                </div>
+                            {% endif %}
+                        {% endwith %}
+                    {% endblock enrollment_count %}
 
                     <div class="subheader__teaser">
                         {% placeholder "course_teaser" or %}

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -366,7 +366,6 @@ def create_demo_site():
             ["de", "en", "es", "fr", "it", "nl"], random.randint(1, 4)  # nosec
         )
         # only half the courses have an enrollment count defined
-        course_runs_with_enrollment_count = random.getrandbits(1)
         for i in range(nb_course_runs):
             course_run = factories.CourseRunFactory(
                 __sequence=i,
@@ -375,11 +374,7 @@ def create_demo_site():
                 ),
                 direct_course=course,
                 resource_link=f"{lms_endpoint}/courses/course-v1:edX+DemoX+Demo_Course/info",
-                enrollment_count=(
-                    random.randint(1, 10000)  # nosec
-                    if course_runs_with_enrollment_count
-                    else 0
-                ),
+                enrollment_count=random.randint(1, 10000),  # nosec
             )
             for language in course.extended_object.get_languages():
                 with translation.override(language):

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -196,8 +196,9 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             response, program_unpublished.extended_object.get_title()
         )
 
-        # Check enrollment count
-        self.assertContains(response, "11,000 already enrolled")
+        # Check that enrollment count is not present
+        self.assertContains(response, "enrollment-count")
+        self.assertContains(response, "11,000 already enrolled!")
 
     def test_templates_course_detail_cms_published_content_no_code(self):
         """
@@ -1053,6 +1054,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
             html=True,
         )
 
+    @override_settings(RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT=3)
     def test_templates_course_detail_runs_with_only_one_enrollment_count(self):
         """
         When a run has any enrollment count number, it should display the sum for all runs
@@ -1114,3 +1116,39 @@ class RunsCourseCMSTestCase(CMSTestCase):
         response = self.client.get(course.extended_object.get_absolute_url())
 
         self.assertNotContains(response, r"already enrolled")
+
+    @override_settings(RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT=0)
+    def test_templates_course_detail_runs_count_minimum_0(self):
+        """
+        When the minimum number of enrollments is set to 0, the count should be hidden
+        """
+        course = CourseFactory()
+        course_run = self.create_run_ongoing_open(
+            course,
+            enrollment_count=3,
+        )
+        self.assertTrue(course.extended_object.publish("en"))
+        course_run.refresh_from_db()
+
+        response = self.client.get(course.extended_object.get_absolute_url())
+
+        self.assertNotContains(response, "enrollment-count")
+        self.assertNotContains(response, "already enrolled")
+
+    @override_settings(RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT=None)
+    def test_templates_course_detail_runs_count_minimum_none(self):
+        """
+        When the minimum number of enrollments is set to None, the count should be hidden
+        """
+        course = CourseFactory()
+        course_run = self.create_run_ongoing_open(
+            course,
+            enrollment_count=3,
+        )
+        self.assertTrue(course.extended_object.publish("en"))
+        course_run.refresh_from_db()
+
+        response = self.client.get(course.extended_object.get_absolute_url())
+
+        self.assertNotContains(response, "enrollment-count")
+        self.assertNotContains(response, "already enrolled")


### PR DESCRIPTION
## Purpose

Enrollment counts are not desirable when used with a low minimum because nobody wants to boast about counts that look like: "2 already subscribed!".

The minimum should be set explicitly and voluntarily. If it is not set, it is better to hide the sentence.

Also, the only way to disable this feature was to override the template but it would be better to use the setting to allow disabling the feature.

## Proposal

When the default value of 0 is set as minimum count, it should be understood as a desire to disable the feature.