### PR TITLE
🐛(course) fix course run deletion when translation title is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Change blogpost detail template to display author even in published mode
   except if its placeholder is empty.
 - Fix missing styles for Organization plugin 'row' variant link wrapper
+- Fix course run deletion when translation title is empty
 
 ## [2.13.0] - 2022-02-18
 

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -929,7 +929,9 @@ class CourseRunTranslation(TranslatedFieldsModel):
     def __str__(self):
         """Human representation of a course run translation."""
         model = self._meta.verbose_name.title()
-        return f"{model:s}: {self.title:s}"
+        title = self.title or str(_("Empty title"))
+
+        return f"{model:s}: {title:s}"
 
     # pylint: disable=signature-differs
     def save(self, *args, **kwargs):

--- a/tests/apps/courses/test_models_course_run.py
+++ b/tests/apps/courses/test_models_course_run.py
@@ -848,3 +848,20 @@ class CourseRunModelsTestCase(TestCase):
 
         self.assertFalse(CourseRun.objects.exists())
         self.assertFalse(CourseRunTranslation.objects.exists())
+
+    def test_models_course_run_empty_translation_title(self):
+        """
+        A CourseRun translation object with an empty title should not raise any error
+        when its '__str__' method is invoked.
+        """
+        course = CourseFactory(page_languages=["en", "fr"])
+        course_run = CourseRunFactory(direct_course=course)
+        french_run_translation = CourseRunTranslation.objects.create(
+            master=course_run, language_code="fr", title=None
+        )
+        self.assertTrue(course_run.direct_course.extended_object.publish("en"))
+        self.assertTrue(course_run.direct_course.extended_object.publish("fr"))
+
+        self.assertEqual(
+            str(french_run_translation), "Course Run Translation: Empty title"
+        )


### PR DESCRIPTION
## Purpose

It has been reported than trying to delete a course run fails to an error when a course run translation have an empty title.

## Proposal

This changes the `__str__` from CourseRunTranslation model to a fallback title "Empty title" when its title is empty. CourseRun deletion won't fail again because of empty translation title.
