### PR TITLE
🐛(elasticsearch) multiple elasticsearch hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix `components.SaleTunnelStepPayment.userBillingAddressNoEntry` misspell
 - Remove z-index of course glimpse icon to fix an overlay issue
 - Fix erratic frontend test failure
+- Allow to configure multiple elasticsearch hosts
 
 
 ##  [2.14.1] - 2022-04-07

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
@@ -501,8 +501,8 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     RICHIE_DEMO_FIXTURES_DIR = os.path.join(BASE_DIR, "base", "fixtures")
 
     # Elasticsearch
-    RICHIE_ES_HOST = values.Value(
-        "elasticsearch", environ_name="RICHIE_ES_HOST", environ_prefix=None
+    RICHIE_ES_HOST = values.ListValue(
+        ["elasticsearch"], environ_name="RICHIE_ES_HOST", environ_prefix=None
     )
     RICHIE_ES_INDICES_PREFIX = values.Value(
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -264,8 +264,8 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     RICHIE_COURSE_RUN_SYNC_SECRETS = values.ListValue([])
 
     # Elasticsearch
-    RICHIE_ES_HOST = values.Value(
-        "elasticsearch", environ_name="RICHIE_ES_HOST", environ_prefix=None
+    RICHIE_ES_HOST = values.ListValue(
+        ["elasticsearch"], environ_name="RICHIE_ES_HOST", environ_prefix=None
     )
     RICHIE_ES_INDICES_PREFIX = values.Value(
         default="richie", environ_name="RICHIE_ES_INDICES_PREFIX", environ_prefix=None

--- a/src/richie/apps/search/__init__.py
+++ b/src/richie/apps/search/__init__.py
@@ -10,7 +10,7 @@ from .elasticsearch import (
 default_app_config = "richie.apps.search.apps.SearchConfig"
 
 ES_CLIENT = ElasticsearchClientCompat7to6(
-    [getattr(settings, "RICHIE_ES_HOST", "elasticsearch")]
+    getattr(settings, "RICHIE_ES_HOST", ["elasticsearch"])
 )
 
 ES_INDICES_CLIENT = ElasticsearchIndicesClientCompat7to6(ES_CLIENT)

--- a/tests/apps/search/test_elasticsearch_compat_layer.py
+++ b/tests/apps/search/test_elasticsearch_compat_layer.py
@@ -62,7 +62,7 @@ class ElasticSearchCompatLayerTestCase(TestCase):
         # - Use a fresh ES client instance to be sure that __es_version__ has
         #   not been called yet
         es_client = ElasticsearchClientCompat7to6(
-            [getattr(settings, "RICHIE_ES_HOST", "elasticsearch")]
+            getattr(settings, "RICHIE_ES_HOST", ["elasticsearch"])
         )
         es_indices_client = ElasticsearchIndicesClientCompat7to6(es_client)
 


### PR DESCRIPTION
Allow to configure multiple elasticsearch hosts.

On sandbox we can try it like:
```
RICHIE_ES_HOST=elasticsearch_unexistence:9200,elasticsearch:9200
```
