### PR TITLE
Fix/layout issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Remove z-index of course glimpse icon to fix an overlay issue
 - Fix erratic frontend test failure
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix `components.SaleTunnelStepPayment.userBillingAddressNoEntry` misspell
 - Remove z-index of course glimpse icon to fix an overlay issue
 - Fix erratic frontend test failure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix header layout issue when logo height is big
 - Fix `components.SaleTunnelStepPayment.userBillingAddressNoEntry` misspell
 - Remove z-index of course glimpse icon to fix an overlay issue
 - Fix erratic frontend test failure

--- a/src/frontend/js/components/SaleTunnelStepPayment/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnelStepPayment/index.spec.tsx
@@ -123,7 +123,7 @@ describe('SaleTunnelStepPayment', () => {
       );
     });
 
-    screen.getByText('You have not yet a billing address.');
+    screen.getByText("You don't have any billing addresses yet.");
     const $button = screen.getByText('Create an address', { selector: 'button' });
 
     await act(async () => {

--- a/src/frontend/js/components/SaleTunnelStepPayment/index.tsx
+++ b/src/frontend/js/components/SaleTunnelStepPayment/index.tsx
@@ -32,7 +32,7 @@ const messages = defineMessages({
     id: 'components.SaleTunnelStepPayment.userBillingAddressSelectLabel',
   },
   userBillingAddressNoEntry: {
-    defaultMessage: 'You have not yet a billing address.',
+    defaultMessage: "You don't have any billing addresses yet.",
     description: 'Message displayed when the user has no address.',
     id: 'components.SaleTunnelStepPayment.userBillingAddressNoEntry',
   },

--- a/src/frontend/scss/components/_header.scss
+++ b/src/frontend/scss/components/_header.scss
@@ -7,7 +7,11 @@
   background: r-theme-val(topbar, base-background);
 
   @include media-breakpoint-up($r-topbar-breakpoint) {
-    height: $r-topbar-height;
+    padding-bottom: 0;
+
+    &__header {
+      max-height: $r-topbar-height;
+    }
 
     &--over {
       position: absolute;
@@ -37,8 +41,13 @@
 
   &__header {
     display: flex;
+    flex-direction: column;
     flex-wrap: wrap;
     width: 100%;
+
+    @include media-breakpoint-up($r-topbar-breakpoint) {
+      flex-direction: row;
+    }
   }
 
   // Will show only on mobile breakpoints
@@ -61,9 +70,9 @@
   // Brand part with hamburger and clickable logo
   &__brand {
     @include sv-flex(1, 0, auto);
+    align-items: stretch;
     display: flex;
     flex-direction: row;
-    align-items: stretch;
     order: 1;
 
     @include media-breakpoint-up($r-topbar-breakpoint) {
@@ -95,6 +104,9 @@
 
   &__logo {
     display: block;
+    max-height: $r-topbar-height;
+    object-fit: contain;
+    object-position: left center;
     width: $r-topbar-logo-width-sm;
 
     @include media-breakpoint-up($r-topbar-breakpoint) {

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -129,7 +129,6 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     box-shadow: r-theme-val(course-glimpse, icon-shadow);
-    z-index: 1;
     pointer-events: none;
 
     .category-badge {


### PR DESCRIPTION
## Purpose

Fix several little issues

### i18n
A default translation message is currently misspelled.

### Layout issues
#### Header
The header has currently a fix height and this can cause layout overflow according to the logo format.

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/9265241/168013562-3c0d7611-2ea0-4ed7-8b87-900a27b4da0c.png">


#### Search page
On mobile, there is an overlay issue on search page. When the searh filters pane is pone, course glimpse icons are over.
<img width="960" alt="image" src="https://user-images.githubusercontent.com/9265241/168011408-8a1cd24c-45fa-41d3-8bc5-dbce22ed10c2.png">




## Proposal

- [x] Fix a misspell
- [x] Fix a layout issue on the search pane
- [x] Fix a layout issue about the header
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/9265241/168013685-a24a1c85-91f3-4d51-ba85-6fe2cc5bfa89.png">

