### PR TITLE
🐛(frontend) LMS authentication is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Refactor scss color variables to be more easily customizable.
 
+### Fixed
+
+- Make LMS authentication optional.
+
 ## [2.10.0] - 2021-12-27
 
 ### Added

--- a/src/frontend/js/data/useSession/index.tsx
+++ b/src/frontend/js/data/useSession/index.tsx
@@ -39,7 +39,26 @@ export const Session = createContext<SessionContext>({} as any);
  * @param user the current user state. Read below to see possible states
  * @param destroy set Session to undefined then make a request to logout user from OpenEdX
  */
-export const SessionProvider = ({ children }: PropsWithChildren<any>) => {
+export const SessionProvider = ({ children }: PropsWithChildren<{}>) => {
+  // Make sure there is an authentication backend before attempting to use it
+  // to provide a session.
+  if (AuthenticationApi) {
+    return <SessionProviderInner>{children}</SessionProviderInner>;
+  } else {
+    const value = useMemo(() => {
+      const destroy = () => {
+        throw new Error('No authentication backend provided.');
+      };
+      const login = destroy;
+      const register = destroy;
+      return { destroy, login, register, user: null };
+    }, []);
+
+    return <Session.Provider value={value}>{children}</Session.Provider>;
+  }
+};
+
+export const SessionProviderInner = ({ children }: PropsWithChildren<{}>) => {
   /**
    * `user` is:
    * - `undefined` when we have not made the `whoami` request yet;

--- a/src/frontend/js/data/useSession/no-authentication.spec.tsx
+++ b/src/frontend/js/data/useSession/no-authentication.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { ContextFactory as mockContextFactory } from 'utils/test/factories';
+import createQueryClient from 'utils/react-query/createQueryClient';
+import { Maybe, Nullable } from 'types/utils';
+import { User } from 'types/User';
+import { SessionProvider, useSession } from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory({
+    authentication: undefined,
+  }).generate(),
+}));
+
+describe('useSession', () => {
+  const queryClient = createQueryClient({ persistor: true });
+
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+    queryClient.clear();
+    fetchMock.restore();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('provides a null user if there is no authentication backend', async () => {
+    let userInComponent: Maybe<Nullable<User>>;
+
+    const Component = () => {
+      const { user } = useSession();
+      userInComponent = user;
+      return <span>component rendered</span>;
+    };
+
+    render(
+      <SessionProvider>
+        <Component />
+      </SessionProvider>,
+    );
+
+    expect(userInComponent).toBeNull();
+    screen.getByText('component rendered');
+  });
+});


### PR DESCRIPTION
## Purpose

As we deployed the latest version of Richie, all frontend code failed to run because authentication via an LMS connection was assumed to be present.

## Proposal

However, LMS authentication is optional in Richie, and some deployed sites do not use it and break if an authentication backend is not provided.

