### PR TITLE
Improve accessibility of the sale tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add disabled style for inputs
 - Add a visually hidden title on video player iframes, meant to be announced
   to screen reader users
+- Improve sale tunnel accessibility, especially when using a keyboard
+  or screen reader
 
 ### Fixed
 

--- a/src/frontend/js/components/AddressesManagement/AddressForm.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm.spec.tsx
@@ -93,8 +93,9 @@ describe('AddressForm', () => {
       name: 'Use this address',
     }) as HTMLButtonElement;
 
-    // - Until form is not fulfill, submit button should be disabled
-    expect($submitButton.disabled).toBe(true);
+    // - submit button should be enabled even when the form is not valid,
+    //   so that every user can get feedback easily (especially screen reader users)
+    expect($submitButton.disabled).toBe(false);
 
     // - User fulfills address fields
     const address = mockFactories.AddressFactory.generate();
@@ -112,7 +113,7 @@ describe('AddressForm', () => {
       fireEvent.blur($countryInput);
     });
 
-    // Once the form has been fulfilled properly, submit button should be enabled.
+    // Once the form has been fulfilled properly, submit button should still be enabled.
     expect($submitButton.disabled).toBe(false);
 
     // Before submitting, we change field values to corrupt the form data
@@ -171,8 +172,8 @@ describe('AddressForm', () => {
       name: 'Use this address',
     }) as HTMLButtonElement;
 
-    // - Until form is not fulfill, submit button should be disabled
-    expect($submitButton.disabled).toBe(true);
+    // - button should never be disabled to allow user feedback at any time
+    expect($submitButton.disabled).toBe(false);
 
     // - User fulfills address fields
     const address = mockFactories.AddressFactory.generate();
@@ -190,7 +191,7 @@ describe('AddressForm', () => {
       fireEvent.blur($countryInput);
     });
 
-    // Once the form has been fulfilled properly, submit button should be enabled.
+    // button should still be enabled especially now that there is no error
     expect($submitButton.disabled).toBe(false);
 
     // Before submitting, we change field values to corrupt the form data

--- a/src/frontend/js/components/AddressesManagement/AddressForm.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm.spec.tsx
@@ -26,6 +26,26 @@ describe('AddressForm', () => {
     jest.resetModules();
   });
 
