### PR TITLE
🐛(frontend) import a missing stylesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Import the missing stylesheet of AddressesManagement component
+
 ##  [2.15.0] - 2022-06-22
 
 ### Added

--- a/src/frontend/scss/components/_index.scss
+++ b/src/frontend/scss/components/_index.scss
@@ -1,3 +1,4 @@
+@import '../../js/components/AddressesManagement/styles';
 @import '../../js/components/CourseProductCertificateItem/styles';
 @import '../../js/components/CourseProductCourseRuns/styles';
 @import '../../js/components/CourseProductItem/styles';


### PR DESCRIPTION
## Purpose

The stylesheet of the AddressesManagement component was not imported, so the
layout of this component was broken.

## Proposal

- [x] Import the missing stylesheet
