### PR TITLE
✨(core) add site name in <title> everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   adjust every possible plugins to fit correctly;
 - Add theme variable to change checkmark color.
 - Add new placeholder 'excerpt' to Organization detail template
+- Add the website's name by default in every page title, that can be changed
+  or disabled by overriding the new `site_title` and `site_title_separator`
+  blocks
 
 ### Changed
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -3,7 +3,11 @@
 <html lang="{{ LANGUAGE_CODE|rfc_5646_locale }}">
     <head>
         {% spaceless %}
-        <title>{% block head_title %}{{ SITE.name }}{% endblock head_title %}</title>
+        <title>
+            {% block head_title %}{% endblock head_title %}
+            {% block site_title_separator %} - {% endblock site_title_separator %}
+            {% block site_title %}{{ SITE.name }}{% endblock site_title %}
+        </title>
         <meta name="viewport" content="width=device-width,initial-scale=1">
         {% block meta %}
             {% block meta_index_rules %}

--- a/tests/apps/courses/test_templates_blogpost_detail.py
+++ b/tests/apps/courses/test_templates_blogpost_detail.py
@@ -123,7 +123,7 @@ class DetailBlogPostCMSTestCase(CMSTestCase):
         response = self.client.get(url)
 
         self.assertContains(
-            response, "<title>Preums</title>", html=True, status_code=200
+            response, "<title>Preums - example.com</title>", html=True, status_code=200
         )
         self.assertContains(
             response, '<h1 class="blogpost-detail__title">Preums</h1>', html=True
@@ -163,7 +163,7 @@ class DetailBlogPostCMSTestCase(CMSTestCase):
         response = self.client.get(url)
 
         self.assertContains(
-            response, "<title>Preums</title>", html=True, status_code=200
+            response, "<title>Preums - example.com</title>", html=True, status_code=200
         )
         self.assertContains(
             response, '<h1 class="blogpost-detail__title">Preums</h1>', html=True

--- a/tests/apps/courses/test_templates_category_detail.py
+++ b/tests/apps/courses/test_templates_category_detail.py
@@ -147,7 +147,7 @@ class CategoryCMSTestCase(CMSTestCase):
         # Ensure the published page content is correct
         response = self.client.get(url)
         self.assertContains(
-            response, "<title>Maths</title>", html=True, status_code=200
+            response, "<title>Maths - example.com</title>", html=True, status_code=200
         )
         self.assertContains(
             response, '<h1 class="category-detail__title">Maths</h1>', html=True
@@ -376,7 +376,7 @@ class CategoryCMSTestCase(CMSTestCase):
         url = page.get_absolute_url()
         response = self.client.get(url)
         self.assertContains(
-            response, "<title>Maths</title>", html=True, status_code=200
+            response, "<title>Maths - example.com</title>", html=True, status_code=200
         )
         self.assertContains(
             response, '<h1 class="category-detail__title">Maths</h1>', html=True

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -113,7 +113,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertContains(
-            response, "<title>Very interesting course</title>", html=True
+            response, "<title>Very interesting course - example.com</title>", html=True
         )
         self.assertContains(
             response,
@@ -270,7 +270,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertContains(
-            response, "<title>Very interesting course</title>", html=True
+            response, "<title>Very interesting course - example.com</title>", html=True
         )
         self.assertContains(
             response,

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -217,7 +217,10 @@ class OrganizationCMSTestCase(CMSTestCase):
         # Ensure the published page content is correct
         response = self.client.get(url)
         self.assertContains(
-            response, "<title>La Sorbonne</title>", html=True, status_code=200
+            response,
+            "<title>La Sorbonne - example.com</title>",
+            html=True,
+            status_code=200,
         )
         self.assertContains(
             response,
@@ -360,7 +363,10 @@ class OrganizationCMSTestCase(CMSTestCase):
         url = page.get_absolute_url()
         response = self.client.get(url)
         self.assertContains(
-            response, "<title>La Sorbonne</title>", html=True, status_code=200
+            response,
+            "<title>La Sorbonne - example.com</title>",
+            html=True,
+            status_code=200,
         )
         self.assertContains(
             response,

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -177,7 +177,10 @@ class PersonCMSTestCase(CMSTestCase):
         # Ensure the published page content is correct
         response = self.client.get(url)
         self.assertContains(
-            response, "<title>My page title</title>", html=True, status_code=200
+            response,
+            "<title>My page title - example.com</title>",
+            html=True,
+            status_code=200,
         )
         self.assertContains(
             response,
@@ -284,7 +287,10 @@ class PersonCMSTestCase(CMSTestCase):
         )
 
         self.assertContains(
-            response, "<title>My page title</title>", html=True, status_code=200
+            response,
+            "<title>My page title - example.com</title>",
+            html=True,
+            status_code=200,
         )
         title = person.extended_object.get_title()
         self.assertContains(

--- a/tests/apps/courses/test_templates_program_detail.py
+++ b/tests/apps/courses/test_templates_program_detail.py
@@ -125,7 +125,7 @@ class ProgramCMSTestCase(CMSTestCase):
         page.publish("en")
         response = self.client.get(url)
         self.assertContains(
-            response, "<title>Preums</title>", html=True, status_code=200
+            response, "<title>Preums - example.com</title>", html=True, status_code=200
         )
         self.assertContains(
             response, '<h1 class="subheader__title">Preums</h1>', html=True
@@ -174,7 +174,7 @@ class ProgramCMSTestCase(CMSTestCase):
         url = page.get_absolute_url()
         response = self.client.get(url)
         self.assertContains(
-            response, "<title>Preums</title>", html=True, status_code=200
+            response, "<title>Preums - example.com</title>", html=True, status_code=200
         )
         self.assertContains(
             response, '<h1 class="subheader__title">Preums</h1>', html=True


### PR DESCRIPTION
## Purpose

Improve a11y (and seo) by always having the website's name in the page `<title>`.

## Proposal

By default for now, the `<title>` only tells us about the current page; it does
not tell us about what website we are on.

Adding the site name after the page name mostly improves two things:

- accessibility. Knowing what is the current site is a great
improvement. Without it, if I have multiple tabs opened, all related to
learning stuff, and a few tabs don't have their website name in the
title, it can be cumbersome to navigate with a screen-reader and
remember what tab is what website.
- SEO

Stuff done to implement this:

- [x] add a new `site_title` block that contains the site name by default, just after the existing `head_title` block. This allows us to change/disable this behavior on a case by case basis on any page we want.
