### PR TITLE
Feat/step manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Create a `StepBreadcrumb` component to display progress within a step process
 - Create a `useStepManager` hook to manage step process
 - Create a React `Icon` component that can optionally take alternative text
   for screen reader users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Create a `useStepManager` hook to manage step process
 - Create a React `Icon` component that can optionally take alternative text
   for screen reader users.
 - Add a heading for screen reader users on the search results page to have a

--- a/src/frontend/js/components/Icon/index.tsx
+++ b/src/frontend/js/components/Icon/index.tsx
@@ -12,7 +12,7 @@ interface IconProps {
 }
 
 // icons from src/richie/apps/core/templates/richie/icons.html
-type IconType =
+export type IconType =
   | 'icon-calendar'
   | 'icon-barcode'
   | 'icon-chevron-down'

--- a/src/frontend/js/components/StepBreadcrumb/_styles.scss
+++ b/src/frontend/js/components/StepBreadcrumb/_styles.scss
@@ -1,0 +1,96 @@
+.StepBreadcrumb {
+  $margin-y: 1.25rem;
+  $icon-size: 3.375rem;
+  display: flex;
+  flex-direction: row;
+  list-style: none;
+  margin: 0 19% 2.375rem 19%;
+  padding: 0;
+
+  &__step {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    margin: $margin-y 1.5rem;
+    position: relative;
+    text-align: center;
+    z-index: 1;
+
+    &__icon {
+      align-items: center;
+      background: r-theme-val(steps-breadcrumb, icon-background);
+      border-radius: 50%;
+      border: 3px solid r-theme-val(steps-breadcrumb, icon-border);
+      box-sizing: border-box;
+      color: r-theme-val(steps-breadcrumb, icon-fill);
+      display: flex;
+      font-family: $r-font-family-montserrat;
+      font-size: 1.25rem;
+      height: $icon-size;
+      justify-content: center;
+      margin-bottom: 0.3125rem;
+      width: $icon-size;
+
+      svg {
+        fill: currentColor;
+        max-height: $icon-size;
+        width: 55%;
+      }
+    }
+
+    &__label {
+      -moz-box-orient: vertical;
+      -moz-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+      bottom: 0;
+      color: r-theme-val(steps-breadcrumb, label-color);
+      display: -moz-box;
+      display: -webkit-box;
+      font-weight: 600;
+      letter-spacing: 1px;
+      overflow: hidden;
+      padding-top: 0.625rem;
+      position: absolute;
+      text-transform: uppercase;
+      transform: translateY(100%);
+    }
+
+    &--active {
+      .StepBreadcrumb__step__icon {
+        background-color: r-theme-val(steps-breadcrumb, icon-background-active);
+        border-color: r-theme-val(steps-breadcrumb, icon-border-active);
+        box-shadow: 0 0 0 3px r-theme-val(steps-breadcrumb, icon-outline);
+        color: r-theme-val(steps-breadcrumb, icon-fill-active);
+      }
+
+      .StepBreadcrumb__step__label {
+        color: r-theme-val(steps-breadcrumb, label-color-active);
+      }
+    }
+  }
+
+  &__separator {
+    $separator-height: 0.1875rem;
+    background-color: r-theme-val(steps-breadcrumb, separator-background);
+    border-radius: 100vw;
+    height: $separator-height;
+    position: relative;
+    transform: translateY($margin-y + ($icon-size - $separator-height) * 0.5);
+    width: 100%;
+
+    &--active {
+      background-color: r-theme-val(steps-breadcrumb, separator-background-active);
+    }
+  }
+
+  @include media-breakpoint-down(xs) {
+    .StepBreadcrumb__separator {
+      display: none;
+    }
+    & > .StepBreadcrumb__step:not(.StepBreadcrumb__step--current) {
+      display: none;
+    }
+  }
+}

