### PR TITLE
➖(backend) remove redis-python from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ install_requires =
     django-redis>=4.11.0
     django-treebeard
     exrex==0.10.5
-    redis>=3,<5
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
## Purpose

We added redis-python to our dependencies to be able to control the version we run: it's a transitive dependency of django-redis, and versions >=4 <4.0.2 broke Richie. Now that the latest version 4.0.2 is not broken anymore, we can remove it from our dependencies and leave it to django-redis.
