### PR TITLE
💄(course-glimpse) fix layout issue with long organization and course titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Improve semantic of glimpses
+
 ### Fixed
 
 - Fixed a layout issue on course glimpse
   when organization title and course title are too long
 - Add missing language parameter in LTI requests issued by LTI consumer plugin
+
 
 ## [2.11.0] - 2022-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed a layout issue on course glimpse
+  when organization title and course title are too long
 - Add missing language parameter in LTI requests issued by LTI consumer plugin
 
 ## [2.11.0] - 2022-01-04

--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -54,7 +54,7 @@ describe('components/CourseGlimpse', () => {
     // The link that wraps the course glimpse should have no title as its content is explicit enough
     expect(screen.getByRole('link')).not.toHaveAttribute('title');
     // The course glimpse shows the relevant information
-    screen.getByText('Course 42');
+    screen.getByRole('heading', { name: 'Course 42', level: 3 });
     screen.getByText('123abc');
     screen.getByText('Some Organization');
     // Matches on 'Starts on Mar 14, 2019', date is wrapped with intl <span>
@@ -98,7 +98,7 @@ describe('components/CourseGlimpse', () => {
     );
 
     // Make sure the component renders and shows the state
-    screen.getByText('Course 42');
+    screen.getByRole('heading', { name: 'Course 42', level: 3 });
     screen.getByText('Archived');
   });
 
@@ -109,7 +109,7 @@ describe('components/CourseGlimpse', () => {
       </IntlProvider>,
     );
 
-    screen.getByText('Course 42');
+    screen.getByRole('heading', { name: 'Course 42', level: 3 });
     screen.getByText('Cover');
   });
 

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -51,7 +51,9 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
         </div>
       ) : null}
       <div className="course-glimpse__wrapper">
