### PR TITLE
🚑(frontend) fix search query string formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix search query string formatting
 - Fix a course glimpse title color issue when used within a section with variant
 
 ##  [2.14.0] - 2022-04-01

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -75,7 +75,7 @@ describe('<SearchFilterGroupModal />', () => {
       const coursesDeferred = new Deferred();
       fetchMock.get(
         '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=' +
-          range(0, 21).join(','),
+          range(0, 21).join('&universities_aggs='),
         coursesDeferred.promise,
       );
 
@@ -145,7 +145,7 @@ describe('<SearchFilterGroupModal />', () => {
       const coursesDeferred = new Deferred();
       fetchMock.get(
         '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=' +
-          range(21, 42).join(','),
+          range(21, 42).join('&universities_aggs='),
         coursesDeferred.promise,
       );
 
@@ -190,7 +190,7 @@ describe('<SearchFilterGroupModal />', () => {
       const coursesDeferred = new Deferred();
       fetchMock.get(
         '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=' +
-          range(42, 46).join(','),
+          range(42, 46).join('&universities_aggs='),
         coursesDeferred.promise,
       );
 
@@ -235,7 +235,7 @@ describe('<SearchFilterGroupModal />', () => {
       fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', universitiesDeferred.promise);
       const coursesDeferred = new Deferred();
       fetchMock.get(
-        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42&universities_aggs=L-84&universities_aggs=L-99',
         coursesDeferred.promise,
       );
 
@@ -312,7 +312,7 @@ describe('<SearchFilterGroupModal />', () => {
       );
       const coursesDeferred = new Deferred();
       fetchMock.get(
-        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-12,L-17',
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-12&universities_aggs=L-17',
         coursesDeferred.promise,
       );
       fireEvent.change(field, { target: { value: 'user' } });
@@ -361,7 +361,7 @@ describe('<SearchFilterGroupModal />', () => {
       );
       const coursesDeferred = new Deferred();
       fetchMock.get(
-        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-03,L-66',
+        '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-03&universities_aggs=L-66',
         coursesDeferred.promise,
       );
       fireEvent.change(field, { target: { value: 'user input' } });
@@ -409,7 +409,7 @@ describe('<SearchFilterGroupModal />', () => {
     fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', universitiesDeferred.promise);
     const coursesDeferred = new Deferred();
     fetchMock.get(
-      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
+      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42&universities_aggs=L-84&universities_aggs=L-99',
       coursesDeferred.promise,
     );
 
@@ -468,7 +468,7 @@ describe('<SearchFilterGroupModal />', () => {
     fetchMock.get('/api/v1.0/universities/?limit=21&offset=0', universitiesDeferred.promise);
     const coursesDeferred = new Deferred();
     fetchMock.get(
-      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
+      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42&universities_aggs=L-84&universities_aggs=L-99',
       coursesDeferred.promise,
     );
 
@@ -583,7 +583,7 @@ describe('<SearchFilterGroupModal />', () => {
       objects: [{ id: 'L-42' }, { id: 'L-84' }, { id: 'L-99' }],
     });
     fetchMock.get(
-      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42,L-84,L-99',
+      '/api/v1.0/courses/?facet_sorting=name&limit=21&offset=0&scope=filters&universities_aggs=L-42&universities_aggs=L-84&universities_aggs=L-99',
       { throws: new Error('Failed to search for universities') },
     );
 

--- a/src/frontend/js/data/getResourceList/index.ts
+++ b/src/frontend/js/data/getResourceList/index.ts
@@ -17,14 +17,11 @@ export async function fetchList(
   params: APIListRequestParams = API_LIST_DEFAULT_PARAMS,
 ): Promise<FetchListResponse> {
   try {
-    const response = await fetch(
-      `/api/v1.0/${kind}/?${stringify(params, { arrayFormat: 'comma' })}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
+    const response = await fetch(`/api/v1.0/${kind}/?${stringify(params)}`, {
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+    });
 
     if (!response.ok) {
       // Push remote errors to the error channel for consistency


### PR DESCRIPTION
## Purpose

The search filter query string was not formatted properly so when a user wanted to filter results with several languages the search request returned a 400 Bad Request error.

Resolve #1673


## Proposal

- [x] Remove `arrayFormat: 'comma'` option to the method to serialize search params into query string 
