### PR TITLE
🚸(courses) include new pages in navigation by default for breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Include new pages in navigation by default so they have a breadcrumb
 - Create a generic React Modal component
 - Create an context util
 - Add react-query to manage API requests and local data store

--- a/src/richie/apps/courses/cms_wizards.py
+++ b/src/richie/apps/courses/cms_wizards.py
@@ -163,6 +163,7 @@ class BaseWizardForm(BaseFormMixin, forms.Form):
             language=get_language(),
             parent=self.parent_page,
             template=self.model.PAGE["template"],
+            in_navigation=True,
             published=False,  # The creation wizard should not publish the page
         )
 

--- a/tests/apps/courses/test_cms_wizards_blogpost.py
+++ b/tests/apps/courses/test_cms_wizards_blogpost.py
@@ -186,6 +186,8 @@ class BlogPostCMSWizardTestCase(CMSTestCase):
         self.assertEqual(blog_page.get_title(), "My title")
         # The slug should have been automatically set
         self.assertEqual(blog_page.get_slug(), "my-title")
+        # The page should be in navigation to appear in the breadcrumb
+        self.assertTrue(blog_page.in_navigation)
 
     def test_cms_wizards_blogpost_submit_form_max_lengths(self):
         """

--- a/tests/apps/courses/test_cms_wizards_category.py
+++ b/tests/apps/courses/test_cms_wizards_category.py
@@ -181,6 +181,8 @@ class CategoryCMSWizardTestCase(CMSTestCase):
         self.assertEqual(page.get_title(), "My title")
         # The slug should have been automatically set
         self.assertEqual(page.get_slug(), "my-title")
+        # The page should be in navigation to appear in the breadcrumb
+        self.assertTrue(page.in_navigation)
 
     def test_cms_wizards_category_submit_form_from_category_page(self):
         """

--- a/tests/apps/courses/test_cms_wizards_course.py
+++ b/tests/apps/courses/test_cms_wizards_course.py
@@ -340,6 +340,8 @@ class CourseCMSWizardTestCase(CMSTestCase):
         self.assertEqual(page.get_title(), "My title")
         # The slug should have been automatically set
         self.assertEqual(page.get_slug(), "my-title")
+        # The page should be in navigation to appear in the breadcrumb
+        self.assertTrue(page.in_navigation)
 
         # The course should have a plugin with the organization
         self.assertEqual(OrganizationPluginModel.objects.count(), 1)

--- a/tests/apps/courses/test_cms_wizards_organization.py
+++ b/tests/apps/courses/test_cms_wizards_organization.py
@@ -240,6 +240,8 @@ class OrganizationCMSWizardTestCase(CMSTestCase):
         self.assertEqual(page.get_slug(), "my-title")
         # The code is left blank in this case
         self.assertIsNone(organization.code)
+        # The page should be in navigation to appear in the breadcrumb
+        self.assertTrue(page.in_navigation)
 
         # A page role should have been created
         self.assertEqual(page.roles.count(), 1)

--- a/tests/apps/courses/test_cms_wizards_person.py
+++ b/tests/apps/courses/test_cms_wizards_person.py
@@ -179,6 +179,8 @@ class PersonCMSWizardTestCase(CMSTestCase):
         self.assertEqual(page.get_title(), "A person")
         # The slug should have been automatically set
         self.assertEqual(page.get_slug(), "a-person")
+        # The page should be in navigation to appear in the breadcrumb
+        self.assertTrue(page.in_navigation)
 
     def test_cms_wizards_person_submit_form_max_lengths(self):
         """

--- a/tests/apps/courses/test_cms_wizards_program.py
+++ b/tests/apps/courses/test_cms_wizards_program.py
@@ -184,6 +184,8 @@ class ProgramCMSWizardTestCase(CMSTestCase):
         self.assertEqual(program_page.get_title(), "My title")
         # The slug should have been automatically set
         self.assertEqual(program_page.get_slug(), "my-title")
+        # The page should be in navigation to appear in the breadcrumb
+        self.assertTrue(program_page.in_navigation)
 
     def test_cms_wizards_program_submit_form_max_lengths(self):
         """


### PR DESCRIPTION
## Purpose

When creating a new page from the DjangoCMS page wizard, we did not set the `in_navigation` flag to `True` by default. This resulted in the new page not being present in the breadcrumb. Users had to systematically
tick the flag to fix that.


## Proposal

- [x] add tests to confirm the issue
- [x] set the `in_navigation` flag to `True` when creating a new page via the DjangoCMS wizard
