### PR TITLE
✨(courses) add 'excerpt' placeholder to Organization detail template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add new page templates for various multiple columns and their own CSS to
   adjust every possible plugins to fit correctly;
 - Add theme variable to change checkmark color.
+- Add new placeholder 'excerpt' to Organization detail template
 
 ### Changed
 
@@ -24,6 +25,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Improve React search suggestion field labels for screen readers.
 - Removed usage of deprecated Sass division '/' operator in favor of
   'math.div'.
+- Organization plugin variant 'row' now use excerpt if not empty else the
+  description with every markup removed
 
 ### Fixed
 
@@ -36,6 +39,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix section tile title with richtext and special character escaping.
 - Change blogpost detail template to display author even in published mode
   except if its placeholder is empty.
+- Fix missing styles for Organization plugin 'row' variant link wrapper
 
 ## [2.13.0] - 2022-02-18
 

--- a/src/frontend/scss/objects/_organization_glimpses.scss
+++ b/src/frontend/scss/objects/_organization_glimpses.scss
@@ -186,6 +186,25 @@
     flex-basis: 100%;
   }
 
+  & > a {
+    align-content: flex-start;
+    align-items: center;
+    color: inherit;
+    display: block;
+    flex-direction: row;
+    flex-wrap: nowrap;
+
+    &:hover,
+    &:focus {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    @include media-breakpoint-up(lg) {
+      display: flex;
+    }
+  }
+
   &:hover,
   &:focus {
     color: inherit;

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -265,6 +265,11 @@ CMS_PLACEHOLDER_CONF = {
         "plugins": ["CKEditorPlugin"],
         "limits": {"CKEditorPlugin": 1},
     },
+    "courses/cms/organization_detail.html excerpt": {
+        "name": _("Excerpt"),
+        "plugins": ["PlainTextPlugin"],
+        "limits": {"PlainTextPlugin": 1},
+    },
     # Category detail
     "courses/cms/category_detail.html banner": {
         "name": _("Banner"),

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
@@ -30,8 +30,22 @@
             {% endblockplugin %}
         </div>
         <div class="organization-{{ organization_variant }}__content">
-            <h{{ header_level|default:3 }} class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</<h{{ header_level|default:3 }}>
-            <div class="organization-{{ organization_variant }}__excerpt" property="description">{% get_placeholder_plugins "description" organization_page as plugins or %}{% trans "Description" %}{% endget_placeholder_plugins %}{% blockplugin plugins.0 %}{{ instance.body|truncatewords_html:40|safe }}{% endblockplugin %}</div>
+            <h{{ header_level|default:3 }} class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</h{{ header_level|default:3 }}>
+            <div class="organization-{{ organization_variant }}__excerpt" property="description">
+                {% get_placeholder_plugins "excerpt" organization_page as plugins %}
+                {% blockplugin plugins.0 %}
+                    <p>{{ instance.body }}</p>
+                {% endblockplugin %}
+                {% if not plugins %}
+                    {% get_placeholder_plugins "description" organization_page as plugins %}
+                    {% blockplugin plugins.0 %}
+                        <p>{{ instance.body|truncatewords_html:40|striptags }}</p>
+                    {% endblockplugin %}
+                    {% if not plugins %}
+                        <p>{% trans "Excerpt" %}</p>
+                    {% endif %}
+                {% endif %}
+            </div>
         </div>
     </a>
 {% else %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -2,7 +2,9 @@
 {% load cms_tags extra_tags i18n pagination_tags static thumbnail %}
 
 {% block meta_html_default %}
-    {% if not current_page|is_empty_placeholder:"description" %}
+    {% if not current_page|is_empty_placeholder:"excerpt" %}
+        <meta name="description" content="{% filter trim|slice:":160" %}{% show_placeholder 'excerpt' current_page %}{% endfilter %}" />
+    {% elif not current_page|is_empty_placeholder:"description" %}
         <meta name="description" content="{% filter striptags|trim|slice:":160" %}{% show_placeholder 'description' current_page %}{% endfilter %}" />
     {% endif %}
 {% endblock meta_html_default %}
@@ -17,7 +19,9 @@
         <meta property="og:image:width" content="{{ thumb.width }}" />
         <meta property="og:image:height" content="{{ thumb.height }}" />
     {% endif %}
-    {% if not current_page|is_empty_placeholder:"description" %}
+    {% if not current_page|is_empty_placeholder:"excerpt" %}
+        <meta property="og:description" content="{% filter trim|slice:":200" %}{% show_placeholder 'excerpt' current_page %}{% endfilter %}" />
+    {% elif not current_page|is_empty_placeholder:"description" %}
         <meta property="og:description" content="{% filter striptags|trim|slice:":200" %}{% show_placeholder 'description' current_page %}{% endfilter %}" />
     {% endif %}
 {% endblock meta_rdfa_context %}
@@ -88,6 +92,16 @@
                     </p>
                     {% endplaceholder %}
                 {% endwith %}
+                </div>
+                {% endif %}
+
+                {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"excerpt" %}
+                <div class="organization-detail__excerpt">
+                    {% placeholder "excerpt" or %}
+                        <p class="organization-detail__empty">
+                            {% trans "No excerpt content" %}
+                        </p>
+                    {% endplaceholder %}
                 </div>
                 {% endif %}
 


### PR DESCRIPTION
## Purpose

Organization plugin 'row' variant has been reported to have broken layout in some situation.

This is due to two things, firstly the CSS was not made for the link wrapper around content, secondly Organization description can include links which break HTML since it is already included in a link wrapper, this is not valid and leads to CSS issues.

Note than the reported bug was when the Org description included a link but in fact there was other issues without any included links, this is because of invalid HTML that leads to erroneous behavior that depended from browser resolution with invalid HTML.

Below you can see a sample of render with the two possibilities (without or with included links in description):

![org_row_sample_bug](https://user-images.githubusercontent.com/1572165/157782250-df74ced5-a5e7-4afd-90b3-cadee6cce84b.png)

Note than when row is hovered, everything adopt the "hover link" CSS behaviors with underlined and colorized text. Finally the expected layout was better when there is included links in description, since the invalid HTML break the DOM and so the row adopt the CSS parent selector which have some CSS properties to make image aside content.

Below you can see a sample with my CSS fix:

![org_row_sample_fixed](https://user-images.githubusercontent.com/1572165/157782693-85cc81d0-accd-46fc-8855-2e81fb7fe973.png)

Here the first row without any included link in description have the expected layout (image and text aside, correct font, correct color, etc..). And the second row which include a link in description is almost correctly but since HTML is broken, the text layout is broken.

## Proposal

This leaded to decision to add a new placeholder 'excerpt' alike with Blogpost, so Organization 'row' variant can still be in a link container since its text content is always plain text. The excerpt is used if not empty, else it will fallback to use the description but with every markup stripped out.

And now it looks like this:

![org_row_sample_expected](https://user-images.githubusercontent.com/1572165/158257952-402ea136-c8c9-4dcb-bc10-6c54740c5d4a.png)
