### PR TITLE
🐛(frontend) clear session on login and register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Clear session cache on login and register
 - Make useCourseSearch hook locale sensitive
 - Stop using {% blockplugin %} template tags in <header> and replace them by
   simple {% if %} tags that do the same and don't inject frontend editing markup

--- a/src/frontend/js/data/SessionProvider/BaseSessionProvider.tsx
+++ b/src/frontend/js/data/SessionProvider/BaseSessionProvider.tsx
@@ -35,11 +35,13 @@ const BaseSessionProvider = ({ children }: PropsWithChildren<any>) => {
 
   const login = useCallback(() => {
     queryClient.clear();
+    sessionStorage.removeItem(REACT_QUERY_SETTINGS.cacheStorage.key);
     AuthenticationApi!.login();
   }, [queryClient]);
 
   const register = useCallback(() => {
     queryClient.clear();
+    sessionStorage.removeItem(REACT_QUERY_SETTINGS.cacheStorage.key);
     AuthenticationApi!.register();
   }, [queryClient]);
 

--- a/src/frontend/js/data/SessionProvider/JoanieSessionProvider.tsx
+++ b/src/frontend/js/data/SessionProvider/JoanieSessionProvider.tsx
@@ -56,12 +56,14 @@ const JoanieSessionProvider = ({ children }: React.PropsWithChildren<any>) => {
   const orders = useOrders();
 
   const login = useCallback(() => {
+    queryClient.clear();
     sessionStorage.removeItem(REACT_QUERY_SETTINGS.cacheStorage.key);
     sessionStorage.removeItem(RICHIE_USER_TOKEN);
     AuthenticationApi!.login();
   }, [queryClient]);
 
   const register = useCallback(() => {
+    queryClient.clear();
     sessionStorage.removeItem(REACT_QUERY_SETTINGS.cacheStorage.key);
     sessionStorage.removeItem(RICHIE_USER_TOKEN);
     AuthenticationApi!.register();


### PR DESCRIPTION
## Purpose

The BaseSessionProvider did not clear session storage before redirect to login
or register page as JoanieSessionProvider do.

## Proposal

- [x] Fix BaseSessionProvider by clearing SessionStorage on login and register.
- [x] Update test suite to ensure that session storage is cleared on login and register 
