### PR TITLE
📝(website) fix doc urls in footer by removing language from url

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -20,9 +20,9 @@ class Footer extends React.Component {
         <section className="sitemap">
           <div>
             <h5>Documentation</h5>
-            <a href={this.docUrl('discover.html', this.props.language)}>Getting&nbsp;Started</a>
+            <a href={this.docUrl('discover.html')}>Getting&nbsp;Started</a>
             <a href="/versions">Versions</a>
-            <a href={this.docUrl('contributing.html', this.props.language)}>Contributing</a>
+            <a href={this.docUrl('contributing.html')}>Contributing</a>
           </div>
           <div>
             <h5>Community</h5>


### PR DESCRIPTION
## Purpose

Urls pointing to pages in the `\docs` folder are broken.

## Proposal 

The documentation pages in `/docs` are not internationalized (yet?). We should not include the language when computing their urls.

