### PR TITLE
💚(circleci) fix npm job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,7 +830,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/fun/.npmrc
       - run:
           name: Publish package
-          command: npm publish src/frontend
+          command: npm publish src/frontend/
 
   # ---- Documentation website jobs ----
 


### PR DESCRIPTION
## Purpose

We recently switch to new circle node images and upgrade to node 16 which has also upgraded npm to version 8.11.0. This has broken the publish command so we have to fix it.


## Proposal

- [x] Fix `npm` job
