### PR TITLE
💄(course_glimpse) fix style with narrow org logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Change blogpost detail template to display author even in published mode
   except if its placeholder is empty.
 - Fix missing styles for Organization plugin 'row' variant link wrapper
+- Fix course glimpse layout when organization logo is too narrow
 - Fix course run deletion when translation title is empty
 - Reordered course glimpse text order in the DOM for better screen reader
   support.

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -264,6 +264,13 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     top: -3.53rem;
     width: 4.3rem;
     z-index: 0;
+
+    img {
+      object-fit: contain;
+      object-position: center;
+      height: 100%;
+      width: 100%;
+    }
   }
 
   &__media {


### PR DESCRIPTION
Fix course glimpse layout when organization logo is too narrow
Closes #1654