### PR TITLE
🏷️(helix) add types for @helpscout/helix package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Type @helpscout/helix package
 - Add catalog visibility field to course run so it's possible to hide a
   course run on the catalog and/or hide it completely. Possible values
   are `course_and_search`, `course_only` and `hidden`.

--- a/src/frontend/js/types/libs/helpscout__helix/index.d.ts
+++ b/src/frontend/js/types/libs/helpscout__helix/index.d.ts
@@ -1,1 +1,80 @@
-declare module '@helpscout/helix';
+declare module '@helpscout/helix' {
+  // Utils types
+  type DerivedValue<T> = T & { isDerivedValue: true };
+
+  type ShapeExtractor<Spec> = Spec extends HelixSpec<infer Shape> ? Shape : Spec;
+
+  type SpecValue<T> = {
+    [K in keyof T]:
+      | T[K]
+      | ((...args: T[K] extends (...a: infer P) => any ? P : never[]) => T[K])
+      | HelixSpec<T[K]>;
+  };
+
+  // HelixSpec Class
+  class HelixSpec<ShapeType, IncomeType = ShapeType> {
+    shape: SpecValue<ShapeType>;
+    seedValue: undefined | number;
+    _afterGenerate(props: ShapeType): IncomeType;
+    generate(count: number, max?: number): IncomeType extends ShapeType ? ShapeType[] : IncomeType;
+    generate(): IncomeType;
+    extend<NewType>(
+      ...specs: NewType[]
+    ): HelixSpec<
+      NewType & Omit<ShapeType, keyof NewType>,
+      IncomeType extends ShapeType ? NewType & Omit<ShapeType, keyof NewType> : IncomeType
+    >;
+    beforeGenerate<NewType>(
+      callback: (props: SpecValue<ShapeType>) => SpecValue<NewType>,
+    ): HelixSpec<NewType, IncomeType extends ShapeType ? NewType : IncomeType>;
+    afterGenerate<K>(callback: (props: ShapeType | ShapeType[]) => K): HelixSpec<ShapeType, K>;
+    seed(seedValue: number): this;
+  }
+
+  // remapped faker
+  type RemappedFaker<T extends Partial<Faker.FakerStatic> = Faker.FakerStatic> = {
+    [K in keyof T]: T[K] extends Function
+      ? (...args: T[K] extends (...a: infer P) => any ? P : never[]) => T[K]
+      : RemappedFaker<T[K]>;
+  };
+  const faker: RemappedFaker;
+
+  // derived
+  function derived<T>(mapper: (shape: any) => T): DerivedValue<T>;
+
+  // createSpec
+  function createSpec<T>(specs: SpecValue<T>): HelixSpec<T>;
+
+  // oneOf
+  function oneOf<T extends SpecValue<any>[]>(
+    specs: T,
+  ): T extends { [key: number]: infer S }
+    ? S extends HelixSpec<unknown>
+      ? S
+      : HelixSpec<S>
+    : never;
+
+  // compose
+  function compose<S1 extends SpecValue<any>>(spec1: S1): HelixSpec<ShapeExtractor<S1>>;
+  function compose<S1 extends SpecValue<any>, S2 extends SpecValue<any>>(
+    spec1: S1,
+    spec2: S2,
+  ): HelixSpec<ShapeExtractor<S1> & ShapeExtractor<S2>>;
+  function compose<S1 extends SpecValue<any>, S2 extends SpecValue<any>, S3 extends SpecValue<any>>(
+    spec1: S1,
+    spec2: S2,
+    spec3: S3,
+  ): HelixSpec<ShapeExtractor<S1> & ShapeExtractor<S2> & ShapeExtractor<S3>>;
+  function compose<
+    S1 extends SpecValue<any>,
+    S2 extends SpecValue<any>,
+    S3 extends SpecValue<any>,
+    S4 extends SpecValue<any>,
+  >(
+    spec1: S1,
+    spec2: S2,
+    spec3: S3,
+    spec4: S4,
+  ): HelixSpec<ShapeExtractor<S1> & ShapeExtractor<S2> & ShapeExtractor<S3> & ShapeExtractor<S4>>;
+  function compose(...specs: SpecValue<any>[]): HelixSpec<ShapeExtractor<SpecValue<any>>>;
+}

--- a/src/frontend/js/utils/test/factories.ts
+++ b/src/frontend/js/utils/test/factories.ts
@@ -6,24 +6,27 @@ import { QueryState } from 'react-query/types/core/query';
 import { MutationState } from 'react-query/types/core/mutation';
 import { PersistedClient } from 'react-query/types/persistQueryClient-experimental';
 import { MutationKey, QueryKey } from 'react-query';
+import { CourseRun, CourseState } from 'types';
+import { User } from 'types/User';
 
-const CourseStateFactory = createSpec({
+const CourseStateFactory = createSpec<CourseState>({
   priority: derived(() => Math.floor(Math.random() * 7)),
   datetime: derived(() => faker.date.past()().toISOString()),
-  call_to_action: faker.random.words(1, 3),
-  text: faker.random.words(1, 3),
+  call_to_action: faker.random.words(3),
+  text: faker.random.words(3),
 });
 
-export const CourseRunFactory = createSpec({
+export const CourseRunFactory = createSpec<CourseRun>({
   id: faker.datatype.number(),
   resource_link: faker.internet.url(),
   start: derived(() => faker.date.past()().toISOString()),
   end: derived(() => faker.date.past()().toISOString()),
   enrollment_start: derived(() => faker.date.past()().toISOString()),
   enrollment_end: derived(() => faker.date.past()().toISOString()),
-  languages: faker.random.locale(),
+  languages: derived(() => [faker.random.locale()()]),
   state: CourseStateFactory,
   starts_in_message: null,
+  dashboard_link: null,
 });
 
 export const EnrollmentFactory = createSpec({
@@ -33,14 +36,13 @@ export const EnrollmentFactory = createSpec({
   course_run: faker.datatype.number(),
 });
 
-export const UserFactory = createSpec({
+export const UserFactory = createSpec<User>({
   full_name: faker.fake('{{name.firstName}} {{name.lastName}}'),
   username: faker.internet.userName(),
 });
 
 export const ContextFactory = (context: Partial<CommonDataProps['context']> = {}) =>
-  createSpec({
-    auth_endpoint: 'https://endpoint.test',
+  createSpec<CommonDataProps['context']>({
     csrftoken: faker.random.alphaNumeric(64),
     environment: 'test',
     authentication: {


### PR DESCRIPTION
## Purpose

We are using `@helpscout/helix` to create factories for our frontend tests. Currently this package has no type so we have no guarantee that our factories stick to real objects implementation. As a little challenge to level up in typescript and in order to improve our factories frontend, I decided to try to type this package.

If this type is reliant from our side, I'm thinking about submit a PR to add these types within definitelyTypes.


## Proposal

- [x] Type `@helpscout/helix` package
