### PR TITLE
♿️(search) add labels to search suggest fields for screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Update frontend overriding system to allow to override any frontend module.
+- Improve React search suggestion field labels for screen readers.
 
 ## [2.13.0] - 2022-02-18
 

--- a/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.spec.tsx
@@ -51,6 +51,8 @@ describe('<RootSearchSuggestField />', () => {
 
     // The placeholder text is shown in the input
     screen.getByPlaceholderText('Search for courses');
+    // Same text should also be recognized as a true input label
+    screen.getByLabelText('Search for courses');
     // The component should not issue any request "on load", before the user starts interacting
     expect(fetchMock.called()).toEqual(false);
   });

--- a/src/frontend/js/components/RootSearchSuggestField/index.tsx
+++ b/src/frontend/js/components/RootSearchSuggestField/index.tsx
@@ -87,6 +87,7 @@ const RootSearchSuggestField = ({
       }
     },
     placeholder: intl.formatMessage(messages.searchFieldPlaceholder),
+    'aria-label': intl.formatMessage(messages.searchFieldPlaceholder),
     value,
   };
 

--- a/src/frontend/js/components/SearchSuggestField/index.spec.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.spec.tsx
@@ -72,7 +72,7 @@ describe('components/SearchSuggestField', () => {
   beforeEach(() => (location.search = ''));
 
   it('renders', () => {
-    const { getByPlaceholderText } = render(
+    const { getByPlaceholderText, getByLabelText } = render(
       <IntlProvider locale="en">
         <HistoryProvider>
           <SearchSuggestField context={context} />
@@ -82,6 +82,8 @@ describe('components/SearchSuggestField', () => {
 
     // The placeholder text is shown in the input
     getByPlaceholderText('Search for courses, organizations, categories');
+    // Same text should also be recognized as a true input label
+    getByLabelText('Search for courses, organizations, categories');
   });
 
   it('picks the query from the URL if there is one', () => {

--- a/src/frontend/js/components/SearchSuggestField/index.tsx
+++ b/src/frontend/js/components/SearchSuggestField/index.tsx
@@ -119,6 +119,7 @@ const SearchSuggestField = ({ context }: CommonDataProps) => {
       }
     },
     placeholder: intl.formatMessage(messages.searchFieldPlaceholder),
+    'aria-label': intl.formatMessage(messages.searchFieldPlaceholder),
     value,
   };
 


### PR DESCRIPTION
## Purpose

Be sure that screen reader users understand when they are on the search suggestion fields.

## Proposal

Add an `aria-label` attribute in addition to the already there `placeholder`. 

accessibility-wise, having only placeholders is not enough for full
screen reader support.

Depending on screen readers, screen reader versions, combination with
different browsers, or configurations, placeholders are not always
announced.

The aria-label attribute is an actual accessible name recognized by all
softwares.