### PR TITLE
💚(ci) upgrade black lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Upgrade black lint version
 - Improve overall accessibility in Richie templates
 - Update frontend overriding system to allow to override any frontend module.
 - Improve React search suggestion field labels for screen readers.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ zip_safe = True
 [options.extras_require]
 dev =
     bandit==1.7.4
-    black==22.1.0
+    black==22.3.0
     pyRdfa3==3.5.3
     cssselect==1.1.0
     factory-boy==3.2.1


### PR DESCRIPTION
Upgrade black linter to version `22.3.0` to fix the error:
`ImportError: cannot import name '_unicodefun' from 'click'`
Closes #1659
