### PR TITLE
📌(backend) pin all python dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,22 +29,22 @@ include_package_data = True
 # `matchPackageNames` (in the "ignored python dependencies" group) within
 # renovate.json file at the root of this repository
 install_requires =
-    arrow
-    Django
-    djangocms-file
-    djangocms-googlemap
-    djangocms-link
-    djangocms-picture
-    djangocms-text-ckeditor
-    djangocms-video
-    djangorestframework
+    arrow==1.2.2
+    Django==3.2.15
+    djangocms-file==3.0.0
+    djangocms-googlemap==2.0.0
+    djangocms-link==3.0.0
+    djangocms-picture==4.0.0
+    djangocms-text-ckeditor==5.1.1
+    djangocms-video==3.0.0
+    djangorestframework==3.13.1
     django-autocomplete-light==3.9.4
-    django-cms>=3.9.0
-    django-parler>=2.0.1
-    django-redis>=4.11.0
-    django-treebeard
-    dj-pagination
-    easy_thumbnails[svg]>=2.8
+    django-cms==3.10.0
+    django-parler==2.3
+    django-redis==5.2.0
+    django-treebeard==4.4
+    dj-pagination==2.5.0
+    easy_thumbnails[svg]==2.8.3
     elasticsearch>=6.0.0,<7.0.0
     exrex==0.10.5
     oauthlib==3.2.0


### PR DESCRIPTION
## Purpose

In one week, Richie master branch has been corrupted twice due to unpinned dependency updates (easy thumbnails 2.8.2 then django-cms 3.11). This is unlucky but we should take action to prevent this happen again.

Currently, python dependencies was not pinned so the main branch could be corrupted if a package update introduces a breaking change. This behaviour is weird. Renovate is in charge to update those packages each week, so we are able to upgrade those package securely and regularly.


## Proposal

- [x] Pin python dependencies
