### PR TITLE
✨(frontend) add a PaymentButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a `PaymentButton` component 
 - Add a `PaymentInterface` component to lazy load the right payment component
   according to the provider used 
 - Create a `StepBreadcrumb` component to display progress within a step process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a `PaymentInterface` component to lazy load the right payment component
+  according to the provider used 
 - Create a `StepBreadcrumb` component to display progress within a step process
 - Create a `useStepManager` hook to manage step process
 - Create a React `Icon` component that can optionally take alternative text

--- a/src/frontend/js/components/PaymentButton/_styles.scss
+++ b/src/frontend/js/components/PaymentButton/_styles.scss
@@ -1,0 +1,8 @@
+.payment-button {
+  text-align: center;
+
+  &__error {
+    color: r-color('firebrick6');
+    margin-top: 0.5rem;
+  }
+}

--- a/src/frontend/js/components/PaymentButton/index.spec.tsx
+++ b/src/frontend/js/components/PaymentButton/index.spec.tsx
@@ -1,0 +1,485 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { PropsWithChildren } from 'react';
+import { IntlProvider } from 'react-intl';
+import { hydrate, QueryClient, QueryClientProvider } from 'react-query';
+import {
+  AddressFactory,
+  ContextFactory as mockContextFactory,
+  CreditCardFactory,
+  OrderWithOneClickPaymentFactory,
+  OrderWithPaymentFactory,
+  PersistedClientFactory,
+  ProductFactory,
+  QueryStateFactory,
+} from 'utils/test/factories';
+import JoanieApiProvider from 'data/JoanieApiProvider';
+import { CourseCodeProvider } from 'data/CourseCodeProvider';
+import { PAYMENT_SETTINGS } from 'settings';
+import type * as Joanie from 'types/Joanie';
+import { OrderState } from 'types/Joanie';
+import createQueryClient from 'utils/react-query/createQueryClient';
+import PaymentButton from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory({
+    authentication: {
+      backend: 'fonzie',
+      endpoint: 'https://authentication.test',
+    },
+    joanie_backend: {
+      endpoint: 'https://joanie.test',
+    },
+  }).generate(),
+}));
+
+jest.mock('components/PaymentInterfaces');
+
+describe('PaymentButton', () => {
+  const formatPrice = (price: number, currency: string) =>
+    new Intl.NumberFormat('en', {
+      currency,
+      style: 'currency',
+    }).format(price);
+
+  const Wrapper = ({
+    client = new QueryClient(),
+    children,
+  }: PropsWithChildren<{ client?: QueryClient }>) => (
+    <IntlProvider locale="en">
+      <JoanieApiProvider>
+        <CourseCodeProvider code="00000">
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        </CourseCodeProvider>
+      </JoanieApiProvider>
+    </IntlProvider>
+  );
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+    jest.clearAllTimers();
+    jest.resetAllMocks();
+  });
+
+  it('should render a payment button', () => {
+    const product: Joanie.Product = ProductFactory.generate();
+
+    render(
+      <Wrapper>
+        <PaymentButton product={product} onSuccess={jest.fn()} />
+      </Wrapper>,
+    );
+
+    const $button = screen.getByRole('button', {
+      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+    }) as HTMLButtonElement;
+
+    // As a billing address is missing, button should be disabled
+    expect($button.disabled).toBe(true);
+  });
+
+  it('should render a payment button with a specific label when a credit card is provided', () => {
+    /*
+      If a credit card is provided, it seems that the payment should be a one click,
+      so the payment button label should mention this information.
+    */
+    const product: Joanie.Product = ProductFactory.generate();
+    const creditCard: Joanie.CreditCard = CreditCardFactory.generate();
+
+    const { rerender } = render(
+      <Wrapper>
+        <PaymentButton product={product} creditCard={creditCard.id} onSuccess={jest.fn()} />
+      </Wrapper>,
+    );
+
+    const $button = screen.getByRole('button', {
+      name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
+    }) as HTMLButtonElement;
+
+    // As a billing address is missing, button should be disabled
+    expect($button.disabled).toBe(true);
+
+    const billingAddress: Joanie.Address = AddressFactory.generate();
+
+    rerender(
+      <Wrapper>
+        <PaymentButton
+          billingAddress={billingAddress}
+          product={product}
+          creditCard={creditCard.id}
+          onSuccess={jest.fn()}
+        />
+      </Wrapper>,
+    );
+
+    // As a billing address is given, the button should be active
+    expect($button.disabled).toBe(false);
+  });
+
+  it('should render an enabled payment button if a billing address is provided', () => {
+    const product: Joanie.Product = ProductFactory.generate();
+    const billingAddress: Joanie.Address = AddressFactory.generate();
+
+    render(
+      <Wrapper>
+        <PaymentButton billingAddress={billingAddress} product={product} onSuccess={jest.fn()} />
+      </Wrapper>,
+    );
+
+    const $button = screen.getByRole('button', {
+      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+    }) as HTMLButtonElement;
+
+    // As a billing address is given, the button should be active
+    expect($button.disabled).toBe(false);
+  });
+
+  it('should create an order then display the payment interface when user clicks on payment button', async () => {
+    const product: Joanie.Product = ProductFactory.generate();
+    const billingAddress: Joanie.Address = AddressFactory.generate();
+    const order: Joanie.OrderWithPaymentInfo = OrderWithPaymentFactory.generate();
+    const handleSuccess = jest.fn();
+
+    fetchMock
+      .post('https://joanie.test/api/orders/', order)
+      .get(`https://joanie.test/api/orders/${order.id}/`, {
+        ...order,
+        state: OrderState.PENDING,
+      });
+
+    const { clientState } = PersistedClientFactory({
+      queries: [QueryStateFactory('user', { data: { username: 'John Doe' } })],
+    });
+    const client = createQueryClient();
+    hydrate(client, clientState);
+
+    render(
+      <Wrapper client={client}>
+        <PaymentButton
+          billingAddress={billingAddress}
+          product={product}
+          onSuccess={handleSuccess}
+        />
+      </Wrapper>,
+    );
+
+    const $button = screen.getByRole('button', {
+      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+    }) as HTMLButtonElement;
+
+    // - As all information are provided, payment button should not be disabled.
+    expect($button.disabled).toBe(false);
+
+    // - User clicks on pay button
+    await act(async () => {
+      fireEvent.click($button);
+    });
+
+    // - Route to create order should have been called
+    expect(fetchMock.calls()).toHaveLength(1);
+    expect(fetchMock.lastUrl()).toBe('https://joanie.test/api/orders/');
+
+    // - Spinner should be displayed
+    screen.getByText('Payment in progress');
+
+    // - Payment interface should be displayed
+    screen.getByText('Payment interface component');
+
+    // - Simulate the payment has succeeded
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('payment-success'));
+    });
+
+    // - Once payment succeeded, order should be refetch
+    expect(fetchMock.calls()).toHaveLength(2);
+    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/orders/${order.id}/`);
+
+    // - Order should be polled until its state is validated
+    fetchMock.get(
+      `https://joanie.test/api/orders/${order.id}/`,
+      {
+        ...order,
+        state: OrderState.VALIDATED,
+      },
+      {
+        overwriteRoutes: true,
+      },
+    );
+
+    // - Advance timer to one tick
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    // - Order should have been refetched
+    expect(fetchMock.calls()).toHaveLength(3);
+    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/orders/${order.id}/`);
+
+    // - As order state is validated, the onSuccess callback should be triggered.
+    expect(handleSuccess).toHaveBeenCalledTimes(1);
+
+    // - And poller should be stopped
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(fetchMock.calls()).toHaveLength(3);
+  });
+
+  it('should render only a spinner if payment is a one click when user clicks on payment button', async () => {
+    const product: Joanie.Product = ProductFactory.generate();
+    const billingAddress: Joanie.Address = AddressFactory.generate();
+    const creditCard: Joanie.CreditCard = CreditCardFactory.generate();
+    const order: Joanie.OrderWithPaymentInfo = OrderWithOneClickPaymentFactory.generate();
+    const handleSuccess = jest.fn();
+
+    fetchMock
+      .post('https://joanie.test/api/orders/', order)
+      .get(`https://joanie.test/api/orders/${order.id}/`, {
+        ...order,
+        state: OrderState.PENDING,
+      });
+
+    const { clientState } = PersistedClientFactory({
+      queries: [QueryStateFactory('user', { data: { username: 'John Doe' } })],
+    });
+    const client = createQueryClient();
+    hydrate(client, clientState);
+
+    render(
+      <Wrapper client={client}>
+        <PaymentButton
+          billingAddress={billingAddress}
+          creditCard={creditCard.id}
+          product={product}
+          onSuccess={handleSuccess}
+        />
+      </Wrapper>,
+    );
+
+    const $button = screen.getByRole('button', {
+      name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
+    }) as HTMLButtonElement;
+
+    // - As all information are provided, payment button should not be disabled.
+    expect($button.disabled).toBe(false);
+
+    // - User clicks on pay button
+    await act(async () => {
+      fireEvent.click($button);
+    });
+
+    // - Route to create order should have been called
+    // - Furthermore, as payment succeeded immediately, order should have been refetched
+    expect(fetchMock.calls()).toHaveLength(2);
+    expect(fetchMock.calls()[0][0]).toBe('https://joanie.test/api/orders/');
+    expect(JSON.parse(fetchMock.calls()[0][1]!.body as string)).toEqual({
+      billing_address: billingAddress,
+      credit_card_id: creditCard.id,
+      course: '00000',
+      product: product.id,
+    });
+    expect(fetchMock.calls()[1][0]).toBe(`https://joanie.test/api/orders/${order.id}/`);
+
+    // - Spinner should be displayed
+    screen.getByText('Payment in progress');
+
+    // - Payment interface should not be displayed
+    expect(screen.queryByText('Payment interface component')).toBeNull();
+
+    // - Order should be polled until its state is validated
+    fetchMock.get(
+      `https://joanie.test/api/orders/${order.id}/`,
+      {
+        ...order,
+        state: OrderState.VALIDATED,
+      },
+      {
+        overwriteRoutes: true,
+      },
+    );
+
+    // - Advance timer to one tick
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    // - Order should have been refetched
+    expect(fetchMock.calls()).toHaveLength(3);
+    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/orders/${order.id}/`);
+
+    // - As order state is validated, the onSuccess callback should be triggered.
+    expect(handleSuccess).toHaveBeenCalledTimes(1);
+
+    // - And poller should be stopped
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(fetchMock.calls()).toHaveLength(3);
+  });
+
+  it('should abort the order if payment does not succeed after a given delay', async () => {
+    const product: Joanie.Product = ProductFactory.generate();
+    const billingAddress: Joanie.Address = AddressFactory.generate();
+    const creditCard: Joanie.CreditCard = CreditCardFactory.generate();
+    const order: Joanie.OrderWithPaymentInfo = OrderWithOneClickPaymentFactory.generate();
+    const handleSuccess = jest.fn();
+
+    fetchMock
+      .post('https://joanie.test/api/orders/', order)
+      .get(`https://joanie.test/api/orders/${order.id}/`, {
+        ...order,
+        state: OrderState.PENDING,
+      })
+      .post(`https://joanie.test/api/orders/${order.id}/abort/`, 200);
+
+    const { clientState } = PersistedClientFactory({
+      queries: [QueryStateFactory('user', { data: { username: 'John Doe' } })],
+    });
+    const client = createQueryClient();
+    hydrate(client, clientState);
+
+    render(
+      <Wrapper client={client}>
+        <PaymentButton
+          billingAddress={billingAddress}
+          creditCard={creditCard.id}
+          product={product}
+          onSuccess={handleSuccess}
+        />
+      </Wrapper>,
+    );
+
+    const $button = screen.getByRole('button', {
+      name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
+    }) as HTMLButtonElement;
+
+    // - As all information are provided, payment button should not be disabled.
+    expect($button.disabled).toBe(false);
+
+    // - User clicks on pay button
+    await act(async () => {
+      fireEvent.click($button);
+    });
+
+    // - Route to create order should have been called
+    // - Furthermore, as payment succeeded immediately, order should have been refetched
+    expect(fetchMock.calls()).toHaveLength(2);
+    expect(fetchMock.calls()[0][0]).toBe('https://joanie.test/api/orders/');
+    expect(JSON.parse(fetchMock.calls()[0][1]!.body as string)).toEqual({
+      billing_address: billingAddress,
+      credit_card_id: creditCard.id,
+      course: '00000',
+      product: product.id,
+    });
+    expect(fetchMock.calls()[1][0]).toBe(`https://joanie.test/api/orders/${order.id}/`);
+
+    // - Spinner should be displayed
+    screen.getByText('Payment in progress');
+
+    // - Payment interface should not be displayed
+    expect(screen.queryByText('Payment interface component')).toBeNull();
+
+    fetchMock.resetHistory();
+    // - Wait until order has been polled 29 times.
+    await waitFor(
+      async () => {
+        expect(fetchMock.calls()).toHaveLength(PAYMENT_SETTINGS.pollLimit - 1);
+      },
+      {
+        timeout: PAYMENT_SETTINGS.pollLimit * 1000,
+        interval: 5,
+      },
+    );
+
+    // - This round should be the last after which the order should be aborted
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(fetchMock.calls()).toHaveLength(PAYMENT_SETTINGS.pollLimit);
+    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/orders/${order.id}/abort/`);
+    expect(JSON.parse(fetchMock.lastOptions()!.body!.toString())).toEqual({
+      payment_id: order.payment_info.payment_id,
+    });
+
+    // - An error message should be displayed
+    screen.getByText('An error occurred during payment. Please retry later.');
+  });
+
+  it('should render an error message when payment failed', async () => {
+    const product: Joanie.Product = ProductFactory.generate();
+    const billingAddress: Joanie.Address = AddressFactory.generate();
+    const order: Joanie.OrderWithPaymentInfo = OrderWithPaymentFactory.generate();
+    const handleSuccess = jest.fn();
+
+    fetchMock
+      .post('https://joanie.test/api/orders/', order)
+      .get(`https://joanie.test/api/orders/${order.id}/`, {
+        ...order,
+        state: OrderState.PENDING,
+      });
+
+    const { clientState } = PersistedClientFactory({
+      queries: [QueryStateFactory('user', { data: { username: 'John Doe' } })],
+    });
+    const client = createQueryClient();
+    hydrate(client, clientState);
+
+    render(
+      <Wrapper client={client}>
+        <PaymentButton
+          billingAddress={billingAddress}
+          product={product}
+          onSuccess={handleSuccess}
+        />
+      </Wrapper>,
+    );
+
+    const $button = screen.getByRole('button', {
+      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+    }) as HTMLButtonElement;
+
+    // - As all information are provided, payment button should not be disabled.
+    expect($button.disabled).toBe(false);
+
+    // - User clicks on pay button
+    await act(async () => {
+      fireEvent.click($button);
+    });
+
+    // - Route to create order should have been called
+    expect(fetchMock.calls()).toHaveLength(1);
+    expect(fetchMock.lastUrl()).toBe('https://joanie.test/api/orders/');
+    expect(JSON.parse(fetchMock.lastOptions()!.body!.toString())).toEqual({
+      billing_address: billingAddress,
+      course: '00000',
+      product: product.id,
+    });
+
+    // - Spinner should be displayed and payment button should be disabled
+    screen.getByText('Payment in progress');
+    expect($button.disabled).toBe(true);
+
+    // - Payment interface should be displayed
+    screen.getByText('Payment interface component');
+
+    // - Simulate the payment has failed
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('payment-failure'));
+    });
+
+    // - An error message should be displayed
+    screen.getByText('An error occurred during payment. Please retry later.');
+    // - Payment interface should have been closed
+    expect(screen.queryByText('Payment interface component')).toBeNull();
+    // - Payment button should have been restore to its idle state
+    expect($button.disabled).toBe(false);
+    screen.getByRole('button', {
+      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+    });
+  });
+});

