### PR TITLE
🚑(frontend) make useCourseSearch hook locale sensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Make useCourseSearch hook locale sensitive
 - Stop using {% blockplugin %} template tags in <header> and replace them by
   simple {% if %} tags that do the same and don't inject frontend editing markup
 - Fix `get_placeholder_plugins` when placed in <header> by refactoring and

--- a/src/frontend/js/data/useCourseSearch/index.ts
+++ b/src/frontend/js/data/useCourseSearch/index.ts
@@ -1,7 +1,8 @@
 import { stringify } from 'query-string';
-import { UseQueryOptions, useQuery } from 'react-query';
+import { useQuery, UseQueryOptions } from 'react-query';
 
 import { APIListRequestParams } from 'types/api';
+import useLocalizedQueryKey from 'utils/react-query/useLocalizedQueryKey';
 import { fetchList, FetchListResponse } from '../getResourceList';
 
 export const useCourseSearch = (
@@ -10,16 +11,20 @@ export const useCourseSearch = (
     FetchListResponse,
     unknown,
     FetchListResponse,
-    (string | APIListRequestParams)[]
+    readonly (string | APIListRequestParams)[]
   > = {},
 ) => {
-  const queryKey = ['courses', stringify(searchParams)];
-  return useQuery<FetchListResponse, unknown, FetchListResponse, (string | APIListRequestParams)[]>(
-    queryKey,
-    async () => fetchList('courses', searchParams),
-    {
-      keepPreviousData: true,
-      ...queryOptions,
-    },
-  );
+  const queryKey = useLocalizedQueryKey(['courses', stringify(searchParams)]) as readonly (
+    | string
+    | APIListRequestParams
+  )[];
+  return useQuery<
+    FetchListResponse,
+    unknown,
+    FetchListResponse,
+    readonly (string | APIListRequestParams)[]
+  >(queryKey, async () => fetchList('courses', searchParams), {
+    keepPreviousData: true,
+    ...queryOptions,
+  });
 };


### PR DESCRIPTION
## Purpose

The `useCourseSearch` is using `useQuery` under the hood but its query key was
not localized so if user changes the language, search results was not refreshed
until current data are stale.


## Proposal

- [x] Localized the query key of `useCourseSearch` 

Fixes https://github.com/openfun/richie/issues/1661
