### PR TITLE
Fix/issue 1578

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Add missing translation within search autocomplete menu
+- Fix a layout issue on autosuggest search menu
 - Fixed a layout issue on course glimpse
   when organization title and course title are too long
 - Add missing language parameter in LTI requests issued by LTI consumer plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Add missing translation within search autocomplete menu
 - Fixed a layout issue on course glimpse
   when organization title and course title are too long
 - Add missing language parameter in LTI requests issued by LTI consumer plugin

--- a/src/frontend/js/data/useStaticFilters/index.spec.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.spec.tsx
@@ -4,6 +4,8 @@ import fetchMock from 'fetch-mock';
 
 import { FilterDefinition } from 'types/filters';
 import { Deferred } from 'utils/test/deferred';
+import { IntlProvider } from 'react-intl';
+import { PropsWithChildren } from 'react';
 import { useStaticFilters } from '.';
 
 describe('data/useStaticFilters', () => {
@@ -51,12 +53,16 @@ describe('data/useStaticFilters', () => {
     subjects,
   };
 
+  const wrapper = ({ children }: PropsWithChildren<any>) => (
+    <IntlProvider locale="en">{children}</IntlProvider>
+  );
+
   afterEach(() => fetchMock.restore());
 
   it('gets and returns the static filter definitions', async () => {
     const deferred = new Deferred();
     fetchMock.get('/api/v1.0/filter-definitions/', deferred.promise);
-    const { result } = renderHook(useStaticFilters);
+    const { result } = renderHook(useStaticFilters, { wrapper });
 
     // No request is made until we actually use the hook's return value
     expect(fetchMock.called('/api/v1.0/filter-definitions/')).toEqual(false);
@@ -83,7 +89,7 @@ describe('data/useStaticFilters', () => {
 
   it('includes a course config when requested', async () => {
     fetchMock.get('/api/v1.0/filter-definitions/', staticFilterDefinitions);
-    const { result } = renderHook(() => useStaticFilters(true));
+    const { result } = renderHook(() => useStaticFilters(true), { wrapper });
 
     let filters;
     await act(async () => {

--- a/src/frontend/js/data/useStaticFilters/index.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from 'react';
 import { FilterDefinition, StaticFilterDefinitions } from 'types/filters';
 import { Nullable } from 'types/utils';
 import { useAsyncEffect } from 'utils/useAsyncEffect';
+import { defineMessages, useIntl } from 'react-intl';
 
 // Our search and autosuggestion pipeline operated based on filter definitions. Obviously, we can't filters
 // courses by courses, but we still need a filter-definition-like config to run courses autocompletion.
@@ -15,6 +16,14 @@ const coursesConfig: FilterDefinition = {
   position: 99,
 };
 
+const messages = defineMessages({
+  courses: {
+    defaultMessage: 'Courses',
+    description: 'localized human_name label for coursesConfig filter name',
+    id: 'components.useStaticFilters.courses',
+  },
+});
+
 /**
  * Hook to provide static filter definitions to components as a promise while abstracting away
  * data-fetching & caching logic.
@@ -23,6 +32,7 @@ const coursesConfig: FilterDefinition = {
  */
 export const useStaticFilters = (includeCoursesConfig = false) => {
   const [needsFilters, setNeedsFilters] = useState(false);
+  const intl = useIntl();
 
   const filtersResolver = useRef<Nullable<(filters: StaticFilterDefinitions) => void>>(null);
   const [filtersPromise] = useState<Promise<StaticFilterDefinitions>>(
@@ -40,7 +50,14 @@ export const useStaticFilters = (includeCoursesConfig = false) => {
 
       filtersResolver.current!({
         ...filters,
-        ...(includeCoursesConfig ? { courses: coursesConfig } : {}),
+        ...(includeCoursesConfig
+          ? {
+              courses: {
+                ...coursesConfig,
+                human_name: intl.formatMessage(messages.courses),
+              },
+            }
+          : {}),
       });
     }
   }, [needsFilters]);

--- a/src/frontend/scss/objects/_react-autosuggest.scss
+++ b/src/frontend/scss/objects/_react-autosuggest.scss
@@ -17,7 +17,8 @@
 
   &__suggestions-container {
     @extend .dropdown-menu;
-    width: 100%;
+    max-width: 480px;
+    min-width: 100%;
 
     &--open {
       display: block; // Show/hide is managed by react-autosuggest with the --open state
@@ -30,6 +31,9 @@
 
   &__suggestion {
     @extend .dropdown-item;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 
     &:hover {
       cursor: pointer;


### PR DESCRIPTION
## Purpose

Within autosuggest menu, Courses section is not localized unlike other section labels. We have to add this missing translation. Furthermore, there is also a layout issue to fix about the autosuggest search menu.


## Proposal

- [x] Add a missing translation related to autosuggest section title
- [x] Fix a autosuggest menu layout issue
