### PR TITLE
🚸(courses) add admin autocomplete for remaining page related plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add settings to setup Joanie
 - Add course runs to the course search API
-- Add autocomplete feature on Page select in Person plugin
+- Add autocomplete feature on Page select in page related plugins
 
 ### Changed
 

--- a/src/richie/apps/courses/cms_plugins.py
+++ b/src/richie/apps/courses/cms_plugins.py
@@ -10,17 +10,7 @@ from cms.plugin_pool import plugin_pool
 from richie.apps.core.defaults import PLUGINS_GROUP
 from richie.apps.core.models import get_relevant_page_with_fallbacks
 
-from .forms import LicencePluginForm, PersonPluginForm
-from .models import (
-    BlogPostPluginModel,
-    CategoryPluginModel,
-    CoursePluginModel,
-    LicencePluginModel,
-    OrganizationPluginModel,
-    OrganizationsByCategoryPluginModel,
-    PersonPluginModel,
-    ProgramPluginModel,
-)
+from . import forms, models
 
 
 @plugin_pool.register_plugin
@@ -31,7 +21,8 @@ class OrganizationPlugin(CMSPluginBase):
 
     cache = True
     fieldsets = ((None, {"fields": ["page", "variant"]}),)
-    model = OrganizationPluginModel
+    form = forms.OrganizationPluginForm
+    model = models.OrganizationPluginModel
     module = PLUGINS_GROUP
     name = _("Organization")
     render_template = "courses/plugins/organization.html"
@@ -58,7 +49,8 @@ class OrganizationsByCategoryPlugin(CMSPluginBase):
     """
 
     cache = True
-    model = OrganizationsByCategoryPluginModel
+    form = forms.OrganizationsByCategoryPluginForm
+    model = models.OrganizationsByCategoryPluginModel
     module = PLUGINS_GROUP
     name = _("Organization by Category")
     render_template = "courses/plugins/organizations_by_category.html"
@@ -89,7 +81,8 @@ class CategoryPlugin(CMSPluginBase):
 
     cache = True
     fieldsets = ((None, {"fields": ["page", "variant"]}),)
-    model = CategoryPluginModel
+    form = forms.CategoryPluginForm
+    model = models.CategoryPluginModel
     module = PLUGINS_GROUP
     name = _("Category")
     render_template = "courses/plugins/category_plugin.html"
@@ -117,7 +110,8 @@ class CoursePlugin(CMSPluginBase):
 
     cache = True
     fieldsets = ((None, {"fields": ["page", "variant"]}),)
-    model = CoursePluginModel
+    form = forms.CoursePluginForm
+    model = models.CoursePluginModel
     module = PLUGINS_GROUP
     name = _("Course")
     render_template = "courses/plugins/course_plugin.html"
@@ -143,8 +137,8 @@ class PersonPlugin(CMSPluginBase):
     """
 
     cache = True
-    form = PersonPluginForm
-    model = PersonPluginModel
+    form = forms.PersonPluginForm
+    model = models.PersonPluginModel
     module = PLUGINS_GROUP
     name = _("Person")
     render_template = "courses/plugins/person.html"
@@ -172,8 +166,8 @@ class LicencePlugin(CMSPluginBase):
     allow_children = False
     cache = True
     fieldsets = ((None, {"fields": ["licence", "description"]}),)
-    form = LicencePluginForm
-    model = LicencePluginModel
+    form = forms.LicencePluginForm
+    model = models.LicencePluginModel
     module = PLUGINS_GROUP
     name = _("Licence")
     render_template = "courses/plugins/licence_plugin.html"
@@ -192,7 +186,8 @@ class BlogPostPlugin(CMSPluginBase):
 
     cache = True
     fieldsets = ((None, {"fields": ["page", "variant"]}),)
-    model = BlogPostPluginModel
+    form = forms.BlogPostPluginForm
+    model = models.BlogPostPluginModel
     module = PLUGINS_GROUP
     name = _("Post")
     render_template = "courses/plugins/blogpost.html"
