### PR TITLE
♿️(course glimpse) improve global accessibility of a course glimpse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   except if its placeholder is empty.
 - Fix missing styles for Organization plugin 'row' variant link wrapper
 - Fix course run deletion when translation title is empty
+- Reordered course glimpse text order in the DOM for better screen reader
+  support.
 
 ## [2.13.0] - 2022-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   in new tabs if they want
 - Improve the `offscreen` class implementation to prevent potential visual
   issues for sighted user keyboards
+- Change how course glimpse anchor is structured (allows text selection
+  in the course glimpse + better screen reader user experience)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add the website's name by default in every page title, that can be changed
   or disabled by overriding the new `site_title` and `site_title_separator`
   blocks
+- Add alternative text on course glimpse icons for screen reader users
 
 ### Changed
 

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpseFooter.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpseFooter.tsx
@@ -1,8 +1,16 @@
-import { useIntl } from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
 
 import { Icon } from 'components/Icon';
 import { CommonDataProps } from 'types/commonDataProps';
 import { Course } from 'types/Course';
+
+const messages = defineMessages({
+  dateIconAlt: {
+    defaultMessage: 'Course date',
+    description: 'Course date logo alternative text for screen reader users',
+    id: 'components.CourseGlimpseFooter.dateIconAlt',
+  },
+});
 
 /**
  * <CourseGlimpseFooter />.
@@ -13,7 +21,7 @@ export const CourseGlimpseFooter: React.FC<{ course: Course } & CommonDataProps>
   return (
     <div className="course-glimpse-footer">
       <div className="course-glimpse-footer__date">
-        <Icon name="icon-calendar" />
+        <Icon name="icon-calendar" title={intl.formatMessage(messages.dateIconAlt)} />
         {course.state.text.charAt(0).toUpperCase() +
           course.state.text.substr(1) +
           (course.state.datetime

--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -17,7 +17,13 @@ describe('components/CourseGlimpse', () => {
     },
     duration: '3 months',
     effort: '3 hours',
-    icon: null,
+    icon: {
+      sizes: '60px',
+      src: '/thumbs/icon_small.png',
+      srcset: 'some srcset',
+      title: 'Some icon',
+      color: 'red',
+    },
     id: '742',
     organization_highlighted: 'Some Organization',
     organization_highlighted_cover_image: {
@@ -50,6 +56,9 @@ describe('components/CourseGlimpse', () => {
         />
       </IntlProvider>,
     );
+
+    // first text we encounter should be the title, so that screen reader users get it first
+    expect(container.textContent?.indexOf('Course 42')).toBe(0);
 
     // The link that wraps the course glimpse should have no title as its content is explicit enough
     expect(screen.getByRole('link')).not.toHaveAttribute('title');

--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -68,6 +68,7 @@ describe('components/CourseGlimpse', () => {
     screen.getByText('123abc');
     screen.getByLabelText('Organization');
     screen.getByText('Some Organization');
+    screen.getByText('Category');
     // Matches on 'Starts on Mar 14, 2019', date is wrapped with intl <span>
     screen.getByLabelText('Course date');
     screen.getByText('Starts on Mar 14, 2019');

--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -61,7 +61,8 @@ describe('components/CourseGlimpse', () => {
     expect(container.textContent?.indexOf('Course 42')).toBe(0);
 
     // The link that wraps the course glimpse should have no title as its content is explicit enough
-    expect(screen.getByRole('link')).not.toHaveAttribute('title');
+    const link = container.querySelector('.course-glimpse__link');
+    expect(link).not.toHaveAttribute('title');
     // The course glimpse shows the relevant information
     screen.getByRole('heading', { name: 'Course 42', level: 3 });
     screen.getByLabelText('Course code');
@@ -76,7 +77,10 @@ describe('components/CourseGlimpse', () => {
     // Check course logo
     const courseGlipseMedia = container.getElementsByClassName('course-glimpse__media');
     expect(courseGlipseMedia.length).toBe(1);
-    const img = courseGlipseMedia[0].firstChild;
+    expect(courseGlipseMedia[0]).toHaveAttribute('aria-hidden', 'true');
+    const mediaLink = courseGlipseMedia[0].firstChild;
+    expect(mediaLink).toHaveAttribute('tabindex', '-1');
+    const img = mediaLink?.firstChild;
     expect(img).toBeInstanceOf(HTMLImageElement);
     // The logo is rendered along with alt text "" as it is decorative and included in a link block
     expect(img).toHaveAttribute('alt', '');

--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -55,9 +55,12 @@ describe('components/CourseGlimpse', () => {
     expect(screen.getByRole('link')).not.toHaveAttribute('title');
     // The course glimpse shows the relevant information
     screen.getByRole('heading', { name: 'Course 42', level: 3 });
+    screen.getByLabelText('Course code');
     screen.getByText('123abc');
+    screen.getByLabelText('Organization');
     screen.getByText('Some Organization');
     // Matches on 'Starts on Mar 14, 2019', date is wrapped with intl <span>
+    screen.getByLabelText('Course date');
     screen.getByText('Starts on Mar 14, 2019');
 
     // Check course logo

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import React, { memo } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { CommonDataProps } from 'types/commonDataProps';
@@ -36,25 +36,33 @@ const messages = defineMessages({
 const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataProps) => {
   const intl = useIntl();
   return (
-    <a className="course-glimpse course-glimpse--link" href={course.absolute_url}>
-      <div className="course-glimpse__media">
-        {/* alt forced to empty string because it's a decorative image */}
-        {course.cover_image ? (
-          <img
-            alt=""
-            sizes={course.cover_image.sizes}
-            src={course.cover_image.src}
-            srcSet={course.cover_image.srcset}
-          />
-        ) : (
-          <div className="course-glimpse__media__empty">
-            <FormattedMessage {...messages.cover} />
-          </div>
-        )}
+    <div className="course-glimpse">
+      {/* the media link is only here for mouse users, so hide it for keyboard/screen reader users.
+      Keyboard/sr will focus the link on the title */}
+      <div aria-hidden="true" className="course-glimpse__media">
+        <a tabIndex={-1} href={course.absolute_url}>
+          {/* alt forced to empty string because it's a decorative image */}
+          {course.cover_image ? (
+            <img
+              alt=""
+              sizes={course.cover_image.sizes}
+              src={course.cover_image.src}
+              srcSet={course.cover_image.srcset}
+            />
+          ) : (
+            <div className="course-glimpse__media__empty">
+              <FormattedMessage {...messages.cover} />
+            </div>
+          )}
+        </a>
       </div>
       <div className="course-glimpse__content">
         <div className="course-glimpse__wrapper">
