### PR TITLE
🚑(frontend) preserve query string on language change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Preserve query string on language switch
 - Fix search query string formatting
 - Fix a course glimpse title color issue when used within a section with variant
 

--- a/src/frontend/js/components/LanguageSelector/index.spec.tsx
+++ b/src/frontend/js/components/LanguageSelector/index.spec.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
-
+import { HistoryProvider } from 'data/useHistory';
 import LanguageSelector from '.';
+
+jest.mock('utils/indirection/window', () => ({
+  location: {
+    assign: jest.fn(),
+    replace: jest.fn(),
+    search: '?args=0',
+  },
+}));
 
 describe('<LanguageSelector />', () => {
   it('shows a dropdown menu that allows the user to change languages', async () => {
@@ -40,5 +48,36 @@ describe('<LanguageSelector />', () => {
     screen.getByRole('link', {
       name: 'Switch to Français (currently selected)',
     });
+  });
+
+  it('should preserve location search parameters if there are any', async () => {
+    const languages = {
+      en: {
+        code: 'en',
+        name: 'Anglais',
+        url: '/switch/to/en/',
+      },
+      fr: {
+        code: 'fr',
+        name: 'Français',
+        url: '/switch/to/fr/',
+      },
+    };
+
+    render(
+      <HistoryProvider>
+        <IntlProvider locale="en">
+          <LanguageSelector currentLanguage="fr" languages={languages} />
+        </IntlProvider>
+      </HistoryProvider>,
+    );
+
+    const button = screen.getByLabelText('Select a language: Français', {
+      selector: 'button',
+    });
+
+    await userEvent.click(button);
+    const link = screen.getByRole('link', { name: 'Switch to Anglais' });
+    expect(link).toHaveAttribute('href', '/switch/to/en/?args=0');
   });
 });

--- a/src/frontend/js/components/LanguageSelector/index.tsx
+++ b/src/frontend/js/components/LanguageSelector/index.tsx
@@ -1,6 +1,6 @@
 import { useSelect } from 'downshift';
 import { FC } from 'react';
-import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { location } from 'utils/indirection/window';
 
@@ -51,7 +51,8 @@ const LanguageSelector: FC<LanguageSelectorProps> = ({ currentLanguage, language
     onSelectedItemChange: ({ selectedItem: newSelectedItem }) => {
       // Manually handle location changes in case the user interacted with a keyboard, and therefore with a
       // list item, and not by clicking on the actual links.
-      location.replace(newSelectedItem!.url);
+
+      location.replace(`${newSelectedItem!.url}${location.search}`);
     },
   });
 
@@ -77,7 +78,7 @@ const LanguageSelector: FC<LanguageSelectorProps> = ({ currentLanguage, language
                 className={`selector__list__link ${
                   highlightedIndex === index ? 'selector__list__link--highlighted' : ''
                 }`}
-                href={language.url}
+                href={`${language!.url}${location.search}`}
                 title={`${intl.formatMessage(messages.switchToLanguage, {
                   language: language.name,
                 })}${
@@ -87,7 +88,6 @@ const LanguageSelector: FC<LanguageSelectorProps> = ({ currentLanguage, language
                 }`}
               >
                 {language.name}
-                {}
               </a>
             </li>
           ))}


### PR DESCRIPTION
## Purpose

When user switches to another language we want to preserve the query string.

## Proposal

- [x] Update LanguageSelector component to append `location.search` to selectedItem url
