### PR TITLE
✨(front) allow display-capture and autoplay in iframe LTI

### DIFF
--- a/src/frontend/js/components/LtiConsumer/index.tsx
+++ b/src/frontend/js/components/LtiConsumer/index.tsx
@@ -90,7 +90,7 @@ const LtiConsumer = ({ id }: LtiConsumerProps) => {
         name={`lti_iframe_${id}`}
         title={context.url}
         src={context.url}
-        allow="microphone *; camera *; midi *; geolocation *; encrypted-media *; fullscreen *"
+        allow="microphone *; camera *; midi *; geolocation *; encrypted-media *; fullscreen *; display-capture *; autoplay *"
         allowFullScreen
       />
     </div>


### PR DESCRIPTION
## Purpose

In the iframce LTI we must allow display-capture and autoply to all
orogin. Without it, the webinat launch with marsha will not be able to
autoplay the stream or to share the screen with jitsi.

## Proposal

- [x] allow display-capture and autoplay in iframe LTI
