### PR TITLE
✨(search) Scroll search filters more options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add infinite scrolling to the facet search modal in course search.
 - Add reusable form components
 - Fix blogpost header image aspect ratio and sizes.
 - Add theme property to `Spinner` component

--- a/src/frontend/js/components/Modal/_styles.scss
+++ b/src/frontend/js/components/Modal/_styles.scss
@@ -1,3 +1,8 @@
+// Make sure random elements with any z-index don't show on top of the modals
+.ReactModal__Overlay {
+  z-index: 1;
+}
+
 .modal {
   background-color: r-theme-val(modal, base-background);
   border-radius: $border-radius;

--- a/src/frontend/js/components/Modal/_styles.scss
+++ b/src/frontend/js/components/Modal/_styles.scss
@@ -1,8 +1,3 @@
-// Make sure random elements with any z-index don't show on top of the modals
-.ReactModal__Overlay {
-  z-index: 1;
-}
-
 .modal {
   background-color: r-theme-val(modal, base-background);
   border-radius: $border-radius;

--- a/src/frontend/js/components/Modal/index.spec.tsx
+++ b/src/frontend/js/components/Modal/index.spec.tsx
@@ -2,6 +2,12 @@ import { render } from '@testing-library/react';
 import { Modal } from '.';
 
 describe('<Modal />', () => {
+  beforeEach(() => {
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
+
   it('merges custom classNames of type string with the default classes', () => {
     render(
       <Modal

--- a/src/frontend/js/components/Modal/index.tsx
+++ b/src/frontend/js/components/Modal/index.tsx
@@ -1,13 +1,5 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useMemo } from 'react';
 import ReactModal from 'react-modal';
-
-// The `setAppElement` needs to happen in proper code but breaks our testing environment.
-// This workaround is not satisfactory but it allows us to both test <SearchFilterGroupModal />
-// and avoid compromising accessibility in real-world use.
-const isTestEnv = process.env.NODE_ENV === 'test';
-if (!isTestEnv) {
-  ReactModal.setAppElement('#modal-exclude');
-}
 
 export const Modal = ({
   className,
@@ -35,9 +27,17 @@ export const Modal = ({
     return base || classes || undefined;
   };
 
+  const modalExclude = useMemo(() => {
+    const exclude = document.getElementById('modal-exclude');
+    if (exclude) {
+      return exclude;
+    }
+    throw new Error('Failed to get #modal-exclude to enable an accessible <ReactModal />.');
+  }, []);
+
   return (
     <ReactModal
-      ariaHideApp={!isTestEnv}
+      appElement={modalExclude}
       className={mergeClasses({ base: 'modal', classes: className })}
       bodyOpenClassName={mergeClasses({ base: 'has-opened-modal', classes: bodyOpenClassName })}
       overlayClassName={mergeClasses({ base: 'modal__overlay', classes: overlayClassName })}

--- a/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroup/index.spec.tsx
@@ -53,6 +53,11 @@ describe('components/SearchFilterGroup', () => {
   };
 
   beforeEach(jest.resetAllMocks);
+  beforeEach(() => {
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
 
   it('renders the name of the filter with the values as SearchFilters', () => {
     render(

--- a/src/frontend/js/components/SearchFilterGroupModal/_styles.scss
+++ b/src/frontend/js/components/SearchFilterGroupModal/_styles.scss
@@ -5,6 +5,12 @@
   justify-content: space-between;
   max-width: 30rem;
 
+  &__close {
+    position: absolute;
+    right: 0;
+    top: 0.25rem;
+  }
+
   &__form {
     display: flex;
     flex-direction: column;
@@ -14,7 +20,6 @@
       display: block;
       margin: 0;
       padding: 1rem;
-      text-align: center;
       font-size: 1.1rem;
       font-weight: $font-weight-boldest;
     }
@@ -50,7 +55,7 @@
     }
   }
 
-  &__close {
+  &__more-results {
     padding: 0.5rem 1rem;
     flex-shrink: 0;
     flex-grow: 0;
@@ -72,25 +77,6 @@
 
     &:hover {
       color: r-theme-val(search-filters-group-modal, button-color);
-    }
-  }
-}
-
-body.has-opened-modal {
-  /*
-   * Flex children in a fixed/absolute container breaks Safari.
-   * Use a specific, admittedly hacky media query to target it with a special layout
-   * that solves the issue on that browser.
-   */
-  @media not all and (min-resolution: 0.001dpcm) {
-    @media all {
-      .search-filter-group-modal {
-        overflow: hidden;
-      }
-
-      .search-filter-group-modal__form__values {
-        overflow: auto;
-      }
     }
   }
 }

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -1,12 +1,29 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
+import { range } from 'lodash-es';
 import { stringify } from 'query-string';
 import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { History, HistoryContext } from 'data/useHistory';
+import { Deferred } from 'utils/test/deferred';
 import { SearchFilterGroupModal } from '.';
 
 jest.mock('utils/errors/handle', () => ({ handle: jest.fn() }));
+
+jest.mock('utils/indirection/window', () => ({
+  location: { pathname: '/', search: '' },
+  matchMedia: () => ({
+    matches: true,
+  }),
+}));
+
+jest.mock('utils/useIntersectionObserver', () => ({
+  useIntersectionObserver: (props: any) => {
+    (globalThis as any).__intersection_observer_props__ = props;
+  },
+}));
 
 const filter = {
   base_path: '0001',
@@ -45,237 +62,440 @@ describe('<SearchFilterGroupModal />', () => {
 
   beforeEach(() => fetchMock.restore());
   beforeEach(jest.resetAllMocks);
+  beforeEach(() => {
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
 
   it('renders a button with a modal to search values for a given filter', async () => {
-    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
-      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
-    });
-    fetchMock.get(
-      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
-      {
-        filters: {
-          universities: {
-            values: [
-              {
-                count: 7,
-                human_name: 'Value #42',
-                key: '42',
-              },
-              {
-                count: 12,
-                human_name: 'Value #84',
-                key: '84',
-              },
-              {
-                count: 21,
-                human_name: 'Value #99',
-                key: '99',
-              },
-            ],
+    {
+      const universitiesDeferred = new Deferred();
+      fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', universitiesDeferred.promise);
+      const coursesDeferred = new Deferred();
+      fetchMock.get(
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=' +
+          range(0, 21).join(','),
+        coursesDeferred.promise,
+      );
+
+      const queryClient = new QueryClient();
+      render(
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '21', offset: '0' })}>
+            <QueryClientProvider client={queryClient}>
+              <SearchFilterGroupModal filter={filter} />
+            </QueryClientProvider>
+          </HistoryContext.Provider>
+        </IntlProvider>,
+      );
+
+      // The modal is not rendered
+      expect(screen.queryByText('Add filters for Universities')).toEqual(null);
+      expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
+
+      // The modal is rendered
+      const openButton = screen.getByText('More options');
+      fireEvent.click(openButton);
+      screen.getByText('Loading search results...');
+
+      await act(async () =>
+        universitiesDeferred.resolve({
+          meta: {
+            offset: 0,
+            count: 21,
+            total_count: 46,
           },
-        },
-      },
-    );
+          objects: range(0, 21).map((id) => ({ id: String(id) })),
+        }),
+      );
+      screen.getByText('Loading search results...');
 
-    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <SearchFilterGroupModal filter={filter} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
-    );
+      await act(async () =>
+        coursesDeferred.resolve({
+          filters: {
+            universities: {
+              values: range(0, 21).map((id) => ({
+                count: id * 100,
+                human_name: `Value #${id}`,
+                key: String(id),
+              })),
+            },
+          },
+        }),
+      );
 
-    // The modal is not rendered
-    expect(queryByText('Add filters for Universities')).toEqual(null);
-    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+      screen.getByText('Add filters for Universities');
+      screen.getByPlaceholderText('Search in Universities');
 
-    // The modal is rendered
-    const openButton = getByText('More options');
-    fireEvent.click(openButton);
-    getByText('Add filters for Universities');
-    getByPlaceholderText('Search in Universities');
+      // Default search results are shown with their facet counts
+      range(0, 21).forEach((value) => {
+        screen.getByText(
+          (content) =>
+            content.startsWith(`Value #${value} `) && content.includes(String(value * 100)),
+        );
+      });
+    }
+    {
+      // Activate intersection observer, make sure more results are loaded
+      const universitiesDeferred = new Deferred();
+      fetchMock.get('/api/v1.0/universities/?limit=21&offset=21', universitiesDeferred.promise);
+      const coursesDeferred = new Deferred();
+      fetchMock.get(
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=' +
+          range(21, 42).join(','),
+        coursesDeferred.promise,
+      );
 
-    // Default search results are shown with their facet counts
-    await screen.findByText(
-      (content) => content.startsWith('Value #42') && content.includes('(7)'),
-    );
-    getByText((content) => content.startsWith('Value #84') && content.includes('(12)'));
-    getByText((content) => content.startsWith('Value #99') && content.includes('(21)'));
+      const { onIntersect } = (globalThis as any).__intersection_observer_props__;
+      onIntersect();
+      await act(async () =>
+        universitiesDeferred.resolve({
+          meta: {
+            offset: 21,
+            count: 21,
+            total_count: 46,
+          },
+          objects: range(21, 42).map((id) => ({ id: String(id) })),
+        }),
+      );
+      await act(async () =>
+        coursesDeferred.resolve({
+          filters: {
+            universities: {
+              values: range(21, 42).map((id) => ({
+                count: id * 100,
+                human_name: `Value #${id}`,
+                key: String(id),
+              })),
+            },
+          },
+        }),
+      );
+
+      // Search results including top 21 and next 21 are shown with their facet counts
+      range(0, 42).forEach((value) => {
+        screen.getByText(
+          (content) =>
+            content.startsWith(`Value #${value} `) && content.includes(String(value * 100)),
+        );
+      });
+    }
+    {
+      // Click on the "more results" button, make sure more results are loaded
+      const universitiesDeferred = new Deferred();
+      fetchMock.get('/api/v1.0/universities/?limit=21&offset=42', universitiesDeferred.promise);
+      const coursesDeferred = new Deferred();
+      fetchMock.get(
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=' +
+          range(42, 46).join(','),
+        coursesDeferred.promise,
+      );
+
+      userEvent.click(screen.getByText('Load more results'));
+      await act(async () =>
+        universitiesDeferred.resolve({
+          meta: {
+            offset: 42,
+            count: 4,
+            total_count: 46,
+          },
+          objects: range(42, 46).map((id) => ({ id: String(id) })),
+        }),
+      );
+      await act(async () =>
+        coursesDeferred.resolve({
+          filters: {
+            universities: {
+              values: range(42, 46).map((id) => ({
+                count: id * 100,
+                human_name: `Value #${id}`,
+                key: String(id),
+              })),
+            },
+          },
+        }),
+      );
+
+      // All three batches of search results are displayed along with facet counts
+      range(0, 46).forEach((value) => {
+        screen.getByText(
+          (content) =>
+            content.startsWith(`Value #${value} `) && content.includes(String(value * 100)),
+        );
+      });
+    }
   });
 
   it('searches as the user types', async () => {
-    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
-      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
-    });
-    fetchMock.get(
-      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
-      {
-        filters: {
-          universities: {
-            values: [
-              {
-                count: 7,
-                human_name: 'Value #42',
-                key: '42',
-              },
-              {
-                count: 12,
-                human_name: 'Value #84',
-                key: '84',
-              },
-            ],
+    {
+      const universitiesDeferred = new Deferred();
+      fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', universitiesDeferred.promise);
+      const coursesDeferred = new Deferred();
+      fetchMock.get(
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
+        coursesDeferred.promise,
+      );
+
+      const queryClient = new QueryClient();
+      render(
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({ limit: '21', offset: '0' })}>
+            <QueryClientProvider client={queryClient}>
+              <SearchFilterGroupModal filter={filter} />
+            </QueryClientProvider>
+          </HistoryContext.Provider>
+        </IntlProvider>,
+      );
+
+      // The modal is rendered
+      const openButton = screen.getByText('More options');
+      fireEvent.click(openButton);
+      screen.getByText('Loading search results...');
+
+      await act(async () => {
+        universitiesDeferred.resolve({
+          meta: {
+            offset: 0,
+            count: 3,
+            total_count: 3,
           },
-        },
-      },
-    );
+          objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
+        });
+      });
+      screen.getByText('Loading search results...');
 
-    const { getByPlaceholderText, getByText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <SearchFilterGroupModal filter={filter} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
-    );
+      await act(async () => {
+        coursesDeferred.resolve({
+          filters: {
+            universities: {
+              values: [
+                {
+                  count: 7,
+                  human_name: 'Value #42',
+                  key: '42',
+                },
+                {
+                  count: 12,
+                  human_name: 'Value #84',
+                  key: '84',
+                },
+              ],
+            },
+          },
+        });
+      });
+    }
 
-    // The modal is rendered
-    const openButton = getByText('More options');
-    fireEvent.click(openButton);
-    getByText('Add filters for Universities');
-    const field = getByPlaceholderText('Search in Universities');
+    screen.getByText('Add filters for Universities');
+    const field = screen.getByPlaceholderText('Search in Universities');
     fireEvent.focus(field);
 
     // Default search results are shown with their facet counts
-    await screen.findByText(
-      (content) => content.startsWith('Value #42') && content.includes('(7)'),
-    );
-    getByText((content) => content.startsWith('Value #84') && content.includes('(12)'));
+    screen.getByText((content) => content.startsWith('Value #42') && content.includes('(7)'));
+    screen.getByText((content) => content.startsWith('Value #84') && content.includes('(12)'));
 
     // User starts typing, less than 3 characters
     fetchMock.resetHistory();
     fireEvent.change(field, { target: { value: 'us' } });
     expect(fetchMock.called()).toEqual(false);
-    getByText('Type at least 3 characters to start searching.');
+    screen.getByText('Type at least 3 characters to start searching.');
 
-    // User inputs a search query
-    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=user', {
-      objects: [{ id: 'L-12' }, { id: 'L-17' }],
-    });
-    fetchMock.get(
-      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_aggs=L-12,L-17',
-      {
-        filters: {
-          universities: {
-            values: [
-              {
-                count: 7,
-                human_name: 'Value #12',
-                key: '12',
-              },
-              {
-                count: 12,
-                human_name: 'Value #17',
-                key: '17',
-              },
-            ],
+    {
+      // User inputs a search query
+      const universitiesDeferred = new Deferred();
+      fetchMock.get(
+        '/api/v1.0/universities/?limit=21&offset=0&query=user',
+        universitiesDeferred.promise,
+      );
+      const coursesDeferred = new Deferred();
+      fetchMock.get(
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-12,L-17',
+        coursesDeferred.promise,
+      );
+      fireEvent.change(field, { target: { value: 'user' } });
+      await act(async () => {
+        universitiesDeferred.resolve({
+          meta: {
+            count: 2,
+            offset: 0,
+            total_count: 2,
           },
-        },
-      },
-    );
-    fireEvent.change(field, { target: { value: 'user' } });
+          objects: [{ id: 'L-12' }, { id: 'L-17' }],
+        });
+      });
+      await act(async () => {
+        coursesDeferred.resolve({
+          filters: {
+            universities: {
+              values: [
+                {
+                  count: 7,
+                  human_name: 'Value #12',
+                  key: '12',
+                },
+                {
+                  count: 12,
+                  human_name: 'Value #17',
+                  key: '17',
+                },
+              ],
+            },
+          },
+        });
+      });
+    }
 
     // New search results are shown with their facet counts
-    await screen.findByText(
-      (content) => content.startsWith('Value #12') && content.includes('(7)'),
-    );
-    getByText((content) => content.startsWith('Value #17') && content.includes('(12)'));
+    screen.getByText((content) => content.startsWith('Value #12') && content.includes('(7)'));
+    screen.getByText((content) => content.startsWith('Value #17') && content.includes('(12)'));
 
-    // User further refines their search query
-    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=user%20input', {
-      objects: [{ id: 'L-03' }, { id: 'L-66' }],
-    });
-    fetchMock.get(
-      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_aggs=L-03,L-66',
-      {
-        filters: {
-          universities: {
-            values: [
-              {
-                count: 12,
-                human_name: 'Value #03',
-                key: '03',
-              },
-              {
-                count: 2,
-                human_name: 'Value #17',
-                key: '17',
-              },
-            ],
+    {
+      // User further refines their search query
+      const universitiesDeferred = new Deferred();
+      fetchMock.get(
+        '/api/v1.0/universities/?limit=21&offset=0&query=user%20input',
+        universitiesDeferred.promise,
+      );
+      const coursesDeferred = new Deferred();
+      fetchMock.get(
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-03,L-66',
+        coursesDeferred.promise,
+      );
+      fireEvent.change(field, { target: { value: 'user input' } });
+      await act(async () => {
+        universitiesDeferred.resolve({
+          meta: {
+            count: 2,
+            offset: 0,
+            total_count: 2,
           },
-        },
-      },
-    );
-    fireEvent.change(field, { target: { value: 'user input' } });
+          objects: [{ id: 'L-03' }, { id: 'L-66' }],
+        });
+      });
+      await act(async () => {
+        coursesDeferred.resolve({
+          filters: {
+            universities: {
+              values: [
+                {
+                  count: 12,
+                  human_name: 'Value #03',
+                  key: '03',
+                },
+                {
+                  count: 2,
+                  human_name: 'Value #66',
+                  key: '66',
+                },
+              ],
+            },
+          },
+        });
+      });
+    }
 
     // New search results are shown with their facet counts
     await screen.findByText(
       (content) => content.startsWith('Value #03') && content.includes('(12)'),
     );
-    getByText((content) => content.startsWith('Value #17') && content.includes('(2)'));
+    screen.getByText((content) => content.startsWith('Value #66') && content.includes('(2)'));
   });
 
   it('closes when the user clicks the close button', async () => {
-    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
-      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
-    });
+    const universitiesDeferred = new Deferred();
+    fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', universitiesDeferred.promise);
+    const coursesDeferred = new Deferred();
     fetchMock.get(
-      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
-      {
-        filters: {
-          universities: {
-            values: [],
-          },
-        },
-      },
+      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
+      coursesDeferred.promise,
     );
 
-    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
+    const queryClient = new QueryClient();
+    render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <SearchFilterGroupModal filter={filter} />
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '21', offset: '0' })}>
+          <QueryClientProvider client={queryClient}>
+            <SearchFilterGroupModal filter={filter} />
+          </QueryClientProvider>
         </HistoryContext.Provider>
       </IntlProvider>,
     );
 
     // The modal is not rendered
-    expect(queryByText('Add filters for Universities')).toEqual(null);
-    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
-    expect(queryByText('Close')).toEqual(null);
+    expect(screen.queryByText('Add filters for Universities')).toEqual(null);
+    expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
+    expect(screen.queryByText('Close modal')).toEqual(null);
 
     // The modal is rendered
-    const openButton = getByText('More options');
+    const openButton = screen.getByText('More options');
     fireEvent.click(openButton);
-    getByText('Add filters for Universities');
-    getByPlaceholderText('Search in Universities');
+    await act(async () => {
+      universitiesDeferred.resolve({
+        meta: { count: 3, offset: 0, total_count: 3 },
+        objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
+      });
+    });
+    await act(async () => {
+      coursesDeferred.resolve({
+        filters: {
+          universities: {
+            values: [],
+          },
+        },
+      });
+    });
+
+    screen.getByText('Add filters for Universities');
+    screen.getByPlaceholderText('Search in Universities');
 
     // User clicks on the close button
-    const closeButton = getByText('Close');
+    const closeButton = screen.getByText('Close modal');
     fireEvent.click(closeButton);
 
     // The modal is not rendered any more
     await waitFor(() => {
-      expect(queryByText('Add filters for Universities')).toEqual(null);
+      expect(screen.queryByText('Add filters for Universities')).toEqual(null);
     });
-    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
-    expect(queryByText('Close')).toEqual(null);
+    expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
+    expect(screen.queryByText('Close modal')).toEqual(null);
   });
 
   it('adds the value and closes when the user clicks a filter value', async () => {
-    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
-      objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
-    });
+    const universitiesDeferred = new Deferred();
+    fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', universitiesDeferred.promise);
+    const coursesDeferred = new Deferred();
     fetchMock.get(
-      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
-      {
+      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
+      coursesDeferred.promise,
+    );
+
+    const queryClient = new QueryClient();
+    render(
+      <IntlProvider locale="en">
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '21', offset: '0' })}>
+          <QueryClientProvider client={queryClient}>
+            <SearchFilterGroupModal filter={filter} />
+          </QueryClientProvider>
+        </HistoryContext.Provider>
+      </IntlProvider>,
+    );
+
+    // The modal is not rendered
+    expect(screen.queryByText('Add filters for Universities')).toEqual(null);
+    expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
+
+    // The modal is rendered
+    const openButton = screen.getByText('More options');
+    fireEvent.click(openButton);
+    await act(async () => {
+      universitiesDeferred.resolve({
+        meta: { count: 3, offset: 0, total_count: 3 },
+        objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
+      });
+    });
+    await act(async () => {
+      coursesDeferred.resolve({
         filters: {
           universities: {
             values: [
@@ -292,32 +512,14 @@ describe('<SearchFilterGroupModal />', () => {
             ],
           },
         },
-      },
-    );
-
-    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
-      <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <SearchFilterGroupModal filter={filter} />
-        </HistoryContext.Provider>
-      </IntlProvider>,
-    );
-
-    // The modal is not rendered
-    expect(queryByText('Add filters for Universities')).toEqual(null);
-    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
-
-    // The modal is rendered
-    const openButton = getByText('More options');
-    fireEvent.click(openButton);
-    getByText('Add filters for Universities');
-    getByPlaceholderText('Search in Universities');
+      });
+    });
+    screen.getByText('Add filters for Universities');
+    screen.getByPlaceholderText('Search in Universities');
 
     // Default search results are shown with their facet counts
-    await screen.findByText(
-      (content) => content.startsWith('Value #84') && content.includes('(12)'),
-    );
-    const value42 = getByText(
+    screen.getByText((content) => content.startsWith('Value #84') && content.includes('(12)'));
+    const value42 = screen.getByText(
       (content) => content.startsWith('Value #42') && content.includes('(7)'),
     );
 
@@ -329,74 +531,80 @@ describe('<SearchFilterGroupModal />', () => {
         data: {
           lastDispatchActions: expect.any(Array),
           params: {
-            limit: '20',
+            limit: '21',
             offset: '0',
             universities: ['42'],
           },
         },
       },
       '',
-      '/?limit=20&offset=0&universities=42',
+      '/?limit=21&offset=0&universities=42',
     );
 
     // The modal is not rendered any more
-    expect(queryByText('Add filters for Universities')).toEqual(null);
-    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+    expect(screen.queryByText('Add filters for Universities')).toEqual(null);
+    expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
   });
 
   it('shows an error message when it fails to search for values', async () => {
-    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
+    fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', {
       throws: new Error('Failed to search for universities'),
     });
 
-    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
+    const queryClient = new QueryClient();
+    render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <SearchFilterGroupModal filter={filter} />
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '21', offset: '0' })}>
+          <QueryClientProvider client={queryClient}>
+            <SearchFilterGroupModal filter={filter} />
+          </QueryClientProvider>
         </HistoryContext.Provider>
       </IntlProvider>,
     );
 
     // The modal is not rendered
