### PR TITLE
♻️(search) fix autocomplete filters in Search

### DIFF
--- a/src/frontend/js/common/searchFields/index.tsx
+++ b/src/frontend/js/common/searchFields/index.tsx
@@ -77,17 +77,5 @@ export const getRelevantFilter = (
   suggestion: SearchSuggestion,
 ) => {
   // Use the `kind` field on the suggestion to pick the relevant filter to update.
-  let filter = Object.values(filters).find((fltr) => fltr.name === suggestion.kind)!;
-
-  // We need a special-case to handle categories until we refactor the API to separate endpoints between
-  // kinds of categories
-  if (!filter) {
-    // Pick the filter to update based on the payload's path: it contains the relevant filter's page path
-    // (for eg. a meta-category or the "organizations" root page)
-    filter = Object.values(filters).find(
-      (fltr) => !!fltr.base_path && String(suggestion.id).substr(2).startsWith(fltr.base_path),
-    )!;
-  }
-
-  return filter;
+  return Object.values(filters).find((fltr) => fltr.name === suggestion.kind)!;
 };

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -239,8 +239,8 @@ describe('components/SearchSuggestField', () => {
 
     fetchMock.get('/api/v1.0/organizations/autocomplete/?query=orga', [
       {
-        id: 'L-00020007',
-        kind: 'whatever',
+        id: '27',
+        kind: 'organizations',
         title: 'Organization #27',
       },
     ]);
@@ -311,13 +311,13 @@ describe('components/SearchSuggestField', () => {
           params: {
             limit: '13',
             offset: '0',
-            organizations: ['L-00020007'],
+            organizations: ['27'],
             query: undefined,
           },
         },
       },
       '',
-      '/search?limit=13&offset=0&organizations=L-00020007',
+      '/search?limit=13&offset=0&organizations=27',
     );
   });
 
@@ -599,8 +599,8 @@ describe('components/SearchSuggestField', () => {
 
     fetchMock.get('/api/v1.0/organizations/autocomplete/?query=orga', [
       {
-        id: 'L-00020007',
-        kind: 'whatever',
+        id: '27',
+        kind: 'organizations',
         title: 'Organization #27',
       },
     ]);
@@ -663,13 +663,13 @@ describe('components/SearchSuggestField', () => {
           params: {
             limit: '13',
             offset: '0',
-            organizations: ['L-00020007'],
+            organizations: ['27'],
             query: undefined,
           },
         },
       },
       '',
-      '/search?limit=13&offset=0&organizations=L-00020007',
+      '/search?limit=13&offset=0&organizations=27',
     );
 
     // The user starts typing a full-text search, the organization remains selected
@@ -689,13 +689,13 @@ describe('components/SearchSuggestField', () => {
           params: {
             limit: '13',
             offset: '0',
-            organizations: ['L-00020007'],
+            organizations: ['27'],
             query: 'ric',
           },
         },
       },
       '',
-      '/search?limit=13&offset=0&organizations=L-00020007&query=ric',
+      '/search?limit=13&offset=0&organizations=27&query=ric',
     );
   });
 });

--- a/src/richie/apps/search/indexers/categories.py
+++ b/src/richie/apps/search/indexers/categories.py
@@ -191,6 +191,6 @@ class CategoriesIndexer:
         """
         return {
             "id": es_document["_id"],
-            "kind": "categories",
+            "kind": es_document["_source"]["kind"],
             "title": get_best_field_language(es_document["_source"]["title"], language),
         }

--- a/tests/apps/search/test_autocomplete_categories.py
+++ b/tests/apps/search/test_autocomplete_categories.py
@@ -145,13 +145,31 @@ class AutocompleteCategoriesTestCase(TestCase):
         all_categories, response = self.execute_query(querystring="query=Electric")
         # Does not include the 4th, "not_subjects" element
         self.assertEqual(
-            [all_categories[0]["id"]], [category["id"] for category in response]
+            response,
+            [
+                {
+                    "id": all_categories[0]["id"],
+                    "kind": "subjects",
+                    "title": all_categories[0]["title"]["en"],
+                }
+            ],
         )
 
         all_categories, response = self.execute_query(querystring="query=bik")
         self.assertEqual(
-            [all_categories[i]["id"] for i in [2, 1]],
-            [category["id"] for category in response],
+            response,
+            [
+                {
+                    "id": all_categories[2]["id"],
+                    "kind": "subjects",
+                    "title": all_categories[2]["title"]["en"],
+                },
+                {
+                    "id": all_categories[1]["id"],
+                    "kind": "subjects",
+                    "title": all_categories[1]["title"]["en"],
+                },
+            ],
         )
 
     def test_autocomplete_diacritics_insensitive_query(self, *_):

--- a/tests/apps/search/test_indexers_categories.py
+++ b/tests/apps/search/test_indexers_categories.py
@@ -272,6 +272,7 @@ class CategoriesIndexersTestCase(TestCase):
             "_source": {
                 "is_meta": True,
                 "logo": {"en": "/image_en.png", "fr": "/image_fr.png"},
+                "kind": "subjects",
                 "nb_children": 3,
                 "path": "00010001",
                 "title": {"en": "Computer science", "fr": "Informatique"},
@@ -279,5 +280,5 @@ class CategoriesIndexersTestCase(TestCase):
         }
         self.assertEqual(
             CategoriesIndexer.format_es_document_for_autocomplete(es_category, "en"),
-            {"id": 89, "kind": "categories", "title": "Computer science"},
+            {"id": 89, "kind": "subjects", "title": "Computer science"},
         )


### PR DESCRIPTION
## Purpose

As a result of an oversight in our latest Search refactor, we broke the addition of autocompleted filters to the current course search params.

This was due to not having the correct "kind" on categories, them having "categories" instead of eg. "subjects" or "levels". There was a fallback relying on MPTT paths as IDs, which we recently removed.

## Proposal

We updated autocompleted categories to have the correct kind and removed the now unnecessary fallback.

NB: no changelog as the commits that broke this are not yet part of a release.