-        <p className="course-glimpse__title">{course.title}</p>
+        <h3 className="course-glimpse__title" title={course.title}>
+          {course.title}
+        </h3>
         {course.organization_highlighted_cover_image ? (
           <div className="course-glimpse__organization-logo">
             {/* alt forced to empty string because it's a decorative image */}
@@ -67,7 +69,9 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
           <svg aria-hidden={true} role="img" className="icon">
             <use xlinkHref="#icon-org" />
           </svg>
-          <span>{course.organization_highlighted}</span>
+          <span className="title" title={course.organization_highlighted}>
+            {course.organization_highlighted}
+          </span>
         </div>
         <div className="course-glimpse__code">
           <svg aria-hidden={true} role="img" className="icon">

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -167,22 +167,30 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
 
   &__title {
     @include font-size($h6-font-size);
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    color: r-theme-val(course-glimpse, title-color);
+    display: block;
+    display: -webkit-box;
     font-family: $r-font-family-montserrat;
     font-weight: $font-weight-boldest;
-    color: r-theme-val(course-glimpse, title-color);
+    line-height: 1.3em;
+    margin-bottom: 1rem;
+    max-height: 1.3em * 3; // 3 lines;
+    overflow: hidden;
   }
 
   &__organization {
-    display: flex;
-    position: absolute;
-    bottom: 1.6rem;
-    left: 0;
-    right: 0;
-    padding: 0 0.6rem;
     align-items: center;
+    bottom: 1.6rem;
     color: r-theme-val(course-glimpse, organization-color);
-    font-size: 0.9rem;
-    line-height: 1.1;
+    display: flex;
+    font-size: 0.7rem;
+    left: 0;
+    line-height: 1.1em;
+    padding: 0 0.6rem;
+    position: absolute;
+    right: 0;
 
     .icon {
       @include sv-flex(1, 0, 1.4rem);
@@ -191,6 +199,15 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
       margin-bottom: 0.15rem;
       margin-right: 0.5rem;
       fill: r-theme-val(course-glimpse, organization-color);
+    }
+
+    .title {
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      display: block;
+      display: -webkit-box;
+      max-height: 2.2em; // 2 lines
+      overflow: hidden;
     }
   }
 

--- a/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_blogpost_glimpse.html
@@ -58,7 +58,7 @@
                         {% show_placeholder "categories" blogpost_page %}
                     {% endwith %}
                 </div>
-                <p class="blogpost-{{ blogpost_variant }}__title">{{ blogpost_page.get_title }}</p>
+                <h{{ header_level|default:3 }} class="blogpost-{{ blogpost_variant }}__title">{{ blogpost_page.get_title }}</h{{ header_level|default:3 }}>
             </div>
         </div>
     </a>
@@ -92,7 +92,7 @@
                     {% endwith %}
                 </div>
 
-                <p class="blogpost-{{ blogpost_variant }}__title">{{ blogpost_page.get_title }}</p>
+                <h{{ header_level|default:3 }} class="blogpost-{{ blogpost_variant }}__title">{{ blogpost_page.get_title }}</h{{ header_level|default:3 }}>
 
                 <p class="blogpost-{{ blogpost_variant }}__excerpt">
                     {% show_placeholder "excerpt" blogpost_page %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -30,7 +30,7 @@
         </div>
         {% endif %}
         <div class="course-{{ course_variant }}__wrapper">
-            <p class="course-{{ course_variant }}__title" title="{{ course_page.get_title }}">{{ course_page.get_title }}</p>
+            <h{{ header_level|default:3 }} class="course-{{ course_variant }}__title" title="{{ course_page.get_title }}">{{ course_page.get_title }}</h{{ header_level|default:3 }}>
             {% if main_organization %}
                 {% with organization_page=main_organization.extended_object %}
                     {% get_page_plugins "logo" organization_page as plugins or %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -30,7 +30,7 @@
         </div>
         {% endif %}
         <div class="course-{{ course_variant }}__wrapper">
-            <p class="course-{{ course_variant }}__title">{{ course_page.get_title }}</p>
+            <p class="course-{{ course_variant }}__title" title="{{ course_page.get_title }}">{{ course_page.get_title }}</p>
             {% if main_organization %}
                 {% with organization_page=main_organization.extended_object %}
                     {% get_page_plugins "logo" organization_page as plugins or %}
@@ -56,14 +56,14 @@
                 <svg role="img" aria-hidden="true" class="icon">
                     <use href="#icon-org" />
                 </svg>
-                <span>{{ main_organization_title }}</span>
+                <span class="title" title="{{ main_organization_title }}">{{ main_organization_title }}</span>
             </div>
             {% endif %}
             <div class="course-{{ course_variant }}__code">
                 <svg role="img" aria-hidden="true" class="icon">
                     <use href="#icon-barcode" />
                 </svg>
-                <span>{% if course.code %}{{ course.code }}{% else %}-{% endif %}
+                <span>{% if course.code %}{{ course.code }}{% else %}-{% endif %}</span>
             </div>
         </div>
 

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
@@ -30,7 +30,7 @@
             {% endblockplugin %}
         </div>
         <div class="organization-{{ organization_variant }}__content">
-            <div class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</div>
+            <h{{ header_level|default:3 }} class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</<h{{ header_level|default:3 }}>
             <div class="organization-{{ organization_variant }}__excerpt" property="description">{% get_page_plugins "description" organization_page as plugins or %}{% trans "Description" %}{% endget_page_plugins %}{% blockplugin plugins.0 %}{{ instance.body|truncatewords_html:40|safe }}{% endblockplugin %}</div>
         </div>
     </a>
@@ -58,7 +58,7 @@
             {% endblockplugin %}
         </div>
         <div class="organization-{{ organization_variant }}__content">
-            <div class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</div>
+            <h{{ header_level|default:3 }} class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</h{{ header_level|default:3 }}>
         </div>
     </a>
 {% endif %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_program_glimpse.html
@@ -20,7 +20,7 @@
     </div>
     <div class="program-glimpse__content">
         <div class="program-glimpse__wrapper">
-            <p class="program-glimpse__title">{{ program_page.get_title }}</p>
+            <h{{ header_level|default:3 }} class="program-glimpse__title">{{ program_page.get_title }}</h{{ header_level|default:3 }}>
             <p>
                 {% show_placeholder "program_excerpt" program_page %}
             </p>

--- a/tests/apps/courses/test_cms_plugins_blogpost.py
+++ b/tests/apps/courses/test_cms_plugins_blogpost.py
@@ -111,12 +111,12 @@ class BlogPostPluginTestCase(CMSTestCase):
             re.sub(" +", " ", str(response.content).replace("\\n", "")),
         )
 
-        # The blogpost's title should be wrapped in a p
+        # The blogpost's title should be wrapped in a h2
         blogpost.refresh_from_db()
         blogpost_title = blogpost.public_extension.extended_object.get_title()
         self.assertContains(
             response,
-            f'<p class="blogpost-glimpse__title">{blogpost_title:s}</p>',
+            f'<h2 class="blogpost-glimpse__title">{blogpost_title:s}</h2>',
             html=True,
         )
         self.assertNotContains(response, "draft title")
@@ -199,11 +199,11 @@ class BlogPostPluginTestCase(CMSTestCase):
             re.sub(" +", " ", str(response.content).replace("\\n", "")),
         )
 
-        # The blogpost's title should be wrapped in a p
+        # The blogpost's title should be wrapped in a h2
         blogpost.refresh_from_db()
         self.assertContains(
             response,
-            '<p class="blogpost-glimpse__title">titre public</p>',
+            '<h2 class="blogpost-glimpse__title">titre public</h2>',
             html=True,
         )
         self.assertNotContains(response, "public title")

--- a/tests/apps/courses/test_cms_plugins_course.py
+++ b/tests/apps/courses/test_cms_plugins_course.py
@@ -116,9 +116,10 @@ class CoursePluginTestCase(TestCase):
         )
 
         # The course's name should be present
+        course_title = course_page.get_title()
         self.assertContains(
             response,
-            f'<p class="course-glimpse__title">{course_page.get_title():s}</p>',
+            f'<h2 class="course-glimpse__title" title="{course_title:s}">{course_title:s}</h2>',
             status_code=200,
         )
         # The course's main organization should be present
@@ -172,9 +173,10 @@ class CoursePluginTestCase(TestCase):
         )
 
         # The course's name should be present
+        course_title = course_page.get_title()
         self.assertContains(
             response,
-            f'<p class="course-glimpse__title">{course_page.get_title():s}</p>',
+            f'<h2 class="course-glimpse__title" title="{course_title:s}">{course_title:s}</h2>',
             status_code=200,
         )
 
@@ -334,7 +336,7 @@ class CoursePluginTestCase(TestCase):
 
         # The course's name should be present
         self.assertIn(
-            '<p class="course-glimpse__title">cours public</p>',
+            '<h2 class="course-glimpse__title" title="cours public">cours public</h2>',
             re.sub(" +", " ", str(response.content).replace("\\n", "")),
         )
         self.assertNotContains(response, "public course")

--- a/tests/apps/courses/test_cms_plugins_organization.py
+++ b/tests/apps/courses/test_cms_plugins_organization.py
@@ -109,11 +109,11 @@ class OrganizationPluginTestCase(CMSTestCase):
             ),
         )
 
