### PR TITLE
💄(frontend) prevent course glimpse title color override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix a course glimpse title color issue when used within a section with variant
+
 ##  [2.14.0] - 2022-04-01
 
 ### Added

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -157,7 +157,8 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     position: relative;
   }
 
-  &__title {
+  &__title,
+  &__title-text {
     @include font-size($h6-font-size);
     color: r-theme-val(course-glimpse, title-color);
     font-family: $r-font-family-montserrat;


### PR DESCRIPTION
## Purpose

When a course glimpse is used within a section using a variant, the course
glimpse title color is set with the section title color scheme property. This
commit fix this issue.

### Before
<img width="975" alt="image" src="https://user-images.githubusercontent.com/9265241/161775388-8a8b2b22-d18d-49e6-9c4e-9fb0f795a6f3.png">

### After
<img width="978" alt="image" src="https://user-images.githubusercontent.com/9265241/161774722-c202d863-9842-4fb8-8462-1c8cf1080d63.png">