@@ -218,7 +213,8 @@ class ProgramPlugin(CMSPluginBase):
     """
 
     cache = True
-    model = ProgramPluginModel
+    form = forms.ProgramPluginForm
+    model = models.ProgramPluginModel
     module = PLUGINS_GROUP
     name = _("Program")
     render_template = "courses/plugins/program.html"

--- a/src/richie/apps/courses/forms.py
+++ b/src/richie/apps/courses/forms.py
@@ -10,7 +10,7 @@ from dal import autocomplete
 from djangocms_text_ckeditor.widgets import TextEditorWidget
 from parler.forms import TranslatableModelForm
 
-from .models import Category, Licence, LicencePluginModel, PersonPluginModel
+from . import models
 
 
 class AdminCategoryForm(forms.ModelForm):
@@ -21,7 +21,7 @@ class AdminCategoryForm(forms.ModelForm):
     class Meta:
 
         fields = ["color"]
-        model = Category
+        model = models.Category
         widgets = {
             "color": widgets.TextInput(attrs={"type": "color", "style": "width: 5rem;"})
         }
@@ -34,7 +34,7 @@ class AdminLicenceForm(TranslatableModelForm):
 
     class Meta:
 
-        model = Licence
+        model = models.Licence
         widgets = {"content": TextEditorWidget}
         fields = ["name", "logo", "url", "content"]
 
@@ -46,9 +46,84 @@ class LicencePluginForm(forms.ModelForm):
 
     class Meta:
 
-        model = LicencePluginModel
+        model = models.LicencePluginModel
         widgets = {"description": TextEditorWidget}
         fields = ["licence", "description"]
+
+
+# Forms for page related plugins
+
+
+def get_plugin_form_widgets(model_name):
+    """Get widgets definition for the plugin form of a model defined by its name."""
+    return {
+        "page": autocomplete.ModelSelect2(
+            url=reverse_lazy(
+                "page-admin-autocomplete",
+                kwargs={"model_name": model_name, "version": "1.0"},
+            )
+        ),
+    }
+
+
+class BlogPostPluginForm(forms.ModelForm):
+    """
+    BlogPostPlugin model form used within DjangoCMS frontend admin.
+    """
+
+    class Meta:
+
+        fields = "__all__"
+        model = models.BlogPostPluginModel
+        widgets = get_plugin_form_widgets("blogpost")
+
+
+class CategoryPluginForm(forms.ModelForm):
+    """
+    CategoryPlugin model form used within DjangoCMS frontend admin.
+    """
+
+    class Meta:
+
+        fields = "__all__"
+        model = models.CategoryPluginModel
+        widgets = get_plugin_form_widgets("category")
+
+
+class CoursePluginForm(forms.ModelForm):
+    """
+    CoursePlugin model form used within DjangoCMS frontend admin.
+    """
+
+    class Meta:
+
+        fields = "__all__"
+        model = models.CoursePluginModel
+        widgets = get_plugin_form_widgets("course")
+
+
+class OrganizationsByCategoryPluginForm(forms.ModelForm):
+    """
+    OrganizationsByCategoryPlugin model form used within DjangoCMS frontend admin.
+    """
+
+    class Meta:
+
+        fields = "__all__"
+        model = models.OrganizationsByCategoryPluginModel
+        widgets = get_plugin_form_widgets("category")
+
+
+class OrganizationPluginForm(forms.ModelForm):
+    """
+    OrganizationPlugin model form used within DjangoCMS frontend admin.
+    """
+
+    class Meta:
+
+        fields = "__all__"
+        model = models.OrganizationPluginModel
+        widgets = get_plugin_form_widgets("organization")
 
 
 class PersonPluginForm(forms.ModelForm):
@@ -59,11 +134,17 @@ class PersonPluginForm(forms.ModelForm):
     class Meta:
 
         fields = "__all__"
-        model = PersonPluginModel
-        widgets = {
-            "page": autocomplete.ModelSelect2(
-                url=reverse_lazy(
-                    "person-page-admin-autocomplete", kwargs={"version": "1.0"}
-                )
-            ),
-        }
+        model = models.PersonPluginModel
+        widgets = get_plugin_form_widgets("person")
+
+
+class ProgramPluginForm(forms.ModelForm):
+    """
+    ProgramPlugin model form used within DjangoCMS frontend admin.
+    """
+
+    class Meta:
+
+        fields = "__all__"
+        model = models.ProgramPluginModel
+        widgets = get_plugin_form_widgets("program")

--- a/src/richie/apps/courses/urls.py
+++ b/src/richie/apps/courses/urls.py
@@ -6,7 +6,7 @@ from django.urls import path, re_path
 from rest_framework import routers
 
 from .api import CourseRunsViewSet, course_runs_sync
-from .views import PersonPageAdminAutocomplete
+from .views import PageAdminAutocomplete
 
 ROUTER = routers.SimpleRouter()
 
@@ -16,8 +16,8 @@ ROUTER.register("course-runs", CourseRunsViewSet, "course_runs")
 urlpatterns = ROUTER.urls + [
     re_path("course-runs-sync/?$", course_runs_sync, name="course_run_sync"),
     path(
-        "person-page-admin-autocomplete/",
-        PersonPageAdminAutocomplete.as_view(),
-        name="person-page-admin-autocomplete",
+        "page-admin-autocomplete/<slug:model_name>>/",
+        PageAdminAutocomplete.as_view(),
+        name="page-admin-autocomplete",
     ),
 ]

--- a/src/richie/apps/courses/views.py
+++ b/src/richie/apps/courses/views.py
@@ -6,7 +6,7 @@ from cms.api import Page
 from dal import autocomplete
 
 
-class PersonPageAdminAutocomplete(autocomplete.Select2QuerySetView):
+class PageAdminAutocomplete(autocomplete.Select2QuerySetView):
     """
     Autocomplete view for Person search in admin
     """
@@ -20,16 +20,20 @@ class PersonPageAdminAutocomplete(autocomplete.Select2QuerySetView):
         Without any search keyword from ``self.q`` every results are returned, if
         keyword is given results are filtered on it with insensitive ``contains``.
         """