-        # The organization's title should be wrapped in a div
+        # The organization's title should be wrapped in a h2
         org_title = organization.public_extension.extended_object.get_title()
         self.assertContains(
             response,
-            f'<div class="organization-glimpse__title" property="name">{org_title:s}</div>',
+            f'<h2 class="organization-glimpse__title" property="name">{org_title:s}</h2>',
             html=True,
         )
         self.assertNotContains(response, "draft title")
@@ -298,7 +298,7 @@ class OrganizationPluginTestCase(CMSTestCase):
         # The organization's full name should be wrapped in a h2
         self.assertContains(
             response,
-            '<div class="organization-glimpse__title" property="name">organisation publique</div>',
+            '<h2 class="organization-glimpse__title" property="name">organisation publique</h2>',
             html=True,
         )
         self.assertNotContains(response, "public organization")

--- a/tests/apps/courses/test_cms_plugins_organizations_by_category.py
+++ b/tests/apps/courses/test_cms_plugins_organizations_by_category.py
@@ -109,13 +109,13 @@ class OrganizationsByCategoryPluginTestCase(CMSTestCase):
             re.sub(" +", " ", str(response.content).replace("\\n", "")),
         )
 
-        # The organization's title should be wrapped in a div
+        # The organization's title should be wrapped in a h2
         public_title = (
             published_organization.public_extension.extended_object.get_title()
         )
         self.assertContains(
             response,
-            f'<div class="organization-glimpse__title" property="name">{public_title:s}</div>',
+            f'<h2 class="organization-glimpse__title" property="name">{public_title:s}</h2>',
             html=True,
         )
         self.assertNotContains(response, "draft")

--- a/tests/apps/courses/test_cms_plugins_program.py
+++ b/tests/apps/courses/test_cms_plugins_program.py
@@ -100,11 +100,11 @@ class ProgramPluginTestCase(CMSTestCase):
             '<a href="/en/public-title/" class="program-glimpse program-glimpse--link',
             status_code=200,
         )
-        # The program's title should be wrapped in a p
+        # The program's title should be wrapped in a h2
         program_title = program.public_extension.extended_object.get_title()
         self.assertContains(
             response,
-            f'<p class="program-glimpse__title">{program_title:s}</p>',
+            f'<h2 class="program-glimpse__title">{program_title:s}</h2>',
             html=True,
         )
         self.assertNotContains(response, "draft title")
