### PR TITLE
♿️(pagination) improve a11y labels when using multiple paginations on same page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+- Improve pagination blocks labels for screen reader users when there are
+  multiple pagination components on one page
+
 ### Added
 
 - Add course runs to the course search API

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -1,5 +1,5 @@
-import { Fragment, useState } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { Fragment } from 'react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
 
@@ -49,11 +49,8 @@ interface PaginateCourseSearchProps {
 }
 
 export const PaginateCourseSearch = ({ courseSearchTotalCount }: PaginateCourseSearchProps) => {
-  // Generate a unique ID per instance to ensure our aria-labelledby do not break if there are two
-  // or more instances of <PaginateCourseSearch /> on the page
-  const [componentId] = useState(Math.random());
   const { courseSearchParams, dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
-
+  const intl = useIntl();
   // Extract pagination information from params and search results meta
   const limit = Number(courseSearchParams.limit);
   const offset = Number(courseSearchParams.offset);
@@ -90,10 +87,7 @@ export const PaginateCourseSearch = ({ courseSearchTotalCount }: PaginateCourseS
 
   return (
     <div className="pagination">
-      <div id={`pagination-label-${componentId}`} className="offscreen">
-        <FormattedMessage {...messages.pagination} />
-      </div>
-      <nav aria-labelledby={`pagination-label-${componentId}`}>
+      <nav aria-label={intl.formatMessage(messages.pagination)}>
         <ul className="pagination__list">
           {pageList.map((page, index) => (
             <Fragment key={page}>

--- a/src/richie/apps/core/templates/richie/pagination.html
+++ b/src/richie/apps/core/templates/richie/pagination.html
@@ -1,56 +1,12 @@
-{% load i18n %}{% spaceless %}
+{% comment %}
+this is meant to be included in a template after using the "autopaginate" tag
+{% endcomment %}
+{% load i18n pagination_tags %}
 
-{% if is_paginated %}
-<div class="pagination">
-  <nav aria-label="{% trans "Pagination" %}">
-    <ul class="pagination__list">
-    {% for page in pages %}
-      {% if page %}
-        {% ifequal page page_obj.number %}
-          <li class="pagination__item pagination__item--current">
-            <span class="pagination__page-number">
-              <span class="offscreen">
-              {% if forloop.last %}
-                {% blocktrans %}Currently reading last page {{ page }}{% endblocktrans %}
-              {% else %}
-                {% blocktrans %}Currently reading page {{ page }}{% endblocktrans %}
-              {% endif %}
-              </span>
-              <span aria-hidden="true">{% if page == 1 %}Page {{ page }}{% else %}{{ page }}{% endif %}</span>
-            </span>
-          </li>
-        {% else %}
-          {% if page == 1 %}
-            <li class="pagination__item">
-              <a href="{{ request.path }}{% if getvars %}?{{ getvars|slice:"1:" }}{% endif %}#page{{ page_suffix }}" class="pagination__page-number">
-                {% blocktrans %}Page {{ page }}{% endblocktrans %}
-              </a>
-            </li>
-          {% else %}
-            <li class="pagination__item">
-              <a href="?page{{ page_suffix }}={{ page }}{{ getvars }}#page{{ page_suffix }}" class="pagination__page-number">
-                <span class="offscreen">
-                  {% if page == page_obj.previous_page_number %}
-                    {% blocktrans %}Previous page {{ page }}{% endblocktrans %}
-                  {% elif forloop.last %}
-                    {% blocktrans %}Last page {{ page }}{% endblocktrans %}
-                  {% elif page == page_obj.next_page_number %}
-                    {% blocktrans %}Next page {{ page }}{% endblocktrans %}
-                  {% else %}
-                    {% blocktrans %}Page {{ page }}{% endblocktrans %}
-                  {% endif %}
-                </span>
-                <span aria-hidden="true">{{ page }}</span>
-              </a>
-            </li>
-          {% endif %}
-        {% endifequal %}
-      {% else %}
-        <li class="pagination__item pagination__item--placeholder">...</li>
-      {% endif %}
-    {% endfor %}
-    </ul>
-  </nav>
-</div>
+{% if paginator.count > paginator.per_page %}
+  <div class="pagination">
+    <nav aria-label="{{ label|default:_("Pagination") }}">
+      {% paginate using "richie/pagination_inner.html" %}
+    </nav>
+  </div>
 {% endif %}
-{% endspaceless %}

--- a/src/richie/apps/core/templates/richie/pagination.html
+++ b/src/richie/apps/core/templates/richie/pagination.html
@@ -2,9 +2,7 @@
 
 {% if is_paginated %}
 <div class="pagination">
-  <div id="pagination-label" class="offscreen">{% trans "Pagination" %}</div>
-
-  <nav aria-labelledby="pagination-label">
+  <nav aria-label="{% trans "Pagination" %}">
     <ul class="pagination__list">
     {% for page in pages %}
       {% if page %}

--- a/src/richie/apps/core/templates/richie/pagination_inner.html
+++ b/src/richie/apps/core/templates/richie/pagination_inner.html
@@ -1,0 +1,54 @@
+{% comment %}
+this is not meant to be included as is in a template,
+because wrapper tags are missing. See richie/pagination.html
+{% endcomment %}
+{% load i18n %}{% spaceless %}
+
+<ul class="pagination__list">
+    {% for page in pages %}
+      {% if page %}
+        {% ifequal page page_obj.number %}
+          <li class="pagination__item pagination__item--current">
+            <span class="pagination__page-number">
+              <span class="offscreen">
+              {% if forloop.last %}
+                {% blocktrans %}Currently reading last page {{ page }}{% endblocktrans %}
+              {% else %}
+                {% blocktrans %}Currently reading page {{ page }}{% endblocktrans %}
+              {% endif %}
+              </span>
+              <span aria-hidden="true">{% if page == 1 %}Page {{ page }}{% else %}{{ page }}{% endif %}</span>
+            </span>
+          </li>
+        {% else %}
+          {% if page == 1 %}
+            <li class="pagination__item">
+              <a href="{{ request.path }}{% if getvars %}?{{ getvars|slice:"1:" }}{% endif %}#page{{ page_suffix }}" class="pagination__page-number">
+                {% blocktrans %}Page {{ page }}{% endblocktrans %}
+              </a>
+            </li>
+          {% else %}
+            <li class="pagination__item">
+              <a href="?page{{ page_suffix }}={{ page }}{{ getvars }}#page{{ page_suffix }}" class="pagination__page-number">
+                <span class="offscreen">
+                  {% if page == page_obj.previous_page_number %}
+                    {% blocktrans %}Previous page {{ page }}{% endblocktrans %}
+                  {% elif forloop.last %}
+                    {% blocktrans %}Last page {{ page }}{% endblocktrans %}
+                  {% elif page == page_obj.next_page_number %}
+                    {% blocktrans %}Next page {{ page }}{% endblocktrans %}
+                  {% else %}
+                    {% blocktrans %}Page {{ page }}{% endblocktrans %}
+                  {% endif %}
+                </span>
+                <span aria-hidden="true">{{ page }}</span>
+              </a>
+            </li>
+          {% endif %}
+        {% endifequal %}
+      {% else %}
+        <li class="pagination__item pagination__item--placeholder">...</li>
+      {% endif %}
+    {% endfor %}
+</ul>
+{% endspaceless %}

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_list.html
@@ -38,7 +38,7 @@
         {% endfor %}
 
         {% if object_list %}
-            {% paginate using "richie/pagination.html" %}
+            {% include "richie/pagination.html" %}
         {% endif %}
     {% endwith %}
 </div>

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -120,7 +120,7 @@
                                 {% include "courses/cms/fragment_course_glimpse.html" %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
-                                {% paginate using "richie/pagination.html" %}
+                                {% include "richie/pagination.html" with label=_("Courses pagination") %}
                                 <div class="button-caesura">
                                 {% if category.get_meta_category %}
                                     <a href="{% page_url 'courses' %}?{{ category.get_meta_category.extended_object.reverse_id }}={{ category.get_es_id }}" class="category-detail__see-more">
@@ -152,7 +152,7 @@
                                 {% include "courses/cms/fragment_organization_glimpse.html" %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
-                                {% paginate using "richie/pagination.html" %}
+                                {% include "richie/pagination.html" with label=_("Related organizations pagination") %}
                             {% endif %}
                         </section>
                     </div>
@@ -171,7 +171,7 @@
                                 {% include "courses/cms/fragment_blogpost_glimpse.html" %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
-                                {% paginate using "richie/pagination.html" %}
+                                {% include "richie/pagination.html" with label=_("Related blogposts pagination") %}
                             {% endif %}
                         </section>
                     </div>
@@ -190,7 +190,7 @@
                                 {% include "courses/cms/fragment_person_glimpse.html" %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
-                                {% paginate using "richie/pagination.html" %}
+                                {% include "richie/pagination.html" with label=_("Related persons pagination") %}
                             {% endif %}
                         </section>
                     </div>

--- a/src/richie/apps/courses/templates/courses/cms/category_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_list.html
@@ -28,7 +28,7 @@
     {% endfor %}
 
     {% if object_list %}
-        {% paginate using "richie/pagination.html" %}
+        {% include "richie/pagination.html" %}
     {% endif %}
 
   </div>

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -398,7 +398,7 @@
                                     {% endfor %}
                                 </div>
                                 {% if paginator.num_pages > 1 %}
-                                    {% paginate using "richie/pagination.html" %}
+                                    {% include "richie/pagination.html" %}
                                 {% endif %}
                             </section>
                         </div>

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -108,7 +108,7 @@
                             {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
                         {% endfor %}
                         {% if paginator.num_pages > 1 %}
-                            {% paginate using "richie/pagination.html" %}
+                            {% include "richie/pagination.html" with label=_("Related courses pagination") %}
                             <div class="button-caesura">
                                 <a href="{% page_url 'courses' %}?organizations={{ organization.get_es_id }}" class="organization-detail__see-more">
                                     {% blocktrans with organization_title=organization.extended_object.get_title %}
@@ -136,7 +136,7 @@
                             {% endwith %}
                         {% endfor %}
                         {% if paginator.num_pages > 1 %}
-                            {% paginate using "richie/pagination.html" %}
+                            {% include "richie/pagination.html" with label=_("Related persons pagination") %}
                         {% endif %}
                     </section>
                 </div>

--- a/src/richie/apps/courses/templates/courses/cms/organization_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_list.html
@@ -25,7 +25,7 @@
         {% endfor %}
 
         {% if object_list %}
-            {% paginate using "richie/pagination.html" %}
+            {% include "richie/pagination.html" %}
         {% endif %}
     </div>
 </div>

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -131,7 +131,7 @@
                                 {% include "courses/cms/fragment_course_glimpse.html" with course=course %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
-                                {% paginate using "richie/pagination.html" %}
+                                {% include "richie/pagination.html" with label=_("Courses pagination") %}
                                 <div class="button-caesura">
                                     <a href="{% page_url 'courses' %}?persons={{ person.extended_object_id }}" class="person-detail__see-more">
                                     {% blocktrans with person_title=person.extended_object.get_title %}
@@ -157,7 +157,7 @@
                                 {% include "courses/cms/fragment_blogpost_glimpse.html" with blogpost=blogpost %}
                             {% endfor %}
                             {% if paginator.num_pages > 1 %}
-                                {% paginate using "richie/pagination.html" %}
+                                {% include "richie/pagination.html" with label=_("Blogposts pagination") %}
                             {% endif %}
                         </section>
                     </div>

--- a/src/richie/apps/courses/templates/courses/cms/person_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_list.html
@@ -28,7 +28,7 @@
   {% endfor %}
 
   {% if object_list %}
-    {% paginate using "richie/pagination.html" %}
+    {% include "richie/pagination.html" %}
   {% endif %}
 </div>
 {% endblock content %}

--- a/src/richie/apps/courses/templates/courses/cms/program_list.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_list.html
@@ -36,7 +36,7 @@
                 {% endfor %}
 
                 {% if object_list %}
-                    {% paginate using "richie/pagination.html" %}
+                    {% include "richie/pagination.html" %}
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
## Purpose

Fix #1581


## Proposal

The idea here is to easily allow custom labels when using multiple pagination components on the same page. We do this by using a new pagination-specific django tag, currently named `richie_pagination`, **but I guess the naming is not that great**.

Allowing custom labels without this new tag was cumbersome because, the dj-pagination `{% paginate %}` tag doesn't accept any custom context (like an `{% include %}` tag). So it would require to create a specific template file for each label change. I figured having a new tag was better?

Because I'm still not sure how it is usually dealt with in this project, **translation strings are missing** in this PR.
