### PR TITLE
💄(frontend) add theme modifier to spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add theme property to `Spinner` component
 - Add setting to limit the number of archived course runs displayed by
   default on a course detail page.
 - Add timing function variables

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,8 @@ $ make migrate
 
 ## Unreleased
 
+- Add to `spinner` scheme property `base-color-light`
+
 ## 2.8.x to 2.9.x
 
 - Add `django.contrib.humanize` to your installed apps.

--- a/src/frontend/js/components/Spinner/_styles.scss
+++ b/src/frontend/js/components/Spinner/_styles.scss
@@ -1,28 +1,34 @@
 .spinner-container {
-  flex-grow: 1;
-  display: flex;
   align-items: center;
+  cursor: wait;
+  display: flex;
+  flex-grow: 1;
   justify-content: center;
 }
 
 .spinner {
+  animation: spin 0.8s linear infinite;
   border: 0.125rem solid transparent;
   border-left-color: r-theme-val(spinner, base-color);
-  border-top-color: r-theme-val(spinner, base-color);
   border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+  border-top-color: r-theme-val(spinner, base-color);
   display: inline-block;
   margin-left: 0.5rem;
   vertical-align: baseline;
 
   &--small {
-    width: 1rem;
     height: 1rem;
+    width: 1rem;
   }
 
   &--large {
-    width: 3rem;
     height: 3rem;
+    width: 3rem;
+  }
+
+  &--light {
+    border-left-color: r-theme-val(spinner, base-color-light);
+    border-top-color: r-theme-val(spinner, base-color-light);
   }
 
   @keyframes spin {

--- a/src/frontend/js/components/Spinner/index.tsx
+++ b/src/frontend/js/components/Spinner/index.tsx
@@ -1,20 +1,30 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 
 interface SpinnerProps {
   'aria-labelledby'?: string;
   size?: 'small' | 'large';
+  theme?: 'light';
 }
 
 /** Component. Displays a rotating CSS loader. */
 export const Spinner: FC<SpinnerProps> = (props) => {
-  const { children, size } = props;
+  const { children, size = 'small', theme } = props;
   const spinnerProps = props['aria-labelledby']
     ? { 'aria-labelledby': props['aria-labelledby'] }
     : {};
 
+  const spinnerClassList = useMemo(() => {
+    const classList = ['spinner', `spinner--${size}`];
+    if (theme) {
+      classList.push(`spinner--${theme}`);
+    }
+
+    return classList.join(' ');
+  }, [size, theme]);
+
   return (
     <div className="spinner-container" role="status" {...spinnerProps}>
-      <div className={`spinner spinner--${size || 'small'}`} />
+      <div className={spinnerClassList} />
       <div className="offscreen">{children}</div>
     </div>
   );

--- a/src/frontend/scss/settings/_colors.scss
+++ b/src/frontend/scss/settings/_colors.scss
@@ -596,5 +596,6 @@ $r-theme: (
   ),
   spinner: (
     base-color: r-color('denim'),
+    base-color-light: r-color('white'),
   )
 );


### PR DESCRIPTION
## Purpose

Spinner component now accepts a theme property.
Right now, this property can set to `light` otherwise it should be undefined.

## Proposal

- [x] Add a `theme` property to Spinner component