-    expect(queryByText('Add filters for Universities')).toEqual(null);
-    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+    expect(screen.queryByText('Add filters for Universities')).toEqual(null);
+    expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
 
     // The modal is rendered
-    const openButton = getByText('More options');
+    const openButton = screen.getByText('More options');
     fireEvent.click(openButton);
-    getByText('Add filters for Universities');
-    getByPlaceholderText('Search in Universities');
+    screen.getByText('Add filters for Universities');
+    screen.getByPlaceholderText('Search in Universities');
 
     // The search request failed, the error is logged and a message is displayed
     await screen.findByText('There was an error while searching for Universities.');
   });
 
   it('shows an error message when it fails to get the actual filter', async () => {
-    fetchMock.get('/api/v1.0/universities/?limit=20&offset=0&query=', {
+    fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', {
       objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
     });
     fetchMock.get(
-      '/api/v1.0/courses/?limit=20&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
+      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
       { throws: new Error('Failed to search for universities') },
     );
 
-    const { getByPlaceholderText, getByText, queryByPlaceholderText, queryByText } = render(
+    const queryClient = new QueryClient();
+    render(
       <IntlProvider locale="en">
-        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
-          <SearchFilterGroupModal filter={filter} />
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '21', offset: '0' })}>
+          <QueryClientProvider client={queryClient}>
+            <SearchFilterGroupModal filter={filter} />
+          </QueryClientProvider>
         </HistoryContext.Provider>
       </IntlProvider>,
     );
 
     // The modal is not rendered
