### PR TITLE
👷(tests) fix tests for mysql

### DIFF
--- a/env.d/development/mysql
+++ b/env.d/development/mysql
@@ -2,13 +2,11 @@
 MYSQL_ROOT_PASSWORD=
 MYSQL_ALLOW_EMPTY_PASSWORD=yes
 MYSQL_DATABASE=richie
-MYSQL_USER=fun
-MYSQL_PASSWORD=pass
 
 # App database configuration
 DB_ENGINE=django.db.backends.mysql
 DB_HOST=mysql
 DB_NAME=richie
-DB_USER=fun
-DB_PASSWORD=pass
+DB_USER=root
+DB_PASSWORD=
 DB_PORT=3306


### PR DESCRIPTION
### Purpose

When Django runs tests, it creates a temporary database with the name "test_{database_name}". The problem is that our `fun` user does not have the right to create a new database.

### Proposal

We can safely run our tests with the mysql `root` user.

Fixes https://github.com/openfun/richie/issues/1594