### PR TITLE
🎨(core) make brand link customizable & rename related template block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Rename `branding_footer` template block to `body_footer_brand` in
+  `richie/base.html`and include link it can be customized.
 - Refactor scss color variables to be more easily customizable.
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,8 @@ $ make migrate
 
 ## 2.9.x to 2.10.x
 
+- If you overrode `richie/base.html`, the `branding_footer` template block has been renamed to
+  `body_footer_brand` and the link was integrated in the block so it can be customized.
 - The file `_colors.scss` has been divided into `_palette.scss` for the palette, 
   `_gradients.scss`, `_schemes.scss`  and `_theme.scss`. Those files are now located in a 
   dedicated folder `colors`.

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -146,11 +146,11 @@
                             </div>
                         </div>
                         <div class="body-footer__brand">
-                            <a href="/">
-                            {% block branding_footer %}
-                                <img src="{% static "richie/images/logo-alt.png" %}" alt="">
-                            {% endblock branding_footer %}
-                            </a>
+                            {% block body_footer_brand %}
+                                <a href="/">
+                                    <img src="{% static "richie/images/logo-alt.png" %}" alt="">
+                                </a>
+                            {% endblock body_footer_brand %}
                         </div>
                         <div class="body-footer__insert">
                             {% block body_footer_title %}


### PR DESCRIPTION
## Purpose

We want to be able to customize the link behind the logo at the left of the footer.

## Proposal

- [x] Rename `branding_footer` template block to `body_footer_brand` for coherence with the `body_footer_title` block
- [x] Include the link in the block so that it can be customized by overriding just this block

