### PR TITLE
✨(course_detail) more emphasis on enroll button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - On course page, make the course title the first thing that is read to
   screen readers (instead of the badges)
 - Fix program glimpse heading level being too high on course detail page
+- Hide title _To be scheduled_, _Upcoming_, _Ongoing_ and _Archived_ when all
+  course runs have catalog visibility `hidden`.
 
 ## [2.13.0] - 2022-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Remove the use of Google Fonts
 - Improve overall accessibility in Richie templates
+- Move enroll button for the first open course run below the contact block.
+  If there are more than one open run, they're all still shown on course
+  detail aside block.
 - Update frontend overriding system to allow to override any frontend module.
 - Improve React search suggestion field labels for screen readers.
 - Removed usage of deprecated Sass division '/' operator in favor of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Change how program glimpses HTML is structured to be clearer when using
   a screen reader
 - Specify that we are on a course page in the course detail page title
+- Remove contact block on course detail page
 
 ### Fixed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -57,6 +57,8 @@ $ make migrate
 - Don't use the `blockplugin` template tag in the page <header>. They can be replaced by a
   simple {% if %} tag since their only purpose is to inject markup for frontend editing (which
   is not valid html in the page header).
+- The `runs_open` django template block have been replaced by `run_open_single` and
+  `runs_open_multiple` blocks on the `course_detail.html` template.
 - Frontend override system has been updated to allow overriding of any frontend module.
   Thus if you override some components, you have to update the module regexp by prefixing
   with `components/`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -59,6 +59,8 @@ $ make migrate
   is not valid html in the page header).
 - The `runs_open` django template block have been replaced by `run_open_single` and
   `runs_open_multiple` blocks on the `course_detail.html` template.
+- The `contact` block has been removed from the `course_detail.html` template, if you overwrite it
+  please consider the new `run_open_single` block as alternative.
 - Frontend override system has been updated to allow overriding of any frontend module.
   Thus if you override some components, you have to update the module regexp by prefixing
   with `components/`.

--- a/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -34,6 +34,14 @@
 
   &__empty {
     @include detail-empty;
+    margin-top: 2rem;
+  }
+
+  &__runs {
+    &--open {
+      margin-top: 2rem;
+      text-align: left;
+    }
   }
 
   &__grid {
@@ -305,6 +313,14 @@
 
     &:hover {
       text-decoration: underline;
+    }
+  }
+
+  &__go-to-open-runs {
+    margin-top: 2rem;
+
+    & > p {
+      margin-bottom: 0.5rem;
     }
   }
 }

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -318,61 +318,71 @@
                 <div class="course-detail__aside" property="isAccessibleForFree" content="true">
                     {% with runs_dict=course.course_runs_dict %}
                         {% block runs_open %}
+                        {% with open_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|dictsort:"start"|visible_on_course_page:request.toolbar.edit_mode_active %}
                             <div class="course-detail__row course-detail__runs course-detail__runs--open">
                                 <h2 class="course-detail__title">
                                     {% blocktrans context "course_detail__title" %}Course runs{% endblocktrans %}
                                     {% render_model_add course "" "" "get_admin_url_to_add_run" %}
                                 </h2>
-                                {% for run in runs_dict.0|add:runs_dict.1|add:runs_dict.2 %}
+                                {% for run in open_runs %}
                                     {% include "courses/cms/fragment_course_run.html" %}
                                 {% empty %}
                                     <div class="course-detail__empty">{% trans "No open course runs" %}</div>
                                 {% endfor %}
                             </div>
+                        {% endwith %}
                         {% endblock runs_open %}
 
                         {% block runs_to_be_scheduled %}
