### PR TITLE
✨(courses) make licenses on course page optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Create an context util
 - Add react-query to manage API requests and local data store
 - Move type utils into type directory
+- Make licenses on course page optional
 
 ### Fixed
 

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -448,10 +448,12 @@
         {% endblock information %}
 
         {% block licenses %}
+            {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_license_content" or not current_page|is_empty_placeholder:"course_license_participation" %}
             <div class="course-detail__license course-detail__block course-detail__block--divider">
                 <section class="course-detail__row">
                     <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}License{% endblocktrans %}</h2>
 
+                    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_license_content" %}
                     <div class="course-detail__item">
                         <h3 class="course-detail__label">{% trans 'License for the course content' %}</h3>
                         {% with header_level=4 %}
@@ -460,7 +462,9 @@
                             {% endplaceholder %}
                         {% endwith %}
                     </div>
+                    {% endif %}
 
+                    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_license_participation" %}
                     <div class="course-detail__item">
                         <h3 class="course-detail__label">{% trans 'License for the content created by course participants' %}</h3>
                         {% with header_level=4 is_license_property=False %}
@@ -469,8 +473,10 @@
                             {% endplaceholder %}
                         {% endwith %}
                     </div>
+                    {% endif %}
                 </section>
             </div>
+            {% endif %}
         {% endblock licenses %}
     </div>
     {% endblock fragment_relations %}


### PR DESCRIPTION
Fixes #1520 

Change course page template so when there isn't a content or participation licenses the course page don't show the block that asks to insert that information on view mode.
