### PR TITLE
📌(backend) remove use of forked djangocms-admin-style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,7 @@ COPY --from=front-builder \
 RUN pip install --upgrade pip
 
 RUN mkdir /install && \
-    pip install --prefix=/install .[sandbox] \
-    # Use temporarily a forked version of djangocms-admin-style
-    # Remove this when djangocms-admin-style 2.0.3 will be released
-    pip install --prefix=/install git+https://github.com/jbpenrath/djangocms-admin-style@fun#egg=djangocms-admin-style
+    pip install --prefix=/install .[sandbox]
 
 # ---- Core application image ----
 FROM base as core


### PR DESCRIPTION
## Purpose
[djangocms-admin-style 3.0.0](https://pypi.org/project/djangocms-admin-style/) has been released and includes fixes we need. So we are now able to remove the use of our forked version of this
package.


## Proposal

- [x] Remove the use of our forked version of djangocms-admin-style
