### PR TITLE
🐛(lti_consumer)  Add missing language parameter in LTI requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Add missing language parameter in LTI requests issued by LTI consumer plugin
+
 ## [2.11.0] - 2022-01-04
 
 ### Changed

--- a/src/richie/plugins/lti_consumer/api.py
+++ b/src/richie/plugins/lti_consumer/api.py
@@ -3,6 +3,7 @@ from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
+from django.utils import translation
 
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -28,7 +29,8 @@ class LTIConsumerViewsSet(viewsets.GenericViewSet):
             - is_automatic_resizing: boolean to control automatic resizing
 
         """
-        cache_key = f"lti_consumer_plugin__pk_{pk}"
+        language = translation.get_language()
+        cache_key = f"lti_consumer_plugin__pk_{pk}_{language}"
         edit = request.toolbar and request.toolbar.edit_mode_active
 
         # Send response from cache only if edition is off

--- a/src/richie/plugins/lti_consumer/models.py
+++ b/src/richie/plugins/lti_consumer/models.py
@@ -6,6 +6,7 @@ from urllib.parse import unquote
 from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.utils import translation
 from django.utils.functional import lazy
 from django.utils.translation import gettext_lazy as _
 
@@ -98,13 +99,14 @@ class LTIConsumer(CMSPlugin):
         site = get_current_site()
 
         lti_parameters = {
+            "context_id": site.domain,
+            "launch_presentation_locale": translation.get_language(),
             "lti_message_type": "basic-lti-launch-request",
+            "lis_person_contact_email_primary": "",
             "lti_version": "LTI-1p0",
             "resource_link_id": self.get_resource_link_id(),
-            "context_id": site.domain,
-            "user_id": "richie",
-            "lis_person_contact_email_primary": "",
             "roles": role,
+            "user_id": "richie",
         }
 
         # Get credentials from the predefined LTI provider if any, or from the model otherwise

--- a/tests/plugins/lti_consumer/test_models.py
+++ b/tests/plugins/lti_consumer/test_models.py
@@ -131,6 +131,7 @@ class ParametersLTIConsumerModelsTestCase(TestCase):
             shared_secret="IgnoredSharedSecret",
         )
         expected_content_parameters = {
+            "launch_presentation_locale": "en",
             "lti_message_type": "basic-lti-launch-request",
             "lti_version": "LTI-1p0",
             "resource_link_id": "1234",
@@ -140,7 +141,7 @@ class ParametersLTIConsumerModelsTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": "TestOauthConsumerKey",
             "oauth_nonce": "59474787080480293391616018589",
-            "oauth_signature": "PkxLai53gItjVvgbccU7AW4HwuY=",
+            "oauth_signature": "r75pOLpVUzPjOgbenOxE0WNIUbc=",
             "oauth_signature_method": "HMAC-SHA1",
             "oauth_timestamp": "1616018589",
             "oauth_version": "1.0",
@@ -166,6 +167,7 @@ class ParametersLTIConsumerModelsTestCase(TestCase):
             shared_secret="ManualTestSharedSecret",
         )
         expected_content_parameters = {
+            "launch_presentation_locale": "en",
             "lti_message_type": "basic-lti-launch-request",
             "lti_version": "LTI-1p0",
             "resource_link_id": "1234",
@@ -175,7 +177,7 @@ class ParametersLTIConsumerModelsTestCase(TestCase):
             "roles": "student",
             "oauth_consumer_key": "ManualTestOauthConsumerKey",
             "oauth_nonce": "59474787080480293391616018589",
-            "oauth_signature": "nh2VyyxvKNTsEFIa68yFmWC+10w=",
+            "oauth_signature": "UU7/veFv5lwc7pOhtz0Y0sowywA=",
             "oauth_signature_method": "HMAC-SHA1",
             "oauth_timestamp": "1616018589",
             "oauth_version": "1.0",
@@ -198,6 +200,7 @@ class ParametersLTIConsumerModelsTestCase(TestCase):
             url="http://localhost:8060/lti/videos/3cd0bcc4-0",
         )
         expected_content_parameters = {
+            "launch_presentation_locale": "en",
             "lti_message_type": "basic-lti-launch-request",
             "lti_version": "LTI-1p0",
             "resource_link_id": "1234",
@@ -207,7 +210,7 @@ class ParametersLTIConsumerModelsTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": "TestOauthConsumerKey",
             "oauth_nonce": "59474787080480293391616018589",
-            "oauth_signature": "Y3d9qVSe+W7kA5E9+7JB/NeF2OA=",
+            "oauth_signature": "XYV4THSMsy4roezJfVEwxhFDF4w=",
             "oauth_signature_method": "HMAC-SHA1",
             "oauth_timestamp": "1616018589",
             "oauth_version": "1.0",
@@ -233,6 +236,7 @@ class ParametersLTIConsumerModelsTestCase(TestCase):
             shared_secret="ManualTestSharedSecret",
         )
         expected_content_parameters = {
+            "launch_presentation_locale": "en",
             "lti_message_type": "basic-lti-launch-request",
             "lti_version": "LTI-1p0",
             "resource_link_id": "1234",
@@ -242,7 +246,7 @@ class ParametersLTIConsumerModelsTestCase(TestCase):
             "roles": "instructor",
             "oauth_consumer_key": "ManualTestOauthConsumerKey",
             "oauth_nonce": "59474787080480293391616018589",
-            "oauth_signature": "CCnCQtLjPlb+Yr2C0FjYmoVO6Gk=",
+            "oauth_signature": "22mJEak6wRKx1Egcw4921Vzniw0=",
             "oauth_signature_method": "HMAC-SHA1",
             "oauth_timestamp": "1616018589",
             "oauth_version": "1.0",


### PR DESCRIPTION

## Purpose

The LTI consumer was not transmitting the language when making an LTI launch request. As a result, marsha was serving the english language on our french sites.

## Proposal

Add missing language parameter in LTI requests and set it with the current language.
