### PR TITLE
🚸(course) add admin autocomplete feature on Page select in Person plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add course runs to the course search API
+- Add autocomplete feature on Page select in Person plugin
 
 ### Changed
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -433,6 +433,9 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         "treebeard",
         "filer",
         "easy_thumbnails",
+        # django-autocomplete-light
+        "dal",
+        "dal_select2",
         # Django
         "django.contrib.auth",
         "django.contrib.contenttypes",

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     django-redis>=4.11.0
     django-treebeard
     exrex==0.10.5
+    django-autocomplete-light==3.9.1
 package_dir =
     =src
 packages = find:
@@ -117,5 +118,5 @@ python_files =
     tests.py
 testpaths =
     tests
-filterwarnings = 
+filterwarnings =
     ignore:::(?!(tests|richie))

--- a/src/richie/apps/courses/cms_plugins.py
+++ b/src/richie/apps/courses/cms_plugins.py
@@ -10,7 +10,7 @@ from cms.plugin_pool import plugin_pool
 from richie.apps.core.defaults import PLUGINS_GROUP
 from richie.apps.core.models import get_relevant_page_with_fallbacks
 
-from .forms import LicencePluginForm
+from .forms import LicencePluginForm, PersonPluginForm
 from .models import (
     BlogPostPluginModel,
     CategoryPluginModel,
@@ -143,6 +143,7 @@ class PersonPlugin(CMSPluginBase):
     """
 
     cache = True
+    form = PersonPluginForm
     model = PersonPluginModel
     module = PLUGINS_GROUP
     name = _("Person")

--- a/src/richie/apps/courses/forms.py
+++ b/src/richie/apps/courses/forms.py
@@ -4,11 +4,13 @@ Courses model forms
 
 from django import forms
 from django.forms import widgets
+from django.urls import reverse_lazy
 
+from dal import autocomplete
 from djangocms_text_ckeditor.widgets import TextEditorWidget
 from parler.forms import TranslatableModelForm
 
-from .models import Category, Licence, LicencePluginModel
+from .models import Category, Licence, LicencePluginModel, PersonPluginModel
 
 
 class AdminCategoryForm(forms.ModelForm):
@@ -47,3 +49,21 @@ class LicencePluginForm(forms.ModelForm):
         model = LicencePluginModel
         widgets = {"description": TextEditorWidget}
         fields = ["licence", "description"]
+
+
+class PersonPluginForm(forms.ModelForm):
+    """
+    PersonPlugin model form used within DjangoCMS frontend admin.
+    """
+
+    class Meta:
+
+        fields = "__all__"
+        model = PersonPluginModel
+        widgets = {
+            "page": autocomplete.ModelSelect2(
+                url=reverse_lazy(
+                    "person-page-admin-autocomplete", kwargs={"version": "1.0"}
+                )
+            ),
+        }

--- a/src/richie/apps/courses/urls.py
+++ b/src/richie/apps/courses/urls.py
@@ -1,11 +1,12 @@
 """
 API routes exposed by our Courses app.
 """
-from django.urls import re_path
+from django.urls import path, re_path
 
 from rest_framework import routers
 
 from .api import CourseRunsViewSet, course_runs_sync
+from .views import PersonPageAdminAutocomplete
 
 ROUTER = routers.SimpleRouter()
 
@@ -14,4 +15,9 @@ ROUTER.register("course-runs", CourseRunsViewSet, "course_runs")
 
 urlpatterns = ROUTER.urls + [
     re_path("course-runs-sync/?$", course_runs_sync, name="course_run_sync"),
+    path(
+        "person-page-admin-autocomplete/",
+        PersonPageAdminAutocomplete.as_view(),
+        name="person-page-admin-autocomplete",
+    ),
 ]

--- a/src/richie/apps/courses/views.py
+++ b/src/richie/apps/courses/views.py
@@ -1,0 +1,41 @@
+"""
+Courses model views
+"""
+
+from cms.api import Page
+from dal import autocomplete
+
+
+class PersonPageAdminAutocomplete(autocomplete.Select2QuerySetView):
+    """
+    Autocomplete view for Person search in admin
+    """
+
+    def get_queryset(self):
+        """
+        Return queryset to use for returning autocomplete results.
+
+        User needs to be authenticated with the view permission on Person model.
+
+        Without any search keyword from ``self.q`` every results are returned, if
+        keyword is given results are filtered on it with insensitive ``contains``.
+        """
+        # Filter out results depending on the visitor
+        if (
+            not self.request.user.is_authenticated
+            or not self.request.user.is_staff
+            or not self.request.user.has_perm("courses.view_person")
+        ):
+            return Page.objects.none()
+
+        # Retrieve only draft Person pages
+        qs = Page.objects.filter(publisher_is_draft=True, person__isnull=False)
+
+        # Perform autocompletion search on Person page
+        if self.q:
+            qs = qs.filter(title_set__title__icontains=self.q)
+
+        # Ensure we get a distinct list.
+        # NOTE: Order is currently not taken care of since correct implementation
+        # with page language fallback is something complicated to achieve
+        return qs.distinct()

--- a/tests/apps/courses/test_cms_views_person.py
+++ b/tests/apps/courses/test_cms_views_person.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the Person views
+"""
+from django.conf import settings
+from django.test.utils import override_settings
+from django.urls import reverse_lazy
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.factories import UserFactory
+from richie.apps.courses.factories import PersonFactory
+
+
+@override_settings(LANGUAGES=(("en", "En"), ("fr", "Fr"), ("de", "De")))
+@override_settings(
+    CMS_LANGUAGES={
+        "default": {
+            "public": True,
+            "hide_untranslated": False,
+            "redirect_on_fallback": False,
+            "fallbacks": ["en", "fr", "de"],
+        }
+    }
+)
+class PersonPluginAutocompleteTestCase(CMSTestCase):
+    """
+    Test that PersonPlugin autocomplete view correctly returns results as expected
+    """
+
+    _VIEW_URL = reverse_lazy(
+        "person-page-admin-autocomplete", kwargs={"version": "1.0"}
+    )
+
+    def test_cms_views_autocomplete_permission(self):
+        """
+        The autocomplete view should return results only to authenticated users with
+        the right permission.
+        """
+        person = PersonFactory(page_title={"en": "donald duck", "fr": "donald duck"})
+        person_page = person.extended_object
+        person_page.publish("en")
+        person_page.publish("fr")
+
+        can_view_person = "courses.view_person"
+
+        # Non authenticated user don't have any results
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        self.assertEqual(len(payload["results"]), 0)
+
+        # Authenticated user needs permissions
+        user = UserFactory()
+        self.client.login(username=user.username, password="password")
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        self.assertEqual(len(payload["results"]), 0)
+
+        # Non staff user even with the right permission don't have any results
+        admin_1 = UserFactory(permissions=[can_view_person])
+        self.client.login(username=admin_1.username, password="password")
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        self.assertEqual(len(payload["results"]), 0)
+
+        # Staff user with view permission is allowed to have results
+        admin_2 = UserFactory(is_staff=True, permissions=[can_view_person])
+        self.client.login(username=admin_2.username, password="password")
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        self.assertEqual(len(payload["results"]), 1)
+
+        # Superuser passby
+        superuser = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=superuser.username, password="password")
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        self.assertEqual(len(payload["results"]), 1)
+
+    def test_cms_views_autocomplete_label_translation(self):
+        """
+        Autocomplete view should return the right title according to the current client
+        language.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        person = PersonFactory(page_title={"en": "a title", "fr": "un titre"})
+        person_page = person.extended_object
+        person_page.publish("en")
+        person_page.publish("fr")
+
+        # Getting response with default language returns titles in default language
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        self.assertEqual(payload["results"][0]["text"], "a title")
+
+        # Setting language to french with accurate cookie returns titles in french
+        # language
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "fr"})
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        self.assertEqual(payload["results"][0]["text"], "un titre")
+
+    def test_cms_views_autocomplete_list(self):
+        """
+        Autocomplete view should return list of all objects with the right title in the
+        current language.
+
+        NOTE: We stand on a queryset arbitrary order, that should be the order of
+        created objects (through their id order).
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create unpublished Person only for english
+
+        # Create persons named from Picsou/Scrooge universe, characters may have their
+        # names depending language
+        person_titles = [
+            {"en": "donald duck", "fr": "donald duck"},
+            {"en": "scrooge mcduck", "fr": "balthazar picsou", "de": "dagobert duck"},
+            {"en": "flintheart glomgold", "fr": "archibald gripsou"},
+            {"en": "gladstone gander", "de": "gustav gans"},
+        ]
+        for title in person_titles:
+            person = PersonFactory(page_title=title)
+            person_page = person.extended_object
+            if "en" in title:
+                person_page.publish("en")
+            if "fr" in title:
+                person_page.publish("fr")
+            if "de" in title:
+                person_page.publish("de")
+
+        # Listing with default language (english)
+        response = self.client.get(self._VIEW_URL, follow=True)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        titles = [item["text"] for item in payload["results"]]
+        self.assertEqual(
+            titles,
+            [
+                "donald duck",
+                "scrooge mcduck",
+                "flintheart glomgold",
+                "gladstone gander",
+            ],
+        )
+
+        # Set language to french and list all Persons
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "fr"})
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        titles = [item["text"] for item in payload["results"]]
+        self.assertEqual(
+            titles,
+            [
+                "donald duck",
+                "balthazar picsou",
+                "archibald gripsou",
+                "gladstone gander",
+            ],
+        )
+
+        # Set language to german and list all Persons
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "de"})
+        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        titles = [item["text"] for item in payload["results"]]
+        self.assertEqual(
+            titles,
+            [
+                "donald duck",
+                "dagobert duck",
+                "flintheart glomgold",
+                "gustav gans",
+            ],
+        )
+
+    def test_cms_views_autocomplete_search(self):
+        """
+        Autocomplete view should return the right results with search keyword.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        # Create unpublished Person only for english
+
+        # Create persons named from Picsou/Scrooge universe, characters may have their
+        # names depending language
+        person_titles = [
+            {"en": "donald duck", "fr": "donald duck"},
+            {"en": "scrooge mcduck", "fr": "balthazar picsou"},
+            {"en": "flintheart glomgold", "fr": "archibald gripsou"},
+            {"en": "gladstone gander"},
+        ]
+        for title in person_titles:
+            person = PersonFactory(page_title=title)
+            person_page = person.extended_object
+            if "en" in title:
+                person_page.publish("en")
+            if "fr" in title:
+                person_page.publish("fr")
+
+        # Search with default language (english)
+        data = {"q": "Duck"}
+        payload = self.client.get(self._VIEW_URL, follow=True, data=data).json()
+        titles = [item["text"] for item in payload["results"]]
+        self.assertEqual(
+            titles,
+            [
+                "donald duck",
+                "scrooge mcduck",
+            ],
+        )
+
+        # Set language to french and search for a keyword that should match for english
+        # and french
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "fr"})
+        data = {"q": "Duck"}
+        payload = self.client.get(self._VIEW_URL, follow=True, data=data).json()
+        titles = [item["text"] for item in payload["results"]]
+        self.assertEqual(
+            titles,
+            [
+                "donald duck",
+                # NOTE: Found 'scrooge mcduck' but display its french translation title
+                "balthazar picsou",
+            ],
+        )
+
+        # Keep language to french and search for a keyword that should match in french
+        # only
+        data = {"q": "picsou"}
+        payload = self.client.get(self._VIEW_URL, follow=True, data=data).json()
+        titles = [item["text"] for item in payload["results"]]
+        self.assertEqual(
+            titles,
+            [
+                "balthazar picsou",
+            ],
+        )


### PR DESCRIPTION
## Purpose

Some sites can have a huge list of objects where it is hard to search for a specific
object. The page selector from Person plugin is one of this case.

## Proposal

We implement usage of an autocomplete feature with Select2.js by the way of new
dependancy 'django-autocomplete-light' enabled and configured on the 'page' field
from Person plugin form.