--- a/src/frontend/js/components/StepBreadcrumb/index.spec.tsx
+++ b/src/frontend/js/components/StepBreadcrumb/index.spec.tsx
@@ -1,0 +1,218 @@
+import {
+  act,
+  getAllByRole,
+  queryAllByRole,
+  queryAllByTestId,
+  queryByRole,
+  render,
+} from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { type Manifest, useStepManager } from 'hooks/useStepManager';
+import { StepBreadcrumb } from '.';
+
+describe('StepBreadcrumb', () => {
+  it('renders visually a minimal manifest', () => {
+    // If manifest's steps does not have `label` and `icon` property,
+    // only a breadcrumb with the step index is displayed.
+    type LastStep = 'step1';
+    type Steps = 'step0' | LastStep;
+    const manifest: Manifest<Steps, LastStep> = {
+      start: 'step0',
+      steps: {
+        step0: {
+          next: 'step1',
+        },
+        step1: {
+          next: null,
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useStepManager(manifest));
+    const { container, rerender } = render(
+      <StepBreadcrumb manifest={manifest} step={result.current.step} />,
+    );
+
+    expect(getAllByRole(container, 'listitem')).toHaveLength(2);
+
+    const labels = queryAllByRole(container, 'heading', { level: 6 });
+    const stepsIcons = queryAllByTestId(container, 'StepBreadcrumb__step__icon');
+    let activeSteps = container.querySelectorAll(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--active',
+    );
+    let currentStep = container.querySelector(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--current',
+    );
+    expect(labels).toHaveLength(0);
+    expect(stepsIcons).toHaveLength(2);
+    stepsIcons.forEach((icon, index) => {
+      expect(icon.firstChild).toBeInstanceOf(HTMLSpanElement);
+      expect(icon.firstChild).toHaveTextContent((index + 1).toString());
+    });
+    expect(activeSteps).toHaveLength(1);
+    expect(currentStep).toHaveTextContent('1');
+
+    act(() => result.current.next());
+    rerender(<StepBreadcrumb manifest={manifest} step={result.current.step} />);
+
+    activeSteps = container.querySelectorAll(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--active',
+    );
+    currentStep = container.querySelector('li.StepBreadcrumb__step.StepBreadcrumb__step--current');
+    expect(activeSteps).toHaveLength(2);
+    expect(currentStep).toHaveTextContent('2');
+  });
+
+  it('renders visually a complete manifest', () => {
+    // If manifest's steps has `label` and `icon` property,
+    // this information was shown.
+    type LastStep = 'step1';
+    type Steps = 'step0' | LastStep;
+    const manifest: Manifest<Steps, LastStep> = {
+      start: 'step0',
+      steps: {
+        step0: {
+          label: '0. Step',
+          icon: 'icon-arrow-right',
+          next: 'step1',
+        },
+        step1: {
+          label: '1. Step',
+          icon: 'icon-arrow-right',
+          next: null,
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useStepManager(manifest));
+    const { container, rerender } = render(
+      <StepBreadcrumb manifest={manifest} step={result.current.step} />,
+    );
+
+    expect(getAllByRole(container, 'listitem')).toHaveLength(2);
+
+    const labels = queryAllByRole(container, 'heading', { level: 6 });
+    const stepsIcons = queryAllByTestId(container, 'StepBreadcrumb__step__icon');
+    let activeSteps = container.querySelectorAll(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--active',
+    );
+    let currentStep = container.querySelector(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--current',
+    );
+
+    expect(labels).toHaveLength(2);
+    queryByRole(container, 'heading', { level: 6, name: '0. Step' });
+    queryByRole(container, 'heading', { level: 6, name: '1. Step' });
+
+    expect(stepsIcons).toHaveLength(2);
+    stepsIcons.forEach((icon) => {
+      expect(icon.firstChild).toBeInstanceOf(SVGElement);
+    });
+    expect(activeSteps).toHaveLength(1);
+    expect(currentStep).toHaveTextContent('0. Step');
+
+    const separator = container.querySelectorAll('li.StepBreadcrumb__separator');
+    let activeSeparator = container.querySelector(
+      'li.StepBreadcrumb__separator.StepBreadcrumb__separator--active',
+    );
+    expect(separator).toHaveLength(1);
+    expect(activeSeparator).toBeNull();
+
+    act(() => result.current.next());
+    rerender(<StepBreadcrumb manifest={manifest} step={result.current.step} />);
+
+    activeSteps = container.querySelectorAll(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--active',
+    );
+    currentStep = container.querySelector('li.StepBreadcrumb__step.StepBreadcrumb__step--current');
+    expect(activeSteps).toHaveLength(2);
+    expect(currentStep).toHaveTextContent('1. Step');
+
+    activeSeparator = container.querySelector(
+      'li.StepBreadcrumb__separator.StepBreadcrumb__separator--active',
+    );
+    expect(activeSeparator).not.toBeNull();
+  });
+
+  it('sorts manifest steps to guarantee the display order of steps', () => {
+    type LastStep = 'step0';
+    type Steps = 'step1' | LastStep;
+    const manifest: Manifest<Steps, LastStep> = {
+      start: 'step1',
+      steps: {
+        step0: {
+          next: null,
+        },
+        step1: {
+          next: 'step0',
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useStepManager(manifest));
+    const { container } = render(<StepBreadcrumb manifest={manifest} step={result.current.step} />);
+
+    expect(getAllByRole(container, 'listitem')).toHaveLength(2);
+
+    const activeSteps = container.querySelectorAll(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--active',
+    );
+    const currentStep = container.querySelector(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--current',
+    );
+    expect(activeSteps).toHaveLength(1);
+    expect(currentStep).toHaveTextContent('1');
+  });
+
+  it('displays all active steps on mount if manifest does not start to the first step', () => {
+    type LastStep = 'step1';
+    type Steps = 'step0' | LastStep;
+    const manifest: Manifest<Steps, LastStep> = {
+      start: 'step1',
+      steps: {
+        step0: {
+          next: 'step1',
+        },
+        step1: {
+          next: null,
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useStepManager(manifest));
+    const { container } = render(<StepBreadcrumb manifest={manifest} step={result.current.step} />);
+
+    expect(getAllByRole(container, 'listitem')).toHaveLength(2);
+
+    const activeSteps = container.querySelectorAll(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--active',
+    );
+    const currentStep = container.querySelector(
+      'li.StepBreadcrumb__step.StepBreadcrumb__step--current',
+    );
+    expect(activeSteps).toHaveLength(2);
+    expect(currentStep).toHaveTextContent('2');
+  });
+
+  it('can contain a single step ', () => {
+    type LastStep = 'step0';
+    const manifest: Manifest<LastStep> = {
+      steps: {
+        step0: {
+          next: null,
+        },
+      },
+      start: 'step0',
+    };
+
+    const { result } = renderHook(() => useStepManager(manifest));
+    // - step 0
+    expect(result.current.step).toEqual('step0');
+    // - terminated state
+    act(() => result.current.next());
+    expect(result.current.step).toEqual(null);
+    // - Reset: should go back to step0
+    act(() => result.current.reset());
+    expect(result.current.step).toEqual('step0');
+  });
+});

--- a/src/frontend/js/components/StepBreadcrumb/index.tsx
+++ b/src/frontend/js/components/StepBreadcrumb/index.tsx
@@ -1,0 +1,101 @@
+// StepBreadcrumb has been created to work in pair with useStepManager hook.
+// Within a step process, it aims to guide the user to know where he/she is in
+// the current process by translating visually the steps manifest.
+import { Children, Fragment, useCallback } from 'react';
+import { Nullable } from 'types/utils';
+import { Manifest, Step, useStepManager } from 'hooks/useStepManager';
+import { Icon } from 'components/Icon';
+
+interface Props<Keys extends PropertyKey, LastKey extends Keys> {
+  manifest: Manifest<Keys, LastKey>;
+  step: Nullable<PropertyKey>;
+}
+
+type FlattenStep = [PropertyKey, Step];
+
+/**
+ * Retrieve the index of the active step.
+ * When step is null, we know that process is terminated so we have to return
+ * the last step index.
+ * @params step[]
+ * @returns {number} active step index
+ */
+function getActiveStepIndex(steps: FlattenStep[], step: Nullable<PropertyKey>) {
+  if (step === null) return steps.length - 1;
+  return steps.findIndex((s) => s[0] === step);
+}
+
+/**
+ * As object properties order is not guaranteed, we have to sort steps to ensure
+ * that they are displayed in the right order.
+ *
+ * // MARK When IE 11 supports will be dropped, we can use a `Map`
+ * to define `manifest.steps` then remove this sort function
+ */
+function sortSteps<Keys extends PropertyKey, LastKey extends Keys>(
+  firstStep: Keys,
+  manifest: Manifest<Keys, LastKey>,
+) {
+  const steps: FlattenStep[] = [];
+  let step = firstStep;
+
+  while (step !== null) {
+    steps.push([step, manifest.steps[step]]);
+    step = manifest.steps[step].next;
+  }
+
+  return steps;
+}
+
+export const StepBreadcrumb = <Keys extends PropertyKey, LastKey extends Keys>({
+  step,
+  manifest,
+}: Props<Keys, LastKey>) => {
+  const { firstStep } = useStepManager(manifest);
+  const orderedSteps = sortSteps(firstStep, manifest);
+  const activeIndex = getActiveStepIndex(orderedSteps, step);
+
+  const getStepClassName = useCallback(
+    (index) => {
+      const className = ['StepBreadcrumb__step'];
+      if (index <= activeIndex) className.push('StepBreadcrumb__step--active');
+      if (index === activeIndex) className.push('StepBreadcrumb__step--current');
+
+      return className.join(' ');
+    },
+    [activeIndex],
+  );
+
+  const getSeparatorClassName = useCallback(
+    (index) => {
+      const className = ['StepBreadcrumb__separator'];
+      if (index < activeIndex) className.push('StepBreadcrumb__separator--active');
+
+      return className.join(' ');
+    },
+    [activeIndex],
+  );
+
+  return (
+    <ol className="StepBreadcrumb">
+      {Children.toArray(
+        orderedSteps.map(([, entry], index) => (
+          <Fragment>
+            <li
+              aria-current={index === activeIndex ? 'step' : 'false'}
+              className={getStepClassName(index)}
+            >
+              <div className="StepBreadcrumb__step__icon" data-testid="StepBreadcrumb__step__icon">
+                {entry.icon ? <Icon name={entry.icon} /> : <span>{index + 1}</span>}
+              </div>
+              {entry.label ? <h6 className="StepBreadcrumb__step__label">{entry.label}</h6> : null}
+            </li>
+            {entry.next !== null ? (
+              <li aria-hidden={true} className={getSeparatorClassName(index)} />
+            ) : null}
+          </Fragment>
+        )),
+      )}
+    </ol>
+  );
+};

--- a/src/frontend/js/hooks/useStepManager/index.spec.ts
+++ b/src/frontend/js/hooks/useStepManager/index.spec.ts
@@ -1,0 +1,172 @@
+import { act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Manifest, useStepManager } from '.';
+
+describe('useStepManager', () => {
+  it('reads the manifest', () => {
+    type LastStep = 'step1';
+    type Steps = 'step0' | LastStep;
+    const manifest: Manifest<Steps, LastStep> = {
+      start: 'step0',
+      steps: {
+        step0: {
+          next: 'step1',
+        },
+        step1: {
+          next: null,
+        },
+      },
+    };
+    const { result } = renderHook(() => useStepManager(manifest));
+
+    // - step 0
+    expect(result.current.step).toEqual('step0');
+
+    // - step 1
+    act(() => result.current.next());
+    expect(result.current.step).toEqual('step1');
+
+    // - terminated state
+    act(() => result.current.next());
+    expect(result.current.step).toEqual(null);
+
+    // As state is terminated, trigger once again next should do nothing
+    act(() => result.current.next());
+    expect(result.current.step).toEqual(null);
+  });
+
+  it('is able to reset the step process', () => {
+    type LastStep = 'step1';
+    type Steps = 'step0' | LastStep;
+    const manifest: Manifest<Steps, LastStep> = {
+      start: 'step0',
+      steps: {
+        step0: {
+          next: 'step1',
+        },
+        step1: {
+          next: null,
+        },
+      },
+    };
+    const { result } = renderHook(() => useStepManager(manifest));
+
+    // - step 0
+    expect(result.current.step).toEqual('step0');
+
+    // - step 1
+    act(() => result.current.next());
+    expect(result.current.step).toEqual('step1');
+
+    // - Reset: should go back to step0
+    act(() => result.current.reset());
+    expect(result.current.step).toEqual('step0');
+  });
+
+  it('is able to find the first step through steps if manifest does not have a start property', () => {
+    type LastStep = 'finally';
+    type Steps = 'first' | 'then' | LastStep;
+    const manifest: Manifest<Steps, LastStep> = {
+      steps: {
+        then: {
+          next: 'finally',
+        },
+        first: {
+          next: 'then',
+        },
+        finally: {
+          next: null,
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useStepManager(manifest));
+
+    expect(result.current.firstStep).toEqual('first');
+
+    // - first
+    expect(result.current.step).toEqual('first');
+
+    // - then
+    act(() => result.current.next());
+    expect(result.current.step).toEqual('then');
+
+    // - finally
+    act(() => result.current.next());
+    expect(result.current.step).toEqual('finally');
+
+    // - Reset: should go back to first
+    act(() => result.current.reset());
+    expect(result.current.step).toEqual('first');
+  });
+
+  it('triggers onEnter and onExit hooks on step transition', () => {
+    type LastStep = 'step1';
+    type Steps = 'step0' | LastStep;
+    const manifest: Manifest<Steps, LastStep> = {
+      start: 'step0',
+      steps: {
+        step0: {
+          next: 'step1',
+          onEnter: jest.fn(),
+          onExit: jest.fn(),
+        },
+        step1: {
+          next: null,
+          onEnter: jest.fn(),
+          onExit: jest.fn(),
+        },
+      },
+    };
+    const { result } = renderHook(() => useStepManager(manifest));
+
+    // - step 0
+    expect(result.current.step).toEqual('step0');
+    expect(manifest.steps.step0.onEnter).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step0.onExit).not.toHaveBeenCalled();
+    expect(manifest.steps.step1.onEnter).not.toHaveBeenCalled();
+    expect(manifest.steps.step1.onExit).not.toHaveBeenCalled();
+
+    // - step 1
+    act(() => result.current.next());
+
+    expect(result.current.step).toEqual('step1');
+    expect(manifest.steps.step0.onEnter).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step0.onExit).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step1.onEnter).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step1.onExit).not.toHaveBeenCalled();
+
+    // - terminated state
+    act(() => result.current.next());
+
+    expect(result.current.step).toEqual(null);
+    expect(manifest.steps.step0.onEnter).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step0.onExit).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step1.onEnter).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step1.onExit).toHaveBeenCalledTimes(1);
+
+    // - Reset: go back to step0
+    act(() => result.current.reset());
+
+    expect(manifest.steps.step0.onEnter).toHaveBeenCalledTimes(2);
+    expect(manifest.steps.step0.onExit).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step1.onEnter).toHaveBeenCalledTimes(1);
+    expect(manifest.steps.step1.onExit).toHaveBeenCalledTimes(1);
+
+    // - step 1
+    act(() => result.current.next());
+
+    expect(manifest.steps.step0.onEnter).toHaveBeenCalledTimes(2);
+    expect(manifest.steps.step0.onExit).toHaveBeenCalledTimes(2);
+    expect(manifest.steps.step1.onEnter).toHaveBeenCalledTimes(2);
+    expect(manifest.steps.step1.onExit).toHaveBeenCalledTimes(1);
+
+    // - Reset: go back to step0
+    act(() => result.current.reset());
+
+    expect(manifest.steps.step0.onEnter).toHaveBeenCalledTimes(3);
+    expect(manifest.steps.step0.onExit).toHaveBeenCalledTimes(2);
+    expect(manifest.steps.step1.onEnter).toHaveBeenCalledTimes(2);
+    expect(manifest.steps.step1.onExit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/frontend/js/hooks/useStepManager/index.ts
+++ b/src/frontend/js/hooks/useStepManager/index.ts
@@ -1,0 +1,82 @@
+import { type IconType } from 'components/Icon';
+import { useEffect, useMemo, useState } from 'react';
+import { type Nullable } from 'types/utils';
+
+export interface Step<Keys extends PropertyKey = PropertyKey> {
+  icon?: IconType;
+  label?: string;
+  next: Nullable<Keys>;
+  onEnter?: Function;
+  onExit?: Function;
+}
+
+interface InStep<Keys extends PropertyKey> extends Step<Keys> {
+  next: Keys;
+}
+
+interface LastStep extends Step {
+  next: null;
+}
+
+type Steps<Keys extends PropertyKey, LastKey extends Keys> = Record<Keys, Step<Keys>> &
+  Record<Exclude<Keys, LastKey>, InStep<Keys>> &
+  Record<LastKey, LastStep>;
+
+export interface Manifest<Keys extends PropertyKey, LastKey extends Keys = Keys> {
+  steps: Steps<Keys, LastKey>;
+  start?: Keys;
+}
+
+/**
+ * The first step of the manifest could be defined as the only step which is
+ * never present in `next` property of another step.
+ * So this method searches which step is not used by another step.
+ * @param {Manifest} manifest
+ * @returns {Manifest.step} step
+ */
+function findFirstStep<Keys extends PropertyKey, LastKey extends Keys>(
+  manifest: Manifest<Keys, LastKey>,
+): Keys {
+  const steps = Object.keys(manifest.steps) as Keys[];
+  const nextSteps = Object.values<Step<Keys>>(manifest.steps).map(({ next }) => next);
+
+  return steps.find((step) => !nextSteps.includes(step))!;
+}
+
+/**
+ * A hook to manage step process.
+ * It takes a manifest which describes each steps and how each of them
+ * are related.
+ * Callbacks `onEnter` and `onExit` can be defined to trigger function
+ * when a step starts or terminates.
+ *
+ * Process terminates when step is null
+ */
+export const useStepManager = <Keys extends PropertyKey, LastKey extends Keys>(
+  manifest: Manifest<Keys, LastKey>,
+) => {
+  const firstStep = findFirstStep<Keys, LastKey>(manifest);
+  const [step, setStep] = useState<Nullable<Keys>>(manifest.start || firstStep);
+  const state = useMemo(() => (step ? manifest.steps[step] : null), [step]);
+
+  const next = () => {
+    if (step !== null) {
+      const nextStep = manifest.steps[step].next;
+      setStep(nextStep);
+    }
+  };
+
+  useEffect(() => {
+    if (state?.onEnter) state.onEnter();
+
+    return () => {
+      if (state?.onExit) state.onExit();
+    };
+  }, [state]);
+
+  const reset = () => {
+    setStep(manifest.start || firstStep);
+  };
+
+  return { step, next, reset, firstStep };
+};

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -79,6 +79,7 @@
 @import '../js/components/SearchFiltersPane/styles';
 @import '../js/components/SearchInput/styles';
 @import '../js/components/Spinner/styles';
+@import '../js/components/StepBreadcrumb/styles';
 @import '../js/components/UserLogin/styles';
 @import '../js/components/UserMenu/styles';
 @import './components/templates/courses/plugins/category_plugin';

--- a/src/frontend/scss/colors/_theme.scss
+++ b/src/frontend/scss/colors/_theme.scss
@@ -436,6 +436,30 @@ $r-theme: (
   spinner: (
     base-color: r-color('denim'),
     base-color-light: r-color('white'),
+  ),
+  steps-breadcrumb: (
+    icon-background-active: r-color(purplish-grey),
+    icon-background: transparent,
+    icon-border-active: transparent,
+    icon-border: r-color('light-grey'),
+    icon-fill-active: r-color('white'),
+    icon-fill: r-color('light-grey'),
+    icon-outline: rgba(r-color(purplish-grey), 0.25),
+    label-color-active: r-color('charcoal'),
+    label-color: r-color('light-grey'),
+    separator-background-active: rgba(r-color(purplish-grey), 0.6),
+    separator-background: rgba(r-color(purplish-grey), 0.25),
+  ),
+  steps-content: (
+    content-color: r-color(purplish-grey),
+    icon-background: r-color(indianred3),
+    icon-color: r-color('white'),
+    icon-big-background: transparent,
+    icon-big-color: r-color('charcoal'),
+    icon-success-background: r-color('mantis'),
+    icon-success-color: r-color('white'),
+    title-color: r-color('charcoal'),
+    subtitle-color: r-color(purplish-grey),
   )
 ) !default;
 


### PR DESCRIPTION
## Purpose

Create a frontend component to manage processes split in step.
To achieve that we created a hook `useStepManager` which takes as argument a manifest in charge to describe each steps (name, icon, callback onEnter & onExit) and their relationships.

Furthermore, we created a `StepBreadcrumb` component which is in charge to display steps of manifest and highlight the active step.

![2022-03-09 18 52 00](https://user-images.githubusercontent.com/9265241/157501538-335f1893-ec5f-439b-b36f-6d91ab00bad7.gif)

## Proposal

- [x] Create a `useStepManager` hook
- [x] Create a `StepBreadcrumb` component