+        model_name = self.kwargs["model_name"]
+
         # Filter out results depending on the visitor
         if (
             not self.request.user.is_authenticated
             or not self.request.user.is_staff
-            or not self.request.user.has_perm("courses.view_person")
+            or not self.request.user.has_perm(f"courses.view_{model_name}")
         ):
             return Page.objects.none()
 
-        # Retrieve only draft Person pages
-        qs = Page.objects.filter(publisher_is_draft=True, person__isnull=False)
+        # Retrieve only draft pages
+        qs = Page.objects.filter(
+            publisher_is_draft=True, **{f"{model_name}__isnull": False}
+        )
 
         # Perform autocompletion search on Person page
         if self.q:

--- a/tests/apps/courses/test_cms_views.py
+++ b/tests/apps/courses/test_cms_views.py
@@ -9,7 +9,7 @@ from django.urls import reverse_lazy
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.core.factories import UserFactory
-from richie.apps.courses.factories import PersonFactory
+from richie.apps.courses import factories
 
 
 @override_settings(LANGUAGES=(("en", "En"), ("fr", "Fr"), ("de", "De")))
@@ -23,79 +23,85 @@ from richie.apps.courses.factories import PersonFactory
         }
     }
 )
-class PersonPluginAutocompleteTestCase(CMSTestCase):
+class PluginAutocompleteTestCase(CMSTestCase):
     """
     Test that PersonPlugin autocomplete view correctly returns results as expected
     """
 
-    _VIEW_URL = reverse_lazy(
-        "person-page-admin-autocomplete", kwargs={"version": "1.0"}
-    )
-
-    def test_cms_views_autocomplete_permission(self):
+    def _test_cms_views_autocomplete_permission(self, model_name, factory_class):
         """
         The autocomplete view should return results only to authenticated users with
         the right permission.
         """
-        person = PersonFactory(page_title={"en": "donald duck", "fr": "donald duck"})
-        person_page = person.extended_object
-        person_page.publish("en")
-        person_page.publish("fr")
+        url = reverse_lazy(
+            "page-admin-autocomplete",
+            kwargs={"model_name": model_name, "version": "1.0"},
+        )
 
-        can_view_person = "courses.view_person"
+        extension = factory_class(page_title={"en": "donald duck", "fr": "donald duck"})
+        page = extension.extended_object
+        page.publish("en")
+        page.publish("fr")
+
+        can_view = f"courses.view_{model_name}"
 
         # Non authenticated user don't have any results
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         self.assertEqual(len(payload["results"]), 0)
 
         # Authenticated user needs permissions
         user = UserFactory()
         self.client.login(username=user.username, password="password")
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         self.assertEqual(len(payload["results"]), 0)
 
         # Non staff user even with the right permission don't have any results