-                        {% if runs_dict.7 and current_page.publisher_is_draft %}
-                            <div class="course-detail__row course-detail__runs course-detail__runs--to_be_scheduled">
-                                <h3 class="course-detail__title">
-                                    {% trans "To be scheduled" context "Course runs to be scheduled (plural)" %}
-                                </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.7 %}
-                            </div>
-                        {% endif %}
+                        {% with to_be_scheduled_runs=runs_dict.7|dictsort:"start"|visible_on_course_page:request.toolbar.edit_mode_active %}
+                            {% if to_be_scheduled_runs|visible_on_course_page:request.toolbar.edit_mode_active and current_page.publisher_is_draft %}
+                                <div class="course-detail__row course-detail__runs course-detail__runs--to_be_scheduled">
+                                    <h3 class="course-detail__title">
+                                        {% trans "To be scheduled" context "Course runs to be scheduled (plural)" %}
+                                    </h3>
+                                    {% include "courses/cms/fragment_course_runs_list.html" with course_runs=to_be_scheduled_runs %}
+                                </div>
+                            {% endif %}
+                        {% endwith %}
                         {% endblock runs_to_be_scheduled %}
 
                         {% block runs_upcoming %}
-                        {% if runs_dict.3 %}
-                            <div class="course-detail__row course-detail__runs course-detail__runs--upcoming">
-                                <h3 class="course-detail__title">
-                                    {% trans "Upcoming" context "Upcoming course runs (plural)" %}
-                                </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.3 %}
-                            </div>
-                        {% endif %}
+                        {% with upcoming_runs=runs_dict.3|dictsort:"start"|visible_on_course_page:request.toolbar.edit_mode_active %}
+                            {% if upcoming_runs|visible_on_course_page:request.toolbar.edit_mode_active %}
+                                <div class="course-detail__row course-detail__runs course-detail__runs--upcoming">
+                                    <h3 class="course-detail__title">
+                                        {% trans "Upcoming" context "Upcoming course runs (plural)" %}
+                                    </h3>
+                                    {% include "courses/cms/fragment_course_runs_list.html" with course_runs=upcoming_runs %}
+                                </div>
+                            {% endif %}
+                        {% endwith %}
                         {% endblock runs_upcoming %}
 
                         {% block runs_ongoing %}
-                        {% if runs_dict.4 or runs_dict.5 %}
-                            <div class="course-detail__row course-detail__runs course-detail__runs--ongoing">
-                                <h3 class="course-detail__title">
-                                    {% trans "Ongoing" context "Ongoing course runs (plural)" %}
-                                </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with course_runs=runs_dict.4|add:runs_dict.5 %}
-                            </div>
-                        {% endif %}
+                        {% with ongoing_runs=runs_dict.4|add:runs_dict.5|dictsort:"start"|visible_on_course_page:request.toolbar.edit_mode_active %}
+                            {% if ongoing_runs|length > 0 %}
+                                <div class="course-detail__row course-detail__runs course-detail__runs--ongoing">
+                                    <h3 class="course-detail__title">
+                                        {% trans "Ongoing" context "Ongoing course runs (plural)" %}
+                                    </h3>
+                                    {% include "courses/cms/fragment_course_runs_list.html" with course_runs=ongoing_runs %}
+                                </div>
+                            {% endif %}
+                        {% endwith %}
                         {% endblock runs_ongoing %}
 
                         {% block runs_archived %}
