### PR TITLE
Ci/replace deprecated images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
   # Check that the CHANGELOG has been updated in the current branch
   check-changelog:
     docker:
-      - image: circleci/buildpack-deps:stretch-scm
+      - image: cimg/base:2022.06
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -132,7 +132,7 @@ jobs:
   # Build the Docker image ready for production
   build-docker:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:2022.06
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -281,7 +281,7 @@ jobs:
           DB_PASSWORD: pass
           DB_PORT: 3306
       # services
-      - image: circleci/mysql:5.6-ram
+      - image: cimg/mysql:5.7
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -373,7 +373,7 @@ jobs:
           DB_PASSWORD: pass
           DB_PORT: 3306
       # services
-      - image: circleci/mysql:8.0-ram
+      - image: cimg/mysql:8.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -461,7 +461,7 @@ jobs:
           DB_PASSWORD: pass
           DB_PORT: 5432
       # services
-      - image: circleci/postgres:9.6-ram
+      - image: cimg/postgres:9.6
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -541,7 +541,7 @@ jobs:
           DB_PASSWORD: pass
           DB_PORT: 5432
       # services
-      - image: circleci/postgres:9.6-ram
+      - image: cimg/postgres:9.6
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@backend.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@backend.yml
@@ -73,7 +73,7 @@ test-back:
         DB_USER: richie_user
         DB_PASSWORD: pass
         DB_PORT: 5432
-    - image: circleci/postgres:9.6-alpine-ram
+    - image: cimg/postgres:9.6
       environment:
         POSTGRES_DB: richie
         POSTGRES_USER: richie_user

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@docker.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@docker.yml
@@ -7,7 +7,7 @@ hub:
     image_name:
       type: string
   docker:
-    - image: circleci/buildpack-deps:stretch
+    - image: cimg/base:2022.06
       environment:
         RICHIE_SITE: << parameters.site >>
   working_directory: ~/fun

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@project.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@project.yml
@@ -61,7 +61,7 @@ check-changelog:
     site:
       type: string
   docker:
-    - image: circleci/buildpack-deps:stretch-scm
+    - image: cimg/base:2022.06
   working_directory: ~/fun
   steps:
     - checkout
@@ -89,7 +89,7 @@ lint-changelog:
 # Check that the CHANGELOG max line length does not exceed 80 characters
 no-change:
   docker:
-    - image: circleci/buildpack-deps:stretch-scm
+    - image: cimg/base:2022.06
   working_directory: ~/fun
   steps:
     - run: echo "Everything is up-to-date ✅"

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -14,6 +14,8 @@ services:
 
   elasticsearch:
     image: fundocker/openshift-elasticsearch:6.6.2
+    environment:
+      - discovery.type=single-node
     env_file:
       - "env.d/development"
     ports:
@@ -98,18 +100,17 @@ services:
   node:
     image: node:16.15
     working_dir: /app/src/frontend
-    user: "${DOCKER_USER:-1000}"
+    user: ${DOCKER_USER:-1000}
     volumes:
       - ./sites/${RICHIE_SITE:-funmooc}:/app
 
   terraform-state:
     image: hashicorp/terraform:latest
     env_file: env.d/aws
-    user: "${DOCKER_USER:-1000}"
+    user: ${DOCKER_USER:-1000}
     working_dir: /app
     volumes:
       - ./aws/create_state_bucket:/app
-    user: ${DOCKER_USER:-1000}
 
   terraform:
     image: hashicorp/terraform:0.12.31
@@ -117,12 +118,11 @@ services:
       - TF_VAR_SITE=${RICHIE_SITE:-funmooc}
       - TF_DATA_DIR=/config
     env_file: env.d/aws
-    user: "${DOCKER_USER:-1000}"
+    user: ${DOCKER_USER:-1000}
     working_dir: /app
     volumes:
       - ./aws:/app
       - ./sites/${RICHIE_SITE:-funmooc}/aws:/config
-    user: ${DOCKER_USER:-1000}
 
   redis-sentinel:
     image: docker.io/bitnami/redis-sentinel:6.0-debian-10

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/env.d/development
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/env.d/development
@@ -7,7 +7,6 @@ DJANGO_ALLOWED_HOSTS=*
 
 # Elastic search
 RICHIE_ES_HOST=elasticsearch
-discovery.type=single-node
 
 # PostgreSQL db container configuration
 POSTGRES_DB=richie


### PR DESCRIPTION
## Purpose

`circleci/*` has been deprecated, we have to switch to new `cimg/*` images. We start the migration but it remains images to upgrade (mysql, postgresql and buildpack-deps).

## Proposal

- [x] Migrate remaining images to new `cimg/`
- [x] Fix an issue with docker compose v2
