### PR TITLE
Show organization code in the course glimpse card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+- Show organization acronym by using the `menu_title` field (if set) on
+  the organization page.
 - Improve pagination blocks labels for screen reader users when there are
   multiple pagination components on one page
 

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -1,7 +1,7 @@
 {% load i18n cms_tags extra_tags static thumbnail %}{% spaceless %}
 {% comment %}Obviously, the context template variable "course" is required and must be a Course page extension{% endcomment %}
 
-{% with course_page=course.extended_object course_state=course.state main_organization_title=course.get_main_organization.extended_object.get_title main_organization=course.get_main_organization course_variant=course_variant|default:'glimpse' %}
+{% with course_page=course.extended_object course_state=course.state main_organization_title=course.get_main_organization.extended_object.get_menu_title main_organization=course.get_main_organization course_variant=course_variant|default:'glimpse' %}
 <a class="course-{{ course_variant }}{% if course_page.publisher_is_draft is True %} course-{{ course_variant }}--draft{% endif %}" href="{{ course_page.get_absolute_url }}">
     <div class="course-{{ course_variant }}__media">
         {% get_page_plugins "course_cover" course_page as cover_plugins or %}

--- a/src/richie/apps/search/indexers/courses.py
+++ b/src/richie/apps/search/indexers/courses.py
@@ -647,7 +647,7 @@ class CoursesIndexer:
             # Pick the highlighted organization from the organizations QuerySet to benefit from
             # the prefetch of related title sets
             "organization_highlighted": {
-                title.language: title.title
+                title.language: title.menu_title if title.menu_title else title.title
                 for title in organization_highlighted.extended_object.published_titles
             }
             if organization_highlighted


### PR DESCRIPTION
Shows the organization menu title in the course glimpse card, if defined.
It retains original functionality, only displaying this field if the organization wants to. 

Solves #1570