### PR TITLE
Refactor/switch to react query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Add react-query to manage API requests and local data store
 - Move type utils into type directory
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Create an context util
 - Add react-query to manage API requests and local data store
 - Move type utils into type directory
 

--- a/src/frontend/js/common/searchFields/getSuggestionsSection.spec.ts
+++ b/src/frontend/js/common/searchFields/getSuggestionsSection.spec.ts
@@ -5,6 +5,7 @@ import { getSuggestionsSection } from './getSuggestionsSection';
 
 const mockHandle: jest.Mock<typeof handle> = handle as any;
 jest.mock('utils/errors/handle');
+jest.mock('utils/context', () => jest.fn());
 
 describe('common/searchFields/getSuggestionsSection', () => {
   afterEach(() => {

--- a/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.spec.tsx
@@ -1,16 +1,17 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
+import { QueryClientProvider } from 'react-query';
 import { IntlProvider } from 'react-intl';
 import faker from 'faker';
 
 import { CourseRun } from 'types';
 import { CommonDataProps } from 'types/commonDataProps';
-import { ApiBackend } from 'types/api';
+import { APIBackend } from 'types/api';
 import { Deferred } from 'utils/test/deferred';
 import * as factories from 'utils/test/factories';
-import { SESSION_CACHE_KEY } from 'settings';
-
+import createQueryClient from 'utils/react-query/createQueryClient';
+import { REACT_QUERY_SETTINGS } from 'settings';
 import { handle } from 'utils/errors/handle';
 
 const mockHandle: jest.Mock<typeof handle> = handle as any;
@@ -23,11 +24,11 @@ describe('<CourseRunEnrollment />', () => {
     .ContextFactory({
       authentication: {
         endpoint,
-        backend: ApiBackend.OPENEDX_HAWTHORN,
+        backend: APIBackend.OPENEDX_HAWTHORN,
       },
       lms_backends: [
         {
-          backend: ApiBackend.OPENEDX_HAWTHORN,
+          backend: APIBackend.OPENEDX_HAWTHORN,
           course_regexp: '(?<course_id>.*)',
           endpoint,
         },
@@ -41,11 +42,10 @@ describe('<CourseRunEnrollment />', () => {
   const initializeUser = (loggedin = true) => {
     const username = faker.internet.userName();
     sessionStorage.setItem(
-      SESSION_CACHE_KEY,
-      btoa(
-        JSON.stringify({
-          value: loggedin ? { username } : null,
-          expiredAt: Date.now() + 60_0000,
+      REACT_QUERY_SETTINGS.cacheStorage.key,
+      JSON.stringify(
+        factories.PersistedClientFactory({
+          queries: [factories.QueryStateFactory('user', { data: loggedin ? { username } : null })],
         }),
       ),
     );
@@ -60,7 +60,12 @@ describe('<CourseRunEnrollment />', () => {
     dashboard_link: courseRun.dashboard_link,
   });
 
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+  });
+
   afterEach(() => {
+    jest.clearAllTimers();
     sessionStorage.clear();
     fetchMock.restore();
   });
@@ -76,13 +81,17 @@ describe('<CourseRunEnrollment />', () => {
       enrollmentsDeferred.promise,
     );
 
-    render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
-        </SessionProvider>
-      </IntlProvider>,
-    );
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
     screen.getByRole('status', { name: 'Loading enrollment information...' });
 
     await act(async () => {
@@ -110,27 +119,28 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 0;
 
-    const enrollmentsDeferred = new Deferred();
+    const enrollmentDeferred = new Deferred();
     fetchMock.get(
       `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
-      enrollmentsDeferred.promise,
+      enrollmentDeferred.promise,
     );
 
-    render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <CourseRunEnrollment
-            context={contextProps}
-            courseRun={getCourseRunProp(courseRun)}
-            loginUrl="/oauth/login/edx-oauth2/?next=/en/courses/"
-          />
-        </SessionProvider>
-      </IntlProvider>,
-    );
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+
     screen.getByRole('status', { name: 'Loading enrollment information...' });
 
     await act(async () => {
-      enrollmentsDeferred.resolve(false);
+      enrollmentDeferred.resolve({});
     });
 
     const button = screen.getByRole('button', { name: 'Enroll now' });
@@ -153,25 +163,27 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 0;
 
-    const courseRunDeferred = new Deferred();
-    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const enrollmentsDeferred = new Deferred();
     fetchMock.get(
       `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
       enrollmentsDeferred.promise,
     );
 
-    render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
-        </SessionProvider>
-      </IntlProvider>,
-    );
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+
     screen.getByRole('status', { name: 'Loading enrollment information...' });
 
     await act(async () => {
-      courseRunDeferred.resolve(courseRun);
       enrollmentsDeferred.resolve({ is_active: true });
     });
 
@@ -186,25 +198,27 @@ describe('<CourseRunEnrollment />', () => {
     courseRun.starts_in_message = 'The course will start in 3 days';
     courseRun.dashboard_link = 'https://edx.local.dev:8073/dashboard';
 
-    const courseRunDeferred = new Deferred();
-    fetchMock.get(`/api/v1.0/course-runs/${courseRun.id}/`, courseRunDeferred.promise);
     const enrollmentsDeferred = new Deferred();
     fetchMock.get(
       `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
       enrollmentsDeferred.promise,
     );
 
-    render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
-        </SessionProvider>
-      </IntlProvider>,
-    );
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+
     screen.getByRole('status', { name: 'Loading enrollment information...' });
 
     await act(async () => {
-      courseRunDeferred.resolve(courseRun);
       enrollmentsDeferred.resolve({ is_active: true });
     });
 
@@ -221,13 +235,17 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 4;
 
-    render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
-        </SessionProvider>
-      </IntlProvider>,
-    );
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
 
     screen.getByText('Enrollment in this course run is closed at the moment');
     expect(screen.queryByRole('button', { name: 'Enroll now' })).toBeNull();
@@ -238,13 +256,17 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = factories.CourseRunFactory.generate();
     courseRun.state.priority = 0;
 
-    render(
-      <IntlProvider locale="en">
-        <SessionProvider>
-          <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
-        </SessionProvider>
-      </IntlProvider>,
-    );
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={contextProps} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
 
     screen.getByRole('button', { name: 'Log in to enroll' });
   });

--- a/src/frontend/js/components/LtiConsumer/index.spec.tsx
+++ b/src/frontend/js/components/LtiConsumer/index.spec.tsx
@@ -14,6 +14,7 @@ import LtiConsumer from '.';
 
 const mockHandle: jest.Mock<typeof handle> = handle as any;
 jest.mock('utils/errors/handle');
+jest.mock('utils/context', () => jest.fn());
 
 describe('components/LtiConsumer', () => {
   afterEach(() => {

--- a/src/frontend/js/components/Root/index.spec.tsx
+++ b/src/frontend/js/components/Root/index.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { IntlProvider } from 'react-intl';
 
 import { findByText, render } from '@testing-library/react';
@@ -13,6 +13,11 @@ jest.mock('components/RootSearchSuggestField', () => ({
   __esModule: true,
   default: ({ exampleProp }: { exampleProp: string }) =>
     `root search suggest field component rendered with ${exampleProp}`,
+}));
+
+jest.mock('data/useSession', () => ({
+  __esModule: true,
+  SessionProvider: (props: PropsWithChildren<any>) => props.children,
 }));
 
 describe('<Root />', () => {
@@ -73,7 +78,7 @@ describe('<Root />', () => {
     // Render the root component, passing our real element and our bogus one
     render(
       <IntlProvider locale="en">
-        <Root richieReactSpots={[userLoginContainer, userFeedbackContainer]} />
+        <Root richieReactSpots={[userFeedbackContainer, userLoginContainer]} />
       </IntlProvider>,
     );
 

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { IntlProvider } from 'react-intl';
 
 import { location } from 'utils/indirection/window';
-import { ContextFactory } from 'utils/test/factories';
-import { CommonDataProps } from 'types/commonDataProps';
+import { ContextFactory as mockContextFactory } from 'utils/test/factories';
+import context from 'utils/context';
 import RootSearchSuggestField from '.';
 
 jest.mock('settings', () => ({
@@ -18,9 +18,12 @@ jest.mock('utils/indirection/window', () => ({
   },
 }));
 
-describe('<RootSearchSuggestField />', () => {
-  const contextProps: CommonDataProps['context'] = ContextFactory().generate();
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory().generate(),
+}));
 
+describe('<RootSearchSuggestField />', () => {
   const subjects = {
     base_path: '00030001',
     has_more_values: false,
@@ -43,7 +46,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={contextProps} />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={context} />
       </IntlProvider>,
     );
 
@@ -68,7 +71,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={contextProps} />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={context} />
       </IntlProvider>,
     );
 
@@ -112,7 +115,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={contextProps} />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={context} />
       </IntlProvider>,
     );
 
@@ -152,7 +155,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={contextProps} />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={context} />
       </IntlProvider>,
     );
 
@@ -189,7 +192,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={contextProps} />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={context} />
       </IntlProvider>,
     );
 
@@ -225,7 +228,7 @@ describe('<RootSearchSuggestField />', () => {
 
     render(
       <IntlProvider locale="en">
-        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={contextProps} />
+        <RootSearchSuggestField courseSearchPageUrl="/en/courses/" context={context} />
       </IntlProvider>,
     );
 

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { QueryClientProvider } from 'react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { stringify } from 'query-string';
@@ -6,6 +7,7 @@ import { IntlProvider } from 'react-intl';
 
 import { History, HistoryContext } from 'data/useHistory';
 import * as mockWindow from 'utils/indirection/window';
+import createQueryClient from 'utils/react-query/createQueryClient';
 import { ContextFactory } from 'utils/test/factories';
 import { CommonDataProps } from 'types/commonDataProps';
 import Search from '.';
@@ -34,10 +36,11 @@ describe('<Search />', () => {
     historyPushState,
     historyReplaceState,
   ];
-
+  const queryClient = createQueryClient();
   const contextProps: CommonDataProps['context'] = ContextFactory().generate();
 
-  beforeEach(() => {
+  afterEach(() => {
+    queryClient.clear();
     fetchMock.restore();
     jest.resetAllMocks();
   });
@@ -51,11 +54,13 @@ describe('<Search />', () => {
     });
 
     render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByText('Loading search results...').parentElement).toHaveAttribute(
@@ -104,11 +109,13 @@ describe('<Search />', () => {
     });
 
     render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0', query: 'vi' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0', query: 'vi' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     // Wait for search results to be loaded
@@ -126,11 +133,13 @@ describe('<Search />', () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', 500);
 
     render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByText('Loading search results...').parentElement).toHaveAttribute(
@@ -154,11 +163,13 @@ describe('<Search />', () => {
 
     mockMatches = true;
     const { container } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     await waitFor(() => {
@@ -181,11 +192,13 @@ describe('<Search />', () => {
 
     mockMatches = false;
     const { container } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <Search context={contextProps} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+            <Search context={contextProps} />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     await waitFor(() => {
@@ -241,17 +254,19 @@ describe('<Search />', () => {
       });
 
       render(
-        <IntlProvider locale="en">
-          <HistoryContext.Provider
-            value={makeHistoryOf({
-              limit: '20',
-              offset: '0',
-              lastDispatchActions: [{ type: 'FILTER_RESET' }],
-            })}
-          >
-            <Search context={contextProps} />
-          </HistoryContext.Provider>
-        </IntlProvider>,
+        <QueryClientProvider client={queryClient}>
+          <IntlProvider locale="en">
+            <HistoryContext.Provider
+              value={makeHistoryOf({
+                limit: '20',
+                offset: '0',
+                lastDispatchActions: [{ type: 'FILTER_RESET' }],
+              })}
+            >
+              <Search context={contextProps} />
+            </HistoryContext.Provider>
+          </IntlProvider>
+        </QueryClientProvider>,
       );
     });
 
@@ -271,17 +286,19 @@ describe('<Search />', () => {
       });
 
       render(
-        <IntlProvider locale="en">
-          <HistoryContext.Provider
-            value={makeHistoryOf({
-              limit: '20',
-              offset: '0',
-              lastDispatchActions: [{ type: 'QUERY_UPDATE' }],
-            })}
-          >
-            <Search context={contextProps} />
-          </HistoryContext.Provider>
-        </IntlProvider>,
+        <QueryClientProvider client={queryClient}>
+          <IntlProvider locale="en">
+            <HistoryContext.Provider
+              value={makeHistoryOf({
+                limit: '20',
+                offset: '0',
+                lastDispatchActions: [{ type: 'QUERY_UPDATE' }],
+              })}
+            >
+              <Search context={contextProps} />
+            </HistoryContext.Provider>
+          </IntlProvider>
+        </QueryClientProvider>,
       );
     });
 

--- a/src/frontend/js/components/Search/index.spec.tsx
+++ b/src/frontend/js/components/Search/index.spec.tsx
@@ -7,9 +7,9 @@ import { IntlProvider } from 'react-intl';
 
 import { History, HistoryContext } from 'data/useHistory';
 import * as mockWindow from 'utils/indirection/window';
+import { ContextFactory as mockContextFactory } from 'utils/test/factories';
 import createQueryClient from 'utils/react-query/createQueryClient';
-import { ContextFactory } from 'utils/test/factories';
-import { CommonDataProps } from 'types/commonDataProps';
+import context from 'utils/context';
 import Search from '.';
 
 let mockMatches = false;
@@ -22,6 +22,11 @@ jest.mock('utils/indirection/window', () => ({
     removeListener: jest.fn(),
   }),
   scroll: jest.fn(),
+}));
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory().generate(),
 }));
 
 describe('<Search />', () => {
@@ -37,7 +42,6 @@ describe('<Search />', () => {
     historyReplaceState,
   ];
   const queryClient = createQueryClient();
-  const contextProps: CommonDataProps['context'] = ContextFactory().generate();
 
   afterEach(() => {
     queryClient.clear();
@@ -57,7 +61,7 @@ describe('<Search />', () => {
       <QueryClientProvider client={queryClient}>
         <IntlProvider locale="en">
           <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-            <Search context={contextProps} />
+            <Search context={context} />
           </HistoryContext.Provider>
         </IntlProvider>
       </QueryClientProvider>,
@@ -112,7 +116,7 @@ describe('<Search />', () => {
       <QueryClientProvider client={queryClient}>
         <IntlProvider locale="en">
           <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0', query: 'vi' })}>
-            <Search context={contextProps} />
+            <Search context={context} />
           </HistoryContext.Provider>
         </IntlProvider>
       </QueryClientProvider>,
@@ -136,7 +140,7 @@ describe('<Search />', () => {
       <QueryClientProvider client={queryClient}>
         <IntlProvider locale="en">
           <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-            <Search context={contextProps} />
+            <Search context={context} />
           </HistoryContext.Provider>
         </IntlProvider>
       </QueryClientProvider>,
@@ -166,7 +170,7 @@ describe('<Search />', () => {
       <QueryClientProvider client={queryClient}>
         <IntlProvider locale="en">
           <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-            <Search context={contextProps} />
+            <Search context={context} />
           </HistoryContext.Provider>
         </IntlProvider>
       </QueryClientProvider>,
@@ -195,7 +199,7 @@ describe('<Search />', () => {
       <QueryClientProvider client={queryClient}>
         <IntlProvider locale="en">
           <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-            <Search context={contextProps} />
+            <Search context={context} />
           </HistoryContext.Provider>
         </IntlProvider>
       </QueryClientProvider>,
@@ -263,7 +267,7 @@ describe('<Search />', () => {
                 lastDispatchActions: [{ type: 'FILTER_RESET' }],
               })}
             >
-              <Search context={contextProps} />
+              <Search context={context} />
             </HistoryContext.Provider>
           </IntlProvider>
         </QueryClientProvider>,
@@ -295,7 +299,7 @@ describe('<Search />', () => {
                 lastDispatchActions: [{ type: 'QUERY_UPDATE' }],
               })}
             >
-              <Search context={contextProps} />
+              <Search context={context} />
             </HistoryContext.Provider>
           </IntlProvider>
         </QueryClientProvider>,

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -48,7 +48,7 @@ const Search = ({ context }: CommonDataProps) => {
   const { courseSearchParams, lastDispatchActions } = useCourseSearchParams();
   const { query, ...courseSearchParamsWithoutQuery } = courseSearchParams;
 
-  const courseSearchResponse = useCourseSearch(
+  const { data: courseSearchResponse } = useCourseSearch(
     query && query.length < 3 ? courseSearchParamsWithoutQuery : courseSearchParams,
   );
 

--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -2,10 +2,12 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { stringify } from 'query-string';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
+import { QueryClientProvider } from 'react-query';
 
 import { fetchList } from 'data/getResourceList';
 import { History, HistoryContext } from 'data/useHistory';
-import { APIListRequestParams } from 'types/api';
+import { APIListRequestParams, RequestStatus } from 'types/api';
+import createQueryClient from 'utils/react-query/createQueryClient';
 
 import { SearchFilterValueParent } from '.';
 
@@ -27,32 +29,38 @@ describe('<SearchFilterValueParent />', () => {
     historyPushState,
     historyReplaceState,
   ];
+  const queryClient = createQueryClient();
 
-  afterEach(jest.resetAllMocks);
+  afterEach(() => {
+    queryClient.clear();
+    jest.resetAllMocks();
+  });
 
   it('renders the parent filter value and a button to show the children', () => {
     const { getByLabelText, queryByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '00010002',
-              has_more_values: false,
-              human_name: 'Subjects',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'subjects',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 12,
-              human_name: 'Literature',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '00010002',
+                has_more_values: false,
+                human_name: 'Subjects',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'subjects',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 12,
+                human_name: 'Literature',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     getByLabelText((content) => content.startsWith('Literature'));
@@ -66,6 +74,7 @@ describe('<SearchFilterValueParent />', () => {
 
   it('shows the children when one of them is active', async () => {
     mockFetchList.mockResolvedValue({
+      status: RequestStatus.SUCCESS,
       content: {
         filters: {
           subjects: {
@@ -88,27 +97,29 @@ describe('<SearchFilterValueParent />', () => {
 
     // Helper to get the React element with the expected params
     const getElement = (params: APIListRequestParams) => (
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf(params)}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '00010002',
-              has_more_values: false,
-              human_name: 'Subjects',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'subjects',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 12,
-              human_name: 'Literature',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf(params)}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '00010002',
+                has_more_values: false,
+                human_name: 'Subjects',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'subjects',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 12,
+                human_name: 'Literature',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>
     );
     const { getByLabelText, queryByLabelText, rerender } = render(
       getElement({ limit: '999', offset: '0', subjects: [] }),
@@ -133,6 +144,7 @@ describe('<SearchFilterValueParent />', () => {
 
   it('hides/shows the children when the user clicks on the toggle button', async () => {
     mockFetchList.mockResolvedValue({
+      status: RequestStatus.SUCCESS,
       content: {
         filters: {
           subjects: {
@@ -154,33 +166,35 @@ describe('<SearchFilterValueParent />', () => {
     } as any);
 
     const { getByLabelText, queryByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({
-            limit: '999',
-            offset: '0',
-            subjects: ['L-000400050004'],
-          })}
-        >
-          <SearchFilterValueParent
-            filter={{
-              base_path: '00010002',
-              has_more_values: false,
-              human_name: 'Subjects',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'subjects',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 12,
-              human_name: 'Literature',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider
+            value={makeHistoryOf({
+              limit: '999',
+              offset: '0',
+              subjects: ['L-000400050004'],
+            })}
+          >
+            <SearchFilterValueParent
+              filter={{
+                base_path: '00010002',
+                has_more_values: false,
+                human_name: 'Subjects',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'subjects',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 12,
+                human_name: 'Literature',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     getByLabelText((content) => content.startsWith('Literature'));
@@ -232,27 +246,29 @@ describe('<SearchFilterValueParent />', () => {
 
   it('shows the parent filter value itself as inactive when it is not in the search params', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 217,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 217,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     // The filter value is displayed with its facet count
@@ -265,27 +281,29 @@ describe('<SearchFilterValueParent />', () => {
 
   it('disables the parent value when its count is 0', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 0,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 0,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     // The filter shows its active state
@@ -296,33 +314,35 @@ describe('<SearchFilterValueParent />', () => {
   });
   it('shows the parent filter value itself as active when it is in the search params', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({
-            filter_name: 'P-00040005',
-            limit: '999',
-            offset: '0',
-          })}
-        >
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 218,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider
+            value={makeHistoryOf({
+              filter_name: 'P-00040005',
+              limit: '999',
+              offset: '0',
+            })}
+          >
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 218,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     const checkbox = getByLabelText((content) => content.startsWith('Human name'));
@@ -333,27 +353,29 @@ describe('<SearchFilterValueParent />', () => {
 
   it('dispatches a FILTER_ADD action on filter click if it was not active', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 217,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 217,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     fireEvent.click(getByLabelText((content) => content.startsWith('Human name')));
@@ -372,33 +394,35 @@ describe('<SearchFilterValueParent />', () => {
 
   it('dispatches a FILTER_REMOVE action on filter click if it was active', () => {
     const { getByLabelText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider
-          value={makeHistoryOf({
-            filter_name: 'P-00040005',
-            limit: '999',
-            offset: '0',
-          })}
-        >
-          <SearchFilterValueParent
-            filter={{
-              base_path: '0009',
-              has_more_values: false,
-              human_name: 'Filter name',
-              is_autocompletable: true,
-              is_searchable: true,
-              name: 'filter_name',
-              position: 0,
-              values: [],
-            }}
-            value={{
-              count: 217,
-              human_name: 'Human name',
-              key: 'P-00040005',
-            }}
-          />
-        </HistoryContext.Provider>
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider
+            value={makeHistoryOf({
+              filter_name: 'P-00040005',
+              limit: '999',
+              offset: '0',
+            })}
+          >
+            <SearchFilterValueParent
+              filter={{
+                base_path: '0009',
+                has_more_values: false,
+                human_name: 'Filter name',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'filter_name',
+                position: 0,
+                values: [],
+              }}
+              value={{
+                count: 217,
+                human_name: 'Human name',
+                key: 'P-00040005',
+              }}
+            />
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>,
     );
 
     fireEvent.click(getByLabelText((content) => content.startsWith('Human name')));

--- a/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.spec.tsx
@@ -11,6 +11,7 @@ import createQueryClient from 'utils/react-query/createQueryClient';
 
 import { SearchFilterValueParent } from '.';
 
+jest.mock('utils/context', () => jest.fn());
 jest.mock('data/getResourceList', () => ({
   fetchList: jest.fn(),
 }));

--- a/src/frontend/js/components/SearchFilterValueParent/index.tsx
+++ b/src/frontend/js/components/SearchFilterValueParent/index.tsx
@@ -2,14 +2,14 @@ import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { SearchFilterValueLeaf } from 'components/SearchFilterValueLeaf';
-import { fetchList } from 'data/getResourceList';
 import { useCourseSearchParams } from 'data/useCourseSearchParams';
 import { useFilterValue } from 'data/useFilterValue';
 import { RequestStatus } from 'types/api';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { getMPTTChildrenPathMatcher } from 'utils/mptt';
 import { Nullable } from 'types/utils';
-import { useAsyncEffect } from 'utils/useAsyncEffect';
+import { useCourseSearch } from 'data/useCourseSearch';
+import { handle } from 'utils/errors/handle';
 
 const messages = defineMessages({
   ariaHideChildren: {
@@ -53,25 +53,26 @@ export const SearchFilterValueParent = ({ filter, value }: SearchFilterValuePare
   const [userShowChildren, setUserShowChildren] = useState(null as Nullable<boolean>);
   const showChildren = userShowChildren !== null ? !!userShowChildren : hasActiveChildren;
 
-  const [children, setChildren] = useState([] as FilterValue[]);
-  useAsyncEffect(async () => {
-    if (showChildren) {
-      // Get only the filters & facet counts for the children of the current parent
-      const childrenResponse = await fetchList('courses', {
-        ...courseSearchParams,
-        [`${filter.name}_children_aggs`]: value.key,
-        scope: 'filters',
-      });
+  const { data: childrenResponse } = useCourseSearch(
+    {
+      ...courseSearchParams,
+      [`${filter.name}_children_aggs`]: value.key,
+      scope: 'filters',
+    },
+    {
+      enabled: showChildren,
+      onSettled: (data) => {
+        if (data?.status === RequestStatus.FAILURE) {
+          handle(new Error(`Failed to get children filters for ${filter.name}/${value.key}`));
+        }
+      },
+    },
+  );
 
-      if (childrenResponse.status === RequestStatus.FAILURE) {
-        throw new Error(`Failed to get children filters for ${filter.name}/${value.key}`);
-      }
-
-      setChildren(childrenResponse.content.filters[filter.name].values);
-    }
-    // Be sure to include courseSearchParams in the dependencies so the children counts are re-fetched whenever
-    // the user applies new filters or queries
-  }, [showChildren, value, courseSearchParams]);
+  const children =
+    childrenResponse?.status === RequestStatus.SUCCESS
+      ? childrenResponse.content.filters[filter.name].values
+      : [];
 
   // We also need to know if the current filter is active itself and let the user toggle it directly
   const [isActive, toggle] = useFilterValue(filter, value);

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -2,13 +2,12 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
-
 import { useCourseSearchParams, CourseSearchParamsAction } from 'data/useCourseSearchParams';
 import { HistoryProvider } from 'data/useHistory';
 import { history, location } from 'utils/indirection/window';
-import { ContextFactory } from 'utils/test/factories';
-import { CommonDataProps } from 'types/commonDataProps';
+import { ContextFactory as mockContextFactory } from 'utils/test/factories';
 import { FilterDefinition } from 'types/filters';
+import context from 'utils/context';
 import SearchSuggestField from '.';
 
 jest.mock('settings', () => ({
@@ -24,9 +23,12 @@ jest.mock('utils/indirection/window', () => ({
   scroll: jest.fn(),
 }));
 
-describe('components/SearchSuggestField', () => {
-  const contextProps: CommonDataProps['context'] = ContextFactory().generate();
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory().generate(),
+}));
 
+describe('components/SearchSuggestField', () => {
   // Make some filters we can reuse through our tests with the filter definitions responses
   const levels: FilterDefinition = {
     base_path: '00030002',
@@ -74,7 +76,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -88,7 +90,7 @@ describe('components/SearchSuggestField', () => {
     const { getByDisplayValue } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -109,7 +111,7 @@ describe('components/SearchSuggestField', () => {
     const { getByDisplayValue, rerender } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
           <OtherComponent />
         </HistoryProvider>
       </IntlProvider>,
@@ -127,7 +129,7 @@ describe('components/SearchSuggestField', () => {
     rerender(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
           <OtherComponent />
         </HistoryProvider>
       </IntlProvider>,
@@ -164,7 +166,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText, getByText, queryByText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -206,7 +208,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -251,7 +253,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText, getByText, queryByText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -343,7 +345,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText, getByText, queryByText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -427,7 +429,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -469,7 +471,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -552,7 +554,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );
@@ -613,7 +615,7 @@ describe('components/SearchSuggestField', () => {
     const { getByPlaceholderText, getByText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
-          <SearchSuggestField context={contextProps} />
+          <SearchSuggestField context={context} />
         </HistoryProvider>
       </IntlProvider>,
     );

--- a/src/frontend/js/components/UserLogin/index.spec.tsx
+++ b/src/frontend/js/components/UserLogin/index.spec.tsx
@@ -6,11 +6,17 @@ import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { IntlProvider } from 'react-intl';
 import { act } from 'react-dom/test-utils';
-
-import { ContextFactory, PersistedClientFactory, QueryStateFactory } from 'utils/test/factories';
+import {
+  ContextFactory as mockContextFactory,
+  PersistedClientFactory,
+  QueryStateFactory,
+} from 'utils/test/factories';
 import { Deferred } from 'utils/test/deferred';
 import createQueryClient from 'utils/react-query/createQueryClient';
+import context from 'utils/context';
 import { REACT_QUERY_SETTINGS } from 'settings';
+import { SessionProvider } from 'data/useSession';
+import UserLogin from '.';
 
 jest.mock('utils/errors/handle', () => ({
   handle: jest.fn(),
@@ -24,12 +30,12 @@ jest.mock('utils/indirection/window', () => ({
   }),
 }));
 
-describe('<UserLogin />', () => {
-  const contextProps = ContextFactory().generate();
-  window.__richie_frontend_context__ = { context: contextProps };
-  const UserLogin = require('.').default;
-  const { SessionProvider } = require('data/useSession');
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory().generate(),
+}));
 
+describe('<UserLogin />', () => {
   const initializeUser = () => {
     const username = faker.internet.userName();
     sessionStorage.setItem(
@@ -56,7 +62,7 @@ describe('<UserLogin />', () => {
         <QueryClientProvider client={createQueryClient({ persistor: true })}>
           <IntlProvider locale="en">
             <SessionProvider>
-              <UserLogin context={contextProps} />
+              <UserLogin context={context} />
             </SessionProvider>
           </IntlProvider>
         </QueryClientProvider>,
@@ -82,7 +88,7 @@ describe('<UserLogin />', () => {
       <QueryClientProvider client={createQueryClient({ persistor: true })}>
         <IntlProvider locale="en">
           <SessionProvider>
-            <UserLogin context={contextProps} />
+            <UserLogin context={context} />
           </SessionProvider>
         </IntlProvider>
       </QueryClientProvider>,
@@ -109,7 +115,7 @@ describe('<UserLogin />', () => {
         <QueryClientProvider client={createQueryClient({ persistor: true })}>
           <IntlProvider locale="en">
             <SessionProvider>
-              <UserLogin context={contextProps} profileUrls={profileUrls} />
+              <UserLogin context={context} profileUrls={profileUrls} />
             </SessionProvider>
           </IntlProvider>
         </QueryClientProvider>,

--- a/src/frontend/js/components/UserLogin/index.tsx
+++ b/src/frontend/js/components/UserLogin/index.tsx
@@ -6,7 +6,6 @@ import { Spinner } from 'components/Spinner';
 import { UserMenu } from 'components/UserMenu';
 import { useSession } from 'data/useSession';
 import { CommonDataProps } from 'types/commonDataProps';
-import { User } from 'types/User';
 
 const messages: { [key: string]: MessageDescriptor } = defineMessages({
   logIn: {
@@ -33,7 +32,12 @@ const messages: { [key: string]: MessageDescriptor } = defineMessages({
 
 interface UserLoginProps {
   context: CommonDataProps['context'];
-  profileUrls?: User['urls'];
+  profileUrls?: {
+    [key: string]: {
+      action: string | (() => void);
+      label: string;
+    };
+  };
 }
 
 /*
@@ -59,7 +63,7 @@ const bindUserDataToUrl = (url: string, user: any) =>
     typeof user[prop] === 'string' ? user[prop] : match,
   );
 
-const UserLogin = ({ profileUrls = [] }: UserLoginProps) => {
+const UserLogin = ({ profileUrls = {} }: UserLoginProps) => {
   /**
    * `user` is:
    * - `undefined` when we have not made the `whoami` request yet;

--- a/src/frontend/js/components/UserMenu/index.tsx
+++ b/src/frontend/js/components/UserMenu/index.tsx
@@ -5,7 +5,13 @@ import { DesktopUserMenu } from './DesktopUserMenu';
 import { MobileUserMenu } from './MobileUserMenu';
 
 export interface UserMenuProps {
-  user: User;
+  user: User & {
+    urls: {
+      key: string;
+      label: string;
+      action: string | (() => void);
+    }[];
+  };
 }
 
 export const UserMenu: React.FC<UserMenuProps> = (props: UserMenuProps) => {

--- a/src/frontend/js/data/useCourseSearch/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearch/index.spec.tsx
@@ -9,6 +9,7 @@ import { APIListRequestParams } from 'types/api';
 import { Deferred } from 'utils/test/deferred';
 import { useCourseSearch } from '.';
 
+jest.mock('utils/context', () => jest.fn());
 jest.mock('data/getResourceList', () => ({
   fetchList: jest.fn(),
 }));

--- a/src/frontend/js/data/useCourseSearch/index.ts
+++ b/src/frontend/js/data/useCourseSearch/index.ts
@@ -1,19 +1,25 @@
 import { stringify } from 'query-string';
-import { useState } from 'react';
+import { UseQueryOptions, useQuery } from 'react-query';
 
 import { APIListRequestParams } from 'types/api';
-import { Nullable } from 'types/utils';
-import { useAsyncEffect } from 'utils/useAsyncEffect';
 import { fetchList, FetchListResponse } from '../getResourceList';
 
-export const useCourseSearch = (searchParams: APIListRequestParams) => {
-  const [courseSearchResponse, setCourseSearchResponse] =
-    useState<Nullable<FetchListResponse>>(null);
-
-  useAsyncEffect(async () => {
-    const response = await fetchList('courses', searchParams);
-    setCourseSearchResponse(response);
-  }, [stringify(searchParams)]);
-
-  return courseSearchResponse;
+export const useCourseSearch = (
+  searchParams: APIListRequestParams,
+  queryOptions: UseQueryOptions<
+    FetchListResponse,
+    unknown,
+    FetchListResponse,
+    (string | APIListRequestParams)[]
+  > = {},
+) => {
+  const queryKey = ['courses', stringify(searchParams)];
+  return useQuery<FetchListResponse, unknown, FetchListResponse, (string | APIListRequestParams)[]>(
+    queryKey,
+    async () => fetchList('courses', searchParams),
+    {
+      keepPreviousData: true,
+      ...queryOptions,
+    },
+  );
 };

--- a/src/frontend/js/data/useEnrollment/index.spec.tsx
+++ b/src/frontend/js/data/useEnrollment/index.spec.tsx
@@ -1,0 +1,111 @@
+import { act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook } from '@testing-library/react-hooks';
+import faker from 'faker';
+import fetchMock from 'fetch-mock';
+import React from 'react';
+import { APIBackend } from 'types/api';
+import { CommonDataProps } from 'types/commonDataProps';
+import { CourseRun } from 'types';
+import { Deferred } from 'utils/test/deferred';
+import { REACT_QUERY_SETTINGS } from 'settings';
+import * as factories from 'utils/test/factories';
+import createQueryClient from 'utils/react-query/createQueryClient';
+
+describe('useEnrollment', () => {
+  const endpoint = 'https://endpoint.test';
+  const contextProps: CommonDataProps['context'] = factories
+    .ContextFactory({
+      authentication: {
+        backend: APIBackend.OPENEDX_HAWTHORN,
+        endpoint,
+      },
+      lms_backends: [
+        {
+          backend: APIBackend.OPENEDX_HAWTHORN,
+          course_regexp: '(.*)',
+          endpoint,
+        },
+      ],
+    })
+    .generate();
+  (window as any).__richie_frontend_context__ = { context: contextProps };
+  const { SessionProvider } = require('data/useSession');
+  const { default: useEnrollment } = require('.');
+  const wrapper = ({ client, children }: React.PropsWithChildren<{ client: QueryClient }>) => (
+    <QueryClientProvider client={client}>
+      <SessionProvider>{children}</SessionProvider>
+    </QueryClientProvider>
+  );
+
+  const initializeUser = (loggedin = true) => {
+    const username = faker.internet.userName();
+    sessionStorage.setItem(
+      REACT_QUERY_SETTINGS.cacheStorage.key,
+      JSON.stringify(
+        factories.PersistedClientFactory({
+          queries: [factories.QueryStateFactory('user', { data: loggedin ? { username } : null })],
+        }),
+      ),
+    );
+    return loggedin ? username : null;
+  };
+
+  afterEach(() => {
+    sessionStorage.clear();
+    fetchMock.restore();
+  });
+
+  it('does not make request when user is not authenticated', async () => {
+    const username = initializeUser(false);
+    const courseRun: CourseRun = factories.CourseRunFactory.generate();
+
+    fetchMock.get(
+      `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
+      401,
+    );
+
+    let client: QueryClient;
+    await waitFor(() => {
+      client = createQueryClient({ persistor: true });
+    });
+
+    const { result } = renderHook(() => useEnrollment(courseRun.resource_link), {
+      wrapper,
+      initialProps: { client: client! },
+    });
+
+    expect(fetchMock.called()).toBeFalsy();
+    expect(result.current.enrollment).toBeUndefined();
+    expect(result.current.enrollmentIsActive).toBeUndefined();
+  });
+
+  it('retrieves enrollment when user is authenticated', async () => {
+    const username = initializeUser();
+    const courseRun: CourseRun = factories.CourseRunFactory.generate();
+    let client: QueryClient;
+    await waitFor(() => {
+      client = createQueryClient({ persistor: true });
+    });
+
+    const enrollmentResponse = { title: courseRun.id, is_active: faker.datatype.boolean() };
+    const enrollementDefered = new Deferred();
+    fetchMock.get(
+      `${endpoint}/api/enrollment/v1/enrollment/${username},${courseRun.resource_link}`,
+      enrollementDefered.promise,
+    );
+
+    const { result } = renderHook(() => useEnrollment(courseRun.resource_link), {
+      wrapper,
+      initialProps: { client: client! },
+    });
+
+    await act(async () => {
+      enrollementDefered.resolve(enrollmentResponse);
+    });
+
+    expect(fetchMock.called()).toBeTruthy();
+    expect(result.current.enrollment).toStrictEqual(enrollmentResponse);
+    expect(result.current.enrollmentIsActive).toStrictEqual(enrollmentResponse.is_active);
+  });
+});

--- a/src/frontend/js/data/useEnrollment/index.ts
+++ b/src/frontend/js/data/useEnrollment/index.ts
@@ -1,0 +1,38 @@
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import CourseEnrollmentAPI from 'utils/api/courseEnrollment';
+import { useSession } from 'data/useSession';
+
+const useEnrollment = (resourceLink: string) => {
+  const { user } = useSession();
+  const queryKey = ['enrollment', resourceLink];
+  const queryClient = useQueryClient();
+  const EnrollmentAPI = CourseEnrollmentAPI(resourceLink);
+
+  const { data: enrollment } = useQuery(queryKey, async () => EnrollmentAPI.get(user!), {
+    enabled: !!user,
+  });
+
+  const { data: isActive } = useQuery(
+    [...queryKey, 'is_active'],
+    async () => EnrollmentAPI.isEnrolled(enrollment),
+    {
+      // Enrollment is null if it has been fetched
+      enabled: enrollment !== undefined,
+    },
+  );
+
+  const { mutateAsync } = useMutation(() => EnrollmentAPI.set(user!), {
+    mutationKey: queryKey,
+    onSuccess: () => {
+      queryClient.invalidateQueries(queryKey);
+    },
+  });
+
+  return {
+    enrollment,
+    enrollmentIsActive: isActive,
+    setEnrollment: mutateAsync,
+  };
+};
+
+export default useEnrollment;

--- a/src/frontend/js/data/useSession/index.spec.tsx
+++ b/src/frontend/js/data/useSession/index.spec.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
+import { QueryClientProvider, QueryClient } from 'react-query';
 import faker from 'faker';
 import fetchMock from 'fetch-mock';
-import { act } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
-import { ContextFactory } from 'utils/test/factories';
-import { base64Decode, base64Encode } from 'utils/base64Parser';
+import { ContextFactory, PersistedClientFactory, QueryStateFactory } from 'utils/test/factories';
+import createQueryClient from 'utils/react-query/createQueryClient';
 import { Deferred } from 'utils/test/deferred';
-import { SESSION_CACHE_KEY } from 'settings';
+import { REACT_QUERY_SETTINGS } from 'settings';
 import { SessionContext } from '.';
 
 describe('useSession', () => {
   const context = ContextFactory().generate();
   window.__richie_frontend_context__ = { context };
+  const queryClient = createQueryClient({ persistor: true });
   const {
     SessionProvider,
     useSession,
@@ -20,27 +22,45 @@ describe('useSession', () => {
     SessionProvider: ({ children }: React.PropsWithChildren<any>) => JSX.Element;
   } = require('.');
 
-  const wrapper = ({ children }: React.PropsWithChildren<any>) => (
-    <SessionProvider>{children}</SessionProvider>
+  const wrapper = ({
+    client = queryClient,
+    children,
+  }: React.PropsWithChildren<{ client: QueryClient }>) => (
+    <QueryClientProvider client={client}>
+      <SessionProvider>{children}</SessionProvider>
+    </QueryClientProvider>
   );
 
   beforeEach(() => {
-    sessionStorage.clear();
+    jest.useFakeTimers('modern');
+    queryClient.clear();
     fetchMock.restore();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
   });
 
   it('provides a null user if whoami return 401', async () => {
     const userDeferred = new Deferred();
     fetchMock.get('https://endpoint.test/api/user/v1/me', userDeferred.promise);
-    const { result } = renderHook(() => useSession(), { wrapper });
+    const { result } = renderHook(() => useSession(), {
+      wrapper,
+      initialProps: { client: queryClient },
+    });
 
     await act(async () => {
       userDeferred.resolve(401);
+      jest.runAllTimers();
     });
 
     expect(result.current.user).toBeNull();
     expect(result.all).toHaveLength(2);
-    expect(sessionStorage.getItem(SESSION_CACHE_KEY)).toBeDefined();
+    const cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    expect(cacheString).not.toBeNull();
+    const client = JSON.parse(cacheString!);
+    expect(client.clientState.queries).toHaveLength(1);
+    expect(client.clientState.queries[0].queryKey).toEqual('user');
   });
 
   it('provides user infos if user is authenticated then stores in cache', async () => {
@@ -51,41 +71,64 @@ describe('useSession', () => {
 
     await act(async () => {
       userDeferred.resolve({ username });
+      jest.runAllTimers();
     });
 
     expect(result.current.user).toStrictEqual({ username });
     expect(result.all).toHaveLength(2);
-    expect(sessionStorage.getItem(SESSION_CACHE_KEY)).toBeDefined();
-    expect(base64Decode(sessionStorage.getItem(SESSION_CACHE_KEY) || '')).toContain(username);
+    const cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    expect(cacheString).not.toBeNull();
+    expect(cacheString).toContain(username);
   });
 
   it('destroy session then logout', async () => {
     const username = faker.internet.userName();
-    sessionStorage.setItem(
-      SESSION_CACHE_KEY,
-      base64Encode(JSON.stringify({ value: { username }, expiredAt: Date.now() + 60_000 })),
-    );
+    const userDeferred = new Deferred();
+
+    fetchMock.get('https://endpoint.test/api/user/v1/me', userDeferred.promise);
     fetchMock.get('https://endpoint.test/logout', 200);
     const { result } = renderHook(useSession, { wrapper });
 
-    expect(result.current.user).toStrictEqual({ username });
-    expect(base64Decode(sessionStorage.getItem(SESSION_CACHE_KEY) || '')).toContain(username);
+    await act(async () => {
+      userDeferred.resolve({ username });
+      jest.runAllTimers();
+    });
 
-    await act(result.current.destroy);
+    const { user, destroy } = result.current;
+    expect(user).toStrictEqual({ username });
+    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key) || '').toContain(username);
+
+    await act(async () => {
+      await destroy();
+      jest.runAllTimers();
+    });
+
     expect(result.current.user).toBeNull();
-    expect(base64Decode(sessionStorage.getItem(SESSION_CACHE_KEY) || '')).toContain('null');
+    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key) || '').toMatch(
+      /"data":null,.*"queryKey":"user"/,
+    );
   });
 
-  it('do not make request if there is a session in cache', () => {
+  it('does not make request if there is a valid session in cache', async () => {
     const username = faker.internet.userName();
-    sessionStorage.setItem(
-      SESSION_CACHE_KEY,
-      base64Encode(JSON.stringify({ value: { username }, expiredAt: Date.now() + 60_000 })),
-    );
-    fetchMock.get('https://endpoint.test/api/user/v1/me', 200);
-    renderHook(useSession, { wrapper });
+    const persistedClient = PersistedClientFactory({
+      queries: [QueryStateFactory('user', { data: { username } })],
+    });
+    sessionStorage.setItem(REACT_QUERY_SETTINGS.cacheStorage.key, JSON.stringify(persistedClient));
 
+    fetchMock.get('https://endpoint.test/api/user/v1/me', 200);
+
+    let client: QueryClient;
+    await waitFor(() => {
+      client = createQueryClient({ persistor: true });
+    });
+
+    const { result } = renderHook(useSession, {
+      wrapper,
+      initialProps: { client: client! },
+    });
+
+    expect(result.current.user).toStrictEqual({ username });
     expect(fetchMock.called()).toBeFalsy();
-    expect(base64Decode(sessionStorage.getItem(SESSION_CACHE_KEY) || '')).toContain(username);
   });
 });

--- a/src/frontend/js/data/useSession/index.spec.tsx
+++ b/src/frontend/js/data/useSession/index.spec.tsx
@@ -4,15 +4,27 @@ import faker from 'faker';
 import fetchMock from 'fetch-mock';
 import { act, waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
-import { ContextFactory, PersistedClientFactory, QueryStateFactory } from 'utils/test/factories';
+import {
+  ContextFactory as mockContextFactory,
+  PersistedClientFactory,
+  QueryStateFactory,
+} from 'utils/test/factories';
 import createQueryClient from 'utils/react-query/createQueryClient';
 import { Deferred } from 'utils/test/deferred';
 import { REACT_QUERY_SETTINGS } from 'settings';
 import { SessionContext } from '.';
 
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory({
+    authentication: {
+      endpoint: 'https://endpoint.test',
+      backend: 'openedx-hawthorn',
+    },
+  }).generate(),
+}));
+
 describe('useSession', () => {
-  const context = ContextFactory().generate();
-  window.__richie_frontend_context__ = { context };
   const queryClient = createQueryClient({ persistor: true });
   const {
     SessionProvider,

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -13,6 +13,8 @@ import 'core-js/modules/es.promise';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { IntlProvider } from 'react-intl';
+import { QueryClientProvider } from 'react-query';
+import createQueryClient from 'utils/react-query/createQueryClient';
 
 import { Root } from 'components/Root';
 import { handle } from 'utils/errors/handle';
@@ -93,11 +95,16 @@ async function render() {
     reactRoot.setAttribute('class', 'richie-react richie-react--root');
     document.body.append(reactRoot);
 
+    // React-query
+    const queryClient = createQueryClient({ logger: true, persistor: true });
+
     // Render the tree inside a shared `IntlProvider` so all components are able to access translated strings.
     ReactDOM.render(
-      <IntlProvider locale={locale} messages={translatedMessages}>
-        <Root richieReactSpots={richieReactSpots} />
-      </IntlProvider>,
+      <QueryClientProvider client={queryClient}>
+        <IntlProvider locale={locale} messages={translatedMessages}>
+          <Root richieReactSpots={richieReactSpots} />
+        </IntlProvider>
+      </QueryClientProvider>,
       reactRoot,
     );
   }

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -101,7 +101,7 @@ async function render() {
     // Render the tree inside a shared `IntlProvider` so all components are able to access translated strings.
     ReactDOM.render(
       <QueryClientProvider client={queryClient}>
-        <IntlProvider locale={locale} messages={translatedMessages}>
+        <IntlProvider locale={locale} messages={translatedMessages} defaultLocale="en-US">
           <Root richieReactSpots={richieReactSpots} />
         </IntlProvider>
       </QueryClientProvider>,

--- a/src/frontend/js/settings.ts
+++ b/src/frontend/js/settings.ts
@@ -4,4 +4,23 @@ export const API_LIST_DEFAULT_PARAMS = {
 };
 
 export const EDX_CSRF_TOKEN_COOKIE_NAME = 'edx_csrf_token';
-export const SESSION_CACHE_KEY = 'richie_session';
+
+export const REACT_QUERY_SETTINGS = {
+  // Cache is garbage collected after this delay
+  cacheTime: 24 * 60 * 60 * 1000, // 24h in ms
+  // Data are considered as stale after this delay
+  staleTimes: {
+    default: 0, // Stale immediately
+    // session lifetime should be synchronized with the access token lifetime of your authentication
+    // service. For example if you are using djangorestframework-simplejwt default value
+    // is 5 minutes.
+    session: 5 * 60 * 1000, // 5 minutes in ms
+    sessionItems: 20 * 60 * 1000, // 20 minutes, items related to the session should not be refreshed as the frequency than session information.
+  },
+  cacheStorage: {
+    // The key used to persist cache within cache storage
+    key: 'RICHIE_PERSISTED_QUERIES',
+    // Cache storage throttle time
+    throttleTime: 250,
+  },
+};

--- a/src/frontend/js/types/User.ts
+++ b/src/frontend/js/types/User.ts
@@ -1,10 +1,5 @@
 export interface User {
   access_token?: string;
   full_name?: string;
-  urls: {
-    key: string;
-    label: string;
-    action: string | (() => void);
-  }[];
   username: string;
 }

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -45,9 +45,9 @@ export interface APIAuthentication {
 }
 
 export interface APIEnrollment {
-  get: (url: string, user: Nullable<User>) => Promise<Nullable<Enrollment>>;
-  isEnrolled: (enrollment: Maybe<Nullable<Enrollment>>) => Promise<Maybe<boolean>>;
-  set: (url: string, user: User) => Promise<boolean>;
+  get(url: string, user: Nullable<User>): Promise<Nullable<Enrollment>>;
+  isEnrolled(enrollment: Maybe<Nullable<Enrollment>>): Promise<Maybe<boolean>>;
+  set(url: string, user: User): Promise<boolean>;
 }
 
 export interface APILms {

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -46,7 +46,7 @@ export interface APIAuthentication {
 
 export interface APIEnrollment {
   get: (url: string, user: Nullable<User>) => Promise<Nullable<Enrollment>>;
-  isEnrolled: (url: string, user: Nullable<User>) => Promise<boolean>;
+  isEnrolled: (enrollment: Maybe<Nullable<Enrollment>>) => Promise<Maybe<boolean>>;
   set: (url: string, user: User) => Promise<boolean>;
 }
 

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -63,7 +63,7 @@ export interface ApiOptions {
   };
 }
 
-export enum ApiBackend {
+export enum APIBackend {
   BASE = 'base',
   FONZIE = 'fonzie',
   OPENEDX_DOGWOOD = 'openedx-dogwood',

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -31,8 +31,24 @@ export interface CourseState {
   text: string;
 }
 
+export interface OpenEdXEnrollment {
+  created: Nullable<string>;
+  mode: 'audit' | 'honor' | 'verified';
+  is_active: boolean;
+  course_details: {
+    course_id: string;
+    course_name: string;
+    enrollment_start: Nullable<string>;
+    enrollment_end: Nullable<string>;
+    course_start: Nullable<string>;
+    course_end: Nullable<string>;
+    invite_only: boolean;
+  };
+  user: string;
+}
+
 /**
- * Use an empty type to make sure we do not depend on any LMS-specific fields
+ * Use an unknown type to make sure we do not depend on any LMS-specific fields
  * on enrollment objects, just use HTTP response codes.
  */
-export interface Enrollment {}
+export type Enrollment = unknown;

--- a/src/frontend/js/utils/api/authentication.ts
+++ b/src/frontend/js/utils/api/authentication.ts
@@ -8,7 +8,7 @@
 import { handle } from 'utils/errors/handle';
 import { AuthenticationBackend } from 'types/commonDataProps';
 import { Nullable } from 'types/utils';
-import { APIAuthentication, ApiBackend } from 'types/api';
+import { APIAuthentication, APIBackend } from 'types/api';
 import BaseApiInterface from './lms/base';
 import OpenEdxDogwoodApiInterface from './lms/openedx-dogwood';
 import OpenEdxHawthornApiInterface from './lms/openedx-hawthorn';
@@ -20,13 +20,13 @@ const AuthenticationAPIHandler = (): Nullable<APIAuthentication> => {
   if (!AUTHENTICATION) return null;
 
   switch (AUTHENTICATION.backend) {
-    case ApiBackend.BASE:
+    case APIBackend.BASE:
       return BaseApiInterface(AUTHENTICATION).user;
-    case ApiBackend.OPENEDX_DOGWOOD:
+    case APIBackend.OPENEDX_DOGWOOD:
       return OpenEdxDogwoodApiInterface(AUTHENTICATION).user;
-    case ApiBackend.OPENEDX_HAWTHORN:
+    case APIBackend.OPENEDX_HAWTHORN:
       return OpenEdxHawthornApiInterface(AUTHENTICATION).user;
-    case ApiBackend.FONZIE:
+    case APIBackend.FONZIE:
       return OpenEdxFonzieApiInterface(AUTHENTICATION).user;
     default:
       handle(new Error(`No Authentication Backend found for ${AUTHENTICATION.backend}.`));

--- a/src/frontend/js/utils/api/authentication.ts
+++ b/src/frontend/js/utils/api/authentication.ts
@@ -8,6 +8,7 @@
 import { handle } from 'utils/errors/handle';
 import { AuthenticationBackend } from 'types/commonDataProps';
 import { Nullable } from 'types/utils';
+import context from 'utils/context';
 import { APIAuthentication, APIBackend } from 'types/api';
 import BaseApiInterface from './lms/base';
 import OpenEdxDogwoodApiInterface from './lms/openedx-dogwood';
@@ -15,8 +16,7 @@ import OpenEdxHawthornApiInterface from './lms/openedx-hawthorn';
 import OpenEdxFonzieApiInterface from './lms/openedx-fonzie';
 
 const AuthenticationAPIHandler = (): Nullable<APIAuthentication> => {
-  const AUTHENTICATION: AuthenticationBackend =
-    window.__richie_frontend_context__?.context?.authentication;
+  const AUTHENTICATION: AuthenticationBackend = context?.authentication;
   if (!AUTHENTICATION) return null;
 
   switch (AUTHENTICATION.backend) {

--- a/src/frontend/js/utils/api/courseEnrollment.ts
+++ b/src/frontend/js/utils/api/courseEnrollment.ts
@@ -1,19 +1,22 @@
 import { User } from 'types/User';
-import { Nullable } from 'types/utils';
+import { Enrollment } from 'types';
+import { Maybe, Nullable } from 'types/utils';
 import APIHandler from './lms';
 
-const EnrollmentApi = {
-  get: (url: string, user: Nullable<User>) => {
-    const LMS = APIHandler(url);
-    return LMS.enrollment.get(url, user);
-  },
-  isEnrolled: (url: string, user: Nullable<User>) => {
-    const LMS = APIHandler(url);
-    return LMS.enrollment.isEnrolled(url, user);
-  },
-  set: (url: string, user: User) => {
-    const LMS = APIHandler(url);
-    return LMS.enrollment.set(url, user);
-  },
+const EnrollmentApi = (resourceLink: string) => {
+  const LMS = APIHandler(resourceLink);
+
+  return {
+    get: async (user: Nullable<User>) => {
+      return LMS.enrollment.get(resourceLink, user);
+    },
+    isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) => {
+      return LMS.enrollment.isEnrolled(enrollment);
+    },
+    set: async (user: User) => {
+      return LMS.enrollment.set(resourceLink, user);
+    },
+  };
 };
+
 export default EnrollmentApi;

--- a/src/frontend/js/utils/api/lms/base.spec.ts
+++ b/src/frontend/js/utils/api/lms/base.spec.ts
@@ -1,11 +1,11 @@
 import { ContextFactory } from 'utils/test/factories';
-import { ApiBackend } from 'types/api';
+import { APIBackend } from 'types/api';
 
 describe('Base API', () => {
   const context = ContextFactory({
     lms_backends: [
       {
-        backend: ApiBackend.BASE,
+        backend: APIBackend.BASE,
         course_regexp: '(?<course_id>.*)',
         endpoint: 'https://demo.endpoint/api',
       },

--- a/src/frontend/js/utils/api/lms/base.spec.ts
+++ b/src/frontend/js/utils/api/lms/base.spec.ts
@@ -50,29 +50,35 @@ describe('Base API', () => {
           username: 'johndoe',
         });
 
-        const response = await BaseAPI.enrollment.isEnrolled(
+        const enrollment = await BaseAPI.enrollment.get(
           'https://demo.endpoint/courses?course_id=af1987efz98:afe78',
           { username: 'johndoe' },
         );
 
-        expect(response).toBeTruthy();
+        const response = await BaseAPI.enrollment.isEnrolled(enrollment);
+
+        expect(response).toStrictEqual(true);
       });
 
       it('returns false if user is not enrolled', async () => {
-        const response = await BaseAPI.enrollment.isEnrolled(
+        const enrollment = await BaseAPI.enrollment.get(
           'https://demo.endpoint/courses?course_id=af1987efz98:afe78',
           { username: 'johndoe' },
         );
 
-        expect(response).toBeFalsy();
+        const response = await BaseAPI.enrollment.isEnrolled(enrollment);
+
+        expect(response).toStrictEqual(false);
       });
 
       it('returns false if user is anonymous', async () => {
-        const response = await BaseAPI.enrollment.isEnrolled(
+        const enrollment = await BaseAPI.enrollment.get(
           'https://demo.endpoint/courses?course_id=af1987efz98:afe78',
         );
 
-        expect(response).toBeFalsy();
+        const response = await BaseAPI.enrollment.isEnrolled(enrollment);
+
+        expect(response).toStrictEqual(false);
       });
     });
 

--- a/src/frontend/js/utils/api/lms/base.ts
+++ b/src/frontend/js/utils/api/lms/base.ts
@@ -2,6 +2,7 @@ import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
 import { Nullable, Maybe } from 'types/utils';
 import { User } from 'types/User';
 import { APILms } from 'types/api';
+import { Enrollment, OpenEdXEnrollment } from 'types';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
 const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
@@ -61,11 +62,8 @@ const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
           }
           resolve(null);
         }),
-      isEnrolled: async (url: string, user: Nullable<User>): Promise<boolean> =>
-        new Promise((resolve) => {
-          const courseId = extractCourseIdFromUrl(url);
-          resolve(Boolean(sessionStorage.getItem(`${user?.username}-${courseId}`)));
-        }),
+      isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) =>
+        new Promise((resolve) => resolve(!!(enrollment as OpenEdXEnrollment)?.is_active)),
       set: (url: string, user: User): Promise<boolean> =>
         new Promise((resolve) => {
           const courseId = extractCourseIdFromUrl(url);

--- a/src/frontend/js/utils/api/lms/index.spec.ts
+++ b/src/frontend/js/utils/api/lms/index.spec.ts
@@ -1,4 +1,4 @@
-import { ApiBackend } from 'types/api';
+import { APIBackend } from 'types/api';
 import { ContextFactory } from 'utils/test/factories';
 
 import { handle } from 'utils/errors/handle';
@@ -10,12 +10,12 @@ describe('API LMS', () => {
   const context = ContextFactory({
     lms_backends: [
       {
-        backend: ApiBackend.BASE,
+        backend: APIBackend.BASE,
         endpoint: 'https://demo.endpoint/api',
         course_regexp: '.*base.org/.*',
       },
       {
-        backend: ApiBackend.OPENEDX_HAWTHORN,
+        backend: APIBackend.OPENEDX_HAWTHORN,
         endpoint: 'https://edx.endpoint/api',
         course_regexp: '.*edx.org/.*',
       },

--- a/src/frontend/js/utils/api/lms/index.spec.ts
+++ b/src/frontend/js/utils/api/lms/index.spec.ts
@@ -1,30 +1,29 @@
-import { APIBackend } from 'types/api';
-import { ContextFactory } from 'utils/test/factories';
-
+import { ContextFactory as mockContextFactory } from 'utils/test/factories';
 import { handle } from 'utils/errors/handle';
+import LMSHandler from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory({
+    lms_backends: [
+      {
+        backend: 'base',
+        endpoint: 'https://demo.endpoint/api',
+        course_regexp: '.*base.org/.*',
+      },
+      {
+        backend: 'openedx-hawthorn',
+        endpoint: 'https://edx.endpoint/api',
+        course_regexp: '.*edx.org/.*',
+      },
+    ],
+  }).generate(),
+}));
 
 const mockHandle: jest.Mock<typeof handle> = handle as any;
 jest.mock('utils/errors/handle');
 
 describe('API LMS', () => {
-  const context = ContextFactory({
-    lms_backends: [
-      {
-        backend: APIBackend.BASE,
-        endpoint: 'https://demo.endpoint/api',
-        course_regexp: '.*base.org/.*',
-      },
-      {
-        backend: APIBackend.OPENEDX_HAWTHORN,
-        endpoint: 'https://edx.endpoint/api',
-        course_regexp: '.*edx.org/.*',
-      },
-    ],
-  }).generate();
-  window.__richie_frontend_context__ = { context };
-
-  const { default: LMSHandler } = require('./index');
-
   it('returns OpenEdX API if url that match edx selector is provided', () => {
     const api = LMSHandler('https://edx.org/courses/a-test-course');
     expect(api).toBeDefined();

--- a/src/frontend/js/utils/api/lms/index.ts
+++ b/src/frontend/js/utils/api/lms/index.ts
@@ -1,6 +1,6 @@
 import { CommonDataProps } from 'types/commonDataProps';
 import { handle } from 'utils/errors/handle';
-import { APILms, ApiBackend } from 'types/api';
+import { APILms, APIBackend } from 'types/api';
 import BaseApiInterface from './base';
 import OpenEdxDogwoodApiInterface from './openedx-dogwood';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
@@ -19,11 +19,11 @@ const LmsAPIHandler = (url: string): APILms => {
   const api = selectAPIWithUrl(url);
 
   switch (api?.backend) {
-    case ApiBackend.BASE:
+    case APIBackend.BASE:
       return BaseApiInterface(api);
-    case ApiBackend.OPENEDX_DOGWOOD:
+    case APIBackend.OPENEDX_DOGWOOD:
       return OpenEdxDogwoodApiInterface(api);
-    case ApiBackend.OPENEDX_HAWTHORN:
+    case APIBackend.OPENEDX_HAWTHORN:
       return OpenEdxHawthornApiInterface(api);
   }
 

--- a/src/frontend/js/utils/api/lms/index.ts
+++ b/src/frontend/js/utils/api/lms/index.ts
@@ -1,14 +1,11 @@
-import { CommonDataProps } from 'types/commonDataProps';
 import { handle } from 'utils/errors/handle';
+import context from 'utils/context';
 import { APILms, APIBackend } from 'types/api';
 import BaseApiInterface from './base';
 import OpenEdxDogwoodApiInterface from './openedx-dogwood';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
-const context: CommonDataProps['context'] = window.__richie_frontend_context__?.context;
-if (!context) throw new Error('No context frontend context available');
-
-const LMS_BACKENDS = context.lms_backends;
+const LMS_BACKENDS = context.lms_backends || [];
 
 const selectAPIWithUrl = (url: string) => {
   const API = LMS_BACKENDS.find((lms) => new RegExp(lms.course_regexp).test(url));

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
@@ -112,22 +112,15 @@ describe('OpenEdX Hawthorn API', () => {
 
       it('returns false if user is not enrolled', async () => {
         fetchMock.get(`${EDX_ENDPOINT}/api/enrollment/v1/enrollment/${username},${courseId}`, 200);
-        const response = await HawthornApi.enrollment.isEnrolled(
+
+        const enrollment = await HawthornApi.enrollment.get(
           `https://demo.endpoint/courses?course_id=${courseId}`,
           { username },
         );
 
-        expect(response).toBeFalsy();
-      });
+        const response = await HawthornApi.enrollment.isEnrolled(enrollment);
 
-      it('returns false if user is anonymous', async () => {
-        fetchMock.get(`${EDX_ENDPOINT}/api/enrollment/v1/enrollment/${username},${courseId}`, 401);
-        const response = await HawthornApi.enrollment.isEnrolled(
-          `https://demo.endpoint/courses?course_id=${courseId}`,
-          { username },
-        );
-
-        expect(response).toBeFalsy();
+        expect(response).toStrictEqual(false);
       });
     });
 

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'fetch-mock';
-import { ApiBackend } from 'types/api';
+import { APIBackend } from 'types/api';
 import { ContextFactory } from 'utils/test/factories';
 import faker from 'faker';
 
@@ -16,7 +16,7 @@ describe('OpenEdX Hawthorn API', () => {
   const context = ContextFactory({
     lms_backends: [
       {
-        backend: ApiBackend.OPENEDX_HAWTHORN,
+        backend: APIBackend.OPENEDX_HAWTHORN,
         course_regexp: 'course_id=(?<course_id>.*$)',
         endpoint: EDX_ENDPOINT,
       },

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
@@ -6,6 +6,7 @@ import { APILms, ApiOptions } from 'types/api';
 import { location } from 'utils/indirection/window';
 import { handle } from 'utils/errors/handle';
 import { EDX_CSRF_TOKEN_COOKIE_NAME } from 'settings';
+import { Enrollment, OpenEdXEnrollment } from 'types';
 
 /**
  *
@@ -89,27 +90,8 @@ const API = (APIConf: AuthenticationBackend | LMSBackend, options?: ApiOptions):
             return null;
           });
       },
-      isEnrolled: async (url: string, user?: Nullable<User>): Promise<boolean> => {
-        const courseId = extractCourseIdFromUrl(url);
-        const params = user ? `${user.username},${courseId}` : courseId;
-
-        return fetch(`${ROUTES.enrollment.isEnrolled}/${params}`, {
-          credentials: 'include',
-        })
-          .then((response) => {
-            if (response.ok) {
-              return response.headers.get('Content-Type') === 'application/json'
-                ? response.json()
-                : false;
-            }
-            if (response.status === 401 || response.status === 403) return false;
-            throw new Error(`[GET - Enrollment] > ${response.status} - ${response.statusText}`);
-          })
-          .then((response) => response.is_active || false)
-          .catch((error) => {
-            handle(error);
-            return false;
-          });
+      isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) => {
+        return new Promise((resolve) => resolve(!!(enrollment as OpenEdXEnrollment)?.is_active));
       },
       set: async (url: string, user: User): Promise<boolean> => {
         try {

--- a/src/frontend/js/utils/context.ts
+++ b/src/frontend/js/utils/context.ts
@@ -1,0 +1,14 @@
+import { handle } from 'utils/errors/handle';
+
+/**
+ * Retrieve the context provided by the backend from `__richie_frontend_context__`
+ */
+const context = window.__richie_frontend_context__?.context;
+
+if (!context) {
+  const error = new Error('Richie frontend context is not defined.');
+  handle(error);
+  throw error;
+}
+
+export default context;

--- a/src/frontend/js/utils/errors/handle.spec.ts
+++ b/src/frontend/js/utils/errors/handle.spec.ts
@@ -2,25 +2,25 @@
  * @jest-environment jsdom
  */
 import * as Sentry from '@sentry/browser';
-import { ContextFactory } from 'utils/test/factories';
+import { ContextFactory as mockContextFactory } from 'utils/test/factories';
+import { handle } from './handle';
 
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory({
+    sentry_dsn: 'https://sentry.local.test',
+  }).generate(),
+}));
 jest.mock('@sentry/browser');
 
 describe('handle', () => {
-  window.__richie_frontend_context__ = {
-    context: ContextFactory({
-      sentry_dsn: 'https://sentry.local.test',
-    }).generate(),
-  };
-  const { handle } = require('./handle');
-
   it('should initialize sentry', () => {
     expect(Sentry.init).toBeCalledTimes(1);
     expect(Sentry.configureScope).toBeCalledTimes(1);
   });
 
   it('should report error to sentry', () => {
-    handle('An error for test');
+    handle(new Error('An error for test'));
     expect(Sentry.captureException).toBeCalledTimes(1);
   });
 });

--- a/src/frontend/js/utils/errors/handle.ts
+++ b/src/frontend/js/utils/errors/handle.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import { CaptureContext } from '@sentry/types';
+import context from 'utils/context';
 
-const context = window.__richie_frontend_context__?.context;
 if (context?.sentry_dsn) {
   Sentry.init({
     dsn: context.sentry_dsn,

--- a/src/frontend/js/utils/index.tsx
+++ b/src/frontend/js/utils/index.tsx
@@ -1,0 +1,1 @@
+export const noop = () => undefined;

--- a/src/frontend/js/utils/react-query/createQueryClient.ts
+++ b/src/frontend/js/utils/react-query/createQueryClient.ts
@@ -1,10 +1,10 @@
 import { createSessionStoragePersistor } from 'utils/react-query/createSessionStoragePersistor';
 import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
 import { QueryClient, setLogger } from 'react-query';
-import { CommonDataProps } from 'types/commonDataProps';
 import { handle } from 'utils/errors/handle';
 import { REACT_QUERY_SETTINGS } from 'settings';
 import { noop } from 'utils';
+import context from 'utils/context';
 
 interface QueryClientOptions {
   logger?: boolean;
@@ -12,7 +12,6 @@ interface QueryClientOptions {
 }
 
 const createQueryClient = (options?: QueryClientOptions) => {
-  const context: CommonDataProps['context'] = (window as any)?.__richie_frontend_context__?.context;
   const environment = context?.environment;
 
   const queryClient = new QueryClient({

--- a/src/frontend/js/utils/react-query/createQueryClient.ts
+++ b/src/frontend/js/utils/react-query/createQueryClient.ts
@@ -1,0 +1,51 @@
+import { createSessionStoragePersistor } from 'utils/react-query/createSessionStoragePersistor';
+import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
+import { QueryClient, setLogger } from 'react-query';
+import { CommonDataProps } from 'types/commonDataProps';
+import { handle } from 'utils/errors/handle';
+import { REACT_QUERY_SETTINGS } from 'settings';
+import { noop } from 'utils';
+
+interface QueryClientOptions {
+  logger?: boolean;
+  persistor?: boolean;
+}
+
+const createQueryClient = (options?: QueryClientOptions) => {
+  const context: CommonDataProps['context'] = (window as any)?.__richie_frontend_context__?.context;
+  const environment = context?.environment;
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        cacheTime: REACT_QUERY_SETTINGS.cacheTime,
+        refetchOnWindowFocus: false,
+        retry: false,
+        staleTime: REACT_QUERY_SETTINGS.staleTimes.default,
+      },
+    },
+  });
+
+  if (options?.logger) {
+    // Link react-query logger to our error handler
+    setLogger({
+      // eslint-disable-next-line no-console
+      log: environment === 'development' ? console.log : noop,
+      warn: environment === 'development' ? console.warn : noop,
+      error: handle,
+    });
+  }
+
+  if (options?.persistor) {
+    // Prepare react-query cache persistance
+    const localStoragePersistor = createSessionStoragePersistor();
+    persistQueryClient({
+      persistor: localStoragePersistor,
+      queryClient,
+    });
+  }
+
+  return queryClient;
+};
+
+export default createQueryClient;

--- a/src/frontend/js/utils/react-query/createSessionStoragePersistor/index.spec.ts
+++ b/src/frontend/js/utils/react-query/createSessionStoragePersistor/index.spec.ts
@@ -1,0 +1,125 @@
+import faker from 'faker';
+import { createSessionStoragePersistor } from 'utils/react-query/createSessionStoragePersistor';
+import { persistQueryClient } from 'react-query/persistQueryClient-experimental';
+import { QueryClient } from 'react-query';
+import {
+  ContextFactory as mockContextFactory,
+  PersistedClientFactory,
+  QueryStateFactory,
+} from 'utils/test/factories';
+import { REACT_QUERY_SETTINGS } from 'settings';
+import { act } from 'react-dom/test-utils';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory().generate(),
+}));
+
+describe('createSessionStoragePersistor', () => {
+  const createQueryClient = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          cacheTime: 5 * 60 * 1000, // 5 minutes
+          staleTime: 2 * 60 * 1000, // 2 minutes
+        },
+      },
+    });
+    persistQueryClient({
+      persistor: createSessionStoragePersistor(),
+      queryClient,
+      maxAge: 2 * 60 * 1000,
+    });
+    return queryClient;
+  };
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    jest.clearAllTimers();
+  });
+
+  it('persists state into sessionStorage', async () => {
+    const username = faker.internet.userName();
+
+    await act(async () => {
+      queryClient = createQueryClient();
+    });
+
+    queryClient.setQueryData('user', { username });
+
+    let cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    expect(cacheString).not.toBeNull();
+    let client = JSON.parse(cacheString!);
+
+    // As persistClient is throttled, it has not been executed yet,
+    // so sessionStorage is not up to date
+    expect(client.clientState.queries).toHaveLength(0);
+
+    // advance timer by the throttle delay to execute persistClient
+    jest.advanceTimersByTime(REACT_QUERY_SETTINGS.cacheStorage.throttleTime);
+
+    // Now all data within sessionStorage are fresh
+    cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    client = JSON.parse(cacheString!);
+
+    expect(client.clientState.queries).toHaveLength(1);
+    expect(client.clientState.queries[0].queryKey).toEqual('user');
+    expect(client.clientState.queries[0].state.data).toStrictEqual({ username });
+  });
+
+  it('hydrates state', async () => {
+    const username = faker.internet.userName();
+
+    sessionStorage.setItem(
+      REACT_QUERY_SETTINGS.cacheStorage.key,
+      JSON.stringify(
+        PersistedClientFactory({
+          queries: [QueryStateFactory('user', { data: { username } })],
+        }),
+      ),
+    );
+
+    await act(async () => {
+      queryClient = createQueryClient();
+    });
+
+    const data = queryClient.getQueryData('user');
+
+    expect(data).toStrictEqual({ username });
+  });
+
+  it('is cleaned when cache has expired', async () => {
+    const username = faker.internet.userName();
+
+    await act(async () => {
+      queryClient = createQueryClient();
+    });
+
+    queryClient.setQueryData('user', { username });
+    jest.advanceTimersByTime(REACT_QUERY_SETTINGS.cacheStorage.throttleTime);
+
+    let cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    expect(cacheString).not.toBeNull();
+
+    const client = JSON.parse(cacheString!);
+    expect(client.clientState.queries).toHaveLength(1);
+    expect(client.clientState.queries[0].queryKey).toEqual('user');
+    expect(client.clientState.queries[0].state.data).toStrictEqual({ username });
+
+    // When sessionStorage has expired, persistClient cleans it through the
+    // removeClient method
+    jest.advanceTimersByTime(2 * 60 * 1000);
+
+    await act(async () => {
+      queryClient = createQueryClient();
+    });
+
+    cacheString = sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+    expect(cacheString).toBeNull();
+  });
+});

--- a/src/frontend/js/utils/react-query/createSessionStoragePersistor/index.ts
+++ b/src/frontend/js/utils/react-query/createSessionStoragePersistor/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Largely inspired by the createLocalStoragePersistor-experimental module
+ * included within react-query
+ *
+ * Just use sessionStorage instead of localStorage
+ */
+
+import { PersistedClient, Persistor } from 'react-query/persistQueryClient-experimental';
+import { throttle } from 'lodash-es';
+import { noop } from 'utils';
+import { REACT_QUERY_SETTINGS } from 'settings';
+
+interface CreateSessionStoragePersistorOptions {
+  localStorageKey?: string;
+  throttleTime?: number;
+}
+
+export function createSessionStoragePersistor({
+  localStorageKey = REACT_QUERY_SETTINGS.cacheStorage.key,
+  throttleTime = REACT_QUERY_SETTINGS.cacheStorage.throttleTime,
+}: CreateSessionStoragePersistorOptions = {}): Persistor {
+  if (typeof sessionStorage !== 'undefined') {
+    return {
+      persistClient: throttle((persistedClient) => {
+        sessionStorage.setItem(localStorageKey, JSON.stringify(persistedClient));
+      }, throttleTime),
+      restoreClient: () => {
+        const cacheString = sessionStorage.getItem(localStorageKey);
+
+        if (!cacheString) {
+          return;
+        }
+
+        return JSON.parse(cacheString) as PersistedClient;
+      },
+      removeClient: () => {
+        sessionStorage.removeItem(localStorageKey);
+      },
+    };
+  }
+
+  return {
+    persistClient: noop,
+    restoreClient: noop,
+    removeClient: noop,
+  };
+}

--- a/src/frontend/js/utils/test/factories.ts
+++ b/src/frontend/js/utils/test/factories.ts
@@ -1,6 +1,11 @@
 import { createSpec, derived, faker } from '@helpscout/helix';
 import { CommonDataProps } from 'types/commonDataProps';
-import { ApiBackend } from 'types/api';
+import { APIBackend } from 'types/api';
+import { DehydratedState } from 'react-query/types/hydration';
+import { QueryState } from 'react-query/types/core/query';
+import { MutationState } from 'react-query/types/core/mutation';
+import { PersistedClient } from 'react-query/types/persistQueryClient-experimental';
+import { MutationKey, QueryKey } from 'react-query';
 
 const CourseStateFactory = createSpec({
   priority: derived(() => Math.floor(Math.random() * 7)),
@@ -33,18 +38,18 @@ export const UserFactory = createSpec({
   username: faker.internet.userName(),
 });
 
-export const ContextFactory = (context: Partial<CommonDataProps['context']> = {}) => {
-  return createSpec({
+export const ContextFactory = (context: Partial<CommonDataProps['context']> = {}) =>
+  createSpec({
     auth_endpoint: 'https://endpoint.test',
     csrftoken: faker.random.alphaNumeric(64),
     environment: 'test',
     authentication: {
-      backend: ApiBackend.BASE,
+      backend: APIBackend.BASE,
       endpoint: 'https://endpoint.test',
     },
     lms_backends: [
       {
-        backend: ApiBackend.BASE,
+        backend: APIBackend.BASE,
         course_regexp: '.*',
         endpoint: 'https://endpoint.test',
       },
@@ -53,4 +58,58 @@ export const ContextFactory = (context: Partial<CommonDataProps['context']> = {}
     sentry_dsn: null,
     ...context,
   });
-};
+
+interface PersistedClientFactoryOptions {
+  buster?: number;
+  mutations?: DehydratedState['mutations'];
+  queries?: DehydratedState['queries'];
+  timestamp?: number;
+}
+export const PersistedClientFactory = ({
+  buster,
+  mutations,
+  queries,
+  timestamp,
+}: PersistedClientFactoryOptions) =>
+  ({
+    timestamp: timestamp || Date.now(),
+    buster: buster || '',
+    clientState: {
+      mutations: mutations || [],
+      queries: queries || [],
+    },
+  } as PersistedClient);
+
+export const QueryStateFactory = (key: QueryKey, state: Partial<QueryState>) => ({
+  queryKey: key,
+  queryHash: Array.isArray(key) ? JSON.stringify(key) : `[${JSON.stringify(key)}]`,
+  state: {
+    data: undefined,
+    dataUpdateCount: 1,
+    dataUpdatedAt: Date.now(),
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    fetchFailureCount: 0,
+    fetchMeta: null,
+    isFetching: false,
+    isInvalidated: false,
+    isPaused: false,
+    status: 'success',
+    ...state,
+  } as QueryState,
+});
+
+export const MutationStateFactory = (key: MutationKey, state: Partial<MutationState> = {}) => ({
+  mutationKey: key,
+  state: {
+    context: undefined,
+    data: undefined,
+    error: null,
+    failureCount: 0,
+    isPaused: false,
+    status: 'success',
+    variables: undefined,
+    ...state,
+  } as MutationState,
+});

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -99,6 +99,7 @@
     "react-dom": "17.0.2",
     "react-intl": "5.21.0",
     "react-modal": "3.14.3",
+    "react-query": "3.16.0",
     "sass": "1.43.4",
     "source-map-loader": "3.0.0",
     "typescript": "4.4.4",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1429,7 +1429,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.14.8":
+"@babel/runtime@^7.14.8", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
   integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
@@ -3189,6 +3189,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -3232,6 +3237,19 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.5.3.tgz#c75c39d923ae8af6284a893bfdc8bd3996d2dd2d"
+  integrity sha512-OLOXfwReZa2AAAh9yOUyiALB3YxBe0QpThwwuyRHLgpl8bSznSDmV6Mz7LeBJg1VZsMcDcNMy7B53w12qHrIhQ==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.0.4"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -3756,6 +3774,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-node@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.5.tgz#9d270aa7eaa5af0b72c4c9d9b814e7f4ce738b79"
+  integrity sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -5728,6 +5751,11 @@ js-cookie@3.0.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
   integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6048,6 +6076,14 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mdn-polyfills@5.20.0:
   version "5.20.0"
   resolved "https://registry.yarnpkg.com/mdn-polyfills/-/mdn-polyfills-5.20.0.tgz#ca8247edf20a4f60dec6804372229812b348260b"
@@ -6078,6 +6114,11 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.44.0:
   version "1.44.0"
@@ -6134,6 +6175,13 @@ ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanocolors@^0.2.2:
   version "0.2.10"
@@ -6745,6 +6793,15 @@ react-modal@3.14.3:
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 
+react-query@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.16.0.tgz#8de1556aabb3d200d0f8eeb74ce2b0b3dd0a0a51"
+  integrity sha512-YOvI8mO9WG+r4XsyJinjlDMiV5IewUWUcTv2J7z6bIP3KOFvgT6k6HM8vQouz4hPnme7Ktq9j5e7LarUqgJXFQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-themeable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
@@ -6862,6 +6919,11 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -6930,7 +6992,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -7621,6 +7683,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 update-notifier@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
## Purpose

With integration of Joanie within Richie, frontend code aims to enlarge and api requests will increase !
In order to manage it with ease, we need an efficient tool to manage requests. React query seems to be the right candidate to achieve that. In fact it helps to manage requests and furthermore it embed a cache system to optimize request sending.

On other hand, currently it can be tricky to test component relying on `window.__richie_frontend_context__`. That's why I decided to create a `context` util. In this way, mocking this context will be easier.

## Proposal

- [x] Set up react-query then refactor code accordingly
- [x] Create a context util to ease tests relying on `window.__richie_frontend_context__`
