### PR TITLE
📝(website) add option to run Cookiecutter from Docker

### DIFF
--- a/docs/cookiecutter.md
+++ b/docs/cookiecutter.md
@@ -8,23 +8,32 @@ We use [Cookiecutter](https://github.com/audreyr/cookiecutter) to help you
 set up a production-ready learning portal website based on
 [Richie](https://github.com/openfun/richie) in seconds.
 
-## Install Cookiecutter
-
-First, you need to [install cookiecutter on your machine][1].
-
 ## Run Cookiecutter
 
-Navigate to the directory in which you want to create your site factory:
+There are 2 options to run Cookiecutter:
+- [install it on your machine][1]
+- run it with Docker
 
-```bash
-$ cd /path/to/your/code/directory
+While you think of it, navigate to the directory in which you want to create
+your site factory:
+
+```
+cd /path/to/your/code/directory
 ```
 
-Run Cookiecutter against our [Cookiecutter template][2]:
+If you chose to install Cookiecutter, you can now run it against our
+[template][2] as follows:
 
 ```bash
-$ cookiecutter gh:openfun/richie --directory cookiecutter
-  > organization: foo
+cookiecutter gh:openfun/richie --directory cookiecutter
+```
+
+If you didn't want to install it on your machine, we provide a Docker image
+built with our [own repository][4] that you can use as follows:
+
+```bash
+docker run --rm -it -u $(id -u):$(id -g) -v $PWD:/app \
+fundocker/cookiecutter gh:openfun/richie --directory cookiecutter
 ```
 
 The `--directory` option is to indicate that our Cookiecutter template is in
@@ -45,9 +54,8 @@ currently are.
 Enter the newly created project and add a new site to your site factory:
 
 ```bash
-$ cd foo-richie-site-factory
-$ make add-site
-  > site: bar
+cd foo-richie-site-factory
+make add-site
 ```
 
 This script also uses Cookiecutter against our [site template][3].
@@ -55,14 +63,14 @@ This script also uses Cookiecutter against our [site template][3].
 Once your new site is created, activate it:
 
 ```bash
-$ bin/activate
+bin/activate
 ```
 
 Now bootstrap the site to build its docker image, create its media folder,
 database, etc.:
 
 ```bash
-$ make bootstrap
+make bootstrap
 ```
 
 Once the bootstrap phase is finished, you should be able to view the site at
@@ -71,7 +79,7 @@ Once the bootstrap phase is finished, you should be able to view the site at
 You can create a full fledge demo to test your site by running:
 
 ```bash
-$ make demo-site
+make demo-site
 ```
 
 Note that the README of your newly created site factory contains detailed
@@ -88,7 +96,7 @@ project's scaffolding but, don't worry, it will respect all the sites you
 will have created in the `sites` directory:
 
 ```
-$ cookiecutter --overwrite-if-exists gh:openfun/richie --directory=cookiecutter
+cookiecutter --overwrite-if-exists gh:openfun/richie --directory=cookiecutter
 ```
 
 ## Help us improve this project
@@ -99,3 +107,4 @@ what other features we should add to make it better.
 [1]: https://cookiecutter.readthedocs.io/en/latest/installation.html
 [2]: https://github.com/openfun/richie/tree/master/cookiecutter
 [3]: https://github.com/openfun/richie/tree/master/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template
+[4]: https://github.com/openfun/dockerfiles


### PR DESCRIPTION
## Purpose

We have published a new Docker image for Cookiecutter: https://hub.docker.com/repository/docker/fundocker/cookiecutter

With this version of Cookiecutter (1.7.3) we can specify a directory inside the repository. It can then be used to generate a richie site factory from the Cookiecutter template in richie's repository: https://github.com/openfun/richie/tree/master/cookiecutter

## Proposal

Add instructions to documentation to run Cookiecutter with Docker.
