### PR TITLE
🐛(course) fix cms toolbar bug when editing a plugin from a detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   more understandable navigation.
 - Add new page templates for various multiple columns and their own CSS to
   adjust every possible plugins to fit correctly;
+- Add new keyword argument `silent` to template tags `get_placeholder_plugins`
+  and `blockplugin`. It have to be set to `True` on these tags when they are
+  used from `<head>` so they never append any invalid markup related to
+  edition mode.
 
 ### Changed
 

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -12,8 +12,8 @@
     <meta property="og:article:published_time" content="{{ current_page.publication_date|date:"c" }}">
     <meta property="og:article:modified_time" content="{{ current_page.changed_date|date:"c" }}">
 
-    {% get_placeholder_plugins "cover" as plugins %}
-    {% blockplugin plugins.0 %}
+    {% get_placeholder_plugins "cover" silent=True as plugins %}
+    {% blockplugin plugins.0 silent=True %}
         {% thumbnail instance.picture 845x500 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -10,8 +10,8 @@
 {% block meta_rdfa_context %}
     <meta property="og:type" content="website" />
 
-    {% get_placeholder_plugins "logo" as og_image_plugins %}
-    {% blockplugin og_image_plugins.0 %}
+    {% get_placeholder_plugins "logo" silent=True as og_image_plugins %}
+    {% blockplugin og_image_plugins.0 silent=True %}
         {% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -17,10 +17,10 @@
 {% endblock meta_html_default %}
 
 {% block meta_rdfa_context %}
-    {% get_placeholder_plugins "course_cover" as plugins or %}
+    {% get_placeholder_plugins "course_cover" silent=True as plugins or %}
         {{ block.super }}
     {% endget_placeholder_plugins %}
-    {% blockplugin plugins.0 %}
+    {% blockplugin plugins.0 silent=True %}
         <meta property="og:type" content="website" />
         {% thumbnail instance.picture 1200x630 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -10,8 +10,8 @@
 {% block meta_rdfa_context %}
     <meta property="og:type" content="website" />
 
-    {% get_placeholder_plugins "logo" as og_image_plugins %}
-    {% blockplugin og_image_plugins.0 %}
+    {% get_placeholder_plugins "logo" silent=True as og_image_plugins %}
+    {% blockplugin og_image_plugins.0 silent=True %}
         {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -10,8 +10,8 @@
 {% block meta_rdfa_context %}
     <meta property="og:type" content="profile" />
 
-    {% get_placeholder_plugins "portrait" as og_image_plugins %}
-    {% blockplugin og_image_plugins.0 %}
+    {% get_placeholder_plugins "portrait" silent=True as og_image_plugins %}
+    {% blockplugin og_image_plugins.0 silent=True %}
         {% thumbnail instance.picture 200x200 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />

--- a/src/richie/apps/courses/templates/courses/cms/program_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_detail.html
@@ -10,12 +10,12 @@
 {% block meta_rdfa_context %}
     <meta property="og:type" content="website" />
 
-    {% get_placeholder_plugins "program_cover" as og_image_plugins %}
-    {% blockplugin og_image_plugins.0 %}
+    {% get_placeholder_plugins "program_cover" silent=True as og_image_plugins %}
+    {% blockplugin og_image_plugins.0 silent=True %}
         {% thumbnail instance.picture 1200x630 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location as thumb %}
         <meta property="og:image" content="{{ MEDIA_URL_PREFIX }}{{ thumb.url }}" />
         <meta property="og:image:width" content="{{ thumb.width }}" />
-        <meta property="og:image:height" content="{{ thumb.height }}" />  
+        <meta property="og:image:height" content="{{ thumb.height }}" />
     {% endblockplugin %}
     {% if not current_page|is_empty_placeholder:"program_excerpt" %}
         <meta property="og:description" content="{% filter slice:":200" %}{% show_placeholder 'program_excerpt' current_page %}{% endfilter %}" />

--- a/tests/apps/courses/test_templatetags_extra_tags_block_plugin.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_block_plugin.py
@@ -49,7 +49,8 @@ class BlockPluginTemplateTagsTestCase(CMSTestCase):
     @transaction.atomic
     def test_templatetags_blockplugin_edit(self):
         """
-        The "blockplugin" template tag should include edit markup when edit mode is on.
+        The "blockplugin" template tag should include edit markup when edit mode is on
+        but not if silent mode is enabled.
         """
         user = UserFactory(is_staff=True, is_superuser=True)
         page = create_page("Test", "richie/single_column.html", "en", published=True)
@@ -81,3 +82,17 @@ class BlockPluginTemplateTagsTestCase(CMSTestCase):
             ).format(pid=plugin.id),
             output,
         )
+
+        # When the silent keyword is set exactly to 'True' string, the tag won't inject
+        # markup related to plugin edition but still render plugin content
+        template = (
+            "{% load extra_tags %}{% blockplugin plugin silent=True %}"
+            "{{ instance.body|safe }}"
+            "{% endblockplugin %}"
+        )
+
+        output = self.render_template_obj(
+            template, {"plugin": plugin}, request
+        ).replace("\n", "")
+
+        self.assertEqual("<b>Test</b>", output)

--- a/tests/apps/courses/test_templatetags_extra_tags_get_placeholder_plugins.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_get_placeholder_plugins.py
@@ -6,7 +6,9 @@ from django.test import RequestFactory
 
 from cms.api import add_plugin, create_page
 from cms.test_utils.testcases import CMSTestCase
+from cms.toolbar.toolbar import CMSToolbar
 
+from richie.apps.core.factories import UserFactory
 from richie.plugins.simple_text_ckeditor.cms_plugins import CKEditorPlugin
 
 
@@ -39,19 +41,123 @@ class GetPlaceholderPluginsTemplateTagsTestCase(CMSTestCase):
         self.assertEqual(output, "<b>Test 1</b>\n<b>Test 2</b>\n")
 
     @transaction.atomic
+    def test_templatetags_get_placeholder_plugins_edit(self):
+        """
+        On default behavior with edit mode enabled, the "get_placeholder_plugins"
+        template tag injects some HTML for the placeholder edition.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        page = create_page("Test", "richie/single_column.html", "en", published=True)
+        placeholder = page.placeholders.all()[0]
+        plugin = add_plugin(placeholder, CKEditorPlugin, "en", body="<b>Test</b>")
+
+        request = RequestFactory().get("/")
+        request.current_page = page
+        request.user = user
+        request.session = {"cms_edit": True}
+        request.toolbar = CMSToolbar(request)
+        request.toolbar.is_staff = True
+
+        template = (
+            "{% load cms_tags extra_tags %}"
+            '{% get_placeholder_plugins "maincontent" as plugins %}'
+        )
+        output = self.render_template_obj(template, {"plugin": plugin}, request)
+
+        # Tag adds HTML placeholder which set stuff for DjangoCMS edition (we don't
+        # assert on Javascript content since it holds too many references to write here)
+        self.assertInHTML(
+            ('<div class="cms-placeholder cms-placeholder-{pid:d}"></div>').format(
+                pid=placeholder.id
+            ),
+            output,
+        )
+
+    @transaction.atomic
+    def test_templatetags_get_placeholder_plugins_silent(self):
+        """
+        The keyword argument "silent" when set to 'True' string will disable any output
+        from tag.
+        """
+        user = UserFactory(is_staff=True, is_superuser=True)
+        page = create_page("Test", "richie/single_column.html", "en", published=True)
+        placeholder = page.placeholders.all()[0]
+        plugin = add_plugin(placeholder, CKEditorPlugin, "en", body="<b>Test 1</b>")
+
+        request = RequestFactory().get("/")
+        request.current_page = page
+        request.user = user
+        request.session = {"cms_edit": True}
+        request.toolbar = CMSToolbar(request)
+        request.toolbar.is_staff = True
+
+        # Default behavior without silent keyword
+        template = (
+            "{% load cms_tags extra_tags %}"
+            '{% get_placeholder_plugins "maincontent" as plugins %}'
+        )
+        output = self.render_template_obj(template, {"plugin": plugin}, request)
+        self.assertInHTML(
+            ('<div class="cms-placeholder cms-placeholder-{pid:d}"></div>').format(
+                pid=placeholder.id
+            ),
+            output,
+        )
+
+        # If silent value is not exactly 'True' string, keep the default behavior
+        template = (
+            "{% load cms_tags extra_tags %}"
+            '{% get_placeholder_plugins "maincontent" silent=False as plugins %}'
+        )
+        output = self.render_template_obj(template, {"plugin": plugin}, request)
+        self.assertInHTML(
+            ('<div class="cms-placeholder cms-placeholder-{pid:d}"></div>').format(
+                pid=placeholder.id
+            ),
+            output,
+        )
+
+        # When the silent keyword is set exactly to 'True' string, the tag won't output
+        # anything but still adds context for 'plugins'
+        template = (
+            "{% load cms_tags extra_tags %}"
+            '{% get_placeholder_plugins "maincontent" silent=True as plugins %}'
+            "{% for plugin in plugins %}{% render_plugin plugin %}{% endfor %}"
+        )
+        output = self.render_template_obj(template, {"plugin": plugin}, request)
+
+        # With available plugins context we can still render each plugin (however
+        # the template elements are useless since they require placeholder output to
+        # work)
+        self.assertEqual(
+            (
+                '<template class="cms-plugin cms-plugin-start cms-plugin-{pid:d}">'
+                "</template>"
+                "<b>Test 1</b>\n"
+                '<template class="cms-plugin cms-plugin-end cms-plugin-{pid:d}">'
+                "</template>"
+            ).format(pid=plugin.id),
+            output,
+        )
+
+    @transaction.atomic
     def test_templatetags_get_placeholder_plugins_empty(self):
         """
         The "get_placeholder_plugins" template tag should render its node content if it has
         no plugins and the "or keyword is passed.
         """
-        page = create_page("Test", "richie/single_column.html", "en", published=True)
-        placeholder = page.placeholders.all()[0]
-        add_plugin(placeholder, CKEditorPlugin, "en", body="<b>Test</b>")
+        page_unexpected = create_page(
+            "Test", "richie/single_column.html", "en", published=True
+        )
+        placeholder_unexpected = page_unexpected.placeholders.all()[0]
+        add_plugin(placeholder_unexpected, CKEditorPlugin, "en", body="<b>Test</b>")
 
-        request = RequestFactory().get("/")
-        request.current_page = create_page(
+        page_expected = create_page(
             "current", "richie/single_column.html", "en", published=True
         )
+
+        request = RequestFactory().get("/")
+        request.current_page = page_expected
         request.user = AnonymousUser()
 
         template = (
@@ -60,6 +166,29 @@ class GetPlaceholderPluginsTemplateTagsTestCase(CMSTestCase):
             "<i>empty content</i>{% endget_placeholder_plugins %}"
             "{% for plugin in plugins %}{% render_plugin plugin %}{% endfor %}"
         )
+        output = self.render_template_obj(template, {}, request)
+        self.assertEqual("<i>empty content</i>", output)
+
+        # Silent keyword argument do not change anything for non edit mode and so node
+        # content is still rendered
+        template = (
+            "{% load cms_tags extra_tags %}"
+            '{% get_placeholder_plugins "maincontent" silent=True as plugins or %}'
+            "<i>empty content</i>{% endget_placeholder_plugins %}"
+            "{% for plugin in plugins %}{% render_plugin plugin %}{% endfor %}"
+        )
+        output = self.render_template_obj(template, {}, request)
+        self.assertEqual("<i>empty content</i>", output)
+
+        # Turning to edition mode
+        user = UserFactory(is_staff=True, is_superuser=True)
+        request.user = user
+        request.session = {"cms_edit": True}
+        request.toolbar = CMSToolbar(request)
+        request.toolbar.is_staff = True
+
+        # Silent keyword argument in edition mode omit markup related to placeholder
+        # edition
         output = self.render_template_obj(template, {}, request)
         self.assertEqual("<i>empty content</i>", output)
 


### PR DESCRIPTION
## Purpose

It has been reported that, when editing a plugin, a bug often appears which turns the CMS toolbar in mobile mode.

It was due to usage of `get_placeholder_plugins` and `blockplugin` tags in page metas. This is because in edit mode these tags append some markup required for the CMS interface to edit in place a plugin and so it appends some HTML elements like `<div>` and `<template>` which are totally invalid in `<head>` elements and also some Javascript code which invoke some object/function that are not yet loaded.

This is more probably the invalid HTML which cause the error since with Firefox 90.0 there is no bug but it always reproduce with Chrome. Firefox and Chrome quirk mode are different and Firefox have commonly a better one which just ignore the invalid HTML.

## Proposal

This commit adds a new keyword argument `silent` to previously cited template tags. This argument when set to 'True' disable default behavior of edition mode and so does not inject any markup related to placeholder and plugin edition. And finally, all detail template now use this argument on tags inside '<head>'.

Tags tests have been updated to cover this new argument behavior.
