### PR TITLE
(search) Manage Keyerror on autocomplete requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Hide enrollment count by default until an explicit minimum is set
+- Improve handling for autocompletion missing query errors
 
 ## [2.9.0] - 2021-10-27
 

--- a/src/frontend/js/common/searchFields/getSuggestionsSection.spec.ts
+++ b/src/frontend/js/common/searchFields/getSuggestionsSection.spec.ts
@@ -8,6 +8,7 @@ jest.mock('utils/errors/handle');
 
 describe('common/searchFields/getSuggestionsSection', () => {
   afterEach(() => {
+    jest.resetAllMocks();
     fetchMock.restore();
   });
 
@@ -50,6 +51,22 @@ describe('common/searchFields/getSuggestionsSection', () => {
     await getSuggestionsSection('courses', 'Courses', 'some search');
     expect(mockHandle).toHaveBeenCalledWith(
       new Error('Failed to get list from courses autocomplete : 403'),
+    );
+  });
+
+  it('reports the error and the explanation when the server returns a 400 error', async () => {
+    fetchMock.get('/api/v1.0/courses/autocomplete/?query=error', {
+      body: {
+        errors: ['Missing autocomplete "query" for request to richie_courses.'],
+      },
+      status: 400,
+    });
+    await getSuggestionsSection('courses', 'Courses', 'error');
+    expect(mockHandle).toHaveBeenCalledWith(
+      new Error('Failed to get list from courses autocomplete : 400'),
+      {
+        errors: ['Missing autocomplete "query" for request to richie_courses.'],
+      },
     );
   });
 

--- a/src/frontend/js/common/searchFields/getSuggestionsSection.ts
+++ b/src/frontend/js/common/searchFields/getSuggestionsSection.ts
@@ -28,7 +28,8 @@ export const getSuggestionsSection = async (kind: string, title: string, query: 
   // Fetch treats remote errors (400, 404, 503...) as successes
   // The ok flag is the way to discriminate
   if (!response.ok) {
-    return handle(new Error(`Failed to get list from ${kind} autocomplete : ${response.status}`));
+    const error = new Error(`Failed to get list from ${kind} autocomplete : ${response.status}`);
+    return response.status === 400 ? handle(error, await response.json()) : handle(error);
   }
 
   let responseData: Suggestion<string>[];

--- a/src/frontend/js/utils/errors/handle.ts
+++ b/src/frontend/js/utils/errors/handle.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/browser';
+import { CaptureContext } from '@sentry/types';
 
 const context = window.__richie_frontend_context__?.context;
 if (context?.sentry_dsn) {
@@ -14,9 +15,9 @@ if (context?.sentry_dsn) {
  * Generic error handler to be called whenever we need to do error reporting throughout the app.
  * Passes errors to Sentry if available, logs the error to the console otherwise.
  */
-export const handle = (error: unknown) => {
+export const handle = (error: unknown, errorContext?: CaptureContext) => {
   if (context?.sentry_dsn) {
-    Sentry.captureException(error);
+    Sentry.captureException(error, errorContext);
   } else {
     // eslint-disable-next-line no-console
     console.error(error);

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -44,6 +44,7 @@
     "@formatjs/intl-relativetimeformat": "9.3.2",
     "@helpscout/helix": "0.2.0",
     "@sentry/browser": "6.13.3",
+    "@sentry/types": "6.13.3",
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "12.1.2",
     "@testing-library/react-hooks": "7.0.2",

--- a/src/richie/apps/search/viewsets/categories.py
+++ b/src/richie/apps/search/viewsets/categories.py
@@ -111,6 +111,24 @@ class CategoriesViewSet(ViewSet):
         # Get a hold of the relevant indexer
         indexer = self._meta.indexer
 
+        # Some malformed requests have been generating 500 errors in autocomplete calls. Make sure
+        # we return the proper error code instead so the frontend can be debugged as well if
+        # necessary.
+        try:
+            query = request.query_params["query"]
+        except KeyError:
+            return Response(
+                status=400,
+                data={
+                    "errors": [
+                        (
+                            'Missing autocomplete "query" for request '
+                            f"to {self._meta.indexer.index_name}."
+                        )
+                    ]
+                },
+            )
+
         # Query our specific ES completion field
         language = get_language_from_request(request)
         autocomplete_query_response = ES_CLIENT.search(
@@ -118,7 +136,7 @@ class CategoriesViewSet(ViewSet):
             body={
                 "suggest": {
                     "categories": {
-                        "prefix": request.query_params["query"],
+                        "prefix": query,
                         "completion": {
                             "contexts": {"kind": [kind]},
                             "field": f"complete.{language:s}",

--- a/tests/apps/search/test_autocomplete_categories.py
+++ b/tests/apps/search/test_autocomplete_categories.py
@@ -123,6 +123,21 @@ class AutocompleteCategoriesTestCase(TestCase):
 
         return categories, json.loads(response.content)
 
+    def test_autocomplete_missing_query(self, *_):
+        """
+        When the query is missing, the API returns a 400 error with an appropriate error.
+        """
+        response = self.client.get("/api/v1.0/subjects/autocomplete/?")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "errors": [
+                    'Missing autocomplete "query" for request to test_categories.'
+                ]
+            },
+        )
+
     def test_autocomplete_text(self, *_):
         """
         Make sure autocomplete is operational and returns the expected categories.

--- a/tests/apps/search/test_autocomplete_courses.py
+++ b/tests/apps/search/test_autocomplete_courses.py
@@ -130,6 +130,17 @@ class AutocompleteCoursesTestCase(TestCase):
 
         return json.loads(results.content)
 
+    def test_autocomplete_missing_query(self, *_):
+        """
+        When the query is missing, the API returns a 400 error with an appropriate error.
+        """
+        response = self.client.get("/api/v1.0/courses/autocomplete/?")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"errors": ['Missing autocomplete "query" for request to test_courses.']},
+        )
+
     def test_autocomplete_text(self, *_):
         """
         Make sure autocomplete is operational and returns the expected courses.

--- a/tests/apps/search/test_autocomplete_organizations.py
+++ b/tests/apps/search/test_autocomplete_organizations.py
@@ -110,6 +110,21 @@ class AutocompleteOrganizationsTestCase(TestCase):
 
         return organizations, json.loads(response.content)
 
+    def test_autocomplete_missing_query(self, *_):
+        """
+        When the query is missing, the API returns a 400 error with an appropriate error.
+        """
+        response = self.client.get("/api/v1.0/organizations/autocomplete/?")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "errors": [
+                    'Missing autocomplete "query" for request to test_organizations.'
+                ]
+            },
+        )
+
     def test_autocomplete_text(self, *_):
         """
         Make sure autocomplete is operational and returns the expected organizations.

--- a/tests/apps/search/test_autocomplete_persons.py
+++ b/tests/apps/search/test_autocomplete_persons.py
@@ -87,6 +87,17 @@ class AutocompletePersonsTestCase(TestCase):
 
         return persons, json.loads(response.content)
 
+    def test_autocomplete_missing_query(self, *_):
+        """
+        When the query is missing, the API returns a 400 error with an appropriate error.
+        """
+        response = self.client.get("/api/v1.0/persons/autocomplete/?")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {"errors": ['Missing autocomplete "query" for request to test_persons.']},
+        )
+
     def test_autocomplete_text(self, *_):
         """
         Make sure autocomplete is operational and returns the expected persons.


### PR DESCRIPTION
## Purpose

Per #1349.

We have been seeing `KeyError` 500 errors on the API, caused by autocomplete calls without a `query`. As far as we can tell from the code, this should not be possible.

Still, the API should not throw up a 500 in this case, but should handle the error and return a 400 with an explanation. This should also help us better understand how the frontend ends up making those broken requests.


## Proposal

- Handle autocomplete errors gracefully on the API
- Improve error handling in the frontend so we can find out the reason for broken requests later on