--- a/src/frontend/js/components/PaymentButton/index.tsx
+++ b/src/frontend/js/components/PaymentButton/index.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import PaymentInterface from 'components/PaymentInterfaces';
+import { Spinner } from 'components/Spinner';
+import { useCourseCode } from 'data/CourseCodeProvider';
+import { useJoanieApi } from 'data/JoanieApiProvider';
+import { useOrders } from 'hooks/useOrders';
+import { PAYMENT_SETTINGS } from 'settings';
+import type * as Joanie from 'types/Joanie';
+import { OrderState } from 'types/Joanie';
+import type { Nullable } from 'types/utils';
+
+const messages = defineMessages({
+  errorAbort: {
+    defaultMessage: 'You have aborted the payment.',
+    description: 'Error message shown when user aborts the payment.',
+    id: 'components.PaymentButton.errorAbort',
+  },
+  errorAborting: {
+    defaultMessage: 'Aborting the payment...',
+    description: 'Error message shown when user asks to abort the payment.',
+    id: 'components.PaymentButton.errorAborting',
+  },
+  errorDefault: {
+    defaultMessage: 'An error occurred during payment. Please retry later.',
+    description: 'Error message shown when payment creation request failed.',
+    id: 'components.PaymentButton.errorDefault',
+  },
+  pay: {
+    defaultMessage: 'Pay {price}',
+    description: 'CTA label to proceed to the payment of the product',
+    id: 'components.PaymentButton.pay',
+  },
+  payInOneClick: {
+    defaultMessage: 'Pay in one click {price}',
+    description: 'CTA label to proceed to the one click payment of the product',
+    id: 'components.PaymentButton.payInOneClick',
+  },
+  paymentInProgress: {
+    defaultMessage: 'Payment in progress',
+    description: 'Label for screen reader when a payment is in progress.',
+    id: 'components.PaymentButton.paymentInProgress',
+  },
+});
+
+export enum PaymentErrorMessageId {
+  ERROR_ABORT = 'errorAbort',
+  ERROR_ABORTING = 'errorAborting',
+  ERROR_DEFAULT = 'errorDefault',
+}
+
+interface PaymentButtonProps {
+  product: Joanie.Product;
+  billingAddress?: Joanie.Address;
+  creditCard?: Nullable<Joanie.CreditCard['id']>;
+  onSuccess: () => void;
+}
+
+type PaymentInfo = Joanie.Payment & { order_id: string };
+type OneClickPaymentInfo = Joanie.PaymentOneClick & { order_id: string };
+
+enum ComponentStates {
+  IDLE = 'idle',
+  LOADING = 'loading',
+  ERROR = 'error',
+}
+
+/**
+ * Displays a button to proceed to the payment.
+ * First it creates the payment from Joanie then displays the payment interface
+ * or the error message.
+ */
+const PaymentButton = ({ product, billingAddress, creditCard, onSuccess }: PaymentButtonProps) => {
+  const intl = useIntl();
+  const API = useJoanieApi();
+  const timeoutRef = useRef<NodeJS.Timeout>();
+  const courseCode = useCourseCode();
+  const orderManager = useOrders();
+
+  const isReadyToPay = useMemo(() => {
+    return courseCode && product.id && billingAddress;
+  }, [product, courseCode, billingAddress]);
+
+  const [payment, setPayment] = useState<PaymentInfo | OneClickPaymentInfo>();
+  const [state, setState] = useState<ComponentStates>(ComponentStates.IDLE);
+  const [error, setError] = useState<PaymentErrorMessageId>(PaymentErrorMessageId.ERROR_DEFAULT);
+
+  /**
+   * Use Joanie API to retrieve an order and check if it's state is validated
+   *
+   * @param {string} id - Order id
+   * @returns {Promise<boolean>} - Promise resolving to true if order is validated
+   */
+  const isOrderValidated = async (id: string): Promise<Boolean> => {
+    const order = await API.user.orders.get(id);
+    return order?.state === OrderState.VALIDATED;
+  };
+
+  /** type guard to check if the payment is a payment one click */
+  const isOneClickPayment = (p: typeof payment): p is OneClickPaymentInfo =>
+    (p as OneClickPaymentInfo)?.is_paid === true;
+
+  const createPayment = async () => {
+    if (isReadyToPay) {
+      setState(ComponentStates.LOADING);
+      let paymentInfos = payment;
+
+      if (!paymentInfos) {
+        try {
+          const order = await orderManager.methods.create({
+            billing_address: billingAddress!,
+            ...(creditCard && { credit_card_id: creditCard }),
+            course: courseCode,
+            product: product.id,
+          });
+          paymentInfos = {
+            ...order.payment_info!,
+            order_id: order.id,
+          };
+        } catch {
+          setState(ComponentStates.ERROR);
+        }
+      }
+
+      setPayment(paymentInfos);
+    }
+  };
+
+  const handleSuccess = () => {
+    let round = 0;
+
+    const checkOrderValidity = async () => {
+      if (round >= PAYMENT_SETTINGS.pollLimit) {
+        timeoutRef.current = undefined;
+        orderManager.methods.abort({ id: payment!.order_id, payment_id: payment!.payment_id });
+        setState(ComponentStates.ERROR);
+      } else {
+        const isValidated = await isOrderValidated(payment!.order_id);
+        if (isValidated) {
+          setState(ComponentStates.IDLE);
+          timeoutRef.current = undefined;
+          onSuccess();
+        } else {
+          round++;
+          timeoutRef.current = setTimeout(checkOrderValidity, PAYMENT_SETTINGS.pollInterval);
+        }
+      }
+    };
+
+    checkOrderValidity();
+  };
+
+  const handleError = (messageId: PaymentErrorMessageId = PaymentErrorMessageId.ERROR_DEFAULT) => {
+    setState(ComponentStates.ERROR);
+    setError(messageId);
+  };
+
+  useEffect(() => {
+    if (isOneClickPayment(payment) && state === ComponentStates.LOADING) {
+      handleSuccess();
+    }
+
+    return () => {
+      if (timeoutRef.current !== undefined) {
+        clearTimeout(timeoutRef.current);
+        if (payment) {
+          orderManager.methods.abort({
+            id: payment.order_id,
+            payment_id: payment.payment_id,
+          });
+        }
+      }
+    };
+  }, [payment]);
+
+  useEffect(() => {
+    if (error === PaymentErrorMessageId.ERROR_ABORTING) {
+      orderManager.methods
+        .abort({
+          id: payment!.order_id,
+          payment_id: payment!.payment_id,
+        })
+        .then(() => {
+          setPayment(undefined);
+          handleError(PaymentErrorMessageId.ERROR_ABORT);
+        });
+    }
+  }, [error]);
+
+  return (
+    <div className="payment-button">
+      <button
+        className="button button--primary"
+        disabled={!isReadyToPay || state === ComponentStates.LOADING}
+        onClick={createPayment}
+      >
+        {state === ComponentStates.LOADING ? (
+          <Spinner theme="light" aria-labelledby="payment-in-progress">
+            <span id="payment-in-progress">
+              <FormattedMessage {...messages.paymentInProgress} />
+            </span>
+          </Spinner>
+        ) : (
+          <FormattedMessage
+            {...(creditCard ? messages.payInOneClick : messages.pay)}
+            values={{
+              price: intl.formatNumber(product.price, {
+                style: 'currency',
+                currency: product.price_currency,
+              }),
+            }}
+          />
+        )}
+      </button>
+      {state === ComponentStates.LOADING && payment && !isOneClickPayment(payment) && (
+        <PaymentInterface {...payment} onError={handleError} onSuccess={handleSuccess} />
+      )}
+      {state === ComponentStates.ERROR && (
+        <p className="payment-button__error">
+          <FormattedMessage {...messages[error]} />
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default PaymentButton;

--- a/src/frontend/js/components/PaymentInterfaces/Dummy.tsx
+++ b/src/frontend/js/components/PaymentInterfaces/Dummy.tsx
@@ -1,0 +1,44 @@
+import { PaymentErrorMessageId } from 'components/PaymentButton';
+import { handle } from 'utils/errors/handle';
+import { useAsyncEffect } from 'utils/useAsyncEffect';
+import type { PaymentInterfaceProps } from '.';
+
+/**
+ * !!! DEVELOPMENT PURPOSE ONLY !!!
+ *
+ * Load the dummy payment interface
+ *
+ */
+
+const DummyPayment = ({ url, payment_id, onSuccess, onError }: PaymentInterfaceProps) => {
+  useAsyncEffect(async () => {
+    try {
+      const response = await fetch(url, {
+        body: JSON.stringify({
+          state: 'success',
+          id: payment_id,
+          type: 'payment',
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Payment registration has failed with status ${response.status} - ${response.statusText}`,
+        );
+      }
+
+      onSuccess();
+    } catch (error) {
+      handle(error);
+      onError(PaymentErrorMessageId.ERROR_DEFAULT);
+    }
+  }, []);
+
+  return null;
+};
+
+export default DummyPayment;

--- a/src/frontend/js/components/PaymentInterfaces/PayplugLightbox.tsx
+++ b/src/frontend/js/components/PaymentInterfaces/PayplugLightbox.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useEffect } from 'react';
+import { PaymentErrorMessageId } from 'components/PaymentButton';
+import { handle } from 'utils/errors/handle';
+import type { PaymentInterfaceProps } from '.';
+
+/**
+ * Load the form payplug script if it has been not yet uploaded then open
+ * the lightbox and listen messages coming from it.
+ *
+ * https://docs.payplug.com/api/lightbox.html#lightbox
+ */
+const PayplugLightbox = ({ url, onSuccess, onError }: PaymentInterfaceProps) => {
+  const listenPayplugIframeMessage = (event: MessageEvent) => {
+    if (typeof event.data === 'string') {
+      switch (event.data) {
+        case 'closePayPlugFrame':
+          onError(PaymentErrorMessageId.ERROR_ABORTING);
+          break;
+      }
+    } else if (typeof event.data === 'object') {
+      switch (event.data.event) {
+        case 'paidByPayPlug':
+          window.Payplug._closeIframe();
+          onSuccess();
+      }
+    } else {
+      handle(`[PayplugLightbox] - Unknown message type posted.`);
+    }
+  };
+
+  const openLightbox = useCallback(() => {
+    window.Payplug.showPayment(url);
+    window.addEventListener('message', listenPayplugIframeMessage);
+  }, [url]);
+
+  useEffect(() => {
+    if (!window.Payplug) {
+      const script = document.createElement('script');
+      script.src = 'https://api.payplug.com/js/1/form.latest.js';
+      script.async = true;
+      document.body.appendChild(script);
+      script.onload = openLightbox;
+      script.onerror = () => onError(PaymentErrorMessageId.ERROR_DEFAULT);
+    } else {
+      openLightbox();
+    }
+
+    return () => {
+      window.removeEventListener('message', listenPayplugIframeMessage);
+    };
+  }, []);
+
+  return null;
+};
+
+export default PayplugLightbox;

--- a/src/frontend/js/components/PaymentInterfaces/__mocks__/index.tsx
+++ b/src/frontend/js/components/PaymentInterfaces/__mocks__/index.tsx
@@ -1,5 +1,5 @@
-import { PaymentInterfaceProps } from 'components/PaymentInterfaces/index';
 import { PaymentErrorMessageId } from 'components/PaymentButton';
+import { PaymentInterfaceProps } from 'components/PaymentInterfaces/index';
 
 const PaymentInterface = ({ onError, onSuccess }: PaymentInterfaceProps) => (
   <p>

--- a/src/frontend/js/components/PaymentInterfaces/__mocks__/index.tsx
+++ b/src/frontend/js/components/PaymentInterfaces/__mocks__/index.tsx
@@ -1,0 +1,25 @@
+import { PaymentInterfaceProps } from 'components/PaymentInterfaces/index';
+import { PaymentErrorMessageId } from 'components/PaymentButton';
+
+const PaymentInterface = ({ onError, onSuccess }: PaymentInterfaceProps) => (
+  <p>
+    Payment interface component
+    <button
+      data-testid="payment-failure"
+      onClick={() => onError(PaymentErrorMessageId.ERROR_DEFAULT)}
+    >
+      Simulate payment failure
+    </button>
+    <button
+      data-testid="payment-abort"
+      onClick={() => onError(PaymentErrorMessageId.ERROR_ABORTING)}
+    >
+      Simulate payment abort
+    </button>
+    <button data-testid="payment-success" onClick={onSuccess}>
+      Simulate payment success
+    </button>
+  </p>
+);
+
+export default PaymentInterface;

--- a/src/frontend/js/components/PaymentInterfaces/index.spec.tsx
+++ b/src/frontend/js/components/PaymentInterfaces/index.spec.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { handle as mockHandle } from 'utils/errors/handle';
+import { ContextFactory as mockContextFactory, PaymentFactory } from 'utils/test/factories';
+import type * as Joanie from 'types/Joanie';
+import { PaymentProviders } from 'types/Joanie';
+import PaymentInterface from '.';
+
+jest.mock('./PayplugLightbox', () => ({
+  __esModule: true,
+  default: () => 'Payplug lightbox',
+}));
+
+jest.mock('utils/errors/handle', () => ({
+  handle: jest.fn(),
+}));
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory().generate(),
+}));
+
+describe('PaymentInterface', () => {
+  const onSuccess = jest.fn();
+  const onError = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return null and handle an error if payment provider is not implemented', () => {
+    const payment: Joanie.Payment = PaymentFactory.afterGenerate((p: Joanie.Payment) => ({
+      ...p,
+      provider: 'unknown-provider',
+    })).generate();
+
+    const { container } = render(
+      <PaymentInterface onSuccess={onSuccess} onError={onError} {...payment} />,
+    );
+
+    expect(mockHandle).toHaveBeenCalledWith(
+      new Error('Payment provider unknown-provider not implemented'),
+    );
+    expect(onError).toHaveBeenNthCalledWith(1, 'errorDefault');
+    expect(container.childElementCount).toEqual(0);
+  });
+
+  it('should render the payplug lightbox when provider is Payplug', async () => {
+    const payment: Joanie.Payment = PaymentFactory.afterGenerate((p: Joanie.Payment) => ({
+      ...p,
+      provider: PaymentProviders.PAYPLUG,
+    })).generate();
+    render(<PaymentInterface onSuccess={onSuccess} onError={onError} {...payment} />);
+
+    await screen.findByText('Payplug lightbox');
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/js/components/PaymentInterfaces/index.spec.tsx
+++ b/src/frontend/js/components/PaymentInterfaces/index.spec.tsx
@@ -1,13 +1,17 @@
 import { render, screen } from '@testing-library/react';
-import { handle as mockHandle } from 'utils/errors/handle';
-import { ContextFactory as mockContextFactory, PaymentFactory } from 'utils/test/factories';
 import type * as Joanie from 'types/Joanie';
 import { PaymentProviders } from 'types/Joanie';
+import { handle as mockHandle } from 'utils/errors/handle';
+import { ContextFactory as mockContextFactory, PaymentFactory } from 'utils/test/factories';
 import PaymentInterface from '.';
 
 jest.mock('./PayplugLightbox', () => ({
   __esModule: true,
   default: () => 'Payplug lightbox',
+}));
+jest.mock('./Dummy', () => ({
+  __esModule: true,
+  default: () => 'Dummy payment component',
 }));
 
 jest.mock('utils/errors/handle', () => ({
@@ -52,6 +56,17 @@ describe('PaymentInterface', () => {
     render(<PaymentInterface onSuccess={onSuccess} onError={onError} {...payment} />);
 
     await screen.findByText('Payplug lightbox');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('should render the dummy payment component when provider is Dummy', async () => {
+    const payment: Joanie.Payment = PaymentFactory.afterGenerate((p: Joanie.Payment) => ({
+      ...p,
+      provider: PaymentProviders.DUMMY,
+    })).generate();
+    render(<PaymentInterface onSuccess={onSuccess} onError={onError} {...payment} />);
+
+    await screen.findByText('Dummy payment component');
     expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/js/components/PaymentInterfaces/index.tsx
+++ b/src/frontend/js/components/PaymentInterfaces/index.tsx
@@ -4,6 +4,7 @@ import * as Joanie from 'types/Joanie';
 import { handle } from 'utils/errors/handle';
 
 const LazyPayplugLightbox = lazy(() => import('./PayplugLightbox'));
+const LazyDummy = lazy(() => import('./Dummy'));
 
 export interface PaymentInterfaceProps extends Joanie.Payment {
   onSuccess: () => void;
@@ -32,6 +33,7 @@ const PaymentInterface = (props: PaymentInterfaceProps) => {
   return (
     <Suspense fallback={null}>
       {props.provider === Joanie.PaymentProviders.PAYPLUG && <LazyPayplugLightbox {...props} />}
+      {props.provider === Joanie.PaymentProviders.DUMMY && <LazyDummy {...props} />}
     </Suspense>
   );
 };

--- a/src/frontend/js/components/PaymentInterfaces/index.tsx
+++ b/src/frontend/js/components/PaymentInterfaces/index.tsx
@@ -1,0 +1,39 @@
+import { lazy, Suspense, useEffect } from 'react';
+import { PaymentErrorMessageId } from 'components/PaymentButton';
+import * as Joanie from 'types/Joanie';
+import { handle } from 'utils/errors/handle';
+
+const LazyPayplugLightbox = lazy(() => import('./PayplugLightbox'));
+
+export interface PaymentInterfaceProps extends Joanie.Payment {
+  onSuccess: () => void;
+  onError: (messageId: PaymentErrorMessageId) => void;
+}
+
+/**
+ * In charge of rendering the right payment interface according to the
+ * `provider` property. Return null if the provider is not supported.
+ */
+const PaymentInterface = (props: PaymentInterfaceProps) => {
+  const isNotImplementedProvider = !Object.values<string>(Joanie.PaymentProviders).includes(
+    props.provider,
+  );
+
+  useEffect(() => {
+    if (isNotImplementedProvider) {
+      props.onError(PaymentErrorMessageId.ERROR_DEFAULT);
+      const error = new Error(`Payment provider ${props.provider} not implemented`);
+      handle(error);
+    }
+  }, [props]);
+
+  if (isNotImplementedProvider) return null;
+
+  return (
+    <Suspense fallback={null}>
+      {props.provider === Joanie.PaymentProviders.PAYPLUG && <LazyPayplugLightbox {...props} />}
+    </Suspense>
+  );
+};
+
+export default PaymentInterface;

--- a/src/frontend/js/hooks/useOrders.ts
+++ b/src/frontend/js/hooks/useOrders.ts
@@ -1,9 +1,9 @@
 import { useQueryClient } from 'react-query';
 import { useJoanieApi } from 'data/JoanieApiProvider';
-import useLocalizedQueryKey from 'utils/react-query/useLocalizedQueryKey';
 import { REACT_QUERY_SETTINGS } from 'settings';
-import { useSessionQuery } from 'utils/react-query/useSessionQuery';
+import useLocalizedQueryKey from 'utils/react-query/useLocalizedQueryKey';
 import { useSessionMutation } from 'utils/react-query/useSessionMutation';
+import { useSessionQuery } from 'utils/react-query/useSessionQuery';
 
 /**
  * Joanie Api hook to retrieve/create/abort an order owned by the authenticated user.
@@ -28,12 +28,7 @@ export const useOrders = () => {
   };
 
   const creationHandler = useSessionMutation(API.user.orders.create, {
-    onSuccess: async (order) => {
-      // Invalidate orders query
-      await invalidate();
-      // Invalidate course's query related to the creatd order.
-      await queryClient.invalidateQueries(['user', 'course', order.course]);
-    },
+    onSuccess: invalidate,
   });
 
   const abortHandler = useSessionMutation(API.user.orders.abort);

--- a/src/frontend/js/settings.ts
+++ b/src/frontend/js/settings.ts
@@ -8,6 +8,12 @@ export const EDX_CSRF_TOKEN_COOKIE_NAME = 'edx_csrf_token';
 export const RICHIE_USER_TOKEN = 'RICHIE_USER_TOKEN';
 
 export const REACT_QUERY_SETTINGS = {
+  cacheStorage: {
+    // The key used to persist cache within cache storage
+    key: 'RICHIE_PERSISTED_QUERIES',
+    // Cache storage throttle time
+    throttleTime: 500,
+  },
   // Cache is garbage collected after this delay
   cacheTime: 24 * 60 * 60 * 1000, // 24h in ms
   // Data are considered as stale after this delay
@@ -19,10 +25,11 @@ export const REACT_QUERY_SETTINGS = {
     session: 5 * 60 * 1000, // 5 minutes in ms
     sessionItems: 20 * 60 * 1000, // 20 minutes, items related to the session should not be refreshed as the frequency than session information.
   },
-  cacheStorage: {
-    // The key used to persist cache within cache storage
-    key: 'RICHIE_PERSISTED_QUERIES',
-    // Cache storage throttle time
-    throttleTime: 500,
-  },
+};
+
+export const PAYMENT_SETTINGS = {
+  // Interval in ms to poll the related order when a payment has succeeded.
+  pollInterval: 1000,
+  // Number of retries
+  pollLimit: 30,
 };

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -157,6 +157,7 @@ export interface Address {
 
 // Payment
 export enum PaymentProviders {
+  DUMMY = 'dummy',
   PAYPLUG = 'payplug',
 }
 

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -162,7 +162,6 @@ export enum PaymentProviders {
 }
 
 export interface Payment {
-  order_id: string;
   payment_id: string;
   provider: string;
   url: string;
@@ -170,6 +169,10 @@ export interface Payment {
 
 export interface PaymentOneClick extends Payment {
   is_paid: boolean;
+}
+
+export interface OrderWithPaymentInfo extends Order {
+  payment_info: Payment | PaymentOneClick;
 }
 
 // - API
@@ -216,9 +219,7 @@ interface APIUser {
   };
   orders: {
     abort(payload: OrderAbortPayload): Promise<void>;
-    create(
-      payload: OrderCreationPayload,
-    ): Promise<Order & { payment_info?: Payment | PaymentOneClick }>;
+    create(payload: OrderCreationPayload): Promise<OrderWithPaymentInfo>;
     get(id: Order['id']): Promise<Nullable<Order>>;
     get(queryParameters?: QueryParameters): Promise<PaginatedResponse<Nullable<Order>>>;
     invoice: {

--- a/src/frontend/js/types/payments/payplug.d.ts
+++ b/src/frontend/js/types/payments/payplug.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  Payplug?: any;
+}

--- a/src/frontend/scss/_main.scss
+++ b/src/frontend/scss/_main.scss
@@ -74,6 +74,7 @@
 @import '../js/components/CourseRunEnrollment/styles';
 @import '../js/components/LtiConsumer/styles';
 @import '../js/components/Modal/styles';
+@import '../js/components/PaymentButton/styles';
 @import '../js/components/SearchFilterGroup/styles';
 @import '../js/components/SearchFilterGroupModal/styles';
 @import '../js/components/SearchFiltersPane/styles';


### PR DESCRIPTION
## Purpose

Add a payment button component which is in charge to create an order from Joanie then launch the right payment interface according to the payment provider used. Currently it supports Payplug and a dummy payment provider for development  purpose only.


## Proposal

- [x] Add a PaymentInterface in charge to lazy load the right payment component according to the payment information
- [x] Implement Payplug lightbox component
- [x] Implement a dummy payment component for dev purpose

### Classic payment with Payplug
![Classic Payment](https://user-images.githubusercontent.com/9265241/141164620-72b1ec62-3e7d-491d-b10a-d8f9f1a164a3.gif)

### One click payment with Payplug
![One click](https://user-images.githubusercontent.com/9265241/141164620-72b1ec62-3e7d-491d-b10a-d8f9f1a164a3.gif)