### PR TITLE
✨(social) improve social sharing with og:description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a meta description default value from course introduction,
   blog excerpt, category description, person bio, program excerpt
   and organization description
+- Improve social sharing by specifying og:description meta
+  for blogpost, category, person, program and organization.
 
 ### Changed
 

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -19,6 +19,9 @@
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
     {% endblockplugin %}
+    {% if not current_page|is_empty_placeholder:"excerpt" %}
+        <meta property="og:description" content="{% filter slice:":200" %}{% show_placeholder 'excerpt' current_page %}{% endfilter %}" />
+    {% endif %}
 {% endblock meta_rdfa_context %}
 
 {% block body_rdfa %} vocab="https://schema.org/" typeof="Article"{% endblock body_rdfa %}

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -17,6 +17,9 @@
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
     {% endblockplugin %}
+    {% if not current_page|is_empty_placeholder:"description" %}
+        <meta property="og:description" content="{% filter striptags|trim|slice:":200" %}{% show_placeholder 'description' current_page %}{% endfilter %}" />
+    {% endif %}
 {% endblock meta_rdfa_context %}
 
 {% block body_rdfa %} vocab="https://schema.org/" typeof="DefinedTerm"{% endblock body_rdfa %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -28,7 +28,7 @@
         <meta property="og:image:height" content="{{ thumb.height }}" />
     {% endblockplugin %}
     {% if not current_page|is_empty_placeholder:"course_introduction" %}
-        <meta property="og:description" content="{% show_placeholder 'course_introduction' current_page %}">
+        <meta property="og:description" content="{% filter slice:":200" %}{% show_placeholder 'course_introduction' current_page %}{% endfilter %}" />
     {% endif %}
 {% endblock meta_rdfa_context %}
 

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -17,6 +17,9 @@
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
     {% endblockplugin %}
+    {% if not current_page|is_empty_placeholder:"description" %}
+        <meta property="og:description" content="{% filter striptags|trim|slice:":200" %}{% show_placeholder 'description' current_page %}{% endfilter %}" />
+    {% endif %}
 {% endblock meta_rdfa_context %}
 
 {% block body_rdfa %} vocab="https://schema.org/" typeof="Organization"{% endblock body_rdfa %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -17,6 +17,9 @@
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
     {% endblockplugin %}
+    {% if not current_page|is_empty_placeholder:"bio" %}
+        <meta property="og:description" content="{% filter slice:":200" %}{% show_placeholder 'bio' current_page %}{% endfilter %}" />
+    {% endif %}
 {% endblock meta_rdfa_context %}
 
 {% block body_rdfa %} vocab="https://schema.org/" typeof="Person"{% endblock body_rdfa %}

--- a/src/richie/apps/courses/templates/courses/cms/program_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_detail.html
@@ -17,6 +17,9 @@
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />  
     {% endblockplugin %}
+    {% if not current_page|is_empty_placeholder:"program_excerpt" %}
+        <meta property="og:description" content="{% filter slice:":200" %}{% show_placeholder 'program_excerpt' current_page %}{% endfilter %}" />
+    {% endif %}
 {% endblock meta_rdfa_context %}
 
 {% block body_rdfa %} vocab="https://schema.org/" typeof="EducationalOccupationalProgram"{% endblock body_rdfa %}


### PR DESCRIPTION
Improve social sharing by specifying og:description meta for blogpost, category, person and program.

* if blog defaults to blog excerpt placeholder
* if category defaults to description placeholder
* if person defaults to bio placeholder
* if program defaults to excerpt placeholder
* if organization defaults to organization description placeholder value