-                        {% if runs_dict.6 %}
-                            <div class="course-detail__row course-detail__runs course-detail__runs--archived">
-                                <h3 class="course-detail__title">
-                                    {% trans "Archived" context "Archived course runs (plural)" %}
-                                </h3>
-                                {% include "courses/cms/fragment_course_runs_list.html" with max_course_runs=RICHIE_MAX_ARCHIVED_COURSE_RUNS course_runs=runs_dict.6%}
-                            </div>
-                        {% endif %}
+                        {% with archived_runs=runs_dict.6|dictsort:"start"|visible_on_course_page:request.toolbar.edit_mode_active %}
+                            {% if archived_runs|length > 0 %}
+                                <div class="course-detail__row course-detail__runs course-detail__runs--archived">
+                                    <h3 class="course-detail__title">
+                                        {% trans "Archived" context "Archived course runs (plural)" %}
+                                    </h3>
+                                    {% include "courses/cms/fragment_course_runs_list.html" with max_course_runs=RICHIE_MAX_ARCHIVED_COURSE_RUNS course_runs=archived_runs%}
+                                </div>
+                            {% endif %}
+                        {% endwith %}
                         {% endblock runs_archived %}
 
                     {% endwith %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -177,6 +177,33 @@
                     {% block contact %}
                         <a href="#" class="subheader__cta">{% trans "Contact us" %}</a>
                     {% endblock contact %}
+
+                    {% block run_open_single %}
+                        {% with runs_dict=course.course_runs_dict %}
+                            {% with open_visible_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|visible_on_course_page:request.toolbar.edit_mode_active %}
+                                {% if open_visible_runs|length == 0 %}
+                                    <div class="course-detail__row course-detail__runs course-detail__runs--open">
+                                        <div class="course-detail__empty">{% trans "No open course runs" %}</div>
+                                    </div>
+                                {% elif open_visible_runs|length == 1 %}
+                                    <div class="course-detail__row course-detail__runs course-detail__runs--open">
+                                        {% for run in open_visible_runs|slice:":1" %}
+                                            {% include "courses/cms/fragment_course_run.html" %}
+                                        {% endfor %}
+                                    </div>
+                                {% else %}
+                                    <div class="course-detail__row course-detail__runs course-detail__go-to-open-runs">
+                                        <p>{{ open_visible_runs|length }} {% trans "course runs are currently open for this course" %}</p>
+                                        <a class="button button--primary"
+                                            href="#courseDetailsRunsOpen"
+                                            onclick="document.getElementById(this.getAttribute('href').substring(1)).scrollIntoView({behavior: 'smooth', block: 'start'}); return false;">
+                                            {% trans "Choose now" %}
+                                        </a>
+                                    </div>
+                                {% endif %}
+                            {% endwith %}
+                        {% endwith %}
+                    {% endblock run_open_single %}
                 </div>
             </div>
         </div>
@@ -317,21 +344,40 @@
             {% block runs %}
                 <div class="course-detail__aside" property="isAccessibleForFree" content="true">
                     {% with runs_dict=course.course_runs_dict %}
-                        {% block runs_open %}
-                        {% with open_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|dictsort:"start"|visible_on_course_page:request.toolbar.edit_mode_active %}
-                            <div class="course-detail__row course-detail__runs course-detail__runs--open">
-                                <h2 class="course-detail__title">
-                                    {% blocktrans context "course_detail__title" %}Course runs{% endblocktrans %}
-                                    {% render_model_add course "" "" "get_admin_url_to_add_run" %}
-                                </h2>
-                                {% for run in open_runs %}
-                                    {% include "courses/cms/fragment_course_run.html" %}
-                                {% empty %}
-                                    <div class="course-detail__empty">{% trans "No open course runs" %}</div>
-                                {% endfor %}
-                            </div>
+                        <h2 class="course-detail__title">
+                            {% if runs_dict.0|add:runs_dict.1|add:runs_dict.2|visible_on_course_page:request.toolbar.edit_mode_active|length == 1 %}
+                                {% blocktrans context "course_detail__title" %}Other course runs{% endblocktrans %}
+                            {% else %}
+                                {% blocktrans context "course_detail__title" %}Course runs{% endblocktrans %}
+                            {% endif %}
+                            {% render_model_add course "" "" "get_admin_url_to_add_run" %}
+                        </h2>
+
+                        {% with open_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|visible_on_course_page:request.toolbar.edit_mode_active %}
+                            {% with other_runs=runs_dict.7|add:runs_dict.3|add:runs_dict.4|add:runs_dict.6|visible_on_course_page:request.toolbar.edit_mode_active %}
+                                {% if open_runs|length <= 1 and other_runs|length == 0 %}
+                                    <div class="course-detail__row course-detail__no-runs">
+                                        {% if open_runs|length == 0 %}
+                                            <p>{% trans "No course runs" %}</p>
+                                        {% else %}
+                                            <p>{% trans "No other course runs" %}</p>
+                                        {% endif %}
+                                    </div>
+                                {% endif %}
+                            {% endwith %}
                         {% endwith %}
-                        {% endblock runs_open %}
+
+                        {% block runs_open_multiple %}
+                        {% with open_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|dictsort:"start" %}
+                            {% if open_runs|visible_on_course_page:request.toolbar.edit_mode_active|length > 1 %}
+                                <div id="courseDetailsRunsOpen" class="course-detail__row course-detail__runs course-detail__runs--open">
+                                    {% for run in open_runs|sort_runs_by_language_and_start_date %}
+                                        {% include "courses/cms/fragment_course_run.html" %}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        {% endwith %}
+                        {% endblock runs_open_multiple %}
 
                         {% block runs_to_be_scheduled %}
                         {% with to_be_scheduled_runs=runs_dict.7|dictsort:"start"|visible_on_course_page:request.toolbar.edit_mode_active %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -174,10 +174,6 @@
                         {% include "social-networks/course-badges.html" with page_title=request.current_page.get_title page_url=request.current_page.get_absolute_url %}
                     {% endblock social_networks %}
 
-                    {% block contact %}
-                        <a href="#" class="subheader__cta">{% trans "Contact us" %}</a>
-                    {% endblock contact %}
-
                     {% block run_open_single %}
                         {% with runs_dict=course.course_runs_dict %}
                             {% with open_visible_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|visible_on_course_page:request.toolbar.edit_mode_active %}

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -227,6 +227,17 @@ def has_connected_lms(course_run):
     return LMSHandler.select_lms(course_run.resource_link) is not None
 
 
+@register.filter()
+def visible_on_course_page(course_runs, edit_mode_active=None):
+    """
+    Determine if the passed course run should be visible on the course page, if on edit mode
+    show all the course runs.
+    """
+    if edit_mode_active:
+        return course_runs
+    return list(filter(lambda run: run.is_visible_on_course_page, course_runs))
+
+
 @register.simple_tag(takes_context=True)
 def course_enrollment_widget_props(context):
     """

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -5,7 +5,7 @@ from django import template
 from django.core.exceptions import ObjectDoesNotExist
 from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
-from django.utils import timezone
+from django.utils import timezone, translation
 from django.utils.translation import get_language
 from django.utils.translation import gettext as _
 from django.utils.translation import to_locale
@@ -236,6 +236,22 @@ def visible_on_course_page(course_runs, edit_mode_active=None):
     if edit_mode_active:
         return course_runs
     return list(filter(lambda run: run.is_visible_on_course_page, course_runs))
+
+
+@register.filter()
+def sort_runs_by_language_and_start_date(course_runs):
+    """
+    Order course runs by: firstly runs that contains the language of the current user and only
+    after the runs that don't match the current user authenticated language. On both groups, they
+    should be sorted by course start date.
+    """
+    current_language = translation.get_language()
+    return list(
+        sorted(
+            course_runs,
+            key=lambda run: (current_language not in run.languages, run.start),
+        )
+    )
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
Move enroll button for the first open course run below the contact block. 
Closes #1612

Same implementation that fun-mooc has on the its site.
Normally every one has a single open course run for each course.
This could be kind of strange if the richie installation has multiple open course runs for the same course.
We on NAU don't have this problem.

Alternatively, I could change the PR and show the single open run bellow, the contact button, if there are exactly one open course. If there are 2 open runs, we could give the current output - show all the open courses near the other runs.

Screenshoot:
![image](https://user-images.githubusercontent.com/67018/155586249-4520951f-b829-4832-b837-1756964ab8bf.png)