### PR TITLE
💄(layout) set font size to 1rem on some detail pages body contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   'math.div'.
 - Organization plugin variant 'row' now use excerpt if not empty else the
   description with every markup removed
+- Set font size to 1rem on some detail pages contents: Organization
+  excerpt, Program body and Person main content
 
 ### Fixed
 

--- a/src/frontend/scss/components/templates/courses/cms/_organization_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_organization_detail.scss
@@ -106,6 +106,11 @@
     }
   }
 
+  &__excerpt {
+    margin-top: 1rem;
+    font-size: 1rem;
+  }
+
   &__description {
     margin-top: 1rem;
     font-size: 1rem;

--- a/src/frontend/scss/components/templates/courses/cms/_person_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_person_detail.scss
@@ -14,6 +14,7 @@
 
   &__row {
     @include detail-row;
+    font-size: 1rem;
   }
 
   &__title {

--- a/src/frontend/scss/components/templates/courses/cms/_program_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_program_detail.scss
@@ -49,6 +49,7 @@
   }
 
   &__body {
+    font-size: 1rem;
     padding-left: $grid-gutter-width;
     padding-right: $grid-gutter-width;
   }


### PR DESCRIPTION

## Purpose

Some text contents from some detail pages have been reported to be too small:

- 'excerpt' placeholder content from Organization detail;
- 'body' placeholder content from Program detail;
- Main content from Person detail.

They are missing font size rule and so inherit it from the <body> base size which is too small for these kind of content.

## Proposal

This commit just set these content to 1rem alike other detail contents.
