### PR TITLE
✨(seo) add default value for meta description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add timing function variables
 - Add a `outline` variant to button
 - Create a `shadowed-box` mixin
+- Add a meta description default value from course introduction,
+  blog excerpt, category description, person bio, program excerpt
+  and organization description
 
 ### Changed
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -28,7 +28,11 @@
 
             {% block meta_html %}
                 {% page_attribute "meta_description" as meta_description %}
-                {% if meta_description and meta_description != "None" %}<meta name="description" content="{% block meta-description %}{{ meta_description }}{% endblock %}">{% endif %}
+                {% if meta_description and meta_description != "None" %}
+                    <meta name="description" content="{% block meta-description %}{{ meta_description }}{% endblock %}" />
+                {% else %}
+                    {% block meta_html_default %}{% endblock meta_html_default %}
+                {% endif %}
             {% endblock meta_html %}
 
             {% block meta_rdfa %}

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -1,6 +1,12 @@
 {% extends "richie/fullwidth.html" %}
 {% load static category_tags cms_tags extra_tags i18n thumbnail %}
 
+{% block meta_html_default %}
+    {% if not current_page|is_empty_placeholder:"excerpt" %}
+        <meta name="description" content="{% filter slice:":160" %}{% show_placeholder 'excerpt' current_page %}{% endfilter %}" />
+    {% endif %}
+{% endblock meta_html_default %}
+
 {% block meta_rdfa_context %}
     <meta property="og:type" content="article" />
     <meta property="og:article:published_time" content="{{ current_page.publication_date|date:"c" }}">

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -1,6 +1,12 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n pagination_tags thumbnail %}
 
+{% block meta_html_default %}
+    {% if not current_page|is_empty_placeholder:"description" %}
+        <meta name="description" content="{% filter striptags|trim|slice:":160" %}{% show_placeholder 'description' current_page %}{% endfilter %}" />
+    {% endif %}
+{% endblock meta_html_default %}
+
 {% block meta_rdfa_context %}
     <meta property="og:type" content="website" />
 

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -10,6 +10,12 @@
     {% endif %}
 {% endblock meta_index_rules %}
 
+{% block meta_html_default %}
+    {% if not current_page|is_empty_placeholder:"course_introduction" %}
+        <meta name="description" content="{% filter slice:":160" %}{% show_placeholder 'course_introduction' current_page %}{% endfilter %}" />
+    {% endif %}
+{% endblock meta_html_default %}
+
 {% block meta_rdfa_context %}
     {% get_placeholder_plugins "course_cover" as plugins or %}
         {{ block.super }}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -1,6 +1,12 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n pagination_tags static thumbnail %}
 
+{% block meta_html_default %}
+    {% if not current_page|is_empty_placeholder:"description" %}
+        <meta name="description" content="{% filter striptags|trim|slice:":160" %}{% show_placeholder 'description' current_page %}{% endfilter %}" />
+    {% endif %}
+{% endblock meta_html_default %}
+
 {% block meta_rdfa_context %}
     <meta property="og:type" content="website" />
 

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -1,6 +1,12 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n pagination_tags static thumbnail %}
 
+{% block meta_html_default %}
+    {% if not current_page|is_empty_placeholder:"bio" %}
+        <meta name="description" content="{% filter slice:":160" %}{% show_placeholder 'bio' current_page %}{% endfilter %}" />
+    {% endif %}
+{% endblock meta_html_default %}
+
 {% block meta_rdfa_context %}
     <meta property="og:type" content="profile" />
 

--- a/src/richie/apps/courses/templates/courses/cms/program_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_detail.html
@@ -1,6 +1,12 @@
 {% extends "richie/fullwidth.html" %}
 {% load cms_tags extra_tags i18n thumbnail %}
 
+{% block meta_html_default %}
+    {% if not current_page|is_empty_placeholder:"program_excerpt" %}
+        <meta name="description" content="{% filter slice:":160" %}{% show_placeholder 'program_excerpt' current_page %}{% endfilter %}" />
+    {% endif %}
+{% endblock meta_html_default %}
+
 {% block meta_rdfa_context %}
     <meta property="og:type" content="website" />
 

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -3,6 +3,7 @@ import json
 
 from django import template
 from django.core.exceptions import ObjectDoesNotExist
+from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import get_language
@@ -273,3 +274,12 @@ def course_enrollment_widget_props(context):
             }
         }
     )
+
+
+@register.filter
+@stringfilter
+def trim(value):
+    """
+    Remove whitespaces before and after a string.
+    """
+    return value.strip()

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -1267,3 +1267,108 @@ class RunsCourseCMSTestCase(CMSTestCase):
             '<li class="is-hidden">',
         )
         self.assertNotContains(response, "course-detail__view-more-runs")
