### PR TITLE
🐛(opengraph) fix og:image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Prevent logout action to be called twice
+- Fix og:image when using S3Boto3Storage
 - Remove error message related with cache when any test fails
 
 ## [2.9.1] - 2021-11-03

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.core.files.storage import get_storage_class
 from django.http.request import HttpRequest
 from django.middleware.csrf import get_token
 from django.utils.translation import get_language_from_request
@@ -53,11 +54,12 @@ def site_metas(request: HttpRequest):
     if getattr(settings, "CDN_DOMAIN", None):
         context["CDN_DOMAIN"] = settings.CDN_DOMAIN
 
+    storage_url = get_storage_class()().url("any-page")
     # Add a MEDIA_URL_PREFIX to context to prefix the media url files to have an absolute URL
-    if settings.MEDIA_URL.startswith("//"):
+    if storage_url.startswith("//"):
         # Eg. //my-cdn-user.cdn-provider.com/media/
         context["MEDIA_URL_PREFIX"] = f"{request.scheme:s}:"
-    elif settings.MEDIA_URL.startswith("/"):
+    elif storage_url.startswith("/"):
         # Eg. /media/
         context["MEDIA_URL_PREFIX"] = f"{protocol:s}://{site_current.domain:s}"
     else:


### PR DESCRIPTION
Fix og:image when using S3Boto3Storage.

Fixes #1510 
