### PR TITLE
✨(frontend) Create a Banner React component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Create a React `Banner` component
 - Add catalog visibility field to course run so it's possible to hide a
   course run on the catalog and/or hide it completely. Possible values
   are `course_and_search`, `course_only` and `hidden`.
@@ -27,7 +28,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed a layout issue on course glimpse
   when organization title and course title are too long
 - Add missing language parameter in LTI requests issued by LTI consumer plugin
-
 
 ## [2.11.0] - 2022-01-04
 

--- a/src/frontend/js/components/Banner/index.spec.tsx
+++ b/src/frontend/js/components/Banner/index.spec.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import Banner, { BannerType } from '.';
+
+describe('Banner', () => {
+  it('displays a message', () => {
+    const { getByText } = render(
+      <Banner type={BannerType.INFO} message="A message for test purpose" />,
+    );
+
+    const $message = getByText('A message for test purpose');
+    expect(Object.values($message.classList)).toEqual(['banner__message']);
+  });
+
+  it('has a type property', () => {
+    const types = Object.keys(BannerType);
+    const randomIndex = Math.floor(Math.random() * types.length);
+    const randomType = types[randomIndex] as BannerType;
+
+    const { container } = render(<Banner type={randomType} message="A message for test purpose" />);
+    const $banner = container.querySelector(`.banner.banner--${randomType}`);
+
+    expect($banner).not.toBeNull();
+  });
+
+  it('has a rounded boolean property', () => {
+    const { container } = render(<Banner message="A message for test purpose" rounded />);
+    const $banner = container.querySelector('.banner.banner--info.banner--rounded');
+
+    expect($banner).not.toBeNull();
+  });
+});

--- a/src/frontend/js/components/Banner/index.tsx
+++ b/src/frontend/js/components/Banner/index.tsx
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+
+export enum BannerType {
+  ERROR = 'error',
+  INFO = 'info',
+  SUCCESS = 'success',
+  WARNING = 'warning',
+}
+
+interface BannerProps {
+  message: string;
+  type?: BannerType;
+  rounded?: boolean;
+}
+
+const Banner = ({ message, rounded, type = BannerType.INFO }: BannerProps) => {
+  const className = useMemo(
+    (): string => ['banner', `banner--${type}`, ...(rounded ? ['banner--rounded'] : [])].join(' '),
+    [type, rounded],
+  );
+
+  return (
+    <div className={className}>
+      <p className="banner__message">{message}</p>
+    </div>
+  );
+};
+
+export default Banner;


### PR DESCRIPTION
## Purpose

Previously we created a styles for a banner block. In the react app context, it could be interesting to have a reusable `Banner` component base on these styles to easily display messages.

## Proposal

- [x] Create a reusable react Banner component
