### PR TITLE
🚸(search) transform pagination buttons in pagination anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   description with every markup removed
 - Set font size to 1rem on some detail pages contents: Organization
   excerpt, Program body and Person main content
+- Use anchors instead of buttons in search pagination to let users open pages
+  in new tabs if they want
 
 ### Fixed
 

--- a/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.spec.tsx
@@ -64,6 +64,19 @@ describe('<PaginateCourseSearch />', () => {
     screen.getByText('11');
   });
 
+  it('uses anchors to allow opening pagination links in a new tab', () => {
+    render(
+      <IntlProvider locale="en">
+        <HistoryContext.Provider value={makeHistoryOf({ limit: '20', offset: '0' })}>
+          <PaginateCourseSearch courseSearchTotalCount={40} />
+        </HistoryContext.Provider>
+      </IntlProvider>,
+    );
+    expect(screen.queryByRole('button')).toBeNull();
+    const nextPageAnchor = screen.getByRole('link');
+    expect(nextPageAnchor).toHaveAttribute('href', '?offset=20');
+  });
+
   it('shows a pagination for course search (when on an arbitrary page)', () => {
     render(
       <IntlProvider locale="en">

--- a/src/frontend/js/components/PaginateCourseSearch/index.tsx
+++ b/src/frontend/js/components/PaginateCourseSearch/index.tsx
@@ -1,5 +1,7 @@
 import { Fragment } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { parse, stringify } from 'query-string';
+import { location } from 'utils/indirection/window';
 
 import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
 
@@ -123,15 +125,22 @@ export const PaginateCourseSearch = ({ courseSearchTotalCount }: PaginateCourseS
                 </li>
               ) : (
                 <li className="pagination__item">
-                  <button
+                  <a
+                    href={`?${stringify({
+                      ...parse(location.search),
+                      offset: String((page - 1) * limit),
+                    })}`}
                     className="pagination__page-number"
-                    onClick={() =>
-                      dispatchCourseSearchParamsUpdate({
-                        // Pages are 1-indexed, we need to 0-index them to calculate the correct offset
-                        offset: String((page - 1) * limit),
-                        type: CourseSearchParamsAction.pageChange,
-                      })
-                    }
+                    onClick={(event) => {
+                      if (!event.metaKey && !event.ctrlKey && !event.shiftKey) {
+                        event.preventDefault();
+                        dispatchCourseSearchParamsUpdate({
+                          // Pages are 1-indexed, we need to 0-index them to calculate the correct offset
+                          offset: String((page - 1) * limit),
+                          type: CourseSearchParamsAction.pageChange,
+                        });
+                      }
+                    }}
                   >
                     {/*  Help assistive technology users with some context */}
                     <span className="offscreen">
@@ -153,7 +162,7 @@ export const PaginateCourseSearch = ({ courseSearchTotalCount }: PaginateCourseS
                         page
                       )}
                     </span>
-                  </button>
+                  </a>
                 </li>
               )}
             </Fragment>


### PR DESCRIPTION
Pagination buttons behave like links: they update the url and make a new request. So we could use actual links instead of buttons.

This now allows users to open search pages in new tabs from the pagination links.