-    expect(queryByText('Add filters for Universities')).toEqual(null);
-    expect(queryByPlaceholderText('Search in Universities')).toEqual(null);
+    expect(screen.queryByText('Add filters for Universities')).toEqual(null);
+    expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
 
     // The modal is rendered
-    const openButton = getByText('More options');
+    const openButton = screen.getByText('More options');
     fireEvent.click(openButton);
-    getByText('Add filters for Universities');
-    getByPlaceholderText('Search in Universities');
+    screen.getByText('Add filters for Universities');
+    screen.getByPlaceholderText('Search in Universities');
 
     // The filters request failed, the error is logged and a message is displayed
     await screen.findByText('There was an error while searching for Universities.');

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -1,21 +1,21 @@
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, FormattedMessage, MessageDescriptor, useIntl } from 'react-intl';
-import { Modal } from 'components/Modal';
+import { useInfiniteQuery } from 'react-query';
 
+import { Modal } from 'components/Modal';
+import { Spinner } from 'components/Spinner';
 import { fetchList } from 'data/getResourceList';
 import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
+import { API_LIST_DEFAULT_PARAMS } from 'settings';
 import { RequestStatus } from 'types/api';
-import { FacetedFilterDefinition, FilterValue } from 'types/filters';
+import { FacetedFilterDefinition } from 'types/filters';
 import { Nullable } from 'types/utils';
