### PR TITLE
⚡️(templates) remove image transparency when not necessary so that thumbnails are converted to jpeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- remove transparency when not necessary so that images are converted to jpg
 - Prevent logout action to be called twice
 - Fix og:image when using S3Boto3Storage
 - Remove error message related with cache when any test fails

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -8,7 +8,7 @@
 
     {% get_placeholder_plugins "cover" as plugins %}
     {% blockplugin plugins.0 %}
-        {% thumbnail instance.picture 845x500 crop upscale subject_location=instance.picture.subject_location as thumb %}
+        {% thumbnail instance.picture 845x500 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
@@ -100,20 +100,20 @@
                                 {% endget_placeholder_plugins %}
                                 {% blockplugin plugins.0 %}
                                     <img
-                                        src="{% thumbnail instance.picture 776x3104 subject_location=instance.picture.subject_location %}"
+                                        src="{% thumbnail instance.picture 776x3104 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %}"
                                         srcset="
-                                            {% thumbnail instance.picture 540x2160 subject_location=instance.picture.subject_location %} 540w
-                                            ,{% thumbnail instance.picture 653x2612 subject_location=instance.picture.subject_location %} 652w
-                                            ,{% thumbnail instance.picture 720x2880 subject_location=instance.picture.subject_location %} 720w
-                                            ,{% thumbnail instance.picture 776x3104 subject_location=instance.picture.subject_location %} 775w
-                                            {% if instance.picture.width >= 1080 %},{% thumbnail instance.picture 1080x4320 subject_location=instance.picture.subject_location %} 1080w{% endif %} {% comment %} 2x540 {% endcomment %}
-                                            {% if instance.picture.width >= 1306 %},{% thumbnail instance.picture 1306x5224 subject_location=instance.picture.subject_location %} 1305w{% endif %} {% comment %} 2x653 {% endcomment %}
-                                            {% if instance.picture.width >= 1440 %},{% thumbnail instance.picture 1440x5760 subject_location=instance.picture.subject_location %} 1440w{% endif %} {% comment %} 2x720 {% endcomment %}
-                                            {% if instance.picture.width >= 1552 %},{% thumbnail instance.picture 1552x6208 subject_location=instance.picture.subject_location %} 1550w{% endif %} {% comment %} 2x776 {% endcomment %}
-                                            {% if instance.picture.width >= 1620 %},{% thumbnail instance.picture 1620x6480 subject_location=instance.picture.subject_location %} 1620w{% endif %} {% comment %} 3x540 {% endcomment %}
-                                            {% if instance.picture.width >= 1959 %},{% thumbnail instance.picture 1959x7836 subject_location=instance.picture.subject_location %} 1958w{% endif %} {% comment %} 3x653 {% endcomment %}
-                                            {% if instance.picture.width >= 2160 %},{% thumbnail instance.picture 2160x8640 subject_location=instance.picture.subject_location %} 2160w{% endif %} {% comment %} 3x720 {% endcomment %}
-                                            {% if instance.picture.width >= 2328 %},{% thumbnail instance.picture 2328x9312 subject_location=instance.picture.subject_location %} 2325w{% endif %} {% comment %} 3x776 {% endcomment %}
+                                            {% thumbnail instance.picture 540x2160 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 540w
+                                            ,{% thumbnail instance.picture 653x2612 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 652w
+                                            ,{% thumbnail instance.picture 720x2880 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 720w
+                                            ,{% thumbnail instance.picture 776x3104 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 775w
+                                            {% if instance.picture.width >= 1080 %},{% thumbnail instance.picture 1080x4320 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 1080w{% endif %} {# 2x540 #}
+                                            {% if instance.picture.width >= 1306 %},{% thumbnail instance.picture 1306x5224 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 1305w{% endif %} {# 2x653 #}
+                                            {% if instance.picture.width >= 1440 %},{% thumbnail instance.picture 1440x5760 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 1440w{% endif %} {# 2x720 #}
+                                            {% if instance.picture.width >= 1552 %},{% thumbnail instance.picture 1552x6208 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 1550w{% endif %} {# 2x776 #}
+                                            {% if instance.picture.width >= 1620 %},{% thumbnail instance.picture 1620x6480 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 1620w{% endif %} {# 3x540 #}
+                                            {% if instance.picture.width >= 1959 %},{% thumbnail instance.picture 1959x7836 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 1958w{% endif %} {# 3x653 #}
+                                            {% if instance.picture.width >= 2160 %},{% thumbnail instance.picture 2160x8640 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 2160w{% endif %} {# 3x720 #}
+                                            {% if instance.picture.width >= 2328 %},{% thumbnail instance.picture 2328x9312 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 2325w{% endif %} {# 3x776 #}
                                         "
                                         sizes="(min-width: 1200px) 775px, (min-width: 992px) 652px, (min-width: 768px) 720px, (min-width: 576px) 540px, 100vw"
                                         alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'blog post cover image' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -6,7 +6,7 @@
 
     {% get_placeholder_plugins "logo" as og_image_plugins %}
     {% blockplugin og_image_plugins.0 %}
-        {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location as thumb %}
+        {% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
@@ -27,11 +27,11 @@
                     {% endget_placeholder_plugins %}
                     {% blockplugin banner_plugins.0 %}
                         <img
-                            src="{% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %}"
+                            src="{% thumbnail instance.picture 1140x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                             srcset="
-                                {% thumbnail instance.picture 1140x400 crop upscale subject_location=instance.picture.subject_location %} 1140w
-                                {% if instance.picture.width >= 2280 %},{% thumbnail instance.picture 2280x800 crop upscale subject_location=instance.picture.subject_location %} 2280w{% endif %}
-                                {% if instance.picture.width >= 3420 %},{% thumbnail instance.picture 3420x600 crop upscale subject_location=instance.picture.subject_location %} 3420w{% endif %}
+                                {% thumbnail instance.picture 1140x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 1140w
+                                {% if instance.picture.width >= 2280 %},{% thumbnail instance.picture 2280x800 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 2280w{% endif %}
+                                {% if instance.picture.width >= 3420 %},{% thumbnail instance.picture 3420x600 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 3420w{% endif %}
                             "
                             sizes="1140px"
                             alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'category banner' %}{% endif %}"
@@ -45,11 +45,11 @@
                     {% endget_placeholder_plugins %}
                     {% blockplugin logo_plugins.0 %}
                         <img
-                            src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
+                            src="{% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                             srcset="
-                                {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
-                                {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                                {% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 200w
+                                {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
                             "
                             sizes="200px"
                             alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'category logo' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -16,7 +16,7 @@
     {% endget_placeholder_plugins %}
     {% blockplugin plugins.0 %}
         <meta property="og:type" content="website" />
-        {% thumbnail instance.picture 1200x630 crop upscale subject_location=instance.picture.subject_location as thumb %}
+        {% thumbnail instance.picture 1200x630 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
@@ -132,11 +132,11 @@
                             {% endget_placeholder_plugins %}
                             {% blockplugin plugins.0 %}
                                 <img
-                                    src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
+                                    src="{% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                                     srcset="
-                                    {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w
-                                    {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                                    {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+                                    {% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 300w
+                                    {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                                    {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
                                     "
                                     sizes="300px"
                                     alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"
@@ -200,7 +200,7 @@
 
                 {% block cover %}
                     {% get_placeholder_plugins "course_cover" as cover_plugins %}
-                    <meta property="image" content="{% thumbnail cover_plugins.0.picture 300x170 crop upscale subject_location=cover_plugins.0.picture.subject_location %}" />
+                    <meta property="image" content="{% thumbnail cover_plugins.0.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=cover_plugins.0.picture.subject_location %}" />
                     {% if current_page.publisher_is_draft %}
                     <div class="course-detail__block course-detail__cover">
                         <div class="course-detail__row">
@@ -210,11 +210,11 @@
                             {% endif %}
                             {% blockplugin cover_plugins.0 %}
                             <img
-                                src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
+                                src="{% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                                 srcset="
-                                {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w
-                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                                {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+                                {% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 300w
+                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                                {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
                                 "
                                 sizes="300px"
                                 alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'course cover image' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
@@ -11,10 +11,10 @@
 
             {% blockplugin plugins.0 %}
             <img
-                src="{% thumbnail instance.picture 845x500 subject_location=instance.picture.subject_location %}"
-                srcset="{% thumbnail instance.picture 845x500 subject_location=instance.picture.subject_location %} 500w
-                    {% if instance.picture.width >= 1000 %},{% thumbnail instance.picture 1000x1000 subject_location=instance.picture.subject_location %} 1000w{% endif %}
-                    {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x2000 subject_location=instance.picture.subject_location %} 2000w{% endif %}"
+                src="{% thumbnail instance.picture 845x500 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %}"
+                srcset="{% thumbnail instance.picture 845x500 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 500w
+                    {% if instance.picture.width >= 1000 %},{% thumbnail instance.picture 1000x1000 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 1000w{% endif %}
+                    {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x2000 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 2000w{% endif %}"
                 sizes="500px"
                 alt="">
             {% endblockplugin %}
@@ -40,11 +40,11 @@
                 <div class="blogpost-{{ blogpost_variant }}__empty">{% trans 'Cover' %}</div>
             {% endget_page_plugins %}
             {% blockplugin plugins.0 %}
-                <img src="{% thumbnail instance.picture 150x85 crop upscale subject_location=instance.picture.subject_location %}"
+                <img src="{% thumbnail instance.picture 150x85 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                     srcset="
-                    {% thumbnail instance.picture 150x85 crop upscale subject_location=instance.picture.subject_location %} 150w
-                    {% if instance.picture.width >= 300 %},{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w{% endif %}
-                    {% if instance.picture.width >= 450 %},{% thumbnail instance.picture 450x255 crop upscale subject_location=instance.picture.subject_location %} 450w{% endif %}
+                    {% thumbnail instance.picture 150x85 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 150w
+                    {% if instance.picture.width >= 300 %},{% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 300w{% endif %}
+                    {% if instance.picture.width >= 450 %},{% thumbnail instance.picture 450x255 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 450w{% endif %}
                     "
                     sizes="150px"
                     alt=""
@@ -76,10 +76,10 @@
             {% endget_page_plugins %}
 
             {% blockplugin plugins.0 %}
-            <img src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
-                srcset="{% thumbnail instance.picture 800x480 crop upscale subject_location=instance.picture.subject_location %} 300w
-                {% if instance.picture.width >= 1600 %},{% thumbnail instance.picture 1600x960 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                {% if instance.picture.width >= 2400 %},{% thumbnail instance.picture 2400x1440 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}"
+            <img src="{% thumbnail instance.picture 300x170 crop replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
+                srcset="{% thumbnail instance.picture 800x480 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 300w
+                {% if instance.picture.width >= 1600 %},{% thumbnail instance.picture 1600x960 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                {% if instance.picture.width >= 2400 %},{% thumbnail instance.picture 2400x1440 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}"
                 sizes="300px"
                 alt="">
             {% endblockplugin %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_category_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_category_glimpse.html
@@ -36,11 +36,11 @@
                         <div class="category-glimpse__logo__empty">{% trans "Logo" %}</div>
                     {% endget_page_plugins %}
                     {% blockplugin plugins.0 %}
-                        <img src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
+                        <img src="{% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                             srcset="
-                                {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
-                                {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                                {% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 200w
+                                {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
                             "
                             sizes="200px"
                             alt="{{ category_page.get_title }}">

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -8,11 +8,11 @@
             <p class="course-{{ course_variant }}--empty">{% trans "Cover" %}</p>
         {% endget_page_plugins %}
         {% blockplugin cover_plugins.0 %}
-            <img src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
+            <img src="{% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                 srcset="
-                    {% thumbnail instance.picture 800x457 crop upscale subject_location=instance.picture.subject_location %} 300w
-                    {% if instance.picture.width >= 1600 %},{% thumbnail instance.picture 1600x914 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                    {% if instance.picture.width >= 2400 %},{% thumbnail instance.picture 2400x1371 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+                    {% thumbnail instance.picture 800x457 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 300w
+                    {% if instance.picture.width >= 1600 %},{% thumbnail instance.picture 1600x914 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                    {% if instance.picture.width >= 2400 %},{% thumbnail instance.picture 2400x1371 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
                 "
                 sizes="300px"
                 {# alt forced to empty string for a11y because the image does not carry more information than the course title #}
@@ -37,12 +37,12 @@
                     {% endget_page_plugins %}
                     {% blockplugin plugins.0 %}
                         <div class="course-glimpse__organization-logo">
-                            <img src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
+                            <img src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
                                 srcset="
-                                    {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w
-                                    {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                                    {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                                    {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+                                    {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 200w
+                                    {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                                    {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                                    {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
                                 "
                                 {# alt forced to empty string for a11y because the image does not carry more information than the course title #}
                                 alt=""

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
@@ -16,12 +16,12 @@
                      alt="">
             {% endget_page_plugins %}
             {% blockplugin plugins.0 %}
-                <img src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
+                <img src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
                     srcset="
-                        {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w
-                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                        {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+                        {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 200w
+                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                        {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
                     "
                     sizes="(min-width: 576px) 50vw, (min-width: 1200px) 25vw, 100vw"
                     alt=""
@@ -44,12 +44,12 @@
                      alt="">
             {% endget_page_plugins %}
             {% blockplugin plugins.0 %}
-                <img src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
+                <img src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
                     srcset="
-                        {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w
-                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                        {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+                        {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 200w
+                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                        {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
                     "
                     sizes="(min-width: 576px) 50vw, (min-width: 1200px) 25vw, 100vw"
                     alt=""

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_main_logo.html
@@ -18,12 +18,12 @@
             {% blockplugin plugins.0 %}
                 <div class="subheader__media">
                     <img
-                      src="{% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %}"
+                      src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
                       srcset="
-                        {% thumbnail instance.picture 200x113 upscale subject_location=instance.picture.subject_location %} 200w
-                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                        {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+                        {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 200w
+                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                        {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
                       "
                       sizes="30vw"
                       alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'main organization logo' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
@@ -18,11 +18,11 @@
                  alt="">
         {% endget_page_plugins %}
         {% blockplugin plugins.0 %}
-            <img src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
+            <img src="{% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                 srcset="
-                    {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
-                    {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                    {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                    {% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 200w
+                    {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                    {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
                 "
                 sizes="200px"
                 alt=""

--- a/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
@@ -7,11 +7,11 @@
         <div class="program-glimpse__empty">{% trans 'Cover' %}</div>
     {% endget_page_plugins %}
     {% blockplugin plugins.0 %}
-    <img src="{% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %}"
+    <img src="{% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
         srcset="
-        {% thumbnail instance.picture 300x170 crop upscale subject_location=instance.picture.subject_location %} 300w
-        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-        {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+        {% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 300w
+        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x340 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+        {% if instance.picture.width >= 900 %},{% thumbnail instance.picture 900x510 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
         "
         sizes="300px"
         alt=""

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -6,7 +6,7 @@
 
     {% get_placeholder_plugins "logo" as og_image_plugins %}
     {% blockplugin og_image_plugins.0 %}
-        {% thumbnail instance.picture 200x113 upscale as thumb %}
+        {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
@@ -29,13 +29,13 @@
                     {% endget_placeholder_plugins %}
                     {% blockplugin plugins.0 %}
                         <img
-                            src="{% thumbnail instance.picture 320x100 upscale %}"
+                            src="{% thumbnail instance.picture 320x100 replace_alpha='#FFFFFF' upscale %}"
                             srcset="
-                                {% thumbnail instance.picture 640x200 upscale %} 640w,
-                                {% thumbnail instance.picture 1280x300 upscale %} 1280w,
-                                {% if instance.picture.width >= 1500 %},{% thumbnail instance.picture 1500x351 upscale %} 1500w,{% endif %}
-                                {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x468 upscale %} 2000w,{% endif %}
-                                {% if instance.picture.width >= 2500 %},{% thumbnail instance.picture 2500x585 upscale %} 2500w,{% endif %}
+                                {% thumbnail instance.picture 640x200 replace_alpha='#FFFFFF' upscale %} 640w,
+                                {% thumbnail instance.picture 1280x300 replace_alpha='#FFFFFF' upscale %} 1280w,
+                                {% if instance.picture.width >= 1500 %},{% thumbnail instance.picture 1500x351 replace_alpha='#FFFFFF' upscale %} 1500w,{% endif %}
+                                {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x468 replace_alpha='#FFFFFF' upscale %} 2000w,{% endif %}
+                                {% if instance.picture.width >= 2500 %},{% thumbnail instance.picture 2500x585 replace_alpha='#FFFFFF' upscale %} 2500w,{% endif %}
                             "
                             sizes="(min-width: 576px) 80vw, (min-width: 1200px) 1140px, 100vw"
                             alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization banner' %}{% endif %}"
@@ -51,12 +51,12 @@
                     {% endget_placeholder_plugins %}
                     {% blockplugin plugins.0 %}
                         <img
-                            src="{% thumbnail instance.picture 200x113 upscale %}"
+                            src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale %}"
                             srcset="
-                                {% thumbnail instance.picture 200x113 upscale %} 200w,
-                                {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 upscale %} 400w,{% endif %}
-                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 upscale %} 600w,{% endif %}
-                                {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 upscale %} 800w{% endif %}
+                                {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale %} 200w,
+                                {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale %} 400w,{% endif %}
+                                {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale %} 600w,{% endif %}
+                                {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale %} 800w{% endif %}
                             "
                             sizes="(min-width: 768px) 16rem, (min-width: 1200px) 20rem, 12rem"
                             alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% trans 'organization logo' %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -6,7 +6,7 @@
 
     {% get_placeholder_plugins "portrait" as og_image_plugins %}
     {% blockplugin og_image_plugins.0 %}
-        {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location as thumb %}
+        {% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
@@ -62,11 +62,11 @@
                             {% blockplugin plugins.0 %}
                             <div class="subheader__media subheader__media--locket">
                                 <img
-                                    src="{% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %}"
+                                    src="{% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
                                     srcset="
-                                        {% thumbnail instance.picture 200x200 crop upscale subject_location=instance.picture.subject_location %} 200w
-                                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                                        {% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 200w
+                                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x600 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
                                     "
                                     sizes="200px"
                                     alt="{% if instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% else %}{% blocktrans with title=current_page.get_title %}{{ title }} avatar{% endblocktrans %}{% endif %}"

--- a/src/richie/apps/courses/templates/courses/cms/program_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_detail.html
@@ -6,7 +6,7 @@
 
     {% get_placeholder_plugins "program_cover" as og_image_plugins %}
     {% blockplugin og_image_plugins.0 %}
-        {% thumbnail instance.picture 1200x630 crop upscale subject_location=instance.picture.subject_location as thumb %}
+        {% thumbnail instance.picture 1200x630 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />  
@@ -32,11 +32,11 @@
             {% endget_placeholder_plugins %}
             {% blockplugin plugins.0 %}
                 <img
-                    src="{% thumbnail instance.picture 500x500 subject_location=instance.picture.subject_location %}"
+                    src="{% thumbnail instance.picture 500x500 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %}"
                     srcset="
-                        {% thumbnail instance.picture 500x500 subject_location=instance.picture.subject_location %} 500w
-                        {% if instance.picture.width >= 1000 %},{% thumbnail instance.picture 1000x1000 subject_location=instance.picture.subject_location %} 1000w{% endif %}
-                        {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x2000 subject_location=instance.picture.subject_location %} 2000w{% endif %}
+                        {% thumbnail instance.picture 500x500 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 500w
+                        {% if instance.picture.width >= 1000 %},{% thumbnail instance.picture 1000x1000 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 1000w{% endif %}
+                        {% if instance.picture.width >= 2000 %},{% thumbnail instance.picture 2000x2000 replace_alpha='#FFFFFF' subject_location=instance.picture.subject_location %} 2000w{% endif %}
                     "
                     sizes="500px"
                     alt="{% trans 'program cover image' %}"

--- a/src/richie/apps/courses/templates/courses/plugins/licence_plugin.html
+++ b/src/richie/apps/courses/templates/courses/plugins/licence_plugin.html
@@ -3,7 +3,7 @@
 {% spaceless %}
 <div class="licence-plugin">
     <p class="licence-plugin__logo">
-        <img src="{% thumbnail instance.licence.logo 100x50 crop='smart' %}" alt="">
+        <img src="{% thumbnail instance.licence.logo 100x50 replace_alpha='#FFFFFF' crop='smart' %}" alt="">
     </p>
     <div class="licence-plugin__wrapper">
         <h{{ header_level|default:2 }} class="licence-plugin__title">

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse.html
@@ -14,17 +14,17 @@
     {% if instance.image %}
     <div class="glimpse-{{ glimpse_variant }}__media">
         {% if glimpse_variant == "card_square" %}
-        <img src="{% thumbnail instance.image 300x170 crop upscale subject_location=instance.image.subject_location %}"
-            srcset="{% thumbnail instance.image 300x170 crop upscale subject_location=instance.image.subject_location %} 300w
-                {% if instance.image.width >= 600 %},{% thumbnail instance.image 600x340 crop upscale subject_location=instance.image.subject_location %} 600w{% endif %}
-                {% if instance.image.width >= 900 %},{% thumbnail instance.image 900x510 crop upscale subject_location=instance.image.subject_location %} 900w{% endif %}"
+        <img src="{% thumbnail instance.image 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %}"
+            srcset="{% thumbnail instance.image 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 300w
+                {% if instance.image.width >= 600 %},{% thumbnail instance.image 600x340 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 600w{% endif %}
+                {% if instance.image.width >= 900 %},{% thumbnail instance.image 900x510 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 900w{% endif %}"
             sizes="300px"
             alt="">
         {% else %}
-        <img src="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %}"
-            srcset="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %} 200w
-                {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
-                {% if instance.image.width >= 800 %},{% thumbnail instance.image 800x800 crop upscale subject_location=instance.image.subject_location %} 800w{% endif %}"
+        <img src="{% thumbnail instance.image 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %}"
+            srcset="{% thumbnail instance.image 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 200w
+                {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
+                {% if instance.image.width >= 800 %},{% thumbnail instance.image 800x800 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 800w{% endif %}"
             sizes="200px"
             alt="">
         {% endif %}

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_person.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_person.html
@@ -6,10 +6,10 @@
     {% else %}
         <div class="person-glimpse__media">
     {% endif %}
-    <img src="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %}"
-    srcset="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %} 200w
-        {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
-        {% if instance.image.width >= 600 %},{% thumbnail instance.image 600x600 crop upscale subject_location=instance.image.subject_location %} 600w{% endif %}"
+    <img src="{% thumbnail instance.image 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %}"
+    srcset="{% thumbnail instance.image 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 200w
+        {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
+        {% if instance.image.width >= 600 %},{% thumbnail instance.image 600x600 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 600w{% endif %}"
     sizes="200px"
     alt="">
     {% if instance.get_link %}

--- a/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_quote.html
+++ b/src/richie/plugins/glimpse/templates/richie/glimpse/glimpse_quote.html
@@ -10,10 +10,10 @@
 <div class="glimpse-{{ glimpse_variant }}__wrapper">
     {% if instance.image %}
     <div class="glimpse-{{ glimpse_variant }}__media">
-        <img src="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %}"
-            srcset="{% thumbnail instance.image 200x200 crop upscale subject_location=instance.image.subject_location %} 200w
-                {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
-                {% if instance.image.width >= 800 %},{% thumbnail instance.image 800x800 crop upscale subject_location=instance.image.subject_location %} 800w{% endif %}"
+        <img src="{% thumbnail instance.image 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %}"
+            srcset="{% thumbnail instance.image 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 200w
+                {% if instance.image.width >= 400 %},{% thumbnail instance.image 400x400 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 400w{% endif %}
+                {% if instance.image.width >= 800 %},{% thumbnail instance.image 800x800 replace_alpha='#FFFFFF' crop upscale subject_location=instance.image.subject_location %} 800w{% endif %}"
             sizes="200px"
             alt="">
     </div>

--- a/src/richie/plugins/large_banner/templates/richie/large_banner/hero-intro.html
+++ b/src/richie/plugins/large_banner/templates/richie/large_banner/hero-intro.html
@@ -1,6 +1,6 @@
 {% load static i18n cms_tags rfc_5646_locale thumbnail %}
 <div class="hero-intro{% if instance.logo %} hero-intro--with-logo{% endif %}"
-    {% if instance.background_image.url %} style="background-image: url('{% thumbnail instance.background_image 1400x800 crop=',0' %}');"{% endif %}
+    {% if instance.background_image.url %} style="background-image: url('{% thumbnail instance.background_image 1400x800 replace_alpha='#FFFFFF' crop=',0' %}');"{% endif %}
     >
     <div class="hero-intro__inner">
         <div class="hero-intro__body">
@@ -8,7 +8,7 @@
                 {{ instance.content|safe }}
 
                 {% if instance.logo %}
-                    <img src="{% thumbnail instance.logo 500x180 %}" class="hero-intro__logo" alt="{{ instance.logo_alt_text }}">
+                    <img src="{% thumbnail instance.logo 500x180 replace_alpha='#FFFFFF' %}" class="hero-intro__logo" alt="{{ instance.logo_alt_text }}">
                 {% endif %}
             </div>
 

--- a/src/richie/plugins/large_banner/templates/richie/large_banner/large_banner.html
+++ b/src/richie/plugins/large_banner/templates/richie/large_banner/large_banner.html
@@ -3,17 +3,17 @@
 <div class="large-banner">
     {% if instance.background_image.url %}
     <img class="large-banner__background"
-            src="{% thumbnail instance.background_image 1900x450 crop='smart' %}"
-            srcset="{% thumbnail instance.background_image 2495x550 crop=',0' %} 2495w,
-                    {% thumbnail instance.background_image 1900x450 crop=',0' %} 1900w,
-                    {% thumbnail instance.background_image 1280x400 crop=',0' %} 1280w,
-                    {% thumbnail instance.background_image 768x450 crop=',0' %} 768w"
+            src="{% thumbnail instance.background_image 1900x450 replace_alpha='#FFFFFF' crop='smart' %}"
+            srcset="{% thumbnail instance.background_image 2495x550 replace_alpha='#FFFFFF' crop=',0' %} 2495w,
+                    {% thumbnail instance.background_image 1900x450 replace_alpha='#FFFFFF' crop=',0' %} 1900w,
+                    {% thumbnail instance.background_image 1280x400 replace_alpha='#FFFFFF' crop=',0' %} 1280w,
+                    {% thumbnail instance.background_image 768x450 replace_alpha='#FFFFFF' crop=',0' %} 768w"
             alt="banner">
     {% endif %}
     <div class="large-banner__body">
         <h1 class="large-banner__title">{{ instance.title }}</h1>
         {% if instance.logo %}
-            <img src="{% thumbnail instance.logo 200x100 crop='smart' %}" class="large-banner__logo" alt="{{ instance.logo_alt_text }}">
+            <img src="{% thumbnail instance.logo 200x100 replace_alpha='#FFFFFF' crop='smart' %}" class="large-banner__logo" alt="{{ instance.logo_alt_text }}">
         {% endif %}
         {% if instance.content %}
             <div class="large-banner__content">{{ instance.content|safe }}</div>

--- a/tests/apps/courses/test_templates_course_detail_rdfa.py
+++ b/tests/apps/courses/test_templates_course_detail_rdfa.py
@@ -164,7 +164,7 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
         (image_value,) = graph.objects(subject, URIRef("http://ogp.me/ns#image"))
         pattern = (
             r"/media/filer_public_thumbnails/filer_public/.*cover\.jpg__"
-            r"1200x630_q85_crop_subject_location"
+            r"1200x630_q85_crop_replace_alpha-%23FFFFFF_subject_location"
         )
         self.assertIsNotNone(re.search(pattern, str(image_value)))
 
@@ -306,7 +306,7 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
         (image_value,) = graph.objects(subject, URIRef("https://schema.org/image"))
         pattern = (
             r"/media/filer_public_thumbnails/filer_public/.*cover\.jpg__"
-            r"300x170_q85_crop_subject_location"
+            r"300x170_q85_crop_replace_alpha-%23FFFFFF_subject_location"
         )
         self.assertIsNotNone(re.search(pattern, str(image_value)))
 
@@ -349,7 +349,7 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
         )
         pattern = (
             r"/media/filer_public_thumbnails/filer_public/.*logo.jpg__"
-            r"200x113_q85_subject_location"
+            r"200x113_q85_replace_alpha-%23FFFFFF_subject_location"
         )
         self.assertIsNotNone(re.search(pattern, str(logo_value)))
 
@@ -414,7 +414,7 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
 
         pattern = (
             r"/media/filer_public_thumbnails/filer_public/.*logo.jpg__"
-            r"200x113_q85_subject_location"
+            r"200x113_q85_replace_alpha-%23FFFFFF_subject_location"
         )
         (logo_value,) = graph.objects(
             URIRef("/en/main-org/"), URIRef("https://schema.org/logo")
@@ -469,7 +469,7 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
 
         pattern = (
             r"/media/filer_public_thumbnails/filer_public/.*portrait.jpg__"
-            r"200x200_q85_crop_subject_location"
+            r"200x200_q85_crop_replace_alpha-%23FFFFFF_subject_location"
         )
         for author_subject in author_subjects:
             (portrait_value,) = graph.objects(


### PR DESCRIPTION
## Purpose

Easy thumbnails converts images to jpg when there is no transparency, but keeps png otherwise. We can't prevent users from uploading images with transparency in places where it is not desired but we can remove
it when generating thumbnails so that the image can be converted to jpg and thus be much smaller.

## Proposal

Force the `replace_alpha` in all thumbnails template tags to get rid of transparency and make sure images are converted to jpg and thus compressed to a much smaller size.