-        admin_1 = UserFactory(permissions=[can_view_person])
+        admin_1 = UserFactory(permissions=[can_view])
         self.client.login(username=admin_1.username, password="password")
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         self.assertEqual(len(payload["results"]), 0)
 
         # Staff user with view permission is allowed to have results
-        admin_2 = UserFactory(is_staff=True, permissions=[can_view_person])
+        admin_2 = UserFactory(is_staff=True, permissions=[can_view])
         self.client.login(username=admin_2.username, password="password")
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         self.assertEqual(len(payload["results"]), 1)
 
         # Superuser passby
         superuser = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=superuser.username, password="password")
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         self.assertEqual(len(payload["results"]), 1)
 
-    def test_cms_views_autocomplete_label_translation(self):
+    def _test_cms_views_autocomplete_label_translation(self, model_name, factory_class):
         """
         Autocomplete view should return the right title according to the current client
         language.
         """
+        url = reverse_lazy(
+            "page-admin-autocomplete",
+            kwargs={"model_name": model_name, "version": "1.0"},
+        )
+
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
-        person = PersonFactory(page_title={"en": "a title", "fr": "un titre"})
-        person_page = person.extended_object
-        person_page.publish("en")
-        person_page.publish("fr")
+        extension = factory_class(page_title={"en": "a title", "fr": "un titre"})
+        page = extension.extended_object
+        page.publish("en")
+        page.publish("fr")
 
         # Getting response with default language returns titles in default language
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         self.assertEqual(payload["results"][0]["text"], "a title")
 
         # Setting language to french with accurate cookie returns titles in french
         # language
         self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "fr"})
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         self.assertEqual(payload["results"][0]["text"], "un titre")
 
-    def test_cms_views_autocomplete_list(self):
+    def _test_cms_views_autocomplete_list(self, model_name, factory_class):
         """
         Autocomplete view should return list of all objects with the right title in the
         current language.
@@ -103,31 +109,36 @@ class PersonPluginAutocompleteTestCase(CMSTestCase):
         NOTE: We stand on a queryset arbitrary order, that should be the order of
         created objects (through their id order).
         """
+        url = reverse_lazy(
+            "page-admin-autocomplete",
+            kwargs={"model_name": model_name, "version": "1.0"},
+        )
+
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
         # Create unpublished Person only for english
 
-        # Create persons named from Picsou/Scrooge universe, characters may have their
+        # Create pages named from Picsou/Scrooge universe, characters may have their
         # names depending language
-        person_titles = [
+        page_titles = [
             {"en": "donald duck", "fr": "donald duck"},
             {"en": "scrooge mcduck", "fr": "balthazar picsou", "de": "dagobert duck"},
             {"en": "flintheart glomgold", "fr": "archibald gripsou"},
             {"en": "gladstone gander", "de": "gustav gans"},
         ]
-        for title in person_titles:
-            person = PersonFactory(page_title=title)
-            person_page = person.extended_object
+        for title in page_titles:
+            extension = factory_class(page_title=title)
+            page = extension.extended_object
             if "en" in title:
-                person_page.publish("en")
+                page.publish("en")
             if "fr" in title:
-                person_page.publish("fr")
+                page.publish("fr")
             if "de" in title:
-                person_page.publish("de")
+                page.publish("de")
 
         # Listing with default language (english)
-        response = self.client.get(self._VIEW_URL, follow=True)
+        response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         titles = [item["text"] for item in payload["results"]]
@@ -143,7 +154,7 @@ class PersonPluginAutocompleteTestCase(CMSTestCase):
 
         # Set language to french and list all Persons
         self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "fr"})
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         titles = [item["text"] for item in payload["results"]]
         self.assertEqual(
             titles,
@@ -157,60 +168,54 @@ class PersonPluginAutocompleteTestCase(CMSTestCase):
 
         # Set language to german and list all Persons
         self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "de"})
-        payload = self.client.get(self._VIEW_URL, follow=True).json()
+        payload = self.client.get(url, follow=True).json()
         titles = [item["text"] for item in payload["results"]]
         self.assertEqual(
             titles,
-            [
-                "donald duck",
-                "dagobert duck",
-                "flintheart glomgold",
-                "gustav gans",
-            ],
+            ["donald duck", "dagobert duck", "flintheart glomgold", "gustav gans"],
         )
 
