### PR TITLE
Improve accessibility on filters pane when using a small screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- On the search page, improve accessibility of the filters pane when using a
+  small screen
+
 ##  [2.15.1] - 2022-08-10
 
 ### Changed

--- a/src/frontend/js/components/Search/FiltersPaneCloseButton.tsx
+++ b/src/frontend/js/components/Search/FiltersPaneCloseButton.tsx
@@ -1,0 +1,49 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Icon } from 'components/Icon';
+
+const messages = defineMessages({
+  hideFiltersPane: {
+    defaultMessage: 'Hide filters pane',
+    description:
+      'Accessibility text for the button/icon that toggles *off* the filters pane on mobile',
+    id: 'components.Search.hideFiltersPane',
+  },
+  showFiltersPane: {
+    defaultMessage: 'Show filters pane',
+    description:
+      'Accessibility text for the button/icon that toggles *on* the filters pane on mobile',
+    id: 'components.Search.showFiltersPane',
+  },
+});
+
+interface FiltersPaneCloseButtonProps {
+  expanded: boolean;
+  controls: string;
+  onClick: () => void;
+  type?: 'top' | 'bottom';
+}
+
+const FiltersPaneCloseButton = ({
+  expanded,
+  controls,
+  onClick,
+  type = 'top',
+}: FiltersPaneCloseButtonProps) => {
+  const iconName = expanded ? 'icon-cross' : 'icon-filter';
+  const message = expanded ? messages.hideFiltersPane : messages.showFiltersPane;
+  return (
+    <button
+      aria-expanded={expanded}
+      aria-controls={controls}
+      className={`search__filters__toggle search__filters__toggle--${type}`}
+      onClick={onClick}
+    >
+      <Icon name={iconName} className="search__filters__toggle__icon" />{' '}
+      <span className="offscreen">
+        <FormattedMessage {...message} />
+      </span>
+    </button>
+  );
+};
+
+export default FiltersPaneCloseButton;

--- a/src/frontend/js/components/SearchFiltersPane/index.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.tsx
@@ -68,7 +68,10 @@ export const SearchFiltersPane = ({
 
   return (
     <div className="search-filters-pane" {...passThroughProps}>
-      <h2 className="search-filters-pane__title">
+      <h2
+        id={`${passThroughProps.id || 'search-filters-pane'}__title`}
+        className="search-filters-pane__title"
+      >
         <FormattedMessage {...messages.filter} />
       </h2>
       <button

--- a/src/frontend/scss/components/templates/search/_search.scss
+++ b/src/frontend/scss/components/templates/search/_search.scss
@@ -65,6 +65,18 @@ $r-search-filters-width: 15rem !default;
       transform: translateX(0);
     }
 
+    &__pane-container:not(.is-closing) {
+      display: none;
+
+      @include media-breakpoint-up(lg) {
+        display: block;
+      }
+    }
+
+    &--active &__pane-container {
+      display: block;
+    }
+
     &__toggle {
       position: absolute;
       top: 1.25rem;
@@ -81,6 +93,11 @@ $r-search-filters-width: 15rem !default;
         width: 100%;
         height: 100%;
         fill: r-theme-val(search-filters, toggler-fill);
+      }
+
+      &--bottom {
+        top: auto;
+        bottom: 1.25rem;
       }
     }
   }


### PR DESCRIPTION
## Purpose

Make sure navigating inside the search page is OK when using a mobile phone/small screen + screen reader/keyboard only navigation.

## Proposal

Everything is precisely described in the commit.

*Note: instead of doing multiple very small commits, I did one big commit concerning everything, let me know if you'd rather have everything split up.*

Todo: 

- [x] add tests