-import { useAsyncEffect } from 'utils/useAsyncEffect';
-
-interface SearchFilterGroupModalProps {
-  filter: FacetedFilterDefinition;
-}
+import { matchMedia } from 'utils/indirection/window';
+import { useIntersectionObserver } from 'utils/useIntersectionObserver';
 
 const messages = defineMessages({
   closeButton: {
-    defaultMessage: 'Close',
+    defaultMessage: 'Close modal',
     description: 'Text for the button to close the search filters modal',
     id: 'components.SearchFilterGroupModal.closeModal',
   },
@@ -34,6 +34,16 @@ const messages = defineMessages({
     defaultMessage: 'Search in { filterName }',
     description: 'Placeholder message for the search input in the search filter modal.',
     id: 'components.SearchFilterGroupModal.inputPlaceholder',
+  },
+  loadingResults: {
+    defaultMessage: 'Loading search results...',
+    description: 'Loading message while loading more results in the search filter modal.',
+    id: 'components.SearchFilterGroupModal.loadingResults',
+  },
+  loadMoreResults: {
+    defaultMessage: 'Load more results',
+    description: 'Button to manually load more results for the current active filter',
+    id: 'components.SearchFilterGroupModal.loadMoreResults',
   },
   modalTitle: {
     defaultMessage: 'Add filters for {filterName}',
@@ -54,59 +64,191 @@ const messages = defineMessages({
   },
 });
 
-export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) => {
-  const intl = useIntl();
+interface ModalContentProps {
+  filter: FacetedFilterDefinition;
+  modalIsOpen: boolean;
+  setModalIsOpen: (newState: boolean) => void;
+}
 
-  const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [values, setValues] = useState([] as FilterValue[]);
+const ModalContent = ({ filter, modalIsOpen, setModalIsOpen }: ModalContentProps) => {
+  const intl = useIntl();
   const [query, setQuery] = useState('');
   const [error, setError] = useState(null as Nullable<MessageDescriptor>);
-
-  // We need the current course search params to get the facet counts
-  const { courseSearchParams, dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
 
   // When the modal is closed, reset state so the user gets a brand-new one if they come back
   useEffect(() => {
     if (!modalIsOpen) {
-      setValues([]);
       setQuery('');
       setError(null);
     }
   }, [modalIsOpen]);
 
-  useAsyncEffect(async () => {
-    // We can't start using full-text search until our text query is at least 3 characters long.
-    if (!modalIsOpen || (query.length > 0 && query.length < 3)) {
-      return;
-    }
+  // We need the current course search params to get the facet counts
+  const { courseSearchParams, dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
 
-    const searchResponse = await fetchList(filter.name, {
-      limit: '20',
-      offset: '0',
-      query,
+  const fetchResults = async (args: any) => {
+    const { pageParam, queryKey } = args;
+    const [filterName, fetchCourseSearchParams, fetchQuery] = queryKey;
+    const searchResponse = await fetchList(filterName, {
+      ...(pageParam || API_LIST_DEFAULT_PARAMS),
+      ...(fetchQuery ? { query: fetchQuery } : {}),
     });
 
     if (searchResponse.status === RequestStatus.FAILURE) {
-      setValues([]);
       return setError(messages.error);
     }
 
     const facetResponse = await fetchList('courses', {
-      ...courseSearchParams,
-      [`${filter.name}_aggs`]: searchResponse.content.objects.map((resource) => resource.id),
+      ...fetchCourseSearchParams,
+      [`${filterName}_aggs`]: searchResponse.content.objects.map((resource) => resource.id),
       scope: 'filters',
+      facet_sorting: 'name',
     });
 
     if (facetResponse.status === RequestStatus.FAILURE) {
-      setValues([]);
       return setError(messages.error);
     }
 
-    const newValues = facetResponse.content.filters[filter.name].values;
+    return {
+      meta: searchResponse.content.meta,
+      objects: facetResponse.content.filters[filterName].values,
+    };
+  };
 
-    setError(null);
-    setValues(newValues);
-  }, [modalIsOpen, query]);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } = useInfiniteQuery(
+    [filter.name, courseSearchParams, query.length > 2 ? query : ''],
+    fetchResults,
+    {
+      enabled: modalIsOpen,
+      getNextPageParam: (lastPage) => {
+        if (!lastPage) {
+          return undefined;
+        }
+        const newOffset = lastPage.meta.offset + lastPage.meta.count;
+        if (newOffset >= lastPage.meta.total_count) {
+          return undefined;
+        }
+        return { limit: API_LIST_DEFAULT_PARAMS.limit, offset: newOffset };
+      },
+    },
+  );
+
+  const searchInputRef = useRef<Nullable<HTMLInputElement>>(null);
+  useEffect(() => {
+    // When the modal opens, if on desktop, focus the search input
+    if (modalIsOpen && matchMedia('(min-width: 992px)').matches) {
+      searchInputRef.current?.focus();
+    }
+  }, [modalIsOpen]);
+
+  const loadMoreButtonRef = useRef<HTMLButtonElement>(null);
+  useIntersectionObserver({
+    target: loadMoreButtonRef,
+    onIntersect: fetchNextPage,
+    enabled: !!hasNextPage,
+  });
+
+  return (
+    <Fragment>
+      <button
+        className="modal__closeButton search-filter-group-modal__close"
+        onClick={() => setModalIsOpen(false)}
+      >
+        <span className="offscreen">
+          <FormattedMessage {...messages.closeButton} />
+        </span>
+        <svg
+          aria-hidden={true}
+          role="img"
+          className="icon modal__closeButton__icon search-filter-group-modal__close__icon"
+        >
+          <use xlinkHref="#icon-cross" />
+        </svg>
+      </button>
+      <fieldset className="search-filter-group-modal__form">
+        <legend className="search-filter-group-modal__form__title">
+          <FormattedMessage {...messages.modalTitle} values={{ filterName: filter.human_name }} />
+        </legend>
+        <input
+          aria-label={intl.formatMessage(messages.inputLabel)}
+          className="search-filter-group-modal__form__input"
+          onChange={(event) => {
+            setQuery(event.target.value);
+          }}
+          placeholder={intl.formatMessage(messages.inputPlaceholder, {
+            filterName: filter.human_name,
+          })}
+          ref={searchInputRef}
+        />
+        {error ? (
+          <div className="search-filter-group-modal__form__error">
+            <FormattedMessage {...messages.error} values={{ filterName: filter.human_name }} />
+          </div>
+        ) : query.length > 0 && query.length < 3 ? (
+          <div className="search-filter-group-modal__form__error">
+            <FormattedMessage {...messages.queryTooShort} />
+          </div>
+        ) : status === 'error' ? (
+          <div>
+            <FormattedMessage {...messages.error} values={{ filterName: filter.human_name }} />
+          </div>
+        ) : ['idle', 'loading'].includes(status) ? (
+          <Spinner>
+            <FormattedMessage {...messages.loadingResults} />
+          </Spinner>
+        ) : (
+          <ul className="search-filter-group-modal__form__values">
+            {data!.pages.map((page, pageIndex) => (
+              <Fragment key={pageIndex}>
+                {page!.objects.map((value) => (
+                  <li className="search-filter-group-modal__form__values__item" key={value.key}>
+                    <button
+                      onClick={() => {
+                        dispatchCourseSearchParamsUpdate({
+                          filter,
+                          payload: value.key,
+                          type: CourseSearchParamsAction.filterAdd,
+                        });
+                        setModalIsOpen(false);
+                      }}
+                    >
+                      {value.human_name}&nbsp;{`(${value.count})`}
+                    </button>
+                  </li>
+                ))}
+              </Fragment>
+            ))}
+          </ul>
+        )}
+      </fieldset>
+      {hasNextPage ? (
+        <button
+          className="search-filter-group-modal__more-results"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+          ref={loadMoreButtonRef}
+        >
+          <FormattedMessage {...messages.loadMoreResults} />
+        </button>
+      ) : null}
+    </Fragment>
+  );
+};
+
+interface SearchFilterGroupModalProps {
+  filter: FacetedFilterDefinition;
+}
+
+export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) => {
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+
+  const modalExclude = useMemo(() => {
+    const exclude = document.getElementById('modal-exclude');
+    if (exclude) {
+      return exclude;
+    }
+    throw new Error('Failed to get #modal-exclude to enable an accessible <ReactModal />.');
+  }, []);
 
   return (
     <Fragment>
@@ -114,58 +256,13 @@ export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) 
         <FormattedMessage {...messages.moreOptionsButton} />
       </button>
       <Modal
+        appElement={modalExclude}
         bodyOpenClassName="has-search-filter-group-modal"
         className="search-filter-group-modal modal--stretched"
         isOpen={modalIsOpen}
         onRequestClose={() => setModalIsOpen(false)}
       >
-        <fieldset className="search-filter-group-modal__form">
-          <legend className="search-filter-group-modal__form__title">
-            <FormattedMessage {...messages.modalTitle} values={{ filterName: filter.human_name }} />
-          </legend>
-          <input
-            aria-label={intl.formatMessage(messages.inputLabel)}
-            className="search-filter-group-modal__form__input"
-            onChange={(event) => {
-              setQuery(event.target.value);
-            }}
-            placeholder={intl.formatMessage(messages.inputPlaceholder, {
-              filterName: filter.human_name,
-            })}
-          />
-          {error ? (
-            <div className="search-filter-group-modal__form__error">
-              <FormattedMessage {...messages.error} values={{ filterName: filter.human_name }} />
-            </div>
-          ) : query.length > 0 && query.length < 3 ? (
-            <div className="search-filter-group-modal__form__error">
-              <FormattedMessage {...messages.queryTooShort} />
-            </div>
-          ) : (
-            <ul className="search-filter-group-modal__form__values">
-              {values.map((value) => (
-                <li className="search-filter-group-modal__form__values__item" key={value.key}>
-                  <button
-                    onClick={() => {
-                      dispatchCourseSearchParamsUpdate({
-                        filter,
-                        payload: value.key,
-                        type: CourseSearchParamsAction.filterAdd,
-                      });
-                      setModalIsOpen(false);
-                    }}
-                  >
-                    {value.human_name}&nbsp;
-                    {value.count || value.count === 0 ? `(${value.count})` : ''}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </fieldset>
-        <button className="search-filter-group-modal__close" onClick={() => setModalIsOpen(false)}>
-          <FormattedMessage {...messages.closeButton} />
-        </button>
+        <ModalContent {...{ filter, modalIsOpen, setModalIsOpen }} />
       </Modal>
     </Fragment>
   );

--- a/src/frontend/js/utils/useIntersectionObserver.tsx
+++ b/src/frontend/js/utils/useIntersectionObserver.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+import { Nullable } from 'types/utils';
+
+interface UseIntersectionObserverProps {
+  root?: React.MutableRefObject<Nullable<Element>>;
+  target: React.MutableRefObject<Nullable<Element>>;
+  onIntersect: Function;
+  threshold?: number;
+  rootMargin?: string;
+  enabled?: boolean;
+}
+
+export const useIntersectionObserver = ({
+  root,
+  target,
+  onIntersect,
+  threshold = 0.99,
+  rootMargin = '0px',
+  enabled = true,
+}: UseIntersectionObserverProps) => {
+  useEffect(() => {
+    if (!enabled || !IntersectionObserver) {
+      return;
+    }
+
+    // eslint-disable-next-line compat/compat
+    const observer = new IntersectionObserver(
+      (entries) => entries.forEach((entry) => entry.isIntersecting && onIntersect()),
+      {
+        root: root?.current,
+        rootMargin,
+        threshold,
+      },
+    );
+
+    const el = target?.current;
+
+    if (!el) {
+      return;
+    }
+
+    observer.observe(el);
+
+    return () => {
+      observer.unobserve(el);
+    };
+  }, [target.current, enabled]);
+};

--- a/src/richie/apps/search/filter_definitions/__init__.py
+++ b/src/richie/apps/search/filter_definitions/__init__.py
@@ -4,7 +4,7 @@ from django.utils.module_loading import import_string
 
 # pylint: disable=unused-import
 from ..defaults import FILTERS_CONFIGURATION
-from .base import NestingWrapper  # noqa
+from .base import BaseFilterDefinition, NestingWrapper  # noqa
 from .courses import (  # noqa
     AvailabilityFilterDefinition,
     IndexableFilterDefinition,

--- a/src/richie/apps/search/filter_definitions/base.py
+++ b/src/richie/apps/search/filter_definitions/base.py
@@ -288,18 +288,19 @@ class BaseChoicesFilterDefinition(BaseFilterDefinition):
         ]
 
         # Sort facets as requested
-        if self.sorting == self.SORTING_NAME:
+        sorting = data["facet_sorting"] or self.sorting
+        if sorting == self.SORTING_NAME:
             # Alphabetical ascending sorting
             values = sorted(
                 values,
                 key=lambda value: (value["human_name"], value["count"] * -1),
             )
-        elif self.sorting == self.SORTING_CONF:
+        elif sorting == self.SORTING_CONF:
             # Respect the order set in filter definitions
             values = sorted(
                 values, key=lambda value: [*human_names].index(value["key"])
             )
-        elif self.sorting == self.SORTING_COUNT:
+        elif sorting == self.SORTING_COUNT:
             # Sorting by descending facet count
             values = sorted(
                 values,
@@ -307,7 +308,7 @@ class BaseChoicesFilterDefinition(BaseFilterDefinition):
             )
         else:
             raise ImproperlyConfigured(
-                f'Facet sorting "{self.sorting}" is invalid for filter {self.name}.'
+                f'Facet sorting "{sorting}" is invalid for filter {self.name}.'
             )
 
         return {

--- a/src/richie/apps/search/filter_definitions/courses.py
+++ b/src/richie/apps/search/filter_definitions/courses.py
@@ -345,14 +345,15 @@ class IndexableFilterDefinition(TermsQueryMixin, BaseFilterDefinition):
             for key, count in key_count_map.items()
         ]
 
+        sorting = data["facet_sorting"] or self.sorting
         # Sort facets as requested
-        if self.sorting == self.SORTING_NAME:
+        if sorting == self.SORTING_NAME:
             # Alphabetical ascending sorting
             values = sorted(
                 values,
                 key=lambda value: (value["human_name"], value["count"] * -1),
             )
-        elif self.sorting == self.SORTING_COUNT:
+        elif sorting == self.SORTING_COUNT:
             # Sorting by descending facet count
             values = sorted(
                 values,
@@ -362,7 +363,7 @@ class IndexableFilterDefinition(TermsQueryMixin, BaseFilterDefinition):
             # NB: self.SORTING_CONF is not appropriate for Indexables as they are not defined
             # in the static filter definition but generated from indices.
             raise ImproperlyConfigured(
-                f'Facet sorting "{self.sorting}" is invalid for filter {self.name}.'
+                f'Facet sorting "{sorting}" is invalid for filter {self.name}.'
             )
 
         return {

--- a/src/richie/apps/search/forms.py
+++ b/src/richie/apps/search/forms.py
@@ -6,13 +6,18 @@ from functools import reduce
 from django import forms
 from django.conf import settings
 from django.utils.translation import get_language
+from django.utils.translation import gettext_lazy as _
 
 import arrow
 
 from richie.apps.courses.models import CourseState
 
 from .defaults import QUERY_ANALYZERS, RELATED_CONTENT_BOOST
-from .filter_definitions import FILTERS, AvailabilityFilterDefinition
+from .filter_definitions import (
+    FILTERS,
+    AvailabilityFilterDefinition,
+    BaseFilterDefinition,
+)
 
 # Instantiate filter fields for each filter defined in settings
 # It is of the form:
@@ -61,6 +66,15 @@ class CourseSearchForm(SearchForm):
     Validate the query string params in the course search request, connect them to filter
     definitions and generate Elasticsearch queries.
     """
+
+    facet_sorting = forms.ChoiceField(
+        required=False,
+        choices=[
+            (BaseFilterDefinition.SORTING_CONF, _("Sort by configuration")),
+            (BaseFilterDefinition.SORTING_COUNT, _("Sort by facet count")),
+            (BaseFilterDefinition.SORTING_NAME, _("Sort alphabetically")),
+        ],
+    )
 
     def __init__(self, *args, data=None, **kwargs):
         """

--- a/tests/apps/search/test_forms_search_courses.py
+++ b/tests/apps/search/test_forms_search_courses.py
@@ -30,6 +30,7 @@ class CourseSearchFormTestCase(TestCase):
             form.cleaned_data,
             {
                 "availability": [],
+                "facet_sorting": "",
                 "languages": [],
                 "levels": [],
                 "levels_aggs": [],
@@ -48,6 +49,19 @@ class CourseSearchFormTestCase(TestCase):
                 "subjects": [],
                 "subjects_aggs": [],
                 "subjects_children_aggs": "",
+            },
+        )
+
+    def test_forms_courses_facet_sorting_among_choices(self, *_):
+        """The `facet_sorting` param should be one of the available choices."""
+        form = CourseSearchForm(data=QueryDict(query_string="facet_sorting=none"))
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors,
+            {
+                "facet_sorting": [
+                    "Select a valid choice. none is not one of the available choices."
+                ]
             },
         )
 
@@ -117,6 +131,7 @@ class CourseSearchFormTestCase(TestCase):
             data=QueryDict(
                 query_string=(
                     "availability=coming_soon"
+                    "&facet_sorting=count"
                     "&languages=fr"
                     "&levels=1"
                     "&limit=9"
@@ -134,6 +149,7 @@ class CourseSearchFormTestCase(TestCase):
             form.cleaned_data,
             {
                 "availability": ["coming_soon"],
+                "facet_sorting": "count",
                 "languages": ["fr"],
                 "levels": ["1"],
                 "levels_aggs": [],
@@ -165,6 +181,7 @@ class CourseSearchFormTestCase(TestCase):
                 query_string=(
                     "availability=coming_soon"
                     "&availability=ongoing"
+                    "&facet_sorting=name"
                     "&languages=fr"
                     "&languages=en"
                     "&levels=1"
@@ -196,6 +213,7 @@ class CourseSearchFormTestCase(TestCase):
             form.cleaned_data,
             {
                 "availability": ["coming_soon", "ongoing"],
+                "facet_sorting": "name",
                 "languages": ["fr", "en"],
                 "levels": ["1", "2"],
                 "levels_aggs": ["33", "34"],

--- a/tests/apps/search/test_query_courses_facets.py
+++ b/tests/apps/search/test_query_courses_facets.py
@@ -248,6 +248,231 @@ class FacetsCoursesQueryTestCase(TestCase):
 
         return {"courses": courses, "subjects": subjects}
 
+    def test_query_courses_facets_sorting_alphabetical(self, *_):
+        """
+        The "facet_sorting" parameter is respected for alphabetical sorting, and is
+        prioritized over the default sorting as defined by the filter configutation.
+        """
+        data = self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?scope=filters&facet_sorting=name"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["filters"]["subjects"],
+            {
+                "base_path": "0001",
+                "has_more_values": True,
+                "human_name": "Subjects",
+                "is_autocompletable": True,
+                "is_drilldown": False,
+                "is_searchable": True,
+                "name": "subjects",
+                "position": 2,
+                "values": [
+                    {
+                        "count": 1,
+                        "human_name": "Computer science",
+                        "key": data["subjects"][7].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Economy and Finance",
+                        "key": data["subjects"][3].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Education and Training",
+                        "key": data["subjects"][4].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Education and career guidance",
+                        "key": data["subjects"][9].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Entrepreneurship",
+                        "key": data["subjects"][6].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Human and social sciences",
+                        "key": data["subjects"][1].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Languages",
+                        "key": data["subjects"][8].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Law",
+                        "key": data["subjects"][2].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Management",
+                        "key": data["subjects"][5].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Science",
+                        "key": data["subjects"][0].get_es_id(),
+                    },
+                ],
+            },
+        )
+
+    def test_query_courses_facets_sorting_by_count(self, *_):
+        """
+        The "facet_sorting" parameter is respected for facet count sorting, and is
+        prioritized over the default sorting as defined by the filter configutation.
+        """
+        data = self.prepare_indices()
+        response = self.client.get(
+            "/api/v1.0/courses/?scope=filters&facet_sorting=count"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["filters"]["subjects"],
+            {
+                "base_path": "0001",
+                "has_more_values": True,
+                "human_name": "Subjects",
+                "is_autocompletable": True,
+                "is_drilldown": False,
+                "is_searchable": True,
+                "name": "subjects",
+                "position": 2,
+                "values": [
+                    {
+                        "count": 2,
+                        "human_name": "Economy and Finance",
+                        "key": data["subjects"][3].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Education and Training",
+                        "key": data["subjects"][4].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Human and social sciences",
+                        "key": data["subjects"][1].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Law",
+                        "key": data["subjects"][2].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Science",
+                        "key": data["subjects"][0].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Computer science",
+                        "key": data["subjects"][7].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Education and career guidance",
+                        "key": data["subjects"][9].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Entrepreneurship",
+                        "key": data["subjects"][6].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Languages",
+                        "key": data["subjects"][8].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Management",
+                        "key": data["subjects"][5].get_es_id(),
+                    },
+                ],
+            },
+        )
+
+    def test_query_courses_facets_sorting_default(self, *_):
+        """
+        When there is no "facet_sorting" param, the default sorting is used.
+        """
+        data = self.prepare_indices()
+        response = self.client.get("/api/v1.0/courses/?scope=filters")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["filters"]["subjects"],
+            {
+                "base_path": "0001",
+                "has_more_values": True,
+                "human_name": "Subjects",
+                "is_autocompletable": True,
+                "is_drilldown": False,
+                "is_searchable": True,
+                "name": "subjects",
+                "position": 2,
+                "values": [
+                    {
+                        "count": 2,
+                        "human_name": "Economy and Finance",
+                        "key": data["subjects"][3].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Education and Training",
+                        "key": data["subjects"][4].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Human and social sciences",
+                        "key": data["subjects"][1].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Law",
+                        "key": data["subjects"][2].get_es_id(),
+                    },
+                    {
+                        "count": 2,
+                        "human_name": "Science",
+                        "key": data["subjects"][0].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Computer science",
+                        "key": data["subjects"][7].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Education and career guidance",
+                        "key": data["subjects"][9].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Entrepreneurship",
+                        "key": data["subjects"][6].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Languages",
+                        "key": data["subjects"][8].get_es_id(),
+                    },
+                    {
+                        "count": 1,
+                        "human_name": "Management",
+                        "key": data["subjects"][5].get_es_id(),
+                    },
+                ],
+            },
+        )
+
     @mock.patch(
         "richie.apps.search.filter_definitions.helpers.FACET_COUNTS_DEFAULT_LIMIT",
         new=5,


### PR DESCRIPTION
## Purpose

It is often the case that facet categories in course search have a lot of possible filter values.

We initially built the `<SearchFilterGroupModal />` to enable users to search through those values. However, we did not set up pagination.

As it turns out, users want to be able to move down the list to get to the value they want.

## Proposal

Implement infinite scrolling in the modal using react-query and IntersectionObserver to make it as effortless as possible for users.
