### PR TITLE
🔧(search) add elastic search client custom settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+## Added
+
+- Add settings that permit to configure elastic search client with custom
+  configuration like custom timeouts.
+
 ##  [2.15.0] - 2022-06-22
 
 ### Added

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -271,6 +271,10 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None
     )
     RICHIE_ES_STATE_WEIGHTS = values.ListValue(None)
+    # Example to change the timeout: RICHIE_ES_CLIENT_KWARGS={'timeout': 30}
+    RICHIE_ES_CLIENT_KWARGS = values.DictValue(
+        {}, environ_name="RICHIE_ES_CLIENT_KWARGS", environ_prefix=None
+    )
 
     # LTI Content
     RICHIE_LTI_PROVIDERS = {

--- a/src/richie/apps/search/__init__.py
+++ b/src/richie/apps/search/__init__.py
@@ -9,8 +9,17 @@ from .elasticsearch import (
 # pylint: disable=invalid-name
 default_app_config = "richie.apps.search.apps.SearchConfig"
 
-ES_CLIENT = ElasticsearchClientCompat7to6(
-    getattr(settings, "RICHIE_ES_HOST", ["elasticsearch"])
-)
+
+def new_elasticsearch_client():
+    """
+    Utility function to allow to test the `RICHIE_ES_CLIENT_KWARGS` setting.
+    """
+    return ElasticsearchClientCompat7to6(
+        getattr(settings, "RICHIE_ES_HOST", ["elasticsearch"]),
+        **getattr(settings, "RICHIE_ES_CLIENT_KWARGS", {}),
+    )
+
+
+ES_CLIENT = new_elasticsearch_client()
 
 ES_INDICES_CLIENT = ElasticsearchIndicesClientCompat7to6(ES_CLIENT)

--- a/tests/apps/search/test_index_client.py
+++ b/tests/apps/search/test_index_client.py
@@ -1,0 +1,22 @@
+"""
+Test the index client initialization.
+"""
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from richie.apps.search import new_elasticsearch_client
+
+
+class IndexClientTestCase(TestCase):
+    """
+    Test the index client.
+    """
+
+    @override_settings(RICHIE_ES_CLIENT_KWARGS={"timeout": 99})
+    def test_index_client_kwargs(self):
+        """
+        Test `RICHIE_ES_CLIENT_KWARGS` setting, that allows to pass extra configurations to the
+        elastic search index client.
+        """
+        es_client_to_test = new_elasticsearch_client()
+        self.assertEqual(es_client_to_test.transport.kwargs, {"timeout": 99})


### PR DESCRIPTION
Add settings that permit to configure elastic search client with custom configuration like custom timeouts.