### PR TITLE
🐛(frontend) do not call logout twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move type utils into type directory
 
+### Fixed
+
+- Prevent logout action to be called twice
+
 ## [2.9.1] - 2021-11-03
 
 ### Fixed

--- a/src/frontend/js/components/UserMenu/DesktopUserMenu.tsx
+++ b/src/frontend/js/components/UserMenu/DesktopUserMenu.tsx
@@ -24,8 +24,9 @@ export const DesktopUserMenu: React.FC<UserMenuProps> = ({ user }) => {
   } = useSelect({
     items: labels,
     onSelectedItemChange: ({ selectedItem }) => {
-      // Manually handle action in case the user interacted with a keyboard, and therefore with a
-      // list item, and not by clicking on the actual links.
+      // We have to handle action manually in case the user
+      // is interacting through keyboard, and therefore with a list item, and
+      // not by clicking on the actual links.
       if (typeof selectedItem!.action === 'string') {
         location.replace(selectedItem!.action);
       } else {
@@ -65,7 +66,6 @@ export const DesktopUserMenu: React.FC<UserMenuProps> = ({ user }) => {
                 <button
                   className={`selector__list__link
                   ${highlightedIndex === index ? 'selector__list__link--highlighted' : ''}`}
-                  onClick={link.action}
                 >
                   {link.label}
                 </button>

--- a/src/frontend/js/components/UserMenu/index.spec.tsx
+++ b/src/frontend/js/components/UserMenu/index.spec.tsx
@@ -7,6 +7,8 @@ import { UserMenu } from '.';
 /* Enforce to use DesktopUserMenu by default */
 let mockMatches = true;
 
+const logout = jest.fn();
+
 const props = {
   user: {
     username: 'John Doe',
@@ -14,7 +16,7 @@ const props = {
       {
         key: 'logout',
         label: 'Log out',
-        action: '/logout',
+        action: logout,
       },
       {
         key: 'profile',
@@ -39,6 +41,8 @@ jest.mock('utils/indirection/window', () => ({
 }));
 
 describe('<UserMenu />', () => {
+  afterEach(() => jest.resetAllMocks());
+
   it('renders a dropdown with links matching the data passed to the "link" prop', async () => {
     render(
       <IntlProvider locale="en">
@@ -54,7 +58,11 @@ describe('<UserMenu />', () => {
 
     screen.getByRole('link', { name: 'Profile' });
     screen.getByRole('link', { name: 'My Dashboard' });
-    screen.getByRole('link', { name: 'Log out' });
+    const logoutButton = screen.getByRole('button', { name: 'Log out' });
+
+    userEvent.click(logoutButton);
+
+    expect(logout).toHaveBeenCalledTimes(1);
   });
 
   it('renders a list of links matching the data passed to the "link" prop on Mobile/Tablet', async () => {
@@ -70,6 +78,10 @@ describe('<UserMenu />', () => {
     screen.getByRole('heading', { name: 'John Doe' });
     screen.getByRole('link', { name: 'Profile' });
     screen.getByRole('link', { name: 'My Dashboard' });
-    screen.getByRole('link', { name: 'Log out' });
+    const logoutButton = screen.getByRole('button', { name: 'Log out' });
+
+    userEvent.click(logoutButton);
+
+    expect(logout).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/frontend/scss/objects/_selector.scss
+++ b/src/frontend/scss/objects/_selector.scss
@@ -75,6 +75,7 @@
       &--highlighted {
         background: r-theme-val(selector, hover-background);
         color: r-theme-val(selector, hover-color);
+        text-decoration: underline;
       }
 
       .selector--dark & {


### PR DESCRIPTION
## Purpose
In DesktopUserMenu, when user clicked on logout button, the action was trigger twice. First through the `onClick` handler then second from the downshift `onSelectedItemChange` handler used for accessibility purpose.

## Proposal

- [x] Trigger actions only through `onSelectedItemChange` handler.
