### PR TITLE
Improve accessibility of header and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   to succeed
 - Improve Sale Tunnel UX
 - Improve sale tunnel theme overriding
+- Improve html header and menu structure for better keyboard and screen reader
+  UX
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   to succeed
 - Improve Sale Tunnel UX
 - Improve sale tunnel theme overriding
-- Improve html header and menu structure for better keyboard and screen reader
-  UX
+- Improve html header, menu and footer structure for better keyboard and
+  screen reader UX
 
 ### Fixed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,10 @@ $ make migrate
 
 ## Unreleased
 
+- `<header>`, `<nav>` and `<footer>` DOM structure was updated for better accessibility. Make
+  sure to check that everything still renders correctly if you override header or footer blocks
+  in your templates.
+
 ## 2.14.x to 2.15.x
 - RegisteredAddress now has a related stylesheet, you have to update the main stylesheet as follows:
   - `_main.scss`

--- a/src/frontend/scss/components/_header.scss
+++ b/src/frontend/scss/components/_header.scss
@@ -35,6 +35,12 @@
     }
   }
 
+  &__header {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
   // Will show only on mobile breakpoints
   &__hamburger {
     @include sv-flex(0, 0, auto);

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -204,6 +204,7 @@
                             const target = document.getElementById(el.dataset.target);
                             // Toggle the "is-active" class on both the burger and container
                             el.classList.toggle("is-active");
+                            el.setAttribute("aria-expanded", el.classList.contains("is-active"));
                             target.classList.toggle("is-open");
                         });
                     });

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -81,47 +81,54 @@
 
             {# Wrap header content in a header tag to improve landmarks around the site #}
 
-            <header id="site-header">
-                <nav class="topbar {% block topbar_classes %}{% endblock topbar_classes %}" id="main-menu">
+            <div id="site-header">
+                <div class="topbar {% block topbar_classes %}{% endblock topbar_classes %}" id="main-menu">
                     <div class="topbar__container">
-                        <div class="topbar__brand">
-                            <button class="topbar__hamburger"
-                                    data-target="main-menu" aria-label="menu" aria-expanded="false">&#8801;</button>
-                            <a href="/" title="{% trans "Go to homepage" %}" rel="home" accesskey="h">
-                            {% block branding_topbar %}
-                                <img src="{% static "richie/images/logo.png" %}" class="topbar__logo" alt="{{ SITE.name }}">
-                            {% endblock branding_topbar %}
-                            </a>
-                        </div>
-                        <div class="topbar__menu">
-                            <ul class="topbar__list"> 
+                        <header class="topbar__header">
+                            <div class="topbar__brand">
+                                <a href="/" title="{% trans "Go to homepage" %}" rel="home" accesskey="h">
+                                {% block branding_topbar %}
+                                    <img src="{% static "richie/images/logo.png" %}" class="topbar__logo" alt="{{ SITE.name }}">
+                                {% endblock branding_topbar %}
+                                </a>
+
+                                <button
+                                    class="topbar__hamburger"
+                                    data-target="main-menu"
+                                    aria-label="{% trans "Menu" %}"
+                                    aria-expanded="false"
+                                >&#8801;</button>
+                            </div>
+                            <div class="topbar__menu topbar__menu--aside">
+                                {% block topbar_searchbar %}
+                                <div class="topbar__search richie-react richie-react--root-search-suggest-field"
+                                    data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}"}'></div>
+                                {% endblock topbar_searchbar %}
+                                <ul class="topbar__list topbar__list--controls">
+                                    {% block userlogin %}
+                                        {% if AUTHENTICATION %}
+                                            <li class="topbar__item topbar__item--login richie-react richie-react--user-login" data-props='{"profileUrls": {{ AUTHENTICATION.profile_urls }}}'></li>
+                                        {% endif %}
+                                    {% endblock userlogin %}
+                                    {% block topbar_contact %}
+                                    <li class="topbar__item topbar__item--cta">
+                                        <a href="#">{% trans "Contact us" %}</a>
+                                    </li>
+                                    {% endblock topbar_contact %}
+                                </ul>
+
+                                {% language_chooser "menu/language_menu.html" %}
+                            </div>
+                        </header>
+
+                        <nav class="topbar__menu">
+                            <ul class="topbar__list">
                                 {% show_menu 0 100 0 0 "menu/header_menu.html" %}
                             </ul>
-                        </div>
-                        <div class="topbar__menu topbar__menu--aside">
-                            {% block topbar_searchbar %}
-                            <div class="topbar__search richie-react richie-react--root-search-suggest-field"
-                                data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}"}'></div>
-                            {% endblock topbar_searchbar %}
-
-                            <ul class="topbar__list topbar__list--controls">
-                                {% block userlogin %}
-                                    {% if AUTHENTICATION %}
-                                        <li class="topbar__item topbar__item--login richie-react richie-react--user-login" data-props='{"profileUrls": {{ AUTHENTICATION.profile_urls }}}'></li>
-                                    {% endif %}
-                                {% endblock userlogin %}
-                                {% block topbar_contact %}
-                                <li class="topbar__item topbar__item--cta">
-                                    <a href="#">{% trans "Contact us" %}</a>
-                                </li>
-                                {% endblock topbar_contact %}
-                            </ul>
-
-                            {% language_chooser "menu/language_menu.html" %}
-                        </div>
+                        </nav>
                     </div>
-                </nav>
-            </header>
+                </div>
+            </div>
             {% endblock body_header %}
             
             {# Main landmark helps redirect users with disabilities directly to the content #}

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -150,12 +150,6 @@
             <footer id="site-footer">
                 <div class="body-footer">
                     <div class="body-footer__container">
-                        <div class="body-footer__menu">
-                            <p class="body-footer__subtitle">{% trans "Learn more" %}</p>
-                            <div class="body-footer__items">
-                                {% static_placeholder "footer" %}
-                            </div>
-                        </div>
                         <div class="body-footer__brand">
                             {% block body_footer_brand %}
                                 <a href="/">
@@ -170,6 +164,12 @@
                             {% language_chooser "menu/language_menu.html" %}
                             <div class="body-footer__badges">
                                 {% include "social-networks/footer-badges.html" %}
+                            </div>
+                        </div>
+                        <div class="body-footer__menu">
+                            <p class="body-footer__subtitle">{% trans "Learn more" %}</p>
+                            <div class="body-footer__items">
+                                {% static_placeholder "footer" %}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Purpose

Make sure screen reader users and keyboard users get a good experience when navigating in the header, nav and footer of richie.


## Proposal

- fix how the `<header>` and `<nav>` tags are used. For best screen reader user experience, the `<nav>` shouldn't be in the `<header>` because some screen readers (NVDA, for example) will not recognize region tags that are wrapped in other region tags
- fix tabulation order, especially on mobile with the hamburger menu, but also on the footer