-          <h3 className="course-glimpse__title">{course.title}</h3>
+          <h3 className="course-glimpse__title">
+            <a className="course-glimpse__link" href={course.absolute_url}>
+              <span className="course-glimpse__title-text">{course.title}</span>
+            </a>
+          </h3>
           {course.organization_highlighted_cover_image ? (
             <div className="course-glimpse__organization-logo">
               {/* alt forced to empty string because the organization name is rendered after */}
@@ -95,7 +103,7 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
         ) : null}
         <CourseGlimpseFooter context={context} course={course} />
       </div>
-    </a>
+    </div>
   );
 };
 

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { CommonDataProps } from 'types/commonDataProps';
 import { Course } from 'types/Course';
@@ -16,67 +16,80 @@ const messages = defineMessages({
     description: 'Placeholder text when the course we are glimpsing at is missing a cover image',
     id: 'components.CourseGlimpse.cover',
   },
+  organizationIconAlt: {
+    defaultMessage: 'Organization',
+    description: 'Organization logo alternative text for screen reader users',
+    id: 'components.CourseGlimpse.organizationIconAlt',
+  },
+  codeIconAlt: {
+    defaultMessage: 'Course code',
+    description: 'Course code logo alternative text for screen reader users',
+    id: 'components.CourseGlimpse.codeIconAlt',
+  },
 });
 
