### PR TITLE
🐛(icons) fix title tooltip not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Create a React `Icon` component.
+- Create a React `Icon` component that can optionally take alternative text
+  for screen reader users.
 
 ### Changed
 

--- a/src/frontend/js/components/Icon/index.tsx
+++ b/src/frontend/js/components/Icon/index.tsx
@@ -44,9 +44,9 @@ export const Icon = ({ name, title, className = '' }: IconProps) => {
       {...(title && {
         role: 'img',
         'aria-label': title,
-        title,
       })}
     >
+      {title && <title>{title}</title>}
       <use href={`#${name}`} />
     </svg>
   );


### PR DESCRIPTION
## Purpose

Fix my morning mistake :upside_down_face: 

## Proposal

Forgot that svg elements don't support `title` attributes but do have
`<title>` tags instead. Fix that.