@@ -210,7 +210,7 @@ class ProgramPluginTestCase(CMSTestCase):
         # The program's full name should be wrapped in a h2
         self.assertContains(
             response,
-            '<p class="program-glimpse__title">programme publique</p>',
+            '<h2 class="program-glimpse__title">programme publique</h2>',
             html=True,
         )
         self.assertNotContains(response, "public program")

--- a/tests/apps/courses/test_templates_category_detail.py
+++ b/tests/apps/courses/test_templates_category_detail.py
@@ -186,7 +186,7 @@ class CategoryCMSTestCase(CMSTestCase):
         self._extension_cms_published_content(
             OrganizationFactory,
             "categories",
-            '<div class="organization-glimpse__title" property="name">{:s}</div>',
+            '<h2 class="organization-glimpse__title" property="name">{:s}</h2>',
         )
 
     def test_templates_category_detail_cms_published_content_courses(self):
@@ -197,7 +197,7 @@ class CategoryCMSTestCase(CMSTestCase):
         self._extension_cms_published_content(
             CourseFactory,
             "course_categories",
-            '<p class="course-glimpse__title">{:s}</p>',
+            '<h2 class="course-glimpse__title" title="{0:s}">{0:s}</h2>',
         )
 
     @mock.patch(
@@ -310,7 +310,9 @@ class CategoryCMSTestCase(CMSTestCase):
         related blogposts in all publication states.
         """
         self._extension_cms_published_content(
-            BlogPostFactory, "categories", '<p class="blogpost-glimpse__title">{:s}</p>'
+            BlogPostFactory,
+            "categories",
+            '<h2 class="blogpost-glimpse__title">{:s}</h2>',
         )
 
     def test_templates_category_detail_cms_published_content_persons(self):
@@ -389,7 +391,9 @@ class CategoryCMSTestCase(CMSTestCase):
         # The not published page extension should be on the page, mark as draft
         self.assertContains(
             response,
-            control_string.format(not_published_extension.extended_object.get_title()),
+            control_string.format(
+                not_published_extension.extended_object.get_title(),
+            ),
             html=True,
         )
 
@@ -397,19 +401,19 @@ class CategoryCMSTestCase(CMSTestCase):
         """Validate how a draft category page is displayed with its related organizations."""
         self._extension_cms_draft_content(
             OrganizationFactory,
-            '<div class="organization-glimpse__title" property="name">{:s}</div>',
+            '<h2 class="organization-glimpse__title" property="name">{:s}</h2>',
         )
 
     def test_templates_category_detail_cms_draft_content_courses(self):
         """Validate how a draft category page is displayed with its related courses."""
         self._extension_cms_draft_content(
-            CourseFactory, '<p class="course-glimpse__title">{:s}</p>'
+            CourseFactory, '<h2 class="course-glimpse__title" title="{0:s}">{0:s}</h2>'
         )
 
     def test_templates_category_detail_cms_draft_content_blogposts(self):
         """Validate how a draft category page is displayed with its related blogposts."""
         self._extension_cms_draft_content(
-            BlogPostFactory, '<p class="blogpost-glimpse__title">{:s}</p>'
+            BlogPostFactory, '<h2 class="blogpost-glimpse__title">{:s}</h2>'
         )
 
     def test_templates_category_detail_cms_draft_content_persons(self):

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -173,7 +173,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             self.assertContains(
                 response,
                 # pylint: disable=consider-using-f-string
-                '<div class="organization-glimpse__title" property="name">{title:s}</div>'.format(
+                '<h2 class="organization-glimpse__title" property="name">{title:s}</h2>'.format(
                     title=organization.extended_object.get_title()
                 ),
                 html=True,
@@ -291,7 +291,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             self.assertContains(
                 response,
                 # pylint: disable=consider-using-f-string
-                '<div class="organization-glimpse__title" property="name">{title:s}</div>'.format(
+                '<h2 class="organization-glimpse__title" property="name">{title:s}</h2>'.format(
                     title=organization.extended_object.get_title()
                 ),
                 html=True,

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -217,8 +217,8 @@ class OrganizationCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             # pylint: disable=consider-using-f-string
-            '<p class="course-glimpse__title">{:s}</p>'.format(
-                published_course.public_extension.extended_object.get_title()
+            '<h2 class="course-glimpse__title" title="{0:s}">{0:s}</h2>'.format(
+                published_course.public_extension.extended_object.get_title(),
             ),
             html=True,
         )
@@ -360,7 +360,7 @@ class OrganizationCMSTestCase(CMSTestCase):
         # The published course should be on the page in its draft version
         self.assertContains(
             response,
-            '<p class="course-glimpse__title">modified course</p>',
+            '<h2 class="course-glimpse__title" title="modified course">modified course</h2>',
             html=True,
         )
 

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -215,7 +215,7 @@ class PersonCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             # pylint: disable=consider-using-f-string
-            '<div class="organization-glimpse__title" property="name">{:s}</div>'.format(
+            '<h2 class="organization-glimpse__title" property="name">{:s}</h2>'.format(
                 published_organization.public_extension.extended_object.get_title()
             ),
             html=True,
@@ -336,7 +336,7 @@ class PersonCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             # pylint: disable=consider-using-f-string
-            '<div class="organization-glimpse__title" property="name">{:s}</div>'.format(
+            '<h2 class="organization-glimpse__title" property="name">{:s}</h2>'.format(
                 published_organization.public_extension.extended_object.get_title()
             ),
             html=True,
@@ -354,7 +354,7 @@ class PersonCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             # pylint: disable=consider-using-f-string
-            '<div class="organization-glimpse__title" property="name">{:s}</div>'.format(
+            '<h2 class="organization-glimpse__title" property="name">{:s}</h2>'.format(
                 not_published_organization.extended_object.get_title()
             ),
             html=True,
@@ -421,7 +421,9 @@ class PersonCMSTestCase(CMSTestCase):
         # The course should be present on the page
         self.assertContains(
             response,
-            f'<p class="course-glimpse__title">{course.extended_object.get_title():s}</p>',
+            '<h2 class="course-glimpse__title" title="{0:s}">{0:s}</h2>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
+                course.extended_object.get_title()
+            ),
             html=True,
         )
 
@@ -481,7 +483,7 @@ class PersonCMSTestCase(CMSTestCase):
         # The blog post should be present on the page
         self.assertContains(
             response,
-            f'<p class="blogpost-glimpse__title">{blog_post.extended_object.get_title():s}</p>',
+            f'<h2 class="blogpost-glimpse__title">{blog_post.extended_object.get_title():s}</h2>',
             html=True,
         )
 

--- a/tests/apps/courses/test_templates_program_detail.py
+++ b/tests/apps/courses/test_templates_program_detail.py
@@ -135,7 +135,9 @@ class ProgramCMSTestCase(CMSTestCase):
         for course in courses[:2]:
             self.assertContains(
                 response,
-                f'<p class="course-glimpse__title">{course.extended_object.get_title():s}</p>',
+                '<h3 class="course-glimpse__title" title="{0:s}">{0:s}</h3>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
+                    course.extended_object.get_title()
+                ),
                 html=True,
             )
         for course in courses[-2:]:
@@ -187,7 +189,9 @@ class ProgramCMSTestCase(CMSTestCase):
             )
             self.assertContains(
                 response,
-                f'<p class="course-glimpse__title">{course.extended_object.get_title():s}</p>',
+                '<h3 class="course-glimpse__title" title="{0:s}">{0:s}</h3>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
+                    course.extended_object.get_title()
+                ),
                 html=True,
             )
         self.assertContains(
@@ -195,9 +199,12 @@ class ProgramCMSTestCase(CMSTestCase):
             '<a class="course-glimpse course-glimpse--draft" '
             f'href="{courses[2].extended_object.get_absolute_url():s}"',
         )
+
         self.assertContains(
             response,
-            f'<p class="course-glimpse__title">{courses[2].extended_object.get_title():s}</p>',
+            '<h3 class="course-glimpse__title" title="{0:s}">{0:s}</h3>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
+                courses[2].extended_object.get_title()
+            ),
             html=True,
         )
         # The unpublished course should not be present on the page


### PR DESCRIPTION
## Purpose

On course glimpse, course and organization titles was not truncated when they
were too long. So when these two contents were too long, they overlap. So we
decided to truncate course title if it exceeds 3 lines and organization title if
it exceeds 2 lines. Furthermore, we decrease font-size of organization title to
0.7rem to homogenize font size within course glimpse.

Fix #1560


## Proposal

- [x] Truncate course and organization titles when they are too longs.


### Before
<img width="283" alt="before" src="https://user-images.githubusercontent.com/9265241/148572036-85dde695-ce39-4ab1-9547-f6dc44c9a42d.png">


### After
<img width="279" alt="after" src="https://user-images.githubusercontent.com/9265241/148572041-a49a7216-b5b1-4fe4-b2b2-e049c56225e4.png">

_Note: If browser does not support `-webkit-line-clamp`, ellipsis will not appear._