### PR TITLE
♿️(search) add a heading for the search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Create a React `Icon` component that can optionally take alternative text
   for screen reader users.
+- Add a heading for screen reader users on the search results page to have a
+  more understandable navigation.
 
 ### Changed
 

--- a/src/frontend/js/components/Search/index.tsx
+++ b/src/frontend/js/components/Search/index.tsx
@@ -31,6 +31,12 @@ const messages = defineMessages({
       'Accessibility text for the button/icon that toggles *on* the filters pane on mobile',
     id: 'components.Search.showFiltersPane',
   },
+  resultsTitle: {
+    defaultMessage: 'Search results',
+    description:
+      'Title for the search results pane in course search (not shown, made for screen reader users).',
+    id: 'components.Search.resultsTitle',
+  },
   spinnerText: {
     defaultMessage: 'Loading search results...',
     description: 'Accessibility text for the spinner while search results are being loaded',
@@ -114,6 +120,9 @@ const Search = ({ context }: CommonDataProps) => {
         )}
       </div>
       <div className="search__results">
+        <h2 className="offscreen">
+          <FormattedMessage {...messages.resultsTitle} />
+        </h2>
         {courseSearchResponse && courseSearchResponse.status === RequestStatus.SUCCESS ? (
           <Fragment>
             {query && query.length < 3 ? (


### PR DESCRIPTION
## Purpose

Make the navigation between the different sections of the search page less confusing for screen reader users.

## Proposal

In the headings hierarchy, it looked like course glimpse headings were
descendants of "Filter courses". This was pretty misleading for screen
reader users that can rely a lot on headings hierarchy to navigate a
page.

This adds a heading for the results block that is the same level as the
filters to prevent this confusion. We can argue the heading is maybe not
that necessary in the UI though, so we can just have it for screen
readers.

To better understand the problem, here are screenshots of NVDA before/after the change:

<details><summary>Screenshots</summary>

**Avant**

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/221253/155706324-070f8417-2a93-4b3d-a084-75dcb258d165.jpg"><img src="https://user-images.githubusercontent.com/221253/155706324-070f8417-2a93-4b3d-a084-75dcb258d165.jpg" alt="avant" width="600" style="max-width: 100%;"></a>

**Après**

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/221253/155706350-7a9aee93-f93d-4dce-ac4f-558b2956a02b.jpg"><img src="https://user-images.githubusercontent.com/221253/155706350-7a9aee93-f93d-4dce-ac4f-558b2956a02b.jpg" alt="apres" width="600" style="max-width: 100%;"></a>

</details>