+
+    def test_templates_course_detail_meta_description(self):
+        """
+        The course meta description should show meta_description placeholder if defined
+        """
+        course = CourseFactory()
+        page = course.extended_object
+
+        title_obj = page.get_title_obj(language="en")
+        title_obj.meta_description = "A custom description of the course"
+        title_obj.save()
+
+        page.publish("en")
+
+        url = course.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response,
+            '<meta name="description" content="A custom description of the course" />',
+        )
+
+    def test_templates_course_detail_meta_description_course_introduction(self):
+        """
+        The course meta description should show the course_introduction if no meta_description is
+        specified
+        """
+        course = CourseFactory()
+        page = course.extended_object
+
+        # Add an course_introduction to the course
+        placeholder = course.extended_object.placeholders.get(
+            slot="course_introduction"
+        )
+        add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="PlainTextPlugin",
+            body="A further course introduction of the course",
+        )
+        page.publish("en")
+
+        url = course.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response,
+            '<meta name="description" content="A further course introduction of the course" />',
+        )
+
+    def test_templates_course_detail_meta_description_course_introduction_max_length(
+        self,
+    ):
+        """
+        The course meta description should be cut if it exceeds more than 160 caracters
+        """
+        course = CourseFactory()
+        page = course.extended_object
+        placeholder_value = (
+            "Long description that describes the page with a summary. "
+            "Long description that describes the page with a summary. "
+            "Long description that describes the page with a summary. "
+        )
+
+        # Add an course_introduction to the course
+        placeholder = course.extended_object.placeholders.get(
+            slot="course_introduction"
+        )
+        add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="PlainTextPlugin",
+            body=placeholder_value,
+        )
+        page.publish("en")
+
+        url = course.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        cut = placeholder_value[0:160]
+        self.assertContains(
+            response,
+            f'<meta name="description" content="{cut}" />',
+        )
+
+    def test_templates_course_detail_meta_description_empty(self):
+        """
+        The course meta description should not be present if neither the meta_description field
+        on the page, nor the `course_introduction` placeholder are filled
+        """
+        course = CourseFactory()
+        page = course.extended_object
+        page.publish("en")
+
+        url = course.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertNotContains(
+            response,
+            '<meta name="description"',
+        )

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -472,3 +472,102 @@ class PersonCMSTestCase(CMSTestCase):
         self.assertContains(
             response, '<meta property="og:image:height" content="200" />'
         )
+
+    def test_templates_person_detail_meta_description(self):
+        """
+        The person meta description should show meta_description placeholder if defined
+        """
+        person = PersonFactory()
+        page = person.extended_object
+
+        title_obj = page.get_title_obj(language="en")
+        title_obj.meta_description = "A custom description of the person"
+        title_obj.save()
+
+        page.publish("en")
+
+        url = person.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response,
+            '<meta name="description" content="A custom description of the person" />',
+        )
+
+    def test_templates_person_detail_meta_description_bio(self):
+        """
+        The person meta description should show the bio if no meta_description is
+        specified
+        """
+        person = PersonFactory()
+        page = person.extended_object
+
+        # Add a bio to a person
+        placeholder = person.extended_object.placeholders.get(slot="bio")
+        add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="PlainTextPlugin",
+            body="A biographic description of the person",
+        )
+        page.publish("en")
+
+        url = person.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response,
+            '<meta name="description" content="A biographic description of the person" />',
+        )
+
+    def test_templates_person_detail_meta_description_bio_exceeds_max_length(self):
+        """
+        The person meta description should be cut if it exceeds more than 160 caracters
+        """
+        person = PersonFactory()
+        page = person.extended_object
+        placeholder_value = (
+            "Long description that describes the page with a summary. "
+            "Long description that describes the page with a summary. "
+            "Long description that describes the page with a summary. "
+        )
+
+        # Add a bio to a person
+        placeholder = person.extended_object.placeholders.get(slot="bio")
+        add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="PlainTextPlugin",
+            body=placeholder_value,
+        )
+        page.publish("en")
+
+        url = person.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        cut = placeholder_value[0:160]
+        self.assertContains(
+            response,
+            f'<meta name="description" content="{cut}" />',
+        )
+
+    def test_templates_person_detail_meta_description_empty(self):
+        """
+        The person meta description should not be present if neither the meta_description field
+        on the page, nor the `bio` placeholder are filled
+        """
+        person = PersonFactory()
+        page = person.extended_object
+        page.publish("en")
+
+        url = person.extended_object.get_absolute_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertNotContains(
+            response,
+            '<meta name="description"',
+        )


### PR DESCRIPTION
Add a default value for the HTML header meta description. 

The default value depends on the page template:
* if course defaults to course introduction
* if blog defaults to blog excerpt
* if category defaults to description
* if person defaults to bio
* if program defaults to excerpt 

Closes #1355