### PR TITLE
Make text-only zoom follow responsive breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Improve overall accessibility, especially for screen reader users,
   on all content pages: category list, category details, blogpost list,
   blogpost details, program list, program details, organization detail.
+- Use `em` based media queries instead of `px` based media queries to fix all
+  UI bugs when using the website with a huge text-only zoom
 
 ### Fixed
 

--- a/src/frontend/scss/settings/_variables.scss
+++ b/src/frontend/scss/settings/_variables.scss
@@ -10,24 +10,24 @@ $onepixel: 0.0625rem;
 // Add a new breakpoint "xxl" for more granular downgrading
 $grid-breakpoints: (
   xs: 0,
-  sm: 576px,
-  md: 768px,
-  lg: 992px,
-  xl: 1200px,
-  xxl: 1900px,
+  sm: em-calc(576px),
+  md: em-calc(768px),
+  lg: em-calc(992px),
+  xl: em-calc(1200px),
+  xxl: em-calc(1900px),
 );
 
 // Add max width for "xxl" breakpoint
 $container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1140px,
-  xxl: 1240px,
+  sm: rem-calc(540px),
+  md: rem-calc(720px),
+  lg: rem-calc(960px),
+  xl: rem-calc(1140px),
+  xxl: rem-calc(1240px),
 );
 
 // More space between columns
-$grid-gutter-width: 20px;
+$grid-gutter-width: rem-calc(20px);
 
 // Base body
 $body-color: r-theme-val(body-content, base-color);

--- a/src/frontend/scss/tools/_rem.scss
+++ b/src/frontend/scss/tools/_rem.scss
@@ -14,5 +14,6 @@ $rem-calc-base-font-size: 16px !default;
 ///
 @function rem-calc($size) {
   $remSize: math.div($size, $rem-calc-base-font-size);
-  @return #{$remSize}rem;
+  @return $remSize * 1rem;
+}
 }

--- a/src/frontend/scss/tools/_rem.scss
+++ b/src/frontend/scss/tools/_rem.scss
@@ -16,4 +16,8 @@ $rem-calc-base-font-size: 16px !default;
   $remSize: math.div($size, $rem-calc-base-font-size);
   @return $remSize * 1rem;
 }
+
+@function em-calc($size) {
+  $emSize: math.div($size, $rem-calc-base-font-size);
+  @return $emSize * 1em;
 }


### PR DESCRIPTION
## Purpose

Make the website clear to use visually when using text-only zoom.

As of now, a high lvl of text-only zoom breaks the websites on multiple occasions, because the website layout doesn't shift at all when zooming in text-only mode.

For example, a list of glimpses displayed with rows of 4 elements in "desktop mode", still displays with rows of 4 elements at 200% text-only zoom. But since the text is huge in this case, it's barely impossible to read the content of each element, they all render with 2 or 3 words max per-line.

*Note: I specifically talk about 200% text zoom because it's the goal in [WCAG/RGAA](https://www.w3.org/TR/WCAG21/#resize-text).*

## Proposal

The proposal to fix this easily is to go from `px` based media queries to `em` based media queries. This basically makes the text-only zoom react like the normal zoom, except that it doesn't resize images.

Fixing text-zoom-specific bugs in another way is a bit tricky. There is no API to listen for text-zoom events or know the current text-zoom level. So in the few spots where we would want to style "only when text-zoomed is > 150%", we'd have to manually check current font size in JS every x seconds, and apply/remove a class on the body that we could rely on. Or we'd need to specifically update all the spots in the CSS where the container are in pixels and where it's bothersome, and replace them by font-size-relative units.