-const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataProps) => (
-  <a className="course-glimpse course-glimpse--link" href={course.absolute_url}>
-    <div className="course-glimpse__media">
-      {/* alt forced to empty string because it's a decorative image */}
-      {course.cover_image ? (
-        <img
-          alt=""
-          sizes={course.cover_image.sizes}
-          src={course.cover_image.src}
-          srcSet={course.cover_image.srcset}
-        />
-      ) : (
-        <div className="course-glimpse__media__empty">
-          <FormattedMessage {...messages.cover} />
-        </div>
-      )}
-    </div>
-    <div className="course-glimpse__content">
-      {course.icon ? (
-        <div className="course-glimpse__icon">
-          <span className="category-badge">
-            {/* alt forced to empty string because it's a decorative image */}
-            <img
-              alt=""
-              className="category-badge__icon"
-              sizes={course.icon.sizes}
-              src={course.icon.src}
-              srcSet={course.icon.srcset}
-            />
-            <span className="category-badge__title">{course.icon.title}</span>
-          </span>
-        </div>
-      ) : null}
-      <div className="course-glimpse__wrapper">
-        <h3 className="course-glimpse__title">{course.title}</h3>
-        {course.organization_highlighted_cover_image ? (
-          <div className="course-glimpse__organization-logo">
-            {/* alt forced to empty string because it's a decorative image */}
-            <img
-              alt=""
-              sizes={course.organization_highlighted_cover_image.sizes}
-              src={course.organization_highlighted_cover_image.src}
-              srcSet={course.organization_highlighted_cover_image.srcset}
-            />
+const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataProps) => {
+  const intl = useIntl();
+  return (
+    <a className="course-glimpse course-glimpse--link" href={course.absolute_url}>
+      <div className="course-glimpse__media">
+        {/* alt forced to empty string because it's a decorative image */}
+        {course.cover_image ? (
+          <img
+            alt=""
+            sizes={course.cover_image.sizes}
+            src={course.cover_image.src}
+            srcSet={course.cover_image.srcset}
+          />
+        ) : (
+          <div className="course-glimpse__media__empty">
+            <FormattedMessage {...messages.cover} />
+          </div>
+        )}
+      </div>
+      <div className="course-glimpse__content">
+        {course.icon ? (
+          <div className="course-glimpse__icon">
+            <span className="category-badge">
+              {/* alt forced to empty string because it's a decorative image */}
+              <img
+                alt=""
+                className="category-badge__icon"
+                sizes={course.icon.sizes}
+                src={course.icon.src}
+                srcSet={course.icon.srcset}
+              />
+              <span className="category-badge__title">{course.icon.title}</span>
+            </span>
           </div>
         ) : null}
-        <div className="course-glimpse__metadata course-glimpse__metadata--organization">
-          <Icon name="icon-org" />
-          <span className="title">{course.organization_highlighted}</span>
+        <div className="course-glimpse__wrapper">
+          <h3 className="course-glimpse__title">{course.title}</h3>
+          {course.organization_highlighted_cover_image ? (
+            <div className="course-glimpse__organization-logo">
+              {/* alt forced to empty string because the organization name is rendered after */}
+              <img
+                alt=""
+                sizes={course.organization_highlighted_cover_image.sizes}
+                src={course.organization_highlighted_cover_image.src}
+                srcSet={course.organization_highlighted_cover_image.srcset}
+              />
+            </div>
+          ) : null}
+          <div className="course-glimpse__metadata course-glimpse__metadata--organization">
+            <Icon name="icon-org" title={intl.formatMessage(messages.organizationIconAlt)} />
+            <span className="title">{course.organization_highlighted}</span>
+          </div>
+          <div className="course-glimpse__metadata course-glimpse__metadata--code">
+            <Icon name="icon-barcode" title={intl.formatMessage(messages.codeIconAlt)} />
+            <span>{course.code || '-'}</span>
+          </div>
         </div>
-        <div className="course-glimpse__metadata course-glimpse__metadata--code">
-          <Icon name="icon-barcode" />
-          <span>{course.code || '-'}</span>
-        </div>
+        <CourseGlimpseFooter context={context} course={course} />
       </div>
-      <CourseGlimpseFooter context={context} course={course} />
-    </div>
-  </a>
-);
+    </a>
+  );
+};
 
 const areEqual: (
   prevProps: Readonly<CourseGlimpseProps & CommonDataProps>,

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -48,21 +48,6 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
         )}
       </div>
       <div className="course-glimpse__content">