-    def test_cms_views_autocomplete_search(self):
+    def _test_cms_views_autocomplete_search(self, model_name, factory_class):
         """
         Autocomplete view should return the right results with search keyword.
         """
+        url = reverse_lazy(
+            "page-admin-autocomplete",
+            kwargs={"model_name": model_name, "version": "1.0"},
+        )
+
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")
 
         # Create unpublished Person only for english
 
-        # Create persons named from Picsou/Scrooge universe, characters may have their
+        # Create objects named from Picsou/Scrooge universe, characters may have their
         # names depending language
-        person_titles = [
+        page_titles = [
             {"en": "donald duck", "fr": "donald duck"},
             {"en": "scrooge mcduck", "fr": "balthazar picsou"},
             {"en": "flintheart glomgold", "fr": "archibald gripsou"},
             {"en": "gladstone gander"},
         ]
-        for title in person_titles:
-            person = PersonFactory(page_title=title)
-            person_page = person.extended_object
+        for title in page_titles:
+            extension = factory_class(page_title=title)
+            page = extension.extended_object
             if "en" in title:
-                person_page.publish("en")
+                page.publish("en")
             if "fr" in title:
-                person_page.publish("fr")
+                page.publish("fr")
 
         # Search with default language (english)
         data = {"q": "Duck"}
-        payload = self.client.get(self._VIEW_URL, follow=True, data=data).json()
+        payload = self.client.get(url, follow=True, data=data).json()
         titles = [item["text"] for item in payload["results"]]
-        self.assertEqual(
-            titles,
-            [
-                "donald duck",
-                "scrooge mcduck",
-            ],
-        )
+        self.assertEqual(titles, ["donald duck", "scrooge mcduck"])
 
         # Set language to french and search for a keyword that should match for english
         # and french
         self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "fr"})
         data = {"q": "Duck"}
-        payload = self.client.get(self._VIEW_URL, follow=True, data=data).json()
+        payload = self.client.get(url, follow=True, data=data).json()
         titles = [item["text"] for item in payload["results"]]
         self.assertEqual(
             titles,
@@ -224,11 +229,29 @@ class PersonPluginAutocompleteTestCase(CMSTestCase):
         # Keep language to french and search for a keyword that should match in french
         # only
         data = {"q": "picsou"}
-        payload = self.client.get(self._VIEW_URL, follow=True, data=data).json()
+        payload = self.client.get(url, follow=True, data=data).json()
         titles = [item["text"] for item in payload["results"]]
-        self.assertEqual(
-            titles,
-            [
-                "balthazar picsou",
-            ],
+        self.assertEqual(titles, ["balthazar picsou"])
+
+
+# Programmatically create test methods from the `_test_*` methods above. One set of test
+# methods for each model that has these features.
+TEST_PREFIX = "_test_cms_views_autocomplete"
+for name, related_factory in (
+    ("blogpost", factories.BlogPostFactory),
+    ("category", factories.CategoryFactory),
+    ("course", factories.CourseFactory),
+    ("organization", factories.OrganizationFactory),
+    ("person", factories.PersonFactory),
+    ("program", factories.ProgramFactory),
+):
+    for method in (
+        f for f in dir(PluginAutocompleteTestCase) if f.startswith(TEST_PREFIX)
+    ):
+        setattr(
+            PluginAutocompleteTestCase,
+            str(method).replace(TEST_PREFIX, f"{TEST_PREFIX[1:]}_{name}"),
+            lambda self, m=method, n=name, rf=related_factory: getattr(
+                PluginAutocompleteTestCase, str(m)
+            )(self, n, rf),
         )


### PR DESCRIPTION
## Purpose

In PR https://github.com/openfun/richie/pull/1590, @sveetch proposed to activate an autocomplete select field for page related plugins in the frontend admin view. This feature was urgently needed for the person object as we have a lot of instances of this type of page in https://www.fun-mooc.fr, but it is also very interesting for all other types of page related plugins: blog post, category, course, organization, organization by category and program.

## Proposal

This is a generalization of @sveetch's  work to all other page related plugins.

We generate tests programmatically, for each type of page related object, in order not to repeat the exact same code 6 times.
