### PR TITLE
🐛(layout) display author name in blogpost detail in published mode also

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Prevent context processor error when WEB_ANALYTICS_ID setting is not defined.
 - Fix autocomplete views tests that may failed because of result order.
 - Fix section tile title with richtext and special character escaping.
+- Change blogpost detail template to display author even in published mode
+  except if its placeholder is empty.
 
 ## [2.13.0] - 2022-02-18
 

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -78,7 +78,7 @@
 
                     {% block authors %}
                         {% with person_variant="tag" %}
-                            {% if current_page.publisher_is_draft %}
+                            {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"author" %}
                             <div class="blogpost-detail__authors">
                                 {% placeholder "author" or %}
                                     <span class="blogpost-detail__empty">{% trans 'No author yet' %}</span>

--- a/tests/apps/courses/test_templates_blogpost_detail.py
+++ b/tests/apps/courses/test_templates_blogpost_detail.py
@@ -128,7 +128,7 @@ class DetailBlogPostCMSTestCase(CMSTestCase):
         self.assertContains(
             response, '<h1 class="blogpost-detail__title">Preums</h1>', html=True
         )
-        self.assertNotContains(response, "Comte de Saint-Germain", html=True)
+        self.assertContains(response, "Comte de Saint-Germain", html=True)
 
         self.assertContains(
             response,
@@ -196,6 +196,38 @@ class DetailBlogPostCMSTestCase(CMSTestCase):
         self.assertContains(
             response,
             '<p class="blogpost-detail__pubdate">Not published yet</p>',
+            html=True,
+        )
+
+    def test_templates_blogpost_detail_author_empty(self):
+        """
+        The empty message for blogpost author should be present in edition but not in
+        published mode if its placeholder is empty.
+        """
+        blogpost = BlogPostFactory()
+        page = blogpost.extended_object
+        page.publish("en")
+
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+
+        # Published view does not have empty author message
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            ('<span class="blogpost-detail__empty">No author yet</span>'),
+            html=True,
+        )
+
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        response = self.client.get(url, {"edit": "true"})
+
+        # Edition view does have empty author message
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            ('<span class="blogpost-detail__empty">No author yet</span>'),
             html=True,
         )
 


### PR DESCRIPTION
## Purpose

The author person name was hidden in blogpost detail when viewed in published mode and only showed in draft mode. But alike categories, the author is required to be displayed in published mode also except if its placeholder is empty.

## Proposal

This commit fix template to use the right condition to display author and add some tests around this behavior.