+  it('shows a note about required fields', () => {
+    const { container } = render(
+      <IntlProvider locale="en">
+        <AddressForm handleReset={handleReset} onSubmit={onSubmit} />
+      </IntlProvider>,
+    );
+
+    // we use this form of testing because screen.getByText doesn't seem
+    // to handle text broken into multiple DOM elements correctly
+    expect(container).toHaveTextContent('Fields marked with * are required');
+
+    // the note should be rendered before any inputs
+    // we assume that it's the case if it's the first child of the form
+    expect(
+      container.querySelector(
+        'form[name="address-form"] > .form__required-fields-note:first-child',
+      ),
+    ).not.toBeNull();
+  });
+
   it('renders a button with label "Use this address" when no address is provided', () => {
     render(
       <IntlProvider locale="en">

--- a/src/frontend/js/components/AddressesManagement/AddressForm.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm.tsx
@@ -76,6 +76,9 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
 
   return (
     <form className="form" name="address-form" onSubmit={handleSubmit(onSubmit)}>
+      <p className="form__required-fields-note">
+        <FormattedMessage {...messages.requiredFields} values={{ symbol: <span>*</span> }} />
+      </p>
       <TextField
         aria-invalid={!!formState.errors.title}
         aria-required={true}

--- a/src/frontend/js/components/AddressesManagement/AddressForm.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm.tsx
@@ -178,7 +178,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
             </button>
             <button
               className="button button-sale--primary"
-              disabled={!formState.isValid || addresses.states.updating}
+              disabled={addresses.states.updating}
               type="submit"
             >
               <FormattedMessage {...messages.updateButton} />
@@ -187,7 +187,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
         ) : (
           <button
             className="button button-sale--primary"
-            disabled={!formState.isValid || addresses.states.creating || addresses.states.updating}
+            disabled={addresses.states.creating || addresses.states.updating}
             type="submit"
           >
             <FormattedMessage {...messages.selectButton} />

--- a/src/frontend/js/components/AddressesManagement/index.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.spec.tsx
@@ -137,7 +137,7 @@ describe('AddressesManagement', () => {
       );
     });
 
-    screen.getByRole('heading', { level: 5, name: 'Add a new address' });
+    screen.getByRole('heading', { level: 2, name: 'Add a new address' });
     screen.getByRole('form');
     const $titleField = screen.getByRole('textbox', { name: 'Address title' });
     const $firstnameField = screen.getByRole('textbox', { name: "Recipient's first name" });
@@ -225,7 +225,7 @@ describe('AddressesManagement', () => {
     });
 
     // - First the creation form should be displayed
-    screen.getByRole('heading', { level: 5, name: 'Add a new address' });
+    screen.getByRole('heading', { level: 2, name: 'Add a new address' });
     screen.getByRole('form');
     screen.getByRole('checkbox', { name: 'Save this address' });
     screen.getByRole('button', { name: 'Use this address' });
@@ -240,7 +240,7 @@ describe('AddressesManagement', () => {
     });
 
     // - Form should be updated
-    screen.getByRole('heading', { level: 5, name: `Update address ${address.title}` });
+    screen.getByRole('heading', { level: 2, name: `Update address ${address.title}` });
 
     let $titleField = screen.getByRole('textbox', { name: 'Address title' }) as HTMLInputElement;
     let $firstnameField = screen.getByRole('textbox', {
@@ -294,7 +294,7 @@ describe('AddressesManagement', () => {
     });
 
     // - Form should be restored and addresses should be updated
-    screen.getByRole('heading', { level: 5, name: 'Add a new address' });
+    screen.getByRole('heading', { level: 2, name: 'Add a new address' });
     screen.getByRole('form');
     screen.getByRole('checkbox', { name: 'Save this address' });
     screen.getByRole('button', { name: 'Use this address' });
@@ -307,7 +307,7 @@ describe('AddressesManagement', () => {
     });
 
     // - Form should be updated
-    screen.getByRole('heading', { level: 5, name: `Update address Home` });
+    screen.getByRole('heading', { level: 2, name: `Update address Home` });
 
     $titleField = screen.getByRole('textbox', { name: 'Address title' }) as HTMLInputElement;
     $firstnameField = screen.getByRole('textbox', {
@@ -339,7 +339,7 @@ describe('AddressesManagement', () => {
     });
 
     // - Form should be restored and addresses should be updated
-    screen.getByRole('heading', { level: 5, name: 'Add a new address' });
+    screen.getByRole('heading', { level: 2, name: 'Add a new address' });
     screen.getByRole('form');
     screen.getByRole('checkbox', { name: 'Save this address' });
     screen.getByRole('button', { name: 'Use this address' });
@@ -380,7 +380,7 @@ describe('AddressesManagement', () => {
     // - As this was the only existing address,
     //   registered addresses section should be hidden
 
-    expect(screen.queryByRole('heading', { level: 5, name: 'Your addresses' })).toBeNull();
+    expect(screen.queryByRole('heading', { level: 2, name: 'Your addresses' })).toBeNull();
     const $addresses = container!.querySelectorAll('.registered-addresses-item');
     expect($addresses).toHaveLength(0);
   });

--- a/src/frontend/js/components/AddressesManagement/index.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.spec.tsx
@@ -265,6 +265,9 @@ describe('AddressesManagement', () => {
     expect($countryField.value).toEqual(address.country);
     expect($saveField).toBeNull();
 
+    // focus should be set to the first input as a way to notify screen reader users
+    expect(document.activeElement).toEqual($titleField);
+
     // - User edits some values then submits its changes
     fetchMock
       .put(`https://joanie.endpoint/api/addresses/${address.id}/`, {

--- a/src/frontend/js/components/AddressesManagement/index.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.spec.tsx
@@ -151,8 +151,8 @@ describe('AddressesManagement', () => {
       name: 'Use this address',
     }) as HTMLButtonElement;
 
-    // - Until form is not fulfill, submit button should be disabled
-    expect($submitButton.disabled).toBe(true);
+    // - submit button should always be enabled to allow early user feedback
+    expect($submitButton.disabled).toBe(false);
 
     // - User fulfills address fields
     let address = mockFactories.AddressFactory.generate();
@@ -170,7 +170,7 @@ describe('AddressesManagement', () => {
       fireEvent.blur($countryField);
     });
 
-    // Once the form has been fulfilled properly, submit button should be enabled.
+    // Once the form has been fulfilled properly, submit button should still be enabled.
     expect($submitButton.disabled).toBe(false);
 
     await act(async () => {

--- a/src/frontend/js/components/AddressesManagement/index.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.tsx
@@ -252,6 +252,10 @@ const AddressesManagement = forwardRef<HTMLDivElement, AddressesManagementProps>
 
     useEffect(() => {
       setError(undefined);
+
+      if (editedAddress) {
+        document.querySelector<HTMLElement>('[name="address-form"] input')?.focus();
+      }
     }, [editedAddress]);
 
     return (

--- a/src/frontend/js/components/AddressesManagement/index.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.tsx
@@ -23,6 +23,11 @@ export const messages = defineMessages({
     description: 'Title of the address creation form',
     defaultMessage: 'Add a new address',
   },
+  requiredFields: {
+    id: 'components.AddressesManagement.requiredFields',
+    description: 'Text at the top of address creation form indicating what are required fields',
+    defaultMessage: 'Fields marked with {symbol} are required',
+  },
   editAddress: {
     id: 'components.AddressesManagement.editAddress',
     description: 'Title of the address edit form',

--- a/src/frontend/js/components/AddressesManagement/index.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.tsx
@@ -1,4 +1,4 @@
-import { Children, useEffect, useState } from 'react';
+import { Children, forwardRef, useEffect, useState } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import Banner, { BannerType } from 'components/Banner';
 import { useAddresses } from 'hooks/useAddresses';
@@ -132,7 +132,7 @@ interface AddressesManagementProps {
   selectAddress: (address: Joanie.Address) => void;
 }
 
-const AddressesManagement = ({ handleClose, selectAddress }: AddressesManagementProps) => {
+const AddressesManagement = forwardRef<HTMLDivElement, AddressesManagementProps>(({ handleClose, selectAddress }, ref) => {
   const intl = useIntl();
   const addresses = useAddresses();
   const [editedAddress, setEditedAddress] = useState<Maybe<Joanie.Address>>();
@@ -249,8 +249,8 @@ const AddressesManagement = ({ handleClose, selectAddress }: AddressesManagement
   }, [editedAddress]);
 
   return (
-    <div className="AddressesManagement">
-      <button className="button button-sale--tertiary" onClick={handleClose}>
+    <div className="AddressesManagement" ref={ref}>
+      <button className="AddressesManagement__closeButton button button-sale--tertiary" onClick={handleClose}>
         <Icon name="icon-chevron-down" className="button__icon" />
         <FormattedMessage {...messages.closeButton} />
       </button>
@@ -303,6 +303,6 @@ const AddressesManagement = ({ handleClose, selectAddress }: AddressesManagement
       </section>
     </div>
   );
-};
+});
 
 export default AddressesManagement;

--- a/src/frontend/js/components/AddressesManagement/index.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.tsx
@@ -132,177 +132,185 @@ interface AddressesManagementProps {
   selectAddress: (address: Joanie.Address) => void;
 }
 
-const AddressesManagement = forwardRef<HTMLDivElement, AddressesManagementProps>(({ handleClose, selectAddress }, ref) => {
-  const intl = useIntl();
-  const addresses = useAddresses();
-  const [editedAddress, setEditedAddress] = useState<Maybe<Joanie.Address>>();
-  const [error, setError] = useState<Maybe<string>>();
+const AddressesManagement = forwardRef<HTMLDivElement, AddressesManagementProps>(
+  ({ handleClose, selectAddress }, ref) => {
+    const intl = useIntl();
+    const addresses = useAddresses();
+    const [editedAddress, setEditedAddress] = useState<Maybe<Joanie.Address>>();
+    const [error, setError] = useState<Maybe<string>>();
 
-  /**
-   * Sort addresses ascending by title according to the locale
-   *
-   * @param {Joanie.Address} a
-   * @param {Joanie.Address} b
-   * @returns {Joanie.Address[]} Sorted addresses ascending by title
-   */
-  const sortAddressByTitleAsc = (a: Joanie.Address, b: Joanie.Address) => {
-    return a.title.localeCompare(b.title, [intl.locale, intl.defaultLocale]);
-  };
+    /**
+     * Sort addresses ascending by title according to the locale
+     *
+     * @param {Joanie.Address} a
+     * @param {Joanie.Address} b
+     * @returns {Joanie.Address[]} Sorted addresses ascending by title
+     */
+    const sortAddressByTitleAsc = (a: Joanie.Address, b: Joanie.Address) => {
+      return a.title.localeCompare(b.title, [intl.locale, intl.defaultLocale]);
+    };
 
-  /**
-   * update `selectedAddress` state with the address provided
-   * then close the address management form
-   *
-   * @param {Joanie.Address} address
-   */
-  const handleSelect = (address: Joanie.Address) => {
-    setError(undefined);
-    selectAddress(address);
-    handleClose();
-  };
+    /**
+     * update `selectedAddress` state with the address provided
+     * then close the address management form
+     *
+     * @param {Joanie.Address} address
+     */
+    const handleSelect = (address: Joanie.Address) => {
+      setError(undefined);
+      selectAddress(address);
+      handleClose();
+    };
 
-  /**
-   * Ask the user to confirm his intention
-   * then make the request to delete the provided address
-   *
-   * @param {Joanie.Address} address
-   */
-  const handleDelete = (address: Joanie.Address) => {
-    setError(undefined);
-    // eslint-disable-next-line no-alert, no-restricted-globals
-    const sure = confirm(
-      intl.formatMessage(messages.deletionConfirmation, { title: address.title }),
-    );
-    if (!address.is_main && sure) {
-      addresses.methods.delete(address.id, {
-        onError: () => setError(intl.formatMessage(messages.actionDeletion)),
-      });
-    }
-  };
+    /**
+     * Ask the user to confirm his intention
+     * then make the request to delete the provided address
+     *
+     * @param {Joanie.Address} address
+     */
+    const handleDelete = (address: Joanie.Address) => {
+      setError(undefined);
+      // eslint-disable-next-line no-alert, no-restricted-globals
+      const sure = confirm(
+        intl.formatMessage(messages.deletionConfirmation, { title: address.title }),
+      );
+      if (!address.is_main && sure) {
+        addresses.methods.delete(address.id, {
+          onError: () => setError(intl.formatMessage(messages.actionDeletion)),
+        });
+      }
+    };
 
-  /**
-   * Create a new address according to form values
-   * then update `selectedAddress` state with this new one.
-   * If `save` checkbox input is checked, the address is persisted
-   * otherwise it is only stored through the `selectedAddress` state.
-   *
-   * @param {AddressFormValues} formValues address fields to update
-   */
-  const handleCreate = async ({ save, ...address }: AddressFormValues) => {
-    setError(undefined);
-    if (save) {
-      await addresses.methods.create(address, {
-        onSuccess: handleSelect,
-        onError: () => setError(intl.formatMessage(messages.actionCreation)),
-      });
-    } else {
-      handleSelect({
-        id: LOCAL_BILLING_ADDRESS_ID,
-        is_main: false,
-        ...address,
-      });
-    }
-  };
+    /**
+     * Create a new address according to form values
+     * then update `selectedAddress` state with this new one.
+     * If `save` checkbox input is checked, the address is persisted
+     * otherwise it is only stored through the `selectedAddress` state.
+     *
+     * @param {AddressFormValues} formValues address fields to update
+     */
+    const handleCreate = async ({ save, ...address }: AddressFormValues) => {
+      setError(undefined);
+      if (save) {
+        await addresses.methods.create(address, {
+          onSuccess: handleSelect,
+          onError: () => setError(intl.formatMessage(messages.actionCreation)),
+        });
+      } else {
+        handleSelect({
+          id: LOCAL_BILLING_ADDRESS_ID,
+          is_main: false,
+          ...address,
+        });
+      }
+    };
 
-  /**
-   * Update the `editedAddress` with new values provided as argument
-   * then clear `editedAddress` state if request succeeded.
-   *
-   * @param {AddressFormValues} formValues address fields to update
-   */
-  const handleUpdate = async ({ save, ...newAddress }: AddressFormValues) => {
-    setError(undefined);
-    addresses.methods.update(
-      {
-        ...editedAddress!,
-        ...newAddress,
-      },
-      {
-        onSuccess: () => setEditedAddress(undefined),
-        onError: () => setError(intl.formatMessage(messages.actionUpdate)),
-      },
-    );
-  };
-
-  /**
-   * Update the provided address to promote it as main
-   *
-   * @param {Joanie.Address} address
-   */
-  const promoteAddress = (address: Joanie.Address) => {
-    if (!address.is_main) {
+    /**
+     * Update the `editedAddress` with new values provided as argument
+     * then clear `editedAddress` state if request succeeded.
+     *
+     * @param {AddressFormValues} formValues address fields to update
+     */
+    const handleUpdate = async ({ save, ...newAddress }: AddressFormValues) => {
       setError(undefined);
       addresses.methods.update(
         {
-          ...address,
-          is_main: true,
+          ...editedAddress!,
+          ...newAddress,
         },
         {
-          onError: () => setError(intl.formatMessage(messages.actionPromotion)),
+          onSuccess: () => setEditedAddress(undefined),
+          onError: () => setError(intl.formatMessage(messages.actionUpdate)),
         },
       );
-    }
-  };
+    };
 
-  useEffect(() => {
-    setError(undefined);
-  }, [editedAddress]);
+    /**
+     * Update the provided address to promote it as main
+     *
+     * @param {Joanie.Address} address
+     */
+    const promoteAddress = (address: Joanie.Address) => {
+      if (!address.is_main) {
+        setError(undefined);
+        addresses.methods.update(
+          {
+            ...address,
+            is_main: true,
+          },
+          {
+            onError: () => setError(intl.formatMessage(messages.actionPromotion)),
+          },
+        );
+      }
+    };
 
-  return (
-    <div className="AddressesManagement" ref={ref}>
-      <button className="AddressesManagement__closeButton button button-sale--tertiary" onClick={handleClose}>
-        <Icon name="icon-chevron-down" className="button__icon" />
-        <FormattedMessage {...messages.closeButton} />
-      </button>
-      {error && (
-        <Banner
-          message={intl.formatMessage(messages.error, { action: error })}
-          type={BannerType.ERROR}
-          rounded
-        />
-      )}
-      {addresses.items.length > 0 ? (
-        <section className="address-registered">
+    useEffect(() => {
+      setError(undefined);
+    }, [editedAddress]);
+
+    return (
+      <div className="AddressesManagement" ref={ref}>
+        <button
+          className="AddressesManagement__closeButton button button-sale--tertiary"
+          onClick={handleClose}
+        >
+          <Icon name="icon-chevron-down" className="button__icon" />
+          <FormattedMessage {...messages.closeButton} />
+        </button>
+        {error && (
+          <Banner
+            message={intl.formatMessage(messages.error, { action: error })}
+            type={BannerType.ERROR}
+            rounded
+          />
+        )}
+        {addresses.items.length > 0 ? (
+          <section className="address-registered">
+            <header>
+              <h5>
+                <FormattedMessage {...messages.registeredAddresses} />
+              </h5>
+            </header>
+            <ul className="registered-addresses-list">
+              {Children.toArray(
+                addresses.items
+                  .sort(sortAddressByTitleAsc)
+                  .map((address) => (
+                    <RegisteredAddress
+                      address={address}
+                      edit={setEditedAddress}
+                      promote={promoteAddress}
+                      remove={handleDelete}
+                      select={handleSelect}
+                    />
+                  )),
+              )}
+            </ul>
+          </section>
+        ) : null}
+        <section className={`address-form ${editedAddress ? 'address-form--highlighted' : ''}`}>
           <header>
             <h5>
-              <FormattedMessage {...messages.registeredAddresses} />
+              {editedAddress ? (
+                <FormattedMessage
+                  {...messages.editAddress}
+                  values={{ title: editedAddress.title }}
+                />
+              ) : (
+                <FormattedMessage {...messages.addAddress} />
+              )}
             </h5>
           </header>
-          <ul className="registered-addresses-list">
-            {Children.toArray(
-              addresses.items
-                .sort(sortAddressByTitleAsc)
-                .map((address) => (
-                  <RegisteredAddress
-                    address={address}
-                    edit={setEditedAddress}
-                    promote={promoteAddress}
-                    remove={handleDelete}
-                    select={handleSelect}
-                  />
-                )),
-            )}
-          </ul>
+          <AddressForm
+            address={editedAddress}
+            handleReset={() => setEditedAddress(undefined)}
+            onSubmit={editedAddress ? handleUpdate : handleCreate}
+          />
         </section>
-      ) : null}
-      <section className={`address-form ${editedAddress ? 'address-form--highlighted' : ''}`}>
-        <header>
-          <h5>
-            {editedAddress ? (
-              <FormattedMessage {...messages.editAddress} values={{ title: editedAddress.title }} />
-            ) : (
-              <FormattedMessage {...messages.addAddress} />
-            )}
-          </h5>
-        </header>
-        <AddressForm
-          address={editedAddress}
-          handleReset={() => setEditedAddress(undefined)}
-          onSubmit={editedAddress ? handleUpdate : handleCreate}
-        />
-      </section>
-    </div>
-  );
-});
+      </div>
+    );
+  },
+);
 
 export default AddressesManagement;

--- a/src/frontend/js/components/AddressesManagement/index.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.tsx
@@ -268,9 +268,9 @@ const AddressesManagement = forwardRef<HTMLDivElement, AddressesManagementProps>
         {addresses.items.length > 0 ? (
           <section className="address-registered">
             <header>
-              <h5>
+              <h2 className="h5">
                 <FormattedMessage {...messages.registeredAddresses} />
-              </h5>
+              </h2>
             </header>
             <ul className="registered-addresses-list">
               {Children.toArray(
@@ -291,7 +291,7 @@ const AddressesManagement = forwardRef<HTMLDivElement, AddressesManagementProps>
         ) : null}
         <section className={`address-form ${editedAddress ? 'address-form--highlighted' : ''}`}>
           <header>
-            <h5>
+            <h2 className="h5">
               {editedAddress ? (
                 <FormattedMessage
                   {...messages.editAddress}
@@ -300,7 +300,7 @@ const AddressesManagement = forwardRef<HTMLDivElement, AddressesManagementProps>
               ) : (
                 <FormattedMessage {...messages.addAddress} />
               )}
-            </h5>
+            </h2>
           </header>
           <AddressForm
             address={editedAddress}

--- a/src/frontend/js/components/CourseProductCertificateItem/index.spec.tsx
+++ b/src/frontend/js/components/CourseProductCertificateItem/index.spec.tsx
@@ -54,7 +54,10 @@ describe('CoursePorductCertificateItem', () => {
       </Wrapper>,
     );
 
-    screen.getByRole('heading', { level: 5, name: certificateDefinition.title });
+    // the title is not a heading to prevent screen reader users "heading spam",
+    // but we want it to visually look like a heading for sighted users
+    expect(screen.queryByRole('heading', { name: certificateDefinition.title })).toBeNull();
+    expect(screen.getByText(certificateDefinition.title).classList.contains('h5')).toBe(true);
     screen.getByText(certificateDefinition.description);
   });
 
@@ -71,7 +74,6 @@ describe('CoursePorductCertificateItem', () => {
       </Wrapper>,
     );
 
-    screen.getByRole('heading', { level: 5, name: certificateDefinition.title });
     screen.getByText(
       'You will be able to download your certificate once you will pass all course runs.',
     );
@@ -88,8 +90,6 @@ describe('CoursePorductCertificateItem', () => {
         <CertificateItem certificate={certificateDefinition} order={order} />
       </Wrapper>,
     );
-
-    screen.getByRole('heading', { level: 5, name: certificateDefinition.title });
 
     // - The certificate description should not be displayed ...
     expect(screen.queryByText(certificateDefinition.description)).toBeNull();

--- a/src/frontend/js/components/CourseProductCertificateItem/index.tsx
+++ b/src/frontend/js/components/CourseProductCertificateItem/index.tsx
@@ -69,7 +69,7 @@ const CertificateItem = ({ certificate, order }: Props) => {
         <use href="#icon-certificate" />
       </svg>
       <div>
-        <h5 className="product-widget__item-title">{certificate.title}</h5>
+        <strong className="product-widget__item-title h5">{certificate.title}</strong>
         <p className="product-widget__item-description">
           {order?.certificate ? (
             <>

--- a/src/frontend/js/components/CourseProductCourseRuns/CourseRunList.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/CourseRunList.tsx
@@ -41,23 +41,29 @@ const CourseRunList = ({ courseRuns }: Props) => {
           courseRuns.map((courseRun) => (
             <li className="course-runs-item course-runs-item--inactive">
               <strong className="course-runs-item__course-dates">
+                <span
+                  className="offscreen"
+                  data-testid={`course-run-${courseRun.id}-offscreen-start-date`}
+                >
+                  <FormattedMessage {...sectionMessages.start} />
+                </span>
                 <em
                   data-testid={`course-run-${courseRun.id}-start-date`}
                   className="course-runs-item__date course-runs-item__date--start"
                 >
-                  <span className="offscreen">
-                    <FormattedMessage {...sectionMessages.start} />
-                  </span>
                   {formatDate(courseRun.start)}
                 </em>
                 <span className="course-runs-item__date-separator" />
+                <span
+                  className="offscreen"
+                  data-testid={`course-run-${courseRun.id}-offscreen-end-date`}
+                >
+                  <FormattedMessage {...sectionMessages.end} />
+                </span>
                 <em
                   data-testid={`course-run-${courseRun.id}-end-date`}
                   className="course-runs-item__date course-runs-item__date--end"
                 >
-                  <span className="offscreen">
-                    <FormattedMessage {...sectionMessages.end} />
-                  </span>
                   {formatDate(courseRun.end)}
                 </em>
               </strong>

--- a/src/frontend/js/components/CourseProductCourseRuns/CourseRunList.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/CourseRunList.tsx
@@ -3,7 +3,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { Icon } from 'components/Icon';
 import type * as Joanie from 'types/Joanie';
 import useDateFormat from 'utils/useDateFormat';
-import CourseRunSection from './CourseRunSection';
+import CourseRunSection, { messages as sectionMessages } from './CourseRunSection';
 
 const messages = defineMessages({
   enrollFromTo: {
@@ -45,6 +45,9 @@ const CourseRunList = ({ courseRuns }: Props) => {
                   data-testid={`course-run-${courseRun.id}-start-date`}
                   className="course-runs-item__date course-runs-item__date--start"
                 >
+                  <span className="offscreen">
+                    <FormattedMessage {...sectionMessages.start} />
+                  </span>
                   {formatDate(courseRun.start)}
                 </em>
                 <span className="course-runs-item__date-separator" />
@@ -52,6 +55,9 @@ const CourseRunList = ({ courseRuns }: Props) => {
                   data-testid={`course-run-${courseRun.id}-end-date`}
                   className="course-runs-item__date course-runs-item__date--end"
                 >
+                  <span className="offscreen">
+                    <FormattedMessage {...sectionMessages.end} />
+                  </span>
                   {formatDate(courseRun.end)}
                 </em>
               </strong>

--- a/src/frontend/js/components/CourseProductCourseRuns/CourseRunSection.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/CourseRunSection.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-const messages = defineMessages({
+export const messages = defineMessages({
   end: {
     defaultMessage: 'End',
     description: 'End label displayed in the header of course run dates section',
@@ -16,7 +16,9 @@ const messages = defineMessages({
 
 const CourseRunSection = ({ children }: PropsWithChildren<{}>) => (
   <section className="course__course-runs">
-    <header className="course__course-runs-header">
+    {/* the "start" and "end" texts will be repeated on each run offscreen
+    so that screen reader users understand correcty, so hide it from them here */}
+    <header className="course__course-runs-header" aria-hidden="true">
       <strong>
         <FormattedMessage {...messages.start} />
       </strong>

--- a/src/frontend/js/components/CourseProductCourseRuns/EnrollableCourseRunList.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/EnrollableCourseRunList.tsx
@@ -9,7 +9,7 @@ import { Priority } from 'types';
 import type * as Joanie from 'types/Joanie';
 import type { Maybe } from 'types/utils';
 import useDateFormat from 'utils/useDateFormat';
-import CourseRunSection from './CourseRunSection';
+import CourseRunSection, { messages as sectionMessages } from './CourseRunSection';
 
 const messages = defineMessages({
   ariaSelectCourseRun: {
@@ -147,6 +147,9 @@ const EnrollableCourseRunList = ({ courseRuns, order }: Props) => {
                       data-testid={`course-run-${courseRun.id}-start-date`}
                       className="course-runs-item__date course-runs-item__date--start"
                     >
+                      <span className="offscreen">
+                        <FormattedMessage {...sectionMessages.start} />
+                      </span>
                       {formatDate(courseRun.start)}
                     </em>
                     <span className="course-runs-item__date-separator" />
@@ -154,6 +157,9 @@ const EnrollableCourseRunList = ({ courseRuns, order }: Props) => {
                       data-testid={`course-run-${courseRun.id}-end-date`}
                       className="course-runs-item__date course-runs-item__date--end"
                     >
+                      <span className="offscreen">
+                        <FormattedMessage {...sectionMessages.end} />
+                      </span>
                       {formatDate(courseRun.end)}
                     </em>
                   </strong>

--- a/src/frontend/js/components/CourseProductCourseRuns/EnrolledCourseRun.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/EnrolledCourseRun.tsx
@@ -5,7 +5,7 @@ import { useCourse } from 'hooks/useCourse';
 import { useEnrollment } from 'hooks/useEnrollment';
 import type * as Joanie from 'types/Joanie';
 import useDateFormat from 'utils/useDateFormat';
-import CourseRunSection from './CourseRunSection';
+import CourseRunSection, { messages as sectionMessages } from './CourseRunSection';
 
 const messages = defineMessages({
   goToCourse: {
@@ -52,6 +52,9 @@ const EnrolledCourseRun = ({ enrollment }: Props) => {
             data-testid={`enrollment-${enrollment.id}-start-date`}
             className="course-runs-item__date course-runs-item__date--start"
           >
+            <span className="offscreen">
+              <FormattedMessage {...sectionMessages.start} />
+            </span>
             {formatDate(enrollment.start)}
           </em>
           <span className="course-runs-item__date-separator" />
@@ -59,6 +62,9 @@ const EnrolledCourseRun = ({ enrollment }: Props) => {
             data-testid={`enrollment-${enrollment.id}-end-date`}
             className="course-runs-item__date course-runs-item__date--end"
           >
+            <span className="offscreen">
+              <FormattedMessage {...sectionMessages.end} />
+            </span>
             {formatDate(enrollment.end)}
           </em>
         </li>

--- a/src/frontend/js/components/CourseProductCourseRuns/EnrolledCourseRun.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/EnrolledCourseRun.tsx
@@ -46,29 +46,35 @@ const EnrolledCourseRun = ({ enrollment }: Props) => {
 
   return (
     <CourseRunSection>
-      <ol className="course-runs-list">
-        <li className="course-runs-item course-runs-item--enrolled">
+      <div className="course-runs-list">
+        <div className="course-runs-item course-runs-item--enrolled">
+          <span
+            className="offscreen"
+            data-testid={`enrollment-${enrollment.id}-offscreen-start-date`}
+          >
+            <FormattedMessage {...sectionMessages.start} />
+          </span>
           <em
             data-testid={`enrollment-${enrollment.id}-start-date`}
             className="course-runs-item__date course-runs-item__date--start"
           >
-            <span className="offscreen">
-              <FormattedMessage {...sectionMessages.start} />
-            </span>
             {formatDate(enrollment.start)}
           </em>
           <span className="course-runs-item__date-separator" />
+          <span
+            className="offscreen"
+            data-testid={`enrollment-${enrollment.id}-offscreen-end-date`}
+          >
+            <FormattedMessage {...sectionMessages.end} />
+          </span>
           <em
             data-testid={`enrollment-${enrollment.id}-end-date`}
             className="course-runs-item__date course-runs-item__date--end"
           >
-            <span className="offscreen">
-              <FormattedMessage {...sectionMessages.end} />
-            </span>
             {formatDate(enrollment.end)}
           </em>
-        </li>
-        <li className="course-runs-item">
+        </div>
+        <div className="course-runs-item">
           <a
             href={enrollment.resource_link}
             className="course-runs-item__cta button--primary button--pill button--tiny"
@@ -86,8 +92,8 @@ const EnrolledCourseRun = ({ enrollment }: Props) => {
               <FormattedMessage {...messages.unroll} />
             )}
           </button>
-        </li>
-      </ol>
+        </div>
+      </div>
     </CourseRunSection>
   );
 };

--- a/src/frontend/js/components/CourseProductCourseRuns/_styles.scss
+++ b/src/frontend/js/components/CourseProductCourseRuns/_styles.scss
@@ -28,98 +28,98 @@
     list-style: none;
   }
 
-    .course-runs-item {
-      align-items: center;
-      color: r-theme-val(product-item, base-color);
-      display: flex;
-      padding-left: 1.5rem;
-      position: relative;
+  .course-runs-item {
+    align-items: center;
+    color: r-theme-val(product-item, base-color);
+    display: flex;
+    padding-left: 1.5rem;
+    position: relative;
 
-      &.course-runs-item--inactive {
+    &.course-runs-item--inactive {
+      display: block;
+
+      .course-runs-item__course-dates::before {
+        background-color: r-theme-val(product-item, lighter-color);
+        border-radius: 100%;
+        content: '';
         display: block;
-
-        .course-runs-item__course-dates::before {
-          background-color: r-theme-val(product-item, lighter-color);
-          border-radius: 100%;
-          content: '';
-          display: block;
-          height: 6px;
-          left: calc(-1.5rem + 6px);
-          position: absolute;
-          width: 6px;
-        }
+        height: 6px;
+        left: calc(-1.5rem + 6px);
+        position: absolute;
+        width: 6px;
       }
+    }
 
     &.course-runs-item--enrolled,
     &.form-field,
     &__feedback:not(:empty) {
-        margin-bottom: 0.5rem;
+      margin-bottom: 0.5rem;
     }
 
     &.form-field {
-        padding-left: 1.5rem;
+      padding-left: 1.5rem;
 
-        .form-field__radio-control {
-          position: absolute;
-          left: 0;
-          top: 0;
-        }
-
-        .form-field__label {
-          display: flex;
-          flex-direction: column;
-          justify-content: space-between;
-          flex: 1;
-        }
+      .form-field__radio-control {
+        position: absolute;
+        left: 0;
+        top: 0;
       }
 
-      &__course-dates {
-        align-items: center;
+      .form-field__label {
         display: flex;
-        flex: 1;
-        font-weight: normal;
+        flex-direction: column;
         justify-content: space-between;
-        position: relative;
-        width: 100%;
+        flex: 1;
+      }
+    }
+
+    &__course-dates {
+      align-items: center;
+      display: flex;
+      flex: 1;
+      font-weight: normal;
+      justify-content: space-between;
+      position: relative;
+      width: 100%;
+    }
+
+    &__date {
+      font-style: inherit;
+      z-index: 1;
+
+      &--start {
+        padding-right: 0.3125rem;
       }
 
-      &__date {
-        font-style: inherit;
-        z-index: 1;
-
-        &--start {
-          padding-right: 0.3125rem;
-        }
-
-        &--end {
-          padding-left: 0.3125rem;
-          text-align: right;
-        }
-
-        &-separator {
-          background-color: r-theme-val(product-item, lighter-color);
-          flex: 1;
-          height: $onepixel;
-        }
+      &--end {
+        padding-left: 0.3125rem;
+        text-align: right;
       }
+
+      &-separator {
+        background-color: r-theme-val(product-item, lighter-color);
+        flex: 1;
+        height: $onepixel;
+      }
+    }
 
     &__feedback,
-      &__enrollment-dates {
-        color: r-theme-val(product-item, lighter-color);
-        display: block;
-        font-size: 0.8125rem;
-        line-height: 1.4em;
-      }
+    &__enrollment-dates {
+      color: r-theme-val(product-item, lighter-color);
+      display: block;
+      font-size: 0.8125rem;
+      line-height: 1.4em;
+    }
 
     &__feedback {
       color: r-theme-val(product-item, feedback-color);
     }
 
-      .course-runs-item__cta {
-        padding: 0.5rem 1rem;
-        min-width: 100px;
-      }
+    .course-runs-item__cta {
+      padding: 0.5rem 1rem;
+      min-width: 100px;
     }
+  }
 
   .course-runs-item--submit {
     flex-direction: column;

--- a/src/frontend/js/components/CourseProductCourseRuns/_styles.scss
+++ b/src/frontend/js/components/CourseProductCourseRuns/_styles.scss
@@ -26,6 +26,7 @@
     @include m-o-list-group__container;
     color: r-theme-val(product-item, lighter-color);
     list-style: none;
+  }
 
     .course-runs-item {
       align-items: center;
@@ -49,8 +50,13 @@
         }
       }
 
-      &.form-field {
+    &.course-runs-item--enrolled,
+    &.form-field,
+    &__feedback:not(:empty) {
         margin-bottom: 0.5rem;
+    }
+
+    &.form-field {
         padding-left: 1.5rem;
 
         .form-field__radio-control {
@@ -97,6 +103,7 @@
         }
       }
 
+    &__feedback,
       &__enrollment-dates {
         color: r-theme-val(product-item, lighter-color);
         display: block;
@@ -104,10 +111,18 @@
         line-height: 1.4em;
       }
 
+    &__feedback {
+      color: r-theme-val(product-item, feedback-color);
+    }
+
       .course-runs-item__cta {
         padding: 0.5rem 1rem;
         min-width: 100px;
       }
     }
+
+  .course-runs-item--submit {
+    flex-direction: column;
+    align-items: baseline;
   }
 }

--- a/src/frontend/js/components/CourseProductItem/CourseRunItem.tsx
+++ b/src/frontend/js/components/CourseProductItem/CourseRunItem.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from 'react';
+import {
+  CourseRunList,
+  EnrollableCourseRunList,
+  EnrolledCourseRun,
+} from 'components/CourseProductCourseRuns';
+import { Priority } from 'types';
+import type * as Joanie from 'types/Joanie';
+
+const findEnrollment = (
+  targetCourse: Joanie.CourseProductTargetCourse,
+  order: Joanie.OrderLite,
+) => {
+  const resourceLinks = targetCourse.course_runs.map(({ resource_link }) => resource_link);
+  return order.enrollments.find(({ is_active, resource_link }) => {
+    return is_active && resourceLinks.includes(resource_link);
+  });
+};
+
+interface Props {
+  targetCourse: Joanie.CourseProductTargetCourse;
+  order?: Joanie.OrderLite;
+}
+
+const CourseRunItem = ({ targetCourse, order }: Props) => {
+  const isOwned = order !== undefined;
+  const courseRunEnrollment = isOwned ? findEnrollment(targetCourse, order) : undefined;
+  const isEnrolled = !!courseRunEnrollment?.is_active;
+  const isOpenedCourseRun = (courseRun: Joanie.CourseRun) =>
+    courseRun.state.priority <= Priority.FUTURE_NOT_YET_OPEN;
+
+  const containerRef = useRef<HTMLLIElement>(null);
+  /**
+   * we make sure that keyboard/screen reader users don't get lost when clicking
+   * the "enroll" or "unroll" buttons. Since these buttons get removed from the DOM
+   * after clicking on them, by default the browser then focuses the <body> tag.
+   * We prefer to stay in the current context and focus the new button replacing the one
+   * we just clicked.
+   */
+  useEffect(() => {
+    const observer = new MutationObserver((mutationsList) => {
+      /**
+       * when the user clicked "enroll" or "unroll", this function is called with
+       * two mutations in mutationsList: one for the removal of a CourseRunSection,
+       * one for the addition of a CourseRunSection
+       * (corresponding to the EnrollableCourseRunList and EnrolledCourseRun components).
+       *
+       * We can assume the only case where our big test passes is when the user
+       * clicked "enroll" or "unroll".
+       */
+      const justClickedCTA =
+        mutationsList.length === 2 &&
+        mutationsList[0].removedNodes.length === 1 &&
+        mutationsList[1].addedNodes.length === 1 &&
+        mutationsList.filter((m) => m.target === containerRef.current).length === 2;
+      if (justClickedCTA) {
+        containerRef.current?.querySelector<HTMLElement>('.course-runs-item__cta')?.focus();
+      }
+    });
+    if (containerRef.current) {
+      observer.observe(containerRef.current, {
+        childList: true,
+        attributes: false,
+      });
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+  return (
+    <li
+      data-testid={`course-item-${targetCourse.code}`}
+      tabIndex={-1}
+      ref={containerRef}
+      className="product-widget__item course"
+    >
+      <strong className="product-widget__item-title h5">{targetCourse.title}</strong>
+      {!isOwned && (
+        <CourseRunList courseRuns={targetCourse.course_runs.filter(isOpenedCourseRun)} />
+      )}
+      {isOwned && !isEnrolled && (
+        <EnrollableCourseRunList
+          courseRuns={targetCourse.course_runs.filter(isOpenedCourseRun)}
+          order={order}
+        />
+      )}
+      {isOwned && isEnrolled && <EnrolledCourseRun enrollment={courseRunEnrollment} />}
+    </li>
+  );
+};
+
+export default CourseRunItem;

--- a/src/frontend/js/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/components/CourseProductItem/_styles.scss
@@ -80,6 +80,7 @@
     &-title {
       font-size: 1rem;
       margin-bottom: 2px;
+      display: block;
     }
 
     &-description {

--- a/src/frontend/js/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.spec.tsx
@@ -1,4 +1,4 @@
-import { getByRole, render, screen } from '@testing-library/react';
+import { getByText, getByRole, render, screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import type { PropsWithChildren } from 'react';
 import { IntlProvider } from 'react-intl';
@@ -90,15 +90,23 @@ describe('CourseProductItem', () => {
     );
 
     screen.getByRole('heading', { level: 3, name: product.title });
-    screen.getByRole('heading', {
-      level: 6,
-      name: priceFormatter(product.price_currency, product.price),
-    });
+    // the price shouldn't be a heading to prevent misdirection for screen reader users
+    // but we want to it to visually look like a h6
+    const $price = screen.getByText(
+      // the price formatter generates non-breaking spaces and getByText doesn't seem to handle that well, replace it
+      priceFormatter(product.price_currency, product.price).replace(/\u00a0/g, ' '),
+    );
+    expect($price.tagName).toBe('STRONG');
+    expect($price.classList.contains('h6')).toBe(true);
 
     // - Render all target courses information
     product.target_courses.forEach((course) => {
       const $item = screen.getByTestId(`course-item-${course.code}`);
-      getByRole($item, 'heading', { level: 5, name: course.title });
+      // the course title shouldn't be a heading to prevent misdirection for screen reader users
+      // but we want to it to visually look like a h5
+      const $courseTitle = getByText($item, course.title);
+      expect($courseTitle.tagName).toBe('STRONG');
+      expect($courseTitle.classList.contains('h5')).toBe(true);
       screen.getByTestId(`CourseRunList-${course.course_runs.map(({ id }) => id).join('-')}`);
     });
 
@@ -136,12 +144,18 @@ describe('CourseProductItem', () => {
 
     screen.getByRole('heading', { level: 3, name: product.title });
     // - In place of product price, a label should be displayed
-    screen.getByRole('heading', { level: 6, name: 'Enrolled' });
+    const $enrolledInfo = screen.getByText('Enrolled');
+    expect($enrolledInfo.tagName).toBe('STRONG');
+    expect($enrolledInfo.classList.contains('h6')).toBe(true);
 
     // - Render all target courses information with EnrollableCourseRunList component
     product.target_courses.forEach((course) => {
       const $item = screen.getByTestId(`course-item-${course.code}`);
-      getByRole($item, 'heading', { level: 5, name: course.title });
+      // the course title shouldn't be a heading to prevent misdirection for screen reader users
+      // but we want to it to visually look like a h5
+      const $courseTitle = getByText($item, course.title);
+      expect($courseTitle.tagName).toBe('STRONG');
+      expect($courseTitle.classList.contains('h5')).toBe(true);
       screen.getByTestId(
         `EnrollableCourseRunList-${course.course_runs.map(({ id }) => id).join('-')}-${order.id}`,
       );
@@ -178,17 +192,24 @@ describe('CourseProductItem', () => {
 
     screen.getByRole('heading', { level: 3, name: product.title });
     // - In place of product price, a label should be displayed
-    screen.getByRole('heading', { level: 6, name: 'Enrolled' });
+    const $enrolledInfo = screen.getByText('Enrolled');
+    expect($enrolledInfo.tagName).toBe('STRONG');
+    expect($enrolledInfo.classList.contains('h6')).toBe(true);
 
     const [targetCourse, ...targetCourses] = product.target_courses;
     // - The first target course should display the EnrolledCourseRun component
-    screen.getByRole('heading', { level: 5, name: targetCourse.title });
+    const $courseTitle = screen.getByText(targetCourse.title);
+    expect($courseTitle.tagName).toBe('STRONG');
+    expect($courseTitle.classList.contains('h5')).toBe(true);
     screen.getByTestId(`EnrolledCourseRun-${enrollment.id}`);
 
     // - Other target courses should display EnrollableCourseRunList component
     targetCourses.forEach((course) => {
       const $item = screen.getByTestId(`course-item-${course.code}`);
-      getByRole($item, 'heading', { level: 5, name: course.title });
+      const $itemTitle = getByText($item, course.title);
+      expect($itemTitle.tagName).toBe('STRONG');
+      expect($itemTitle.classList.contains('h5')).toBe(true);
+
       screen.getByTestId(
         `EnrollableCourseRunList-${course.course_runs.map(({ id }) => id).join('-')}-${order.id}`,
       );

--- a/src/frontend/js/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.spec.tsx
@@ -1,4 +1,4 @@
-import { getByText, getByRole, render, screen } from '@testing-library/react';
+import { getByText, render, screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import type { PropsWithChildren } from 'react';
 import { IntlProvider } from 'react-intl';

--- a/src/frontend/js/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.tsx
@@ -51,7 +51,7 @@ const CourseProductItem = ({ product, order }: Props) => {
     <section className="product-widget">
       <header className="product-widget__header">
         <h3 className="product-widget__title">{product.title}</h3>
-        <h6 className="product-widget__price">
+        <strong className="product-widget__price h6">
           {isOwned ? (
             <FormattedMessage {...messages.enrolled} />
           ) : (
@@ -61,7 +61,7 @@ const CourseProductItem = ({ product, order }: Props) => {
               style="currency"
             />
           )}
-        </h6>
+        </strong>
       </header>
       <ol className="product-widget__content">
         {Children.toArray(
@@ -70,7 +70,7 @@ const CourseProductItem = ({ product, order }: Props) => {
               data-testid={`course-item-${target_course.code}`}
               className="product-widget__item course"
             >
-              <h5 className="product-widget__item-title">{target_course.title}</h5>
+              <strong className="product-widget__item-title">{target_course.title}</strong>
               {!isOwned && (
                 <CourseRunList courseRuns={target_course.course_runs.filter(isOpenedCourseRun)} />
               )}

--- a/src/frontend/js/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.tsx
@@ -1,14 +1,9 @@
-import { Children, useCallback } from 'react';
+import { Children } from 'react';
 import { defineMessages, FormattedMessage, FormattedNumber } from 'react-intl';
 import CertificateItem from 'components/CourseProductCertificateItem';
-import {
-  CourseRunList,
-  EnrollableCourseRunList,
-  EnrolledCourseRun,
-} from 'components/CourseProductCourseRuns';
 import SaleTunnel from 'components/SaleTunnel';
-import { Priority } from 'types';
 import type * as Joanie from 'types/Joanie';
+import CourseRunItem from './CourseRunItem';
 
 const messages = defineMessages({
   enrolled: {
@@ -25,27 +20,6 @@ export interface Props {
 
 const CourseProductItem = ({ product, order }: Props) => {
   const isOwned = order !== undefined;
-
-  const isOpenedCourseRun = (courseRun: Joanie.CourseRun) =>
-    courseRun.state.priority <= Priority.FUTURE_NOT_YET_OPEN;
-
-  const getCourseRunEnrollment = useCallback(
-    (targetCourse: Joanie.CourseProductTargetCourse) => {
-      if (!isOwned) return undefined;
-
-      const resourceLinks = targetCourse.course_runs.map(({ resource_link }) => resource_link);
-      return order.enrollments.find(({ is_active, resource_link }) => {
-        return is_active && resourceLinks.includes(resource_link);
-      });
-    },
-    [order],
-  );
-
-  const isEnrolled = useCallback(
-    (targetCourse: Joanie.CourseProductTargetCourse) =>
-      !!getCourseRunEnrollment(targetCourse)?.is_active,
-    [getCourseRunEnrollment],
-  );
 
   return (
     <section className="product-widget">
@@ -66,24 +40,7 @@ const CourseProductItem = ({ product, order }: Props) => {
       <ol className="product-widget__content">
         {Children.toArray(
           product.target_courses.map((target_course) => (
-            <li
-              data-testid={`course-item-${target_course.code}`}
-              className="product-widget__item course"
-            >
-              <strong className="product-widget__item-title">{target_course.title}</strong>
-              {!isOwned && (
-                <CourseRunList courseRuns={target_course.course_runs.filter(isOpenedCourseRun)} />
-              )}
-              {isOwned && !isEnrolled(target_course) && (
-                <EnrollableCourseRunList
-                  courseRuns={target_course.course_runs.filter(isOpenedCourseRun)}
-                  order={order}
-                />
-              )}
-              {isOwned && isEnrolled(target_course) && (
-                <EnrolledCourseRun enrollment={getCourseRunEnrollment(target_course)!} />
-              )}
-            </li>
+            <CourseRunItem targetCourse={target_course} order={order} />
           )),
         )}
         {product.certificate && <CertificateItem certificate={product.certificate} order={order} />}

--- a/src/frontend/js/components/CourseProductsList/index.spec.tsx
+++ b/src/frontend/js/components/CourseProductsList/index.spec.tsx
@@ -26,10 +26,10 @@ jest.mock('utils/context', () => ({
 jest.mock('components/CourseProductItem', () => ({
   __esModule: true,
   default: ({ product, order }: CourseProductItemProps) => (
-    <>
-      <h2>{product.title}</h2>
-      {order && <h3>{order.id}</h3>}
-    </>
+    <section data-testid="product-widget">
+      <h3>{product.title}</h3>
+      {order && <strong data-testid="product-widget__price">Enrolled</strong>}
+    </section>
   ),
 }));
 
@@ -111,6 +111,10 @@ describe('CourseProductsList', () => {
       </Wrapper>,
     );
 
+    // it should render a visually hidden heading for screen reader users
+    const $offscreenTitle = screen.getByRole('heading', { name: 'Products' });
+    expect($offscreenTitle.classList.contains('offscreen')).toBe(true);
+
     // - A loader should be displayed while couse information are fetching
     screen.getByRole('status', { name: 'Loading course information...' });
 
@@ -119,11 +123,8 @@ describe('CourseProductsList', () => {
     });
 
     // - It should render one <CourseProductItem /> per product
-    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(course.products.length);
-
+    expect(screen.queryAllByTestId('product-widget')).toHaveLength(course.products.length);
     // - It should also pass order information if user owns a product
-    const $orders = screen.getAllByRole('heading', { level: 3 });
-    expect($orders).toHaveLength(1);
-    screen.getByRole('heading', { level: 3, name: course.orders![0].id });
+    expect(screen.queryAllByTestId('product-widget__price')).toHaveLength(1);
   });
 });

--- a/src/frontend/js/components/CourseProductsList/index.tsx
+++ b/src/frontend/js/components/CourseProductsList/index.tsx
@@ -13,6 +13,11 @@ export const messages = defineMessages({
       'Accessible text for the initial loading spinner displayed when course is fetching',
     id: 'components.CourseProductsList.loadingInitial',
   },
+  title: {
+    defaultMessage: 'Products',
+    description: 'Course products list title (screen readers only)',
+    id: 'components.CourseProductsList.title',
+  },
 });
 
 interface Props {
@@ -29,11 +34,14 @@ const CourseProductsList = ({ code }: Props) => {
   // - useCourse hook is fetching data
   if (course.states.fetching) {
     return (
-      <Spinner aria-labelledby="loading-course">
-        <span id="loading-course">
-          <FormattedMessage {...messages.loading} />
-        </span>
-      </Spinner>
+      <div>
+        <OffscreenTitle />
+        <Spinner aria-labelledby="loading-course">
+          <span id="loading-course">
+            <FormattedMessage {...messages.loading} />
+          </span>
+        </Spinner>
+      </div>
     );
   }
 
@@ -42,6 +50,7 @@ const CourseProductsList = ({ code }: Props) => {
 
   return (
     <CourseCodeProvider code={code}>
+      <OffscreenTitle />
       {Children.toArray(
         course.item!.products.map((product) => (
           <CourseProductItem product={product} order={getProductOrder(product.id)} />
@@ -50,5 +59,11 @@ const CourseProductsList = ({ code }: Props) => {
     </CourseCodeProvider>
   );
 };
+
+const OffscreenTitle = () => (
+  <h2 className="offscreen">
+    <FormattedMessage {...messages.title} />
+  </h2>
+);
 
 export default CourseProductsList;

--- a/src/frontend/js/components/Form/Inputs.tsx
+++ b/src/frontend/js/components/Form/Inputs.tsx
@@ -10,7 +10,7 @@ import { forwardRef, type ReactNode, useMemo } from 'react';
  */
 
 interface FieldProps {
-  id?: string;
+  inputId?: string;
   error?: Boolean;
   message?: ReactNode | string;
   fieldClasses?: string[];
@@ -19,7 +19,7 @@ interface FieldProps {
 // - Field
 const Field = ({
   fieldClasses = [],
-  id,
+  inputId,
   error,
   message,
   children,
@@ -38,7 +38,7 @@ const Field = ({
     <p className={classList}>
       <span className="form-field__box">{children}</span>
       {message && (
-        <span className="form-field__message" {...(!!id && { id: `${id}-message` })}>
+        <span className="form-field__message" {...(!!inputId && { id: `${inputId}-message` })}>
           <svg aria-hidden={true} className="form-field__message__icon">
             <use href={iconHref} />
           </svg>
@@ -79,7 +79,7 @@ interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputElement>, Fi
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   ({ fieldClasses = [], label, id, type = 'text', error, message, ...props }, ref) => (
-    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
+    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
       <input
         className="form-field__input"
         id={id}
@@ -117,7 +117,7 @@ interface TextareaFieldProps extends React.TextareaHTMLAttributes<HTMLTextAreaEl
  */
 export const TextareaField = forwardRef<HTMLTextAreaElement, TextareaFieldProps>(
   ({ fieldClasses = [], error, message, label, id, ...props }, ref) => (
-    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
+    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
       <textarea
         className="form-field__textarea"
         id={id}
@@ -155,7 +155,7 @@ interface SelectFieldProps extends React.SelectHTMLAttributes<HTMLSelectElement>
  */
 export const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
   ({ fieldClasses = [], error, message, label, id, children, ...props }, ref) => (
-    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
+    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
       {label && (
         <label className="form-field__label" htmlFor={id}>
           {label}
@@ -196,7 +196,7 @@ interface CheckboxFieldProps extends Omit<TextFieldProps, 'type'> {
  */
 export const CheckboxField = forwardRef<HTMLInputElement, CheckboxFieldProps>(
   ({ fieldClasses = [], error, message, label, id, ...props }, ref) => (
-    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
+    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
       <input
         className="form-field__checkbox-input"
         id={id}
@@ -233,7 +233,7 @@ interface RadioFieldProps extends CheckboxFieldProps {}
  */
 export const RadioField = forwardRef<HTMLInputElement, RadioFieldProps>(
   ({ fieldClasses = [], error, label, message, id, onClick, ...props }, ref) => (
-    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
+    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
       <input
         className="form-field__radio-input"
         id={id}

--- a/src/frontend/js/components/Form/Inputs.tsx
+++ b/src/frontend/js/components/Form/Inputs.tsx
@@ -10,6 +10,7 @@ import { forwardRef, type ReactNode, useMemo } from 'react';
  */
 
 interface FieldProps {
+  id?: string;
   error?: Boolean;
   message?: ReactNode | string;
   fieldClasses?: string[];
@@ -18,6 +19,7 @@ interface FieldProps {
 // - Field
 const Field = ({
   fieldClasses = [],
+  id,
   error,
   message,
   children,
@@ -36,8 +38,8 @@ const Field = ({
     <p className={classList}>
       <span className="form-field__box">{children}</span>
       {message && (
-        <span className="form-field__message">
-          <svg className="form-field__message__icon">
+        <span className="form-field__message" {...(!!id && { id: `${id}-message` })}>
+          <svg aria-hidden={true} className="form-field__message__icon">
             <use href={iconHref} />
           </svg>
           {message}
@@ -77,15 +79,17 @@ interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputElement>, Fi
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   ({ fieldClasses = [], label, id, type = 'text', error, message, ...props }, ref) => (
-    <Field error={error} message={message} fieldClasses={fieldClasses}>
+    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
       <input
-        aria-label={label}
         className="form-field__input"
         id={id}
         placeholder={label}
         ref={ref}
         type={type}
         {...props}
+        {...(!!message && {
+          'aria-describedby': `${id}-message`,
+        })}
       />
       {label && (
         <label className="form-field__label" htmlFor={id}>
@@ -113,14 +117,16 @@ interface TextareaFieldProps extends React.TextareaHTMLAttributes<HTMLTextAreaEl
  */
 export const TextareaField = forwardRef<HTMLTextAreaElement, TextareaFieldProps>(
   ({ fieldClasses = [], error, message, label, id, ...props }, ref) => (
-    <Field error={error} message={message} fieldClasses={fieldClasses}>
+    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
       <textarea
-        aria-label={label}
         className="form-field__textarea"
         id={id}
         placeholder={label}
         ref={ref}
         {...props}
+        {...(!!message && {
+          'aria-describedby': `${id}-message`,
+        })}
       />
       {label && (
         <label className="form-field__label" htmlFor={id}>
@@ -149,7 +155,7 @@ interface SelectFieldProps extends React.SelectHTMLAttributes<HTMLSelectElement>
  */
 export const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
   ({ fieldClasses = [], error, message, label, id, children, ...props }, ref) => (
-    <Field error={error} message={message} fieldClasses={fieldClasses}>
+    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
       {label && (
         <label className="form-field__label" htmlFor={id}>
           {label}
@@ -157,11 +163,13 @@ export const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
       )}
       <span className="form-field__select-container">
         <select
-          aria-label={label}
           className="form-field__select-input"
           id={id}
           ref={ref}
           {...props}
+          {...(!!message && {
+            'aria-describedby': `${id}-message`,
+          })}
         >
           {children}
         </select>
@@ -188,14 +196,16 @@ interface CheckboxFieldProps extends Omit<TextFieldProps, 'type'> {
  */
 export const CheckboxField = forwardRef<HTMLInputElement, CheckboxFieldProps>(
   ({ fieldClasses = [], error, message, label, id, ...props }, ref) => (
-    <Field error={error} message={message} fieldClasses={fieldClasses}>
+    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
       <input
-        aria-label={label}
         className="form-field__checkbox-input"
         id={id}
         ref={ref}
         type="checkbox"
         {...props}
+        {...(!!message && {
+          'aria-describedby': `${id}-message`,
+        })}
       />
       <label className="form-field__label" htmlFor={id}>
         <span className="form-field__checkbox-control" aria-hidden={true}>
@@ -223,14 +233,16 @@ interface RadioFieldProps extends CheckboxFieldProps {}
  */
 export const RadioField = forwardRef<HTMLInputElement, RadioFieldProps>(
   ({ fieldClasses = [], error, label, message, id, onClick, ...props }, ref) => (
-    <Field error={error} message={message} fieldClasses={fieldClasses}>
+    <Field id={id} error={error} message={message} fieldClasses={fieldClasses}>
       <input
-        aria-label={label}
         className="form-field__radio-input"
         id={id}
         ref={ref}
         type="radio"
         {...props}
+        {...(!!message && {
+          'aria-describedby': `${id}-message`,
+        })}
       />
       <label className="form-field__label" htmlFor={id}>
         <span className="form-field__radio-control" aria-hidden={true} />

--- a/src/frontend/js/components/Form/index.spec.tsx
+++ b/src/frontend/js/components/Form/index.spec.tsx
@@ -20,6 +20,12 @@ describe('Field', () => {
 
     const $fieldMessageIcon = $fieldMessage!.querySelector('svg use');
     expect($fieldMessageIcon?.getAttribute('href')).toEqual('#icon-info-rounded');
+
+    // the message should be tied to the input (for screen reader users)
+    expect($fieldMessage!.id).not.toBe('');
+    expect(container.querySelector('.form-field__input')?.getAttribute('aria-describedby')).toEqual(
+      $fieldMessage!.id,
+    );
   });
 
   it('applies error class modifier when error is true', () => {

--- a/src/frontend/js/components/PaymentButton/index.spec.tsx
+++ b/src/frontend/js/components/PaymentButton/index.spec.tsx
@@ -66,7 +66,7 @@ describe('PaymentButton', () => {
     jest.resetAllMocks();
   });
 
-  it('should render a payment button', () => {
+  it('should render a payment button', async () => {
     const product: Joanie.Product = ProductFactory.generate();
 
     render(
@@ -79,8 +79,16 @@ describe('PaymentButton', () => {
       name: `Pay ${formatPrice(product.price, product.price_currency)}`,
     }) as HTMLButtonElement;
 
-    // As a billing address is missing, button should be disabled
-    expect($button.disabled).toBe(true);
+    // a billing address is missing, but the button stays enabled
+    // this allows the user to get feedback on what's missing to make the payment by clicking on the button
+    expect($button.disabled).toBe(false);
+
+    // clicking the button should show an error and focus it so that screen reader users know what's happening
+    await act(async () => {
+      fireEvent.click($button);
+    });
+    const $error = screen.getByText('You must have a billing address.');
+    expect(document.activeElement).toBe($error);
   });
 
   it('should render a payment button with a specific label when a credit card is provided', () => {
@@ -101,8 +109,9 @@ describe('PaymentButton', () => {
       name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
     }) as HTMLButtonElement;
 
-    // As a billing address is missing, button should be disabled
-    expect($button.disabled).toBe(true);
+    // a billing address is missing, but the button stays enabled
+    // this allows the user to get feedback on what's missing to make the payment by clicking on the button
+    expect($button.disabled).toBe(false);
 
     const billingAddress: Joanie.Address = AddressFactory.generate();
 
@@ -117,7 +126,7 @@ describe('PaymentButton', () => {
       </Wrapper>,
     );
 
-    // As a billing address is given, the button should be active
+    // the button should be active
     expect($button.disabled).toBe(false);
   });
 
@@ -135,7 +144,7 @@ describe('PaymentButton', () => {
       name: `Pay ${formatPrice(product.price, product.price_currency)}`,
     }) as HTMLButtonElement;
 
-    // As a billing address is given, the button should be active
+    // the button should be active
     expect($button.disabled).toBe(false);
   });
 
@@ -172,7 +181,7 @@ describe('PaymentButton', () => {
       name: `Pay ${formatPrice(product.price, product.price_currency)}`,
     }) as HTMLButtonElement;
 
-    // - As all information are provided, payment button should not be disabled.
+    // - Payment button should not be disabled.
     expect($button.disabled).toBe(false);
 
     // - User clicks on pay button
@@ -265,7 +274,7 @@ describe('PaymentButton', () => {
       name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
     }) as HTMLButtonElement;
 
-    // - As all information are provided, payment button should not be disabled.
+    // - Payment button should not be disabled.
     expect($button.disabled).toBe(false);
 
     // - User clicks on pay button
@@ -358,7 +367,7 @@ describe('PaymentButton', () => {
       name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
     }) as HTMLButtonElement;
 
-    // - As all information are provided, payment button should not be disabled.
+    // - Payment button should not be disabled.
     expect($button.disabled).toBe(false);
 
     // - User clicks on pay button
@@ -406,8 +415,9 @@ describe('PaymentButton', () => {
       payment_id: order.payment_info.payment_id,
     });
 
-    // - An error message should be displayed
-    screen.getByText('An error occurred during payment. Please retry later.');
+    // - An error message should be displayed and focused (for screen reader users)
+    const $error = screen.getByText('An error occurred during payment. Please retry later.');
+    expect(document.activeElement).toBe($error);
   });
 
   it('should render an error message when payment failed', async () => {
@@ -473,7 +483,8 @@ describe('PaymentButton', () => {
     });
 
     // - An error message should be displayed
-    screen.getByText('An error occurred during payment. Please retry later.');
+    const $error = screen.getByText('An error occurred during payment. Please retry later.');
+    expect(document.activeElement).toBe($error);
     // - Payment interface should have been closed
     expect(screen.queryByText('Payment interface component')).toBeNull();
     // - Payment button should have been restore to its idle state

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -21,7 +21,7 @@ const StepComponent =
   ({ next }: { next: () => void }) =>
     (
       <Fragment>
-        <h1>{title}</h1>
+        <h2>{title}</h2>
         <button onClick={next}>Next</button>
       </Fragment>
     );
@@ -104,7 +104,7 @@ describe('SaleTunnel', () => {
       );
     });
 
-    screen.getByRole('button', { name: 'Login to purchase' });
+    screen.getByRole('button', { name: `Login to purchase "${product.title}"` });
   });
 
   it('shows cta to open sale tunnel when user is authenticated', async () => {

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -29,9 +29,15 @@ const messages = defineMessages({
     id: 'components.SaleTunnel.stepResume',
   },
   loginToPurchase: {
-    defaultMessage: 'Login to purchase',
+    defaultMessage: 'Login to purchase {product}',
     description: "Label displayed inside the product's CTA when user is not logged in",
     id: 'components.SaleTunnel.loginToPurchase',
+  },
+  callToActionDescription: {
+    defaultMessage: 'Purchase {product}',
+    description:
+      'Additional description announced by screen readers when focusing the call to action buying button',
+    id: 'components.SaleTunnel.callToActionDescription',
   },
 });
 
@@ -83,14 +89,26 @@ const SaleTunnel = ({ product }: SaleTunnelProps) => {
   if (!user) {
     return (
       <button className="product-item__cta" onClick={login}>
-        <FormattedMessage {...messages.loginToPurchase} />
+        <FormattedMessage
+          {...messages.loginToPurchase}
+          values={{ product: <span className="offscreen">&quot;{product.title}&quot;</span> }}
+        />
       </button>
     );
   }
 
   return (
     <Fragment>
-      <button className="product-item__cta" onClick={() => setIsOpen(true)}>
+      <button
+        className="product-item__cta"
+        onClick={() => setIsOpen(true)}
+        // so that the button is explicit on its own, we add a description that doesn't
+        // rely on the text coming from the CMS
+        // eslint-disable-next-line jsx-a11y/aria-props
+        aria-description={intl.formatMessage(messages.callToActionDescription, {
+          product: product.title,
+        })}
+      >
         {product.call_to_action}
       </button>
       <Modal

--- a/src/frontend/js/components/SaleTunnelStepPayment/_styles.scss
+++ b/src/frontend/js/components/SaleTunnelStepPayment/_styles.scss
@@ -26,6 +26,7 @@
   &__block {
     &__title {
       color: r-theme-val(steps-content, title-color);
+      font-size: $h4-font-size;
     }
   }
 

--- a/src/frontend/js/components/SaleTunnelStepPayment/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnelStepPayment/index.spec.tsx
@@ -9,12 +9,6 @@ import { Address, CreditCard } from 'types/Joanie';
 import createQueryClient from 'utils/react-query/createQueryClient';
 import { SaleTunnelStepPayment } from '.';
 
-jest.mock('components/AddressesManagement', () => ({
-  __esModule: true,
-  LOCAL_BILLING_ADDRESS_ID: 'local-billing-address',
-  default: () => <h1>Addresses Management</h1>,
-}));
-
 jest.mock('components/PaymentButton', () => ({
   __esModule: true,
   default: () => <h1>Payment Button</h1>,
@@ -130,8 +124,14 @@ describe('SaleTunnelStepPayment', () => {
       fireEvent.click($button);
     });
 
-    // - Click on the "create an address" button should mount the AddressesManagement component
-    screen.getByRole('heading', { level: 1, name: 'Addresses Management' });
+    // - Click on the "create an address" button should mount the AddressesManagement component and focus the back button
+    expect(screen.getByRole('button', { name: 'Go back' })).toEqual(document.activeElement);
+
+    // clicking the addresses back button should focus the address info zone
+    await act(async () => {
+      fireEvent.click(document.activeElement!);
+    });
+    expect(document.activeElement?.id).toBe('sale-tunnel-address-header');
   });
 
   it('should display registered addresses', async () => {
@@ -199,7 +199,7 @@ describe('SaleTunnelStepPayment', () => {
     });
 
     // - Click on the "create an address" button should mount the AddressesManagement component
-    screen.getByRole('heading', { level: 1, name: 'Addresses Management' });
+    expect(screen.getByRole('button', { name: 'Go back' })).toEqual(document.activeElement);
   });
 
   it('should not display registered credit cards section if user has no credit cards', async () => {

--- a/src/frontend/js/components/SaleTunnelStepPayment/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnelStepPayment/index.spec.tsx
@@ -82,7 +82,7 @@ describe('SaleTunnelStepPayment', () => {
     });
 
     // - It should display product information (title & price)
-    screen.getByRole('heading', { level: 5, name: 'You are about to purchase' });
+    screen.getByRole('heading', { level: 2, name: 'You are about to purchase' });
     screen.getByText(product.title, { exact: true });
     screen.getByText(formatter.format(product.price).replaceAll(' ', ' '));
   });
@@ -104,7 +104,7 @@ describe('SaleTunnelStepPayment', () => {
     });
 
     // - It should display user information
-    screen.getByRole('heading', { level: 5, name: 'Your personal information' });
+    screen.getByRole('heading', { level: 2, name: 'Your personal information' });
     screen.getByText(user.username, { exact: true });
   });
 
@@ -154,7 +154,7 @@ describe('SaleTunnelStepPayment', () => {
       );
     });
 
-    screen.getByRole('heading', { level: 6, name: 'Billing address' });
+    screen.getByRole('heading', { level: 3, name: 'Billing address' });
 
     // - A button to add an address should be displayed
     screen.getByText('Add an address', { selector: 'button' });

--- a/src/frontend/js/components/SaleTunnelStepPayment/index.tsx
+++ b/src/frontend/js/components/SaleTunnelStepPayment/index.tsx
@@ -152,9 +152,9 @@ export const SaleTunnelStepPayment = ({ product, next }: SaleTunnelStepPaymentPr
     <section className="SaleTunnelStepPayment">
       <section className="SaleTunnelStepPayment__block">
         <header className="SaleTunnelStepPayment__block__header">
-          <h5 className="SaleTunnelStepPayment__block__title">
+          <h2 className="SaleTunnelStepPayment__block__title">
             <FormattedMessage {...messages.resumeTile} />
-          </h5>
+          </h2>
         </header>
         <div className="SaleTunnelStepPayment__block--product">
           <strong className="SaleTunnelStepPayment__block--product__title">{product.title}</strong>
@@ -169,9 +169,9 @@ export const SaleTunnelStepPayment = ({ product, next }: SaleTunnelStepPaymentPr
       </section>
       <section className="SaleTunnelStepPayment__block">
         <header className="SaleTunnelStepPayment__block__header">
-          <h5 className="SaleTunnelStepPayment__block__title">
+          <h2 className="SaleTunnelStepPayment__block__title">
             <FormattedMessage {...messages.userTile} />
-          </h5>
+          </h2>
         </header>
         <div className="SaleTunnelStepPayment__block--buyer">
           <strong className="h6 SaleTunnelStepPayment__block--buyer__name">
@@ -181,9 +181,9 @@ export const SaleTunnelStepPayment = ({ product, next }: SaleTunnelStepPaymentPr
             <p className="SaleTunnelStepPayment__block--buyer__email">{user.email}</p>
           ) : null}
           <header className="SaleTunnelStepPayment__block--buyer__address-header">
-            <h6>
+            <h3 className="SaleTunnelStepPayment__block--buyer__address-title">
               <FormattedMessage {...messages.userBillingAddressFieldset} />
-            </h6>
+            </h3>
             {addressesItems.length > 0 && (
               <button
                 className="button button--tiny button--pill button-sale--secondary"

--- a/src/frontend/js/components/SaleTunnelStepPayment/index.tsx
+++ b/src/frontend/js/components/SaleTunnelStepPayment/index.tsx
@@ -137,13 +137,12 @@ export const SaleTunnelStepPayment = ({ product, next }: SaleTunnelStepPaymentPr
     }
   };
 
-  const addressToggleRef = useRef<HTMLButtonElement>(null);
   const addressRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (showAddressCreationForm) {
       addressRef.current?.querySelector<HTMLElement>('.AddressesManagement__closeButton')?.focus();
     } else {
-      addressToggleRef.current?.focus();
+      document.querySelector<HTMLElement>('#sale-tunnel-address-header')?.focus();
     }
   }, [showAddressCreationForm]);
 
@@ -193,8 +192,12 @@ export const SaleTunnelStepPayment = ({ product, next }: SaleTunnelStepPaymentPr
           {user.email ? (
             <p className="SaleTunnelStepPayment__block--buyer__email">{user.email}</p>
           ) : null}
-          <header className="SaleTunnelStepPayment__block--buyer__address-header">
-            <h3 className="SaleTunnelStepPayment__block--buyer__address-title">
+          <header
+            tabIndex={-1}
+            id="sale-tunnel-address-header"
+            className="SaleTunnelStepPayment__block--buyer__address-header"
+          >
+            <h3 className="h6">
               <FormattedMessage {...messages.userBillingAddressFieldset} />
             </h3>
             {addressesItems.length > 0 && (
@@ -245,7 +248,6 @@ export const SaleTunnelStepPayment = ({ product, next }: SaleTunnelStepPaymentPr
                 </em>
               </p>
               <button
-                ref={addressToggleRef}
                 className="button button--tiny button--pill button-sale--primary"
                 onClick={() => setShowAddressCreationForm(true)}
               >

--- a/src/frontend/js/components/SaleTunnelStepPayment/index.tsx
+++ b/src/frontend/js/components/SaleTunnelStepPayment/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
 import AddressesManagement, { LOCAL_BILLING_ADDRESS_ID } from 'components/AddressesManagement';
 import { SelectField } from 'components/Form';
@@ -137,10 +137,23 @@ export const SaleTunnelStepPayment = ({ product, next }: SaleTunnelStepPaymentPr
     }
   };
 
+  const addressToggleRef = useRef<HTMLButtonElement>(null);
+  const addressRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (showAddressCreationForm) {
+      addressRef.current?.querySelector<HTMLElement>('.AddressesManagement__closeButton')?.focus();
+    } else {
+      addressToggleRef.current?.focus();
+    }
+  }, [showAddressCreationForm]);
+
   if (showAddressCreationForm) {
     return (
       <AddressesManagement
-        handleClose={() => setShowAddressCreationForm(false)}
+        ref={addressRef}
+        handleClose={() => {
+          setShowAddressCreationForm(false);
+        }}
         selectAddress={setAddress}
       />
     );
@@ -232,7 +245,7 @@ export const SaleTunnelStepPayment = ({ product, next }: SaleTunnelStepPaymentPr
                 </em>
               </p>
               <button
-                aria-hidden="true"
+                ref={addressToggleRef}
                 className="button button--tiny button--pill button-sale--primary"
                 onClick={() => setShowAddressCreationForm(true)}
               >

--- a/src/frontend/js/components/SaleTunnelStepValidation/_styles.scss
+++ b/src/frontend/js/components/SaleTunnelStepValidation/_styles.scss
@@ -83,6 +83,7 @@
     &__title {
       color: r-theme-val(steps-content, title-color);
       margin-bottom: 0.5rem;
+      font-size: $h4-font-size;
     }
 
     &__content {

--- a/src/frontend/js/components/SaleTunnelStepValidation/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnelStepValidation/index.spec.tsx
@@ -26,7 +26,7 @@ describe('SaleTunnelStepValidation', () => {
       style: 'currency',
     });
 
-    screen.getByRole('heading', { level: 3, name: product.title });
+    screen.getByRole('heading', { level: 2, name: product.title });
     screen.getByText(`${formatter.format(product.price).replaceAll(' ', ' ')} including VAT`);
 
     const courses = container.querySelectorAll('.product-detail-row--course');
@@ -35,7 +35,7 @@ describe('SaleTunnelStepValidation', () => {
       const courseItem = product.target_courses[index];
       expect(
         getByRole(course as HTMLElement, 'heading', {
-          level: 4,
+          level: 3,
           name: courseItem.title,
         }),
       );
@@ -50,7 +50,7 @@ describe('SaleTunnelStepValidation', () => {
 
     const certificate = container.querySelector('.product-detail-row--certificate');
     expect(certificate).not.toBeNull();
-    expect(getByRole(container, 'heading', { level: 4, name: product.certificate.title }));
+    expect(getByRole(container, 'heading', { level: 3, name: product.certificate.title }));
 
     // Click on the button trigger the next function
     const button = screen.getByRole('button', { name: 'Proceed to payment' });

--- a/src/frontend/js/components/SaleTunnelStepValidation/index.tsx
+++ b/src/frontend/js/components/SaleTunnelStepValidation/index.tsx
@@ -28,7 +28,7 @@ export const SaleTunnelStepValidation = ({ product, next }: SaleTunnelStepValida
   return (
     <section className="SaleTunnelStepValidation">
       <header className="SaleTunnelStepValidation__header">
-        <h3 className="SaleTunnelStepValidation__title">{product.title}</h3>
+        <h2 className="SaleTunnelStepValidation__title">{product.title}</h2>
         <strong className="h4 SaleTunnelStepValidation__price">
           <FormattedNumber
             value={product.price}
@@ -50,7 +50,7 @@ export const SaleTunnelStepValidation = ({ product, next }: SaleTunnelStepValida
                 <use href="#icon-check" />
               </svg>
             </span>
-            <h4 className="product-detail-row__title">{course.title}</h4>
+            <h3 className="product-detail-row__title">{course.title}</h3>
             <CourseRunsList courseRuns={course.course_runs.filter(isOpenedCourseRun)} />
           </li>
         ))}
@@ -61,7 +61,7 @@ export const SaleTunnelStepValidation = ({ product, next }: SaleTunnelStepValida
                 <use href="#icon-certificate" />
               </svg>
             </span>
-            <h4 className="product-detail-row__title">{product.certificate.title}</h4>
+            <h3 className="product-detail-row__title">{product.certificate.title}</h3>
             {product.certificate.description ? (
               <p className="product-detail-row__content">{product.certificate.description}</p>
             ) : null}

--- a/src/frontend/js/components/StepBreadcrumb/index.spec.tsx
+++ b/src/frontend/js/components/StepBreadcrumb/index.spec.tsx
@@ -1,11 +1,4 @@
-import {
-  act,
-  getAllByRole,
-  getByText,
-  queryAllByTestId,
-  render,
-  screen,
-} from '@testing-library/react';
+import { act, getAllByRole, getByText, queryAllByTestId, render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { IntlProvider } from 'react-intl';
 import { type Manifest, useStepManager } from 'hooks/useStepManager';
@@ -58,6 +51,7 @@ describe('StepBreadcrumb', () => {
     });
     expect(activeSteps).toHaveLength(1);
     expect(currentStep).toHaveTextContent('1');
+    expect(currentStep).toHaveAttribute('tabindex', '-1');
 
     act(() => result.current.next());
     rerender(
@@ -124,6 +118,8 @@ describe('StepBreadcrumb', () => {
     // there should be hidden text that make things more explicit for screen reader users
     expect(currentStepLabel?.querySelector('.offscreen')).toHaveTextContent('Step 1 of 2 (active)');
     expect(nextStepLabel?.querySelector('.offscreen')).toHaveTextContent('Step 2 of 2');
+    // the current step should be programmatically focusable
+    expect(currentStep).toHaveAttribute('tabindex', '-1');
     const separator = container.querySelectorAll('li.StepBreadcrumb__separator');
     let activeSeparator = container.querySelector(
       'li.StepBreadcrumb__separator.StepBreadcrumb__separator--active',

--- a/src/frontend/js/components/StepBreadcrumb/index.spec.tsx
+++ b/src/frontend/js/components/StepBreadcrumb/index.spec.tsx
@@ -1,9 +1,21 @@
-import { act, getAllByRole, getByText, queryAllByTestId, render } from '@testing-library/react';
+import {
+  act,
+  getAllByRole,
+  getByText,
+  queryAllByTestId,
+  render,
+  screen,
+} from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
+import { IntlProvider } from 'react-intl';
 import { type Manifest, useStepManager } from 'hooks/useStepManager';
 import { StepBreadcrumb } from '.';
 
 describe('StepBreadcrumb', () => {
+  const Wrapper = ({ children }: React.PropsWithChildren<{}>) => (
+    <IntlProvider locale="en">{children}</IntlProvider>
+  );
+
   it('renders visually a minimal manifest', () => {
     // If manifest's steps does not have `label` and `icon` property,
     // only a breadcrumb with the step index is displayed.
@@ -23,7 +35,9 @@ describe('StepBreadcrumb', () => {
 
     const { result } = renderHook(() => useStepManager(manifest));
     const { container, rerender } = render(
-      <StepBreadcrumb manifest={manifest} step={result.current.step} />,
+      <Wrapper>
+        <StepBreadcrumb manifest={manifest} step={result.current.step} />
+      </Wrapper>,
     );
 
     expect(getAllByRole(container, 'listitem')).toHaveLength(2);
@@ -46,7 +60,11 @@ describe('StepBreadcrumb', () => {
     expect(currentStep).toHaveTextContent('1');
 
     act(() => result.current.next());
-    rerender(<StepBreadcrumb manifest={manifest} step={result.current.step} />);
+    rerender(
+      <Wrapper>
+        <StepBreadcrumb manifest={manifest} step={result.current.step} />
+      </Wrapper>,
+    );
 
     activeSteps = container.querySelectorAll(
       'li.StepBreadcrumb__step.StepBreadcrumb__step--active',
@@ -79,7 +97,9 @@ describe('StepBreadcrumb', () => {
 
     const { result } = renderHook(() => useStepManager(manifest));
     const { container, rerender } = render(
-      <StepBreadcrumb manifest={manifest} step={result.current.step} />,
+      <Wrapper>
+        <StepBreadcrumb manifest={manifest} step={result.current.step} />
+      </Wrapper>,
     );
 
     expect(getAllByRole(container, 'listitem')).toHaveLength(2);
@@ -92,8 +112,8 @@ describe('StepBreadcrumb', () => {
       'li.StepBreadcrumb__step.StepBreadcrumb__step--current',
     );
 
-    getByText(container, '0. Step', { exact: true });
-    getByText(container, '1. Step', { exact: true });
+    const currentStepLabel = getByText(container, '0. Step', { exact: true });
+    const nextStepLabel = getByText(container, '1. Step', { exact: true });
 
     expect(stepsIcons).toHaveLength(2);
     stepsIcons.forEach((icon) => {
@@ -101,7 +121,9 @@ describe('StepBreadcrumb', () => {
     });
     expect(activeSteps).toHaveLength(1);
     expect(currentStep).toHaveTextContent('0. Step');
-
+    // there should be hidden text that make things more explicit for screen reader users
+    expect(currentStepLabel?.querySelector('.offscreen')).toHaveTextContent('Step 1 of 2 (active)');
+    expect(nextStepLabel?.querySelector('.offscreen')).toHaveTextContent('Step 2 of 2');
     const separator = container.querySelectorAll('li.StepBreadcrumb__separator');
     let activeSeparator = container.querySelector(
       'li.StepBreadcrumb__separator.StepBreadcrumb__separator--active',
@@ -110,7 +132,11 @@ describe('StepBreadcrumb', () => {
     expect(activeSeparator).toBeNull();
 
     act(() => result.current.next());
-    rerender(<StepBreadcrumb manifest={manifest} step={result.current.step} />);
+    rerender(
+      <Wrapper>
+        <StepBreadcrumb manifest={manifest} step={result.current.step} />
+      </Wrapper>,
+    );
 
     activeSteps = container.querySelectorAll(
       'li.StepBreadcrumb__step.StepBreadcrumb__step--active',
@@ -141,7 +167,11 @@ describe('StepBreadcrumb', () => {
     };
 
     const { result } = renderHook(() => useStepManager(manifest));
-    const { container } = render(<StepBreadcrumb manifest={manifest} step={result.current.step} />);
+    const { container } = render(
+      <Wrapper>
+        <StepBreadcrumb manifest={manifest} step={result.current.step} />
+      </Wrapper>,
+    );
 
     expect(getAllByRole(container, 'listitem')).toHaveLength(2);
 
@@ -171,7 +201,11 @@ describe('StepBreadcrumb', () => {
     };
 
     const { result } = renderHook(() => useStepManager(manifest));
-    const { container } = render(<StepBreadcrumb manifest={manifest} step={result.current.step} />);
+    const { container } = render(
+      <Wrapper>
+        <StepBreadcrumb manifest={manifest} step={result.current.step} />
+      </Wrapper>,
+    );
 
     expect(getAllByRole(container, 'listitem')).toHaveLength(2);
 

--- a/src/frontend/js/components/StepBreadcrumb/index.tsx
+++ b/src/frontend/js/components/StepBreadcrumb/index.tsx
@@ -94,6 +94,7 @@ export const StepBreadcrumb = <Keys extends PropertyKey, LastKey extends Keys>({
             <li
               aria-current={index === activeIndex ? 'step' : 'false'}
               className={getStepClassName(index)}
+              tabIndex={index === activeIndex ? -1 : undefined}
             >
               <div className="StepBreadcrumb__step__icon" data-testid="StepBreadcrumb__step__icon">
                 {entry.icon ? <Icon name={entry.icon} /> : <span>{index + 1}</span>}

--- a/src/frontend/js/components/StepBreadcrumb/index.tsx
+++ b/src/frontend/js/components/StepBreadcrumb/index.tsx
@@ -2,6 +2,7 @@
 // Within a step process, it aims to guide the user to know where he/she is in
 // the current process by translating visually the steps manifest.
 import { Children, Fragment, useCallback } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { Nullable } from 'types/utils';
 import { Manifest, Step, useStepManager } from 'hooks/useStepManager';
 import { Icon } from 'components/Icon';
@@ -46,6 +47,15 @@ function sortSteps<Keys extends PropertyKey, LastKey extends Keys>(
 
   return steps;
 }
+
+const messages = defineMessages({
+  stepCount: {
+    defaultMessage:
+      'Step {current, number} of {total, number} {active, select, true {(active)} other {}}',
+    description: 'Info about current step, not visible, only announced by screen readers',
+    id: 'components.StepBreadcrumb.stepCount',
+  },
+});
 
 export const StepBreadcrumb = <Keys extends PropertyKey, LastKey extends Keys>({
   step,
@@ -94,6 +104,18 @@ export const StepBreadcrumb = <Keys extends PropertyKey, LastKey extends Keys>({
                   data-testid="StepBreadcrumb__step__label"
                 >
                   {entry.label}
+                  <span className="offscreen">
+                    {/* we repeat the "active" info in the hidden SR message because not all screen
+                    readers support the aria-current="step" attribute */}
+                    <FormattedMessage
+                      {...messages.stepCount}
+                      values={{
+                        current: index + 1,
+                        total: orderedSteps.length,
+                        active: index === activeIndex,
+                      }}
+                    />
+                  </span>
                 </strong>
               ) : null}
             </li>

--- a/src/frontend/scss/colors/_theme.scss
+++ b/src/frontend/scss/colors/_theme.scss
@@ -374,6 +374,7 @@ $r-theme: (
     lighter-color: r-color('battleship-grey'),
     button-color: r-color('white'),
     button-background: r-color('firebrick6'),
+    feedback-color: r-color('indianred3'),
   ),
   program-detail: (
     cover-empty-background: r-color('smoke'),

--- a/src/frontend/scss/colors/_theme.scss
+++ b/src/frontend/scss/colors/_theme.scss
@@ -237,6 +237,7 @@ $r-theme: (
     input-disabled-background: r-color('grey87'),
     input-hover-color: r-color('grey59'),
     message-color: r-color('grey32'),
+    required-note-color: r-color('indianred3'),
   ),
   organization-glimpse-list: (
     empty-color: r-color('slate-grey'),

--- a/src/frontend/scss/objects/_form.scss
+++ b/src/frontend/scss/objects/_form.scss
@@ -360,4 +360,11 @@
       }
     }
   }
+
+  &__required-fields-note {
+    font-style: italic;
+    span {
+      color: r-theme-val(form, required-note-color);
+    }
+  }
 }


### PR DESCRIPTION
## Purpose

Make sure keyboard and screen reader users can navigate through a course product widget and its sale tunnel.

## Proposal

There are a few tricky stuff to get right here:

- make sure things announced by screen readers are in correct order
- make sure things announced are explicit enough without having to navigate around items to understand the context
- make sure navigation between steps is handled correctly
- make sure navigation between payment info/address creation is handled correctly
- make sure the address form is accessible

Opening this early for the curious @jbpenrath @sandroscosta.

I'm currently on step 2, on the address form. Didn't get a chance to check the last step, and the product widget after the user bought it. Also didn't update the tests for now.