-        {course.icon ? (
-          <div className="course-glimpse__icon">
-            <span className="category-badge">
-              {/* alt forced to empty string because it's a decorative image */}
-              <img
-                alt=""
-                className="category-badge__icon"
-                sizes={course.icon.sizes}
-                src={course.icon.src}
-                srcSet={course.icon.srcset}
-              />
-              <span className="category-badge__title">{course.icon.title}</span>
-            </span>
-          </div>
-        ) : null}
         <div className="course-glimpse__wrapper">
           <h3 className="course-glimpse__title">{course.title}</h3>
           {course.organization_highlighted_cover_image ? (
@@ -85,6 +70,21 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
             <span>{course.code || '-'}</span>
           </div>
         </div>
+        {course.icon ? (
+          <div className="course-glimpse__icon">
+            <span className="category-badge">
+              {/* alt forced to empty string because it's a decorative image */}
+              <img
+                alt=""
+                className="category-badge__icon"
+                sizes={course.icon.sizes}
+                src={course.icon.src}
+                srcSet={course.icon.srcset}
+              />
+              <span className="category-badge__title">{course.icon.title}</span>
+            </span>
+          </div>
+        ) : null}
         <CourseGlimpseFooter context={context} course={course} />
       </div>
     </a>

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -26,6 +26,11 @@ const messages = defineMessages({
     description: 'Course code logo alternative text for screen reader users',
     id: 'components.CourseGlimpse.codeIconAlt',
   },
+  categoryLabel: {
+    defaultMessage: 'Category',
+    description: 'Category label text for screen reader users',
+    id: 'components.CourseGlimpse.categoryLabel',
+  },
 });
 
 const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataProps) => {
@@ -81,6 +86,9 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
                 src={course.icon.src}
                 srcSet={course.icon.srcset}
               />
+              <span className="offscreen">
+                <FormattedMessage {...messages.categoryLabel} />
+              </span>
               <span className="category-badge__title">{course.icon.title}</span>
             </span>
           </div>

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -68,8 +68,19 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     @include sv-flex(1, 0, calc(25% - #{$r-course-glimpse-gutter * 2}));
   }
 
+  // We want to trigger the card shadow on hovering links inside the card,
+  // but not when hovering non-interactive text.
+  // we handle this via these pointer-events rules
+  pointer-events: none;
+
+  a,
+  button,
+  .icon[aria-label] {
+    pointer-events: auto;
+  }
+
   &:hover,
-  &:focus {
+  &:focus-within {
     color: inherit;
     text-decoration: none;
     border: 0;
@@ -119,6 +130,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     border-bottom-left-radius: 0;
     box-shadow: r-theme-val(course-glimpse, icon-shadow);
     z-index: 1;
+    pointer-events: none;
 
     .category-badge {
       padding: 0;
@@ -147,17 +159,59 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
 
   &__title {
     @include font-size($h6-font-size);
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
     color: r-theme-val(course-glimpse, title-color);
-    display: block;
-    display: -webkit-box;
     font-family: $r-font-family-montserrat;
     font-weight: $font-weight-boldest;
     flex: 1 0 1.3em * 3; // 3 lines;
     line-height: 1.3em;
     margin-bottom: 1rem;
+  }
+
+  &__link {
+    color: inherit;
+    display: block;
+
+    // we extend the clickable zone of the link,
+    // so that the clickable zone actually sticks to the edges of the card
+    // we keep a tiny space between the link and the text after to prevent misclicks
+    height: 100%;
+    box-sizing: content-box;
+    padding: 1.7rem $course-glimpse-content-padding-sides 0.5rem;
+    margin: -1.7rem #{$course-glimpse-content-padding-sides * -1} -0.5rem;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+      color: inherit;
+      outline: 0;
+    }
+  }
+
+  &__title-text {
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    display: block;
+    display: -webkit-box;
     overflow: hidden;
+  }
+
+  &__link:focus &__title-text {
+    outline: 1px dotted;
+    outline: 1px auto -webkit-focus-ring-color;
+    outline-offset: 1px;
+  }
+
+  // we use focus-visible to prevent the outline on click, but we need to support safari
+  // that doesn't support focus-visible quite yet
+  @supports selector(:focus-visible) {
+    &__link:focus &__title-text {
+      outline: 0;
+    }
+    &__link:focus-visible &__title-text {
+      outline: 1px dotted;
+      outline: 1px auto -webkit-focus-ring-color;
+      outline-offset: 1px;
+    }
   }
 
   &__metadata {
@@ -205,6 +259,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     overflow: hidden;
     padding: 0.25rem;
     position: absolute;
+    pointer-events: none;
     right: 0;
     top: -3.53rem;
     width: 4.3rem;

--- a/src/richie/apps/courses/templates/courses/cms/fragment_category_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_category_glimpse.html
@@ -21,9 +21,10 @@
                     "
                     sizes="40px"
                     class="category-badge__icon"
-                    alt="{{ category_page.get_title }}">
+                    alt="">
                 {% endblockplugin %}
             {% endif %}
+            <span class="offscreen">{% trans "Category" %}</span>
             <span class="category-badge__title">{{ category_page.get_title }}</span>
         {% elif category_variant == "tag" %}
             {% comment %}Small CTA alike, only title and no image, commonly horizontal{% endcomment %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -21,14 +21,6 @@
         {% endblockplugin %}
     </div>
     <div class="course-{{ course_variant }}__content">
-        {% get_placeholder_plugins "course_icons" course_page as icon_plugins %}
-        {% if icon_plugins %}
-        <div class="course-{{ course_variant }}__icon">
-            {% with category_variant="badge" has_link=False %}
-                {% render_plugin icon_plugins.0 %}
-            {% endwith %}
-        </div>
-        {% endif %}
         <div class="course-{{ course_variant }}__wrapper">
             <h{{ header_level|default:3 }} class="course-{{ course_variant }}__title">{{ course_page.get_title }}</h{{ header_level|default:3 }}>
             {% if main_organization %}
@@ -68,6 +60,15 @@
                 <span>{% if course.code %}{{ course.code }}{% else %}-{% endif %}</span>
             </div>
         </div>
+
+        {% get_placeholder_plugins "course_icons" course_page as icon_plugins %}
+        {% if icon_plugins %}
+        <div class="course-{{ course_variant }}__icon">
+            {% with category_variant="badge" has_link=False %}
+                {% render_plugin icon_plugins.0 %}
+            {% endwith %}
+        </div>
+        {% endif %}
 
         {% block course_glimpse_footer %}
         <div class="course-{{ course_variant }}-footer">

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -53,14 +53,16 @@
             {% endif %} 
             {% if main_organization_title %}
             <div class="course-{{ course_variant }}__metadata course-{{ course_variant }}__metadata--organization">
-                <svg role="img" aria-hidden="true" class="icon">
+                <svg role="img" aria-label="{% trans "Organization" %}" class="icon">
+                    <title>{% trans "Organization" %}</title>
                     <use href="#icon-org" />
                 </svg>
                 <span class="title">{{ main_organization_title }}</span>
             </div>
             {% endif %}
             <div class="course-{{ course_variant }}__metadata course-{{ course_variant }}__metadata--code">
-                <svg role="img" aria-hidden="true" class="icon">
+                <svg role="img" aria-label="{% trans "Course code" %}" class="icon">
+                    <title>{% trans "Course code" %}</title>
                     <use href="#icon-barcode" />
                 </svg>
                 <span>{% if course.code %}{{ course.code }}{% else %}-{% endif %}</span>
@@ -70,7 +72,8 @@
         {% block course_glimpse_footer %}
         <div class="course-{{ course_variant }}-footer">
             <div class="course-{{ course_variant }}-footer__date">
-                <svg role="img" aria-hidden="true" class="icon">
+                <svg role="img" aria-label="{% trans "Course date" %}" class="icon">
+                    <title>{% trans "Course date" %}</title>
                     <use href="#icon-calendar" />
                 </svg>
                 {{ course_state.text|capfirst }}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_course_glimpse.html
@@ -2,27 +2,33 @@
 {% comment %}Obviously, the context template variable "course" is required and must be a Course page extension{% endcomment %}
 
 {% with course_page=course.extended_object course_state=course.state main_organization_title=course.get_main_organization.extended_object.get_menu_title main_organization=course.get_main_organization course_variant=course_variant|default:'glimpse' %}
-<a class="course-{{ course_variant }}{% if course_page.publisher_is_draft is True %} course-{{ course_variant }}--draft{% endif %}" href="{{ course_page.get_absolute_url }}">
-    <div class="course-{{ course_variant }}__media">
-        {% get_placeholder_plugins "course_cover" course_page as cover_plugins or %}
-            <p class="course-{{ course_variant }}--empty">{% trans "Cover" %}</p>
-        {% endget_placeholder_plugins %}
-        {% blockplugin cover_plugins.0 %}
-            <img src="{% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
-                srcset="
-                    {% thumbnail instance.picture 800x457 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 300w
-                    {% if instance.picture.width >= 1600 %},{% thumbnail instance.picture 1600x914 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                    {% if instance.picture.width >= 2400 %},{% thumbnail instance.picture 2400x1371 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
-                "
-                sizes="300px"
-                {# alt forced to empty string for a11y because the image does not carry more information than the course title #}
-                alt=""
-            />
-        {% endblockplugin %}
+<div class="course-{{ course_variant }}{% if course_page.publisher_is_draft is True %} course-{{ course_variant }}--draft{% endif %}">
+    <div aria-hidden="true" class="course-{{ course_variant }}__media">
+        <a tabindex="-1" href="{{ course_page.get_absolute_url }}">
+            {% get_placeholder_plugins "course_cover" course_page as cover_plugins or %}
+                <p class="course-{{ course_variant }}--empty">{% trans "Cover" %}</p>
+            {% endget_placeholder_plugins %}
+            {% blockplugin cover_plugins.0 %}
+                <img src="{% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}"
+                    srcset="
+                        {% thumbnail instance.picture 800x457 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 300w
+                        {% if instance.picture.width >= 1600 %},{% thumbnail instance.picture 1600x914 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                        {% if instance.picture.width >= 2400 %},{% thumbnail instance.picture 2400x1371 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %} 900w{% endif %}
+                    "
+                    sizes="300px"
+                    {# alt forced to empty string for a11y because the image does not carry more information than the course title #}
+                    alt=""
+                />
+            {% endblockplugin %}
+        </a>
     </div>
     <div class="course-{{ course_variant }}__content">
         <div class="course-{{ course_variant }}__wrapper">
-            <h{{ header_level|default:3 }} class="course-{{ course_variant }}__title">{{ course_page.get_title }}</h{{ header_level|default:3 }}>
+            <h{{ header_level|default:3 }} class="course-{{ course_variant }}__title">
+                <a class="course-{{ course_variant }}__link" href="{{ course_page.get_absolute_url }}">
+                    <span class="course-{{ course_variant }}__title-text">{{ course_page.get_title }}</span>
+                </a>
+            </h{{ header_level|default:3 }}>
             {% if main_organization %}
                 {% with organization_page=main_organization.extended_object %}
                     {% get_placeholder_plugins "logo" organization_page as plugins or %}
@@ -85,6 +91,6 @@
         </div>
         {% endblock course_glimpse_footer %}
     </div>
-</a>
+</div>
 {% endwith %}
 {% endspaceless %}

--- a/tests/apps/courses/test_cms_plugins_course.py
+++ b/tests/apps/courses/test_cms_plugins_course.py
@@ -74,7 +74,7 @@ class CoursePluginTestCase(TestCase):
 
         # Create a course with a page in both english and french
         organization = OrganizationFactory(
-            page_title="public title",
+            page_title="organization public title",
             should_publish=True,
             fill_logo={
                 "original_filename": "org_logo.jpg",
@@ -83,7 +83,7 @@ class CoursePluginTestCase(TestCase):
         )
 
         course = CourseFactory(
-            page_title={"en": "public title", "fr": "titre public"},
+            page_title={"en": "course public title", "fr": "titre public cours"},
             fill_organizations=[organization],
             fill_icons=[icon_category_main, icon_category_secondary],
             fill_cover={
@@ -111,7 +111,7 @@ class CoursePluginTestCase(TestCase):
 
         # The course's url should be present
         self.assertIn(
-            '<a class="course-glimpse" href="/en/public-title/"',
+            '<a class="course-glimpse__link" href="/en/course-public-title/"',
             re.sub(" +", " ", str(response.content).replace("\\n", "")),
         )
 
@@ -119,7 +119,7 @@ class CoursePluginTestCase(TestCase):
         course_title = course_page.get_title()
         self.assertContains(
             response,
-            f'<h2 class="course-glimpse__title">{course_title:s}</h2>',
+            f'<span class="course-glimpse__title-text">{course_title:s}</span>',
             status_code=200,
         )
         # The course's main organization should be present
@@ -141,7 +141,8 @@ class CoursePluginTestCase(TestCase):
 
         # The course's cover should be present
         pattern = (
-            r'<div class="course-glimpse__media">'
+            r'<div aria-hidden="true" class="course-glimpse__media">'
+            r'<a tabindex="-1" href="/en/course-public-title/">'
             r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x170'
             r'.*alt=""'
         )
@@ -170,7 +171,7 @@ class CoursePluginTestCase(TestCase):
 
         # The course's url should be present
         self.assertIn(
-            '<a class="course-glimpse" href="/fr/titre-public/"',
+            '<a class="course-glimpse__link" href="/fr/titre-public-cours/"',
             re.sub(" +", " ", str(response.content).replace("\\n", "")),
         )
 
@@ -178,7 +179,7 @@ class CoursePluginTestCase(TestCase):
         course_title = course_page.get_title()
         self.assertContains(
             response,
-            f'<h2 class="course-glimpse__title">{course_title:s}</h2>',
+            f'<span class="course-glimpse__title-text">{course_title:s}</span>',
             status_code=200,
         )
 
@@ -209,7 +210,8 @@ class CoursePluginTestCase(TestCase):
 
         # The course's cover should be present
         pattern = (
-            r'<div class="course-glimpse__media">'
+            r'<div aria-hidden="true" class="course-glimpse__media">'
+            r'<a tabindex="-1" href="/fr/titre-public-cours/">'
             r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x170'
             r'.*alt=""'
         )
@@ -334,20 +336,21 @@ class CoursePluginTestCase(TestCase):
         # The course path in french should be in the url but the locale in the
         # url should remain "en"
         self.assertIn(
-            '<a class="course-glimpse" href="/en/cours-public/"',
+            '<a class="course-glimpse__link" href="/en/cours-public/"',
             re.sub(" +", " ", str(response.content).replace("\\n", "")),
         )
 
         # The course's name should be present
         self.assertIn(
-            '<h2 class="course-glimpse__title">cours public</h2>',
+            '<span class="course-glimpse__title-text">cours public</span>',
             re.sub(" +", " ", str(response.content).replace("\\n", "")),
         )
         self.assertNotContains(response, "public course")
 
         # The course's cover should be present
         pattern = (
-            r'<div class="course-glimpse__media">'
+            r'<div aria-hidden="true" class="course-glimpse__media">'
+            r'<a tabindex="-1" href="/en/cours-public/">'
             r'<img src="/media/filer_public_thumbnails/filer_public/.*cover\.jpg__300x170'
             r'.*alt=""'
         )

--- a/tests/apps/courses/test_cms_plugins_course.py
+++ b/tests/apps/courses/test_cms_plugins_course.py
@@ -151,7 +151,7 @@ class CoursePluginTestCase(TestCase):
         pattern = (
             r'<div class="course-glimpse__icon">'
             r'.*<img src="/media/filer_public_thumbnails/filer_public/.*icon\.jpg__40x40'
-            r'.*alt="icon title"'
+            r'.*alt=""'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))
 
@@ -219,7 +219,7 @@ class CoursePluginTestCase(TestCase):
         pattern = (
             r'<div class="course-glimpse__icon">'
             r'.*<img src="/media/filer_public_thumbnails/filer_public/.*icon\.jpg__40x40'
-            r'.*alt="titre icone"'
+            r'.*alt=""'
         )
         self.assertIsNotNone(re.search(pattern, str(response.content)))
 

--- a/tests/apps/courses/test_cms_plugins_course.py
+++ b/tests/apps/courses/test_cms_plugins_course.py
@@ -431,7 +431,8 @@ class CoursePluginTestCase(TestCase):
                 # pylint: disable=consider-using-f-string
                 '<div class="course-glimpse__metadata '
                 'course-glimpse__metadata--organization">'
-                '<svg role="img" aria-hidden="true" class="icon">'
+                '<svg role="img" aria-label="Organization" class="icon">'
+                "<title>Organization</title>"
                 '<use href="#icon-org"></use></svg>'
                 '<span class="title">{0:s}</span>'
             ).format(menu_title),

--- a/tests/apps/courses/test_templates_category_detail.py
+++ b/tests/apps/courses/test_templates_category_detail.py
@@ -197,7 +197,7 @@ class CategoryCMSTestCase(CMSTestCase):
         self._extension_cms_published_content(
             CourseFactory,
             "course_categories",
-            '<h2 class="course-glimpse__title">{0:s}</h2>',
+            '<span class="course-glimpse__title-text">{0:s}</span>',
         )
 
     @mock.patch(
@@ -407,7 +407,7 @@ class CategoryCMSTestCase(CMSTestCase):
     def test_templates_category_detail_cms_draft_content_courses(self):
         """Validate how a draft category page is displayed with its related courses."""
         self._extension_cms_draft_content(
-            CourseFactory, '<h2 class="course-glimpse__title">{0:s}</h2>'
+            CourseFactory, '<span class="course-glimpse__title-text">{0:s}</span>'
         )
 
     def test_templates_category_detail_cms_draft_content_blogposts(self):

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -136,6 +136,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
                 (
                     # pylint: disable=consider-using-f-string
                     '<a class="category-badge" href="{:s}">'
+                    '<span class="offscreen">Category</span>'
                     '<span class="category-badge__title">{:s}</span></a>'
                 ).format(
                     category.extended_object.get_absolute_url(),
@@ -149,7 +150,8 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         # Only published icons should be present on the page
         pattern = (
             r'<a.*class="category-badge".*href="{link:s}".*>'
-            r'<img src="/media/filer_public_thumbnails/filer_public/.*icon\.jpg.*alt="{title:s}">'
+            r'<img src="/media/filer_public_thumbnails/filer_public/.*icon\.jpg.*alt="">'
+            r'<span class="offscreen">Category</span>'
             r'<span class="category-badge__title">'
             r".*{title:s}.*</span>"
         )
@@ -308,6 +310,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
                 (
                     # pylint: disable=consider-using-f-string
                     '<a class="category-badge" href="{:s}">'
+                    '<span class="offscreen">Category</span>'
                     '<span class="category-badge__title">{:s}</span></a>'
                 ).format(
                     category.extended_object.get_absolute_url(),
@@ -320,6 +323,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             (
                 # pylint: disable=consider-using-f-string
                 '<a class="category-badge category-badge--draft" href="{:s}">'
+                '<span class="offscreen">Category</span>'
                 '<span class="category-badge__title">{:s}</span></a>'
             ).format(
                 categories[2].extended_object.get_absolute_url(),

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -260,7 +260,7 @@ class OrganizationCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             # pylint: disable=consider-using-f-string
-            '<h2 class="course-glimpse__title">{0:s}</h2>'.format(
+            '<span class="course-glimpse__title-text">{0:s}</span>'.format(
                 published_course.public_extension.extended_object.get_title(),
             ),
             html=True,
@@ -406,7 +406,7 @@ class OrganizationCMSTestCase(CMSTestCase):
         # The published course should be on the page in its draft version
         self.assertContains(
             response,
-            '<h2 class="course-glimpse__title">modified course</h2>',
+            '<span class="course-glimpse__title-text">modified course</span>',
             html=True,
         )
 

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -193,6 +193,7 @@ class PersonCMSTestCase(CMSTestCase):
             (
                 # pylint: disable=consider-using-f-string
                 '<a class="category-badge" href="{:s}">'
+                '<span class="offscreen">Category</span>'
                 '<span class="category-badge__title">{:s}</span></a>'
             ).format(
                 published_category.public_extension.extended_object.get_absolute_url(),
@@ -308,6 +309,7 @@ class PersonCMSTestCase(CMSTestCase):
             (
                 # pylint: disable=consider-using-f-string
                 '<a class="category-badge" href="{:s}">'
+                '<span class="offscreen">Category</span>'
                 '<span class="category-badge__title">{:s}</span></a>'
             ).format(
                 published_category.public_extension.extended_object.get_absolute_url(),
@@ -321,6 +323,7 @@ class PersonCMSTestCase(CMSTestCase):
             (
                 # pylint: disable=consider-using-f-string
                 '<a class="category-badge category-badge--draft" href="{:s}">'
+                '<span class="offscreen">Category</span>'
                 '<span class="category-badge__title">{:s}</span></a>'
             ).format(
                 not_published_category.extended_object.get_absolute_url(),

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -430,7 +430,7 @@ class PersonCMSTestCase(CMSTestCase):
         # The course should be present on the page
         self.assertContains(
             response,
-            '<h2 class="course-glimpse__title">{0:s}</h2>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
+            '<span class="course-glimpse__title-text">{0:s}</span>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
                 course.extended_object.get_title()
             ),
             html=True,

--- a/tests/apps/courses/test_templates_program_detail.py
+++ b/tests/apps/courses/test_templates_program_detail.py
@@ -135,7 +135,7 @@ class ProgramCMSTestCase(CMSTestCase):
         for course in courses[:2]:
             self.assertContains(
                 response,
-                '<h3 class="course-glimpse__title">{0:s}</h3>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
+                '<span class="course-glimpse__title-text">{0:s}</span>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
                     course.extended_object.get_title()
                 ),
                 html=True,
@@ -184,25 +184,26 @@ class ProgramCMSTestCase(CMSTestCase):
         for course in courses[:2]:
             self.assertContains(
                 response,
-                '<a class="course-glimpse" '
+                '<a class="course-glimpse__link" '
                 f'href="{course.extended_object.get_absolute_url():s}"',
             )
             self.assertContains(
                 response,
-                '<h3 class="course-glimpse__title">{0:s}</h3>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
+                '<span class="course-glimpse__title-text">{0:s}</span>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
                     course.extended_object.get_title()
                 ),
                 html=True,
             )
         self.assertContains(
             response,
-            '<a class="course-glimpse course-glimpse--draft" '
-            f'href="{courses[2].extended_object.get_absolute_url():s}"',
+            '<div class="course-glimpse course-glimpse--draft">'
+            '<div aria-hidden="true" class="course-glimpse__media">'
+            f'<a tabindex="-1" href="{courses[2].extended_object.get_absolute_url():s}"',
         )
 
         self.assertContains(
             response,
-            '<h3 class="course-glimpse__title">{0:s}</h3>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
+            '<span class="course-glimpse__title-text">{0:s}</span>'.format(  # noqa pylint: disable=consider-using-f-string,line-too-long
                 courses[2].extended_object.get_title()
             ),
             html=True,


### PR DESCRIPTION
## Purpose

Make a course glimpse more understandable when using a screen reader.

## Proposal


A few stuff can be done:

- [x] add alt text to meaningful icons
- [x] reorder the DOM
- [x] change the structure with the one `<a>` wrapping everything

Note: some improvements are already added via https://github.com/openfun/richie/pull/1611 (most notably, the removal of redundant `title` attributes)
