### PR TITLE
✨(search) update ES indices when a page is moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add enrollment count to course run and to course page
 - Add blocks on header and footer for branding overrides
 - Add organization logo to course glimpse
+- Add a signal to update the ES index when a category page is moved
 
 ### Fixed
 


### PR DESCRIPTION
## Purpose

When a page is moved in the MPTT tree, it can change the paths of an unbounded number of other pages linked to the same kind of objects. Right now, paths are only used for categories.

## Proposal

Therefore, when a category is moved in the page tree, we need to re-index all categories, as we do not know which pages may be impacted by the move.

Note: although there still is a `page_moved` signal (https://github.com/django-cms/django-cms/blob/f622008b471e664249b72db6dec528d4d8bd4255/cms/signals/__init__.py#L16), it is not called anywhere as it was intentionally removed (https://github.com/django-cms/django-cms/issues/6356).

The approach we propose relies on an internal tool, but thanks to our unit test, we should be warned if/when it is broken by Django CMS.