### PR TITLE
Feat/address form display error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Allow form messages to go on multiple lines
 - On the search page, improve accessibility of the filters pane when using a
   small screen
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Display error messages in `AddressForm`
+
 ### Changed
 
 - Allow form messages to go on multiple lines

--- a/src/frontend/jest/setup.ts
+++ b/src/frontend/jest/setup.ts
@@ -4,6 +4,23 @@ import '@testing-library/jest-dom/extend-expect';
 import { setLogger } from 'react-query';
 import { noop } from 'utils';
 
+/*
+ * A little trick to prevent so package to be reset when using `jest.resetModules()`.
+ * https://github.com/facebook/jest/issues/8987#issuecomment-584898030
+ */
+const RESET_MODULE_EXCEPTIONS = ['react', 'react-intl'];
+
+const mockActualRegistry: Record<PropertyKey, any> = {};
+
+RESET_MODULE_EXCEPTIONS.forEach((moduleName) => {
+  jest.doMock(moduleName, () => {
+    if (!mockActualRegistry[moduleName]) {
+      mockActualRegistry[moduleName] = jest.requireActual(moduleName);
+    }
+    return mockActualRegistry[moduleName];
+  });
+});
+
 /* Prevent log error during tests */
 setLogger({
   // eslint-disable-next-line no-console

--- a/src/frontend/js/components/AddressesManagement/AddressForm.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm.spec.tsx
@@ -1,0 +1,191 @@
+import { act } from '@testing-library/react-hooks';
+import { fireEvent, getByText, render, screen } from '@testing-library/react';
+import * as mockFactories from 'utils/test/factories';
+import { AddressFactory } from 'utils/test/factories';
+import countries from 'i18n-iso-countries';
+import { IntlProvider } from 'react-intl';
+import { Address } from 'types/Joanie';
+import { ErrorKeys } from './validationSchema';
+import AddressForm from './AddressForm';
+
+jest.mock('hooks/useAddresses', () => ({
+  useAddresses: () => ({
+    states: {
+      creating: false,
+      updating: false,
+    },
+  }),
+}));
+
+describe('AddressForm', () => {
+  const handleReset = jest.fn();
+  const onSubmit = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+  });
+
+  it('renders a button with label "Use this address" when no address is provided', () => {
+    render(
+      <IntlProvider locale="en">
+        <AddressForm handleReset={handleReset} onSubmit={onSubmit} />
+      </IntlProvider>,
+    );
+
+    screen.getByRole('button', { name: 'Use this address' });
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+  });
+
+  it('renders a button with label "Use this address" and a cancel button when no address is provided', async () => {
+    const address: Address = AddressFactory.generate();
+    render(
+      <IntlProvider locale="en">
+        <AddressForm handleReset={handleReset} onSubmit={onSubmit} address={address} />
+      </IntlProvider>,
+    );
+
+    screen.getByRole('button', { name: 'Update this address' });
+
+    const $button = screen.getByRole('button', { name: 'Cancel' });
+    await act(async () => {
+      fireEvent.click($button);
+    });
+    expect(handleReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an error message when a value in the form is invalid', async () => {
+    render(
+      <IntlProvider locale="en">
+        <AddressForm handleReset={handleReset} onSubmit={onSubmit} />
+      </IntlProvider>,
+    );
+
+    screen.getByRole('form');
+    const $titleInput = screen.getByRole('textbox', { name: 'Address title' });
+    const $firstnameInput = screen.getByRole('textbox', { name: "Recipient's first name" });
+    const $lastnameInput = screen.getByRole('textbox', { name: "Recipient's last name" });
+    const $addressInput = screen.getByRole('textbox', { name: 'Address' });
+    const $cityInput = screen.getByRole('textbox', { name: 'City' });
+    const $postcodeInput = screen.getByRole('textbox', { name: 'Postcode' });
+    const $countryInput = screen.getByRole('combobox', { name: 'Country' });
+    const $submitButton = screen.getByRole('button', {
+      name: 'Use this address',
+    }) as HTMLButtonElement;
+
+    // - Until form is not fulfill, submit button should be disabled
+    expect($submitButton.disabled).toBe(true);
+
+    // - User fulfills address fields
+    const address = mockFactories.AddressFactory.generate();
+
+    await act(async () => {
+      fireEvent.input($titleInput, { target: { value: address.title } });
+      fireEvent.change($firstnameInput, { target: { value: address.first_name } });
+      fireEvent.change($lastnameInput, { target: { value: address.last_name } });
+      fireEvent.change($addressInput, { target: { value: address.address } });
+      fireEvent.change($cityInput, { target: { value: address.city } });
+      fireEvent.change($postcodeInput, { target: { value: address.postcode } });
+      fireEvent.change($countryInput, { target: { value: address.country } });
+      // - As form validation is triggered on blur, we need to trigger this event in
+      //   order to update form state.
+      fireEvent.blur($countryInput);
+    });
+
+    // Once the form has been fulfilled properly, submit button should be enabled.
+    expect($submitButton.disabled).toBe(false);
+
+    // Before submitting, we change field values to corrupt the form data
+    await act(async () => {
+      fireEvent.input($titleInput, { target: { value: 'a' } });
+      fireEvent.input($firstnameInput, { target: { value: '' } });
+      fireEvent.change($countryInput, { target: { value: '-' } });
+      fireEvent.click($submitButton);
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    // Error messages should have been displayed.
+    // Title field should have a message saying that the value is too short.
+    getByText($titleInput.closest('.form-field')!, 'The minimum length is 2 chars.');
+    // Firstname field should have a message saying that the value is required.
+    getByText($firstnameInput.closest('.form-field')!, 'This field is required.');
+    // Country field should have a message saying that the value is not valid.
+    getByText(
+      $countryInput.closest('.form-field')!,
+      `You must select a value within: ${Object.keys(countries.getAlpha2Codes()).join(', ')}.`,
+    );
+  });
+
+  it('renders default error message when error message does not exist', async () => {
+    jest.doMock('./validationSchema', () => ({
+      __esModule: true,
+      ...jest.requireActual('./validationSchema'),
+      errorMessages: {
+        [ErrorKeys.MIXED_INVALID]: {
+          id: 'components.AddressesManagement.validationSchema.mixedInvalid',
+          defaultMessage: 'This field is invalid.',
+          description: 'Error message displayed when a field value is invalid.',
+        },
+      },
+    }));
+
+    // Import locally to get module with mocked error messages.
+    const Form = jest.requireActual('./AddressForm').default;
+
+    render(
+      <IntlProvider locale="en">
+        <Form handleReset={handleReset} onSubmit={onSubmit} />
+      </IntlProvider>,
+    );
+
+    screen.getByRole('form');
+    const $titleInput = screen.getByRole('textbox', { name: 'Address title' });
+    const $firstnameInput = screen.getByRole('textbox', { name: "Recipient's first name" });
+    const $lastnameInput = screen.getByRole('textbox', { name: "Recipient's last name" });
+    const $addressInput = screen.getByRole('textbox', { name: 'Address' });
+    const $cityInput = screen.getByRole('textbox', { name: 'City' });
+    const $postcodeInput = screen.getByRole('textbox', { name: 'Postcode' });
+    const $countryInput = screen.getByRole('combobox', { name: 'Country' });
+    const $submitButton = screen.getByRole('button', {
+      name: 'Use this address',
+    }) as HTMLButtonElement;
+
+    // - Until form is not fulfill, submit button should be disabled
+    expect($submitButton.disabled).toBe(true);
+
+    // - User fulfills address fields
+    const address = mockFactories.AddressFactory.generate();
+
+    await act(async () => {
+      fireEvent.input($titleInput, { target: { value: address.title } });
+      fireEvent.change($firstnameInput, { target: { value: address.first_name } });
+      fireEvent.change($lastnameInput, { target: { value: address.last_name } });
+      fireEvent.change($addressInput, { target: { value: address.address } });
+      fireEvent.change($cityInput, { target: { value: address.city } });
+      fireEvent.change($postcodeInput, { target: { value: address.postcode } });
+      fireEvent.change($countryInput, { target: { value: address.country } });
+      // - As form validation is triggered on blur, we need to trigger this event in
+      //   order to update form state.
+      fireEvent.blur($countryInput);
+    });
+
+    // Once the form has been fulfilled properly, submit button should be enabled.
+    expect($submitButton.disabled).toBe(false);
+
+    // Before submitting, we change field values to corrupt the form data
+    await act(async () => {
+      fireEvent.input($titleInput, { target: { value: 'a' } });
+      fireEvent.input($firstnameInput, { target: { value: '' } });
+      fireEvent.change($countryInput, { target: { value: '-' } });
+      fireEvent.click($submitButton);
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    // Default error messages should have been displayed.
+    getByText($titleInput.closest('.form-field')!, 'This field is invalid.');
+    getByText($firstnameInput.closest('.form-field')!, 'This field is invalid.');
+    getByText($countryInput.closest('.form-field')!, `This field is invalid.`);
+  });
+});

--- a/src/frontend/js/components/AddressesManagement/AddressForm.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm.tsx
@@ -7,7 +7,8 @@ import { messages } from 'components/AddressesManagement/index';
 import { CheckboxField, SelectField, TextField } from 'components/Form';
 import { useAddresses } from 'hooks/useAddresses';
 import type { Address } from 'types/Joanie';
-import validationSchema from './validationSchema';
+import { Maybe } from 'types/utils';
+import validationSchema, { ErrorKeys, errorMessages } from './validationSchema';
 
 export type AddressFormValues = Omit<Address, 'id' | 'is_main'> & { save: boolean };
 
@@ -41,6 +42,25 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
   const [languageCode] = intl.locale.split('-');
   const countryList = countries.getNames(languageCode);
 
+  const getLocalizedErrorMessage = (
+    error: Maybe<
+      | string
+      | {
+          key: ErrorKeys;
+          values: Record<PropertyKey, string | number | Array<string | number>>;
+        }
+    >,
+  ) => {
+    if (!error) return undefined;
+
+    if (typeof error === 'string' || errorMessages[error.key] === undefined) {
+      // If the error has not been translated we return a default error message.
+      return intl.formatMessage(errorMessages[ErrorKeys.MIXED_INVALID]);
+    }
+
+    return intl.formatMessage(errorMessages[error.key], error.values);
+  };
+
   /**
    * Prevent form to be submitted and clear `editedAddress` state.
    */
@@ -62,6 +82,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
         id="title"
         label={intl.formatMessage(messages.titleInputLabel)}
         error={!!formState.errors.title}
+        message={getLocalizedErrorMessage(formState.errors.title?.message)}
         {...register('title')}
       />
       <div className="form-group">
@@ -71,6 +92,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
           id="first_name"
           label={intl.formatMessage(messages.first_nameInputLabel)}
           error={!!formState.errors.first_name}
+          message={getLocalizedErrorMessage(formState.errors.first_name?.message)}
           {...register('first_name')}
         />
         <TextField
@@ -79,6 +101,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
           id="last_name"
           label={intl.formatMessage(messages.last_nameInputLabel)}
           error={!!formState.errors.last_name}
+          message={getLocalizedErrorMessage(formState.errors.last_name?.message)}
           {...register('last_name')}
         />
       </div>
@@ -88,6 +111,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
         id="address"
         label={intl.formatMessage(messages.addressInputLabel)}
         error={!!formState.errors.address}
+        message={getLocalizedErrorMessage(formState.errors.address?.message)}
         {...register('address')}
       />
       <div className="form-group">
@@ -97,6 +121,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
           id="postcode"
           label={intl.formatMessage(messages.postcodeInputLabel)}
           error={!!formState.errors.postcode}
+          message={getLocalizedErrorMessage(formState.errors.postcode?.message)}
           {...register('postcode')}
         />
         <TextField
@@ -105,6 +130,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
           id="city"
           label={intl.formatMessage(messages.cityInputLabel)}
           error={!!formState.errors.city}
+          message={getLocalizedErrorMessage(formState.errors.city?.message)}
           {...register('city')}
         />
       </div>
@@ -114,6 +140,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
         id="country"
         label={intl.formatMessage(messages.countryInputLabel)}
         error={!!formState.errors.country}
+        message={getLocalizedErrorMessage(formState.errors.country?.message)}
         {...register('country', { value: address?.country, required: true })}
       >
         <option disabled value="-">
@@ -132,6 +159,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
           id="save"
           label={intl.formatMessage(messages.saveInputLabel)}
           error={!!formState.errors?.save}
+          message={getLocalizedErrorMessage(formState.errors.save?.message)}
           {...register('save')}
         />
       ) : null}

--- a/src/frontend/js/components/AddressesManagement/index.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.spec.tsx
@@ -1,20 +1,16 @@
 /**
  * Test suite for AddressesManagement component
  */
-import { yupResolver } from '@hookform/resolvers/yup';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { act, renderHook } from '@testing-library/react-hooks';
-import faker from 'faker';
+import { act } from '@testing-library/react-hooks';
 import fetchMock from 'fetch-mock';
 import * as mockFactories from 'utils/test/factories';
 import { IntlProvider } from 'react-intl';
 import { QueryClientProvider } from 'react-query';
-import { useForm } from 'react-hook-form';
 import { SessionProvider } from 'data/SessionProvider';
 import { REACT_QUERY_SETTINGS, RICHIE_USER_TOKEN } from 'settings';
 import type * as Joanie from 'types/Joanie';
 import createQueryClient from 'utils/react-query/createQueryClient';
-import validationSchema from './validationSchema';
 import AddressesManagement from '.';
 
 jest.mock('utils/context', () => ({
@@ -30,142 +26,6 @@ jest.mock('utils/context', () => ({
 jest.mock('utils/indirection/window', () => ({
   confirm: jest.fn(() => true),
 }));
-
-describe('validationSchema', () => {
-  // Creation and Update form validation relies on a schema resolves by Yup.
-  it('should not have error if values are valid', async () => {
-    const defaultValues = {
-      address: faker.address.streetAddress(),
-      city: faker.address.city(),
-      country: faker.address.countryCode(),
-      first_name: faker.name.firstName(),
-      last_name: faker.name.lastName(),
-      postcode: faker.address.zipCode(),
-      title: faker.random.word(),
-      save: false,
-    };
-
-    const { result } = renderHook(() =>
-      useForm({
-        defaultValues,
-        resolver: yupResolver(validationSchema),
-      }),
-    );
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    result.current.formState.errors;
-    result.current.register('address');
-    result.current.register('city');
-    result.current.register('country');
-    result.current.register('first_name');
-    result.current.register('last_name');
-    result.current.register('postcode');
-    result.current.register('title');
-    result.current.register('save');
-
-    await act(async () => {
-      result.current.trigger();
-    });
-
-    const { formState } = result.current;
-
-    expect(formState.errors.address).not.toBeDefined();
-    expect(formState.errors.city).not.toBeDefined();
-    expect(formState.errors.country).not.toBeDefined();
-    expect(formState.errors.first_name).not.toBeDefined();
-    expect(formState.errors.last_name).not.toBeDefined();
-    expect(formState.errors.postcode).not.toBeDefined();
-    expect(formState.errors.title).not.toBeDefined();
-    expect(formState.errors.save).not.toBeDefined();
-    expect(formState.isValid).toBe(true);
-  });
-
-  it('should have an error if values are invalid', async () => {
-    const { result } = renderHook(() =>
-      useForm({
-        resolver: yupResolver(validationSchema),
-      }),
-    );
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    result.current.formState.errors;
-    result.current.register('address');
-    result.current.register('city');
-    result.current.register('country');
-    result.current.register('first_name');
-    result.current.register('last_name');
-    result.current.register('postcode');
-    result.current.register('title');
-    result.current.register('save');
-
-    // - Trigger form validation with empty values
-    await act(async () => {
-      result.current.trigger();
-    });
-
-    let { formState } = result.current;
-    expect(formState.errors.address?.type).toEqual('required');
-    expect(formState.errors.address?.message).toEqual('address is a required field');
-    expect(formState.errors.city?.type).toEqual('required');
-    expect(formState.errors.city?.message).toEqual('city is a required field');
-    expect(formState.errors.country?.type).toEqual('required');
-    expect(formState.errors.country?.message).toEqual('country is a required field');
-    expect(formState.errors.first_name?.type).toEqual('required');
-    expect(formState.errors.first_name?.message).toEqual('first_name is a required field');
-    expect(formState.errors.last_name?.type).toEqual('required');
-    expect(formState.errors.last_name?.message).toEqual('last_name is a required field');
-    expect(formState.errors.postcode?.type).toEqual('required');
-    expect(formState.errors.postcode?.message).toEqual('postcode is a required field');
-    expect(formState.errors.title?.type).toEqual('required');
-    expect(formState.errors.title?.message).toEqual('title is a required field');
-    expect(formState.errors.save).not.toBeDefined();
-    expect(formState.isValid).toBe(false);
-
-    // - Set values for all field but with a wrong one for country field
-    await act(async () => {
-      result.current.setValue('address', faker.address.streetAddress());
-      result.current.setValue('city', faker.address.city());
-      // set country value with an invalid country code
-      result.current.setValue('country', 'AA');
-      result.current.setValue('first_name', faker.name.firstName());
-      result.current.setValue('last_name', faker.name.lastName());
-      result.current.setValue('postcode', faker.address.zipCode());
-      result.current.setValue('title', faker.random.word());
-      result.current.trigger();
-    });
-
-    formState = result.current.formState;
-    expect(formState.errors.address).not.toBeDefined();
-    expect(formState.errors.city).not.toBeDefined();
-    expect(formState.errors.country?.type).toEqual('oneOf');
-    expect(formState.errors.country?.message).toContain(
-      'country must be one of the following values:',
-    );
-    expect(formState.errors.first_name).not.toBeDefined();
-    expect(formState.errors.last_name).not.toBeDefined();
-    expect(formState.errors.postcode).not.toBeDefined();
-    expect(formState.errors.title).not.toBeDefined();
-    expect(formState.errors.save).not.toBeDefined();
-    expect(formState.isValid).toBe(false);
-
-    // - Set country value with a valid country code
-    await act(async () => {
-      result.current.setValue('country', 'FR');
-      result.current.trigger();
-    });
-
-    formState = result.current.formState;
-    expect(formState.errors.address).not.toBeDefined();
-    expect(formState.errors.city).not.toBeDefined();
-    expect(formState.errors.country).not.toBeDefined();
-    expect(formState.errors.first_name).not.toBeDefined();
-    expect(formState.errors.last_name).not.toBeDefined();
-    expect(formState.errors.postcode).not.toBeDefined();
-    expect(formState.errors.title).not.toBeDefined();
-    expect(formState.errors.save).not.toBeDefined();
-    expect(formState.isValid).toBe(true);
-  });
-});
 
 describe('AddressesManagement', () => {
   const initializeUser = () => {
@@ -219,6 +79,46 @@ describe('AddressesManagement', () => {
     expect(handleClose).toHaveBeenCalledTimes(0);
     fireEvent.click($closeButton);
     expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the user's addresses", async () => {
+    initializeUser();
+    const addresses = mockFactories.AddressFactory.generate(Math.ceil(Math.random() * 5));
+    fetchMock.get('https://joanie.endpoint/api/addresses/', addresses);
+
+    let container: HTMLElement;
+
+    await act(async () => {
+      ({ container } = render(
+        <QueryClientProvider client={createQueryClient({ persistor: true })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <AddressesManagement handleClose={handleClose} selectAddress={selectAddress} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      ));
+    });
+
+    // All user's addresses should be displayed
+    const $addresses = container!.querySelectorAll('.registered-addresses-item');
+    expect($addresses).toHaveLength(addresses.length);
+
+    addresses.forEach((address: Joanie.Address) => {
+      const $address = screen.getByTestId(`address-${address.id}-title`);
+      expect($address.textContent).toEqual(address.title);
+    });
+
+    // - User selects one of its existing address
+    const address = addresses[0];
+    const $selectButton = screen.getByRole('button', {
+      name: `Select "${address.title}" address`,
+      exact: true,
+    });
+    await act(async () => {
+      fireEvent.click($selectButton);
+    });
+    expect(selectAddress).toHaveBeenNthCalledWith(1, address);
   });
 
   it('renders a form to create an address', async () => {
@@ -307,47 +207,7 @@ describe('AddressesManagement', () => {
     });
   });
 
-  it("renders the user's addresses", async () => {
-    initializeUser();
-    const addresses = mockFactories.AddressFactory.generate(Math.ceil(Math.random() * 5));
-    fetchMock.get('https://joanie.endpoint/api/addresses/', addresses);
-
-    let container: HTMLElement;
-
-    await act(async () => {
-      ({ container } = render(
-        <QueryClientProvider client={createQueryClient({ persistor: true })}>
-          <IntlProvider locale="en">
-            <SessionProvider>
-              <AddressesManagement handleClose={handleClose} selectAddress={selectAddress} />
-            </SessionProvider>
-          </IntlProvider>
-        </QueryClientProvider>,
-      ));
-    });
-
-    // All user's addresses should be displayed
-    const $addresses = container!.querySelectorAll('.registered-addresses-item');
-    expect($addresses).toHaveLength(addresses.length);
-
-    addresses.forEach((address: Joanie.Address) => {
-      const $address = screen.getByTestId(`address-${address.id}-title`);
-      expect($address.textContent).toEqual(address.title);
-    });
-
-    // - User selects one of its existing address
-    const address = addresses[0];
-    const $selectButton = screen.getByRole('button', {
-      name: `Select "${address.title}" address`,
-      exact: true,
-    });
-    await act(async () => {
-      fireEvent.click($selectButton);
-    });
-    expect(selectAddress).toHaveBeenNthCalledWith(1, address);
-  });
-
-  it('renders an updated form when user selects an address to edit', async () => {
+  it('renders a form to edit an address when user selects an address to edit', async () => {
     initializeUser();
     const address = mockFactories.AddressFactory.generate();
     fetchMock.get('https://joanie.endpoint/api/addresses/', [address]);

--- a/src/frontend/js/components/AddressesManagement/validationSchema.spec.ts
+++ b/src/frontend/js/components/AddressesManagement/validationSchema.spec.ts
@@ -1,0 +1,147 @@
+import faker from 'faker';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import validationSchema from './validationSchema';
+
+describe('validationSchema', () => {
+  // Creation and Update form validation relies on a schema resolves by Yup.
+  it('should not have error if values are valid', async () => {
+    const defaultValues = {
+      address: faker.address.streetAddress(),
+      city: faker.address.city(),
+      country: faker.address.countryCode(),
+      first_name: faker.name.firstName(),
+      last_name: faker.name.lastName(),
+      postcode: faker.address.zipCode(),
+      title: faker.random.word(),
+      save: false,
+    };
+
+    const { result } = renderHook(() =>
+      useForm({
+        defaultValues,
+        resolver: yupResolver(validationSchema),
+      }),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    result.current.formState.errors;
+    result.current.register('address');
+    result.current.register('city');
+    result.current.register('country');
+    result.current.register('first_name');
+    result.current.register('last_name');
+    result.current.register('postcode');
+    result.current.register('title');
+    result.current.register('save');
+
+    await act(async () => {
+      result.current.trigger();
+    });
+
+    const { formState } = result.current;
+
+    expect(formState.errors.address).not.toBeDefined();
+    expect(formState.errors.city).not.toBeDefined();
+    expect(formState.errors.country).not.toBeDefined();
+    expect(formState.errors.first_name).not.toBeDefined();
+    expect(formState.errors.last_name).not.toBeDefined();
+    expect(formState.errors.postcode).not.toBeDefined();
+    expect(formState.errors.title).not.toBeDefined();
+    expect(formState.errors.save).not.toBeDefined();
+    expect(formState.isValid).toBe(true);
+  });
+
+  it('should have an error if values are invalid', async () => {
+    const { result } = renderHook(() =>
+      useForm({
+        resolver: yupResolver(validationSchema),
+      }),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    result.current.formState.errors;
+    result.current.register('address');
+    result.current.register('city');
+    result.current.register('country');
+    result.current.register('first_name');
+    result.current.register('last_name');
+    result.current.register('postcode');
+    result.current.register('title');
+    result.current.register('save');
+
+    // - Trigger form validation with empty values
+    await act(async () => {
+      result.current.trigger();
+    });
+
+    let { formState } = result.current;
+    expect(formState.errors.address?.type).toEqual('required');
+    expect(formState.errors.address?.message?.key).toEqual('mixedRequired');
+    expect(formState.errors.address?.message?.values?.path).toEqual('address');
+    expect(formState.errors.city?.type).toEqual('required');
+    expect(formState.errors.city?.message?.key).toEqual('mixedRequired');
+    expect(formState.errors.city?.message?.values?.path).toEqual('city');
+    expect(formState.errors.country?.type).toEqual('required');
+    expect(formState.errors.country?.message?.key).toEqual('mixedRequired');
+    expect(formState.errors.country?.message?.values?.path).toEqual('country');
+    expect(formState.errors.first_name?.type).toEqual('required');
+    expect(formState.errors.first_name?.message?.key).toEqual('mixedRequired');
+    expect(formState.errors.first_name?.message?.values?.path).toEqual('first_name');
+    expect(formState.errors.last_name?.type).toEqual('required');
+    expect(formState.errors.last_name?.message?.key).toEqual('mixedRequired');
+    expect(formState.errors.last_name?.message?.values?.path).toEqual('last_name');
+    expect(formState.errors.postcode?.type).toEqual('required');
+    expect(formState.errors.postcode?.message?.key).toEqual('mixedRequired');
+    expect(formState.errors.postcode?.message?.values?.path).toEqual('postcode');
+    expect(formState.errors.title?.type).toEqual('required');
+    expect(formState.errors.title?.message?.key).toEqual('mixedRequired');
+    expect(formState.errors.title?.message?.values?.path).toEqual('title');
+    expect(formState.errors.save).not.toBeDefined();
+    expect(formState.isValid).toBe(false);
+
+    // - Set values for all field but with a wrong one for country field
+    await act(async () => {
+      result.current.setValue('address', faker.address.streetAddress());
+      result.current.setValue('city', faker.address.city());
+      // set country value with an invalid country code
+      result.current.setValue('country', 'AA');
+      result.current.setValue('first_name', faker.name.firstName());
+      result.current.setValue('last_name', faker.name.lastName());
+      result.current.setValue('postcode', faker.address.zipCode());
+      result.current.setValue('title', faker.random.word());
+      result.current.trigger();
+    });
+
+    formState = result.current.formState;
+    expect(formState.errors.address).not.toBeDefined();
+    expect(formState.errors.city).not.toBeDefined();
+    expect(formState.errors.country?.type).toEqual('oneOf');
+    expect(formState.errors.country?.message?.key).toEqual('mixedOneOf');
+    expect(formState.errors.country?.message?.values?.path).toEqual('country');
+    expect(formState.errors.first_name).not.toBeDefined();
+    expect(formState.errors.last_name).not.toBeDefined();
+    expect(formState.errors.postcode).not.toBeDefined();
+    expect(formState.errors.title).not.toBeDefined();
+    expect(formState.errors.save).not.toBeDefined();
+    expect(formState.isValid).toBe(false);
+
+    // - Set country value with a valid country code
+    await act(async () => {
+      result.current.setValue('country', 'FR');
+      result.current.trigger();
+    });
+
+    formState = result.current.formState;
+    expect(formState.errors.address).not.toBeDefined();
+    expect(formState.errors.city).not.toBeDefined();
+    expect(formState.errors.country).not.toBeDefined();
+    expect(formState.errors.first_name).not.toBeDefined();
+    expect(formState.errors.last_name).not.toBeDefined();
+    expect(formState.errors.postcode).not.toBeDefined();
+    expect(formState.errors.title).not.toBeDefined();
+    expect(formState.errors.save).not.toBeDefined();
+    expect(formState.isValid).toBe(true);
+  });
+});

--- a/src/frontend/js/components/AddressesManagement/validationSchema.ts
+++ b/src/frontend/js/components/AddressesManagement/validationSchema.ts
@@ -1,6 +1,57 @@
 import countries from 'i18n-iso-countries';
+import { defineMessages } from 'react-intl';
 import * as Yup from 'yup';
 
+export enum ErrorKeys {
+  MIXED_INVALID = 'mixedInvalid',
+  MIXED_REQUIRED = 'mixedRequired',
+  MIXED_ONEOF = 'mixedOneOf',
+  STRING_MAX = 'stringMax',
+  STRING_MIN = 'stringMin',
+}
+
+export const errorMessages = defineMessages<ErrorKeys>({
+  [ErrorKeys.MIXED_INVALID]: {
+    id: 'components.AddressesManagement.validationSchema.mixedInvalid',
+    defaultMessage: 'This field is invalid.',
+    description: 'Error message displayed when a field value is invalid.',
+  },
+  [ErrorKeys.MIXED_REQUIRED]: {
+    id: 'components.AddressesManagement.validationSchema.mixedRequired',
+    defaultMessage: 'This field is required.',
+    description: 'Error message displayed when a field is required.',
+  },
+  [ErrorKeys.MIXED_ONEOF]: {
+    id: 'components.AddressesManagement.validationSchema.mixedOneOf',
+    defaultMessage: 'You must select a value within: {values}.',
+    description: 'Error message displayed when a field value must be one of a list.',
+  },
+  [ErrorKeys.STRING_MAX]: {
+    id: 'components.AddressesManagement.validationSchema.stringMax',
+    defaultMessage: 'The maximum length is {max} {max, plural, one {char} other {chars}}.',
+    description: 'Error message displayed when a field value is too long.',
+  },
+  [ErrorKeys.STRING_MIN]: {
+    id: 'components.AddressesManagement.validationSchema.stringMin',
+    defaultMessage: 'The minimum length is {min} {min, plural, one {char} other {chars}}.',
+    description: 'Error message displayed when a field value is too short.',
+  },
+});
+
+Yup.setLocale({
+  mixed: {
+    default: (values) => ({ key: ErrorKeys.MIXED_INVALID, values }),
+    required: (values) => ({ key: ErrorKeys.MIXED_REQUIRED, values }),
+    oneOf: (values) => ({ key: ErrorKeys.MIXED_ONEOF, values }),
+  },
+  string: {
+    max: (values) => ({ key: ErrorKeys.STRING_MAX, values }),
+    min: (values) => ({ key: ErrorKeys.STRING_MIN, values }),
+  },
+});
+
+// / ! \ If you need to edit the validation schema,
+// you should also add/edit error messages above.
 const schema = Yup.object().shape({
   address: Yup.string().required(),
   city: Yup.string().required(),

--- a/src/frontend/js/components/Form/Inputs.tsx
+++ b/src/frontend/js/components/Form/Inputs.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from 'react';
+import { forwardRef, type ReactNode, useMemo } from 'react';
 
 /**
  * A collection of form input elements
@@ -11,7 +11,7 @@ import { forwardRef, useMemo } from 'react';
 
 interface FieldProps {
   error?: Boolean;
-  message?: string;
+  message?: ReactNode | string;
   fieldClasses?: string[];
 }
 

--- a/src/frontend/js/components/Form/Inputs.tsx
+++ b/src/frontend/js/components/Form/Inputs.tsx
@@ -34,7 +34,7 @@ const Field = ({
 
   return (
     <p className={classList}>
-      {children}
+      <span className="form-field__box">{children}</span>
       {message && (
         <span className="form-field__message">
           <svg className="form-field__message__icon">

--- a/src/frontend/scss/objects/_form.scss
+++ b/src/frontend/scss/objects/_form.scss
@@ -11,21 +11,25 @@
 // .form
 //  .form-group
 //    .form-field
-//      .form-field__input
-//      .form-field__label
+//      .form-field__box
+//        .form-field__input
+//        .form-field__label
 //      .form-field__message--error
 //    .form-field
-//      .form-field__input
+//      .form-field__box
+//        .form-field__input
+//        .form-field__label
+//    .form-field
+//      .form-field__box
+//        .form-field__checkbox-input
+//        .form-field__checkbox-control
+//        .form-field__label
+//  .form-field
+//    .form-field__box
 //      .form-field__label
-//  .form-field
-//    .form-field__checkbox-input
-//    .form-field__checkbox-control
-//    .form-field__label
-//  .form-field
-//    .form-field__label
-//    .form-field__select-container
-//      .form-field__select-input
-//      .form-field__select-arrow
+//      .form-field__select-container
+//        .form-field__select-input
+//        .form-field__select-arrow
 
 @mixin input-base-style() {
   -webkit-appearance: none;
@@ -37,7 +41,6 @@
   color: r-theme-val(form, input-color);
   min-height: 3rem;
   display: block;
-  height: 100%;
   padding: 1rem 1rem 0 1rem;
   width: 100%;
 
@@ -79,6 +82,11 @@
     }
 
     // Common elements
+    &__box {
+      display: block;
+      position: relative;
+    }
+
     &__label {
       color: r-theme-val(form, input-placeholder);
       cursor: pointer;
@@ -117,7 +125,7 @@
     }
 
     &__textarea + &__label {
-      top: 0.33rem;
+      top: 0.5rem;
       z-index: 1;
     }
 
@@ -128,7 +136,7 @@
 
     &__textarea:focus + &__label,
     &__textarea:not(:placeholder-shown) + &__label {
-      transform: scale(0.66);
+      transform: scale(0.66) translateY(-0.25rem);
     }
 
     &__input[aria-required='true'] + &__label:after,
@@ -247,15 +255,12 @@
 
     // Message
     &__message {
-      bottom: 0;
       color: r-theme-val(form, message-color);
+      display: inline-block;
       font-size: 0.875rem;
-      left: 2px;
       line-height: 1.75em;
-      position: absolute;
-      transform: translateY(100%);
-      user-select: none;
-      vertical-align: middle;
+      padding: 0 2px;
+      text-align: justify;
 
       &__icon {
         fill: currentColor;

--- a/src/richie/apps/core/templates/richie/styleguide/index.html
+++ b/src/richie/apps/core/templates/richie/styleguide/index.html
@@ -317,17 +317,23 @@
             <form class="mb-5">
                 <div class="form-group">
                     <p class="form-field">
-                        <input class="form-field__input" id="field_1" placeholder="field_1" type="text" required="" />
-                        <label class="form-field__label" for="field_1">Field 1</label>
+                        <span class="form-field__box">
+                          <input class="form-field__input" id="field_1" placeholder="field_1" type="text" required="" />
+                          <label class="form-field__label" for="field_1">Field 1</label>
+                        </span>
                     </p>
                     <p class="form-field">
-                        <input class="form-field__input" id="field_2" placeholder="field_2" type="text" />
-                        <label class="form-field__label" for="field_2">Field 2</label>
+                        <span class="form-field__box">
+                          <input class="form-field__input" id="field_2" placeholder="field_2" type="text" />
+                          <label class="form-field__label" for="field_2">Field 2</label>
+                        </span>
                     </p>
                 </div>
                 <p class="form-field">
-                    <input class="form-field__input" id="field_3" placeholder="field_3" type="date" required />
-                    <label class="form-field__label" for="field_3">Field 3</label>
+                    <span class="form-field__box">
+                      <input class="form-field__input" id="field_3" placeholder="field_3" type="date" required />
+                      <label class="form-field__label" for="field_3">Field 3</label>
+                    </span>
                     <span class="form-field__message">
                         <svg class="form-field__message__icon">
                             <use href="#icon-info-rounded" />
@@ -336,45 +342,55 @@
                     </span>
                 </p>
                 <p class="form-field">
-                    <input class="form-field__radio-input" id="field_4-1" type="radio" name="field_4" />
-                    <label class="form-field__label" for="field_4-1">
-                        <span class="form-field__radio-control"></span>
-                        Field 4 - Option 1
-                    </label>
-                </p>
-                <p class="form-field">
-                    <input class="form-field__radio-input" id="field_4-2" type="radio" name="field_4" />
-                    <label class="form-field__label" for="field_4-2">
-                        <span class="form-field__radio-control" ></span>
-                        Field 4 - Option 2
-                    </label>
-                </p>
-                <p class="form-field">
-                    <textarea class="form-field__textarea" id="field_5" placeholder="Field 5" rows="10"></textarea>
-                    <label class="form-field__label" for="field_5">Field 5</label>
-                </p>
-                <p class="form-field">
-                    <label class="form-field__label" for="field_6">Field 6</label>
-                    <span class="form-field__select-container">
-                        <select class="form-field__select-input" id="field_6">
-                            <option disabled value="-">-</option>
-                            <option value="">Option 1</option>
-                            <option value="">Option 2</option>
-                            <option value="">Option 3</option>
-                        </select>
-                        <span class="form-field__select-arrow"></span>
+                    <span class="form-field__box">
+                      <input class="form-field__radio-input" id="field_4-1" type="radio" name="field_4" />
+                      <label class="form-field__label" for="field_4-1">
+                          <span class="form-field__radio-control"></span>
+                          Field 4 - Option 1
+                      </label>
                     </span>
                 </p>
                 <p class="form-field">
-                    <input class="form-field__checkbox-input" id="field_7" type="checkbox" />
-                    <label class="form-field__label" for="field_7">
-                        <span class="form-field__checkbox-control">
-                            <svg role="img">
-                                <use href="#icon-check"></use>
-                            </svg>
-                        </span>
-                        Field 7 (Checkbox)
-                    </label>
+                    <span class="form-field__box">
+                      <input class="form-field__radio-input" id="field_4-2" type="radio" name="field_4" />
+                      <label class="form-field__label" for="field_4-2">
+                          <span class="form-field__radio-control" ></span>
+                          Field 4 - Option 2
+                      </label>
+                    </span>
+                </p>
+                <p class="form-field">
+                    <span class="form-field__box">
+                      <textarea class="form-field__textarea" id="field_5" placeholder="Field 5" rows="10"></textarea>
+                      <label class="form-field__label" for="field_5">Field 5</label>
+                    </span>
+                </p>
+                <p class="form-field">
+                    <span class="form-field__box">
+                      <label class="form-field__label" for="field_6">Field 6</label>
+                      <span class="form-field__select-container">
+                          <select class="form-field__select-input" id="field_6">
+                              <option disabled value="-">-</option>
+                              <option value="">Option 1</option>
+                              <option value="">Option 2</option>
+                              <option value="">Option 3</option>
+                          </select>
+                          <span class="form-field__select-arrow"></span>
+                      </span>
+                    </span>
+                </p>
+                <p class="form-field">
+                    <span class="form-field__box">
+                      <input class="form-field__checkbox-input" id="field_7" type="checkbox" />
+                      <label class="form-field__label" for="field_7">
+                          <span class="form-field__checkbox-control">
+                              <svg role="img">
+                                  <use href="#icon-check"></use>
+                              </svg>
+                          </span>
+                          Field 7 (Checkbox)
+                      </label>
+                    </span>
                 </p>
             </form>
             <hr />
@@ -382,8 +398,10 @@
             <form>
                 <div class="form-group">
                     <p class="form-field form-field--error">
-                        <input class="form-field__input" id="error_field_1" placeholder="error_field_1" type="text" required="" />
-                        <label class="form-field__label" for="error_field_1">Field 1</label>
+                        <span class="form-field__box">
+                          <input class="form-field__input" id="error_field_1" placeholder="error_field_1" type="text" required="" />
+                          <label class="form-field__label" for="error_field_1">Field 1</label>
+                        </span>
                         <span class="form-field__message">
                             <svg class="form-field__message__icon">
                             <use href="#icon-warning" /></svg>
@@ -391,13 +409,17 @@
                         </span>
                     </p>
                     <p class="form-field form-field--error">
-                        <input class="form-field__input" id="error_field_2" placeholder="error_field_2" type="text" />
-                        <label class="form-field__label" for="error_field_2">Field 2</label>
+                        <span class="form-field__box">
+                          <input class="form-field__input" id="error_field_2" placeholder="error_field_2" type="text" />
+                          <label class="form-field__label" for="error_field_2">Field 2</label>
+                        </span>
                     </p>
                 </div>
                 <p class="form-field form-field--error">
-                    <input class="form-field__input" id="error_field_3" placeholder="error_field_3" type="date" />
-                    <label class="form-field__label" for="error_field_3">Field 3</label>
+                    <span class="form-field__box">
+                      <input class="form-field__input" id="error_field_3" placeholder="error_field_3" type="date" />
+                      <label class="form-field__label" for="error_field_3">Field 3</label>
+                    </span>
                     <span class="form-field__message">
                         <svg class="form-field__message__icon">
                             <use href="#icon-warning" />
@@ -406,51 +428,27 @@
                     </span>
                 </p>
                 <p class="form-field form-field--error">
-                    <input class="form-field__radio-input" id="error_field_4-1" type="radio" name="error_field_4" />
-                    <label class="form-field__label" for="error_field_4-1">
-                        <span class="form-field__radio-control"></span>
-                        Field 4 - Option 1
+                    <span class="form-field__box">
+                      <input class="form-field__radio-input" id="error_field_4-1" type="radio" name="error_field_4" />
+                      <label class="form-field__label" for="error_field_4-1">
+                          <span class="form-field__radio-control"></span>
+                          Field 4 - Option 1
+                      </label>
+                    </span>
+                    <span class="form-field__message">
+                        <svg class="form-field__message__icon">
+                            <use href="#icon-warning" />
+                        </svg>
+                        There is an error.
+                    </span>
+                </p>
+                <p class="form-field form-field--error">
+                    <span class="form-field__box">
+                      <input class="form-field__radio-input" id="error_field_4-2" type="radio" name="error_field_4" />
+                      <label class="form-field__label" for="error_field_4-2">
+                          <span class="form-field__radio-control" ></span>
+                          Field 4 - Option 2
                     </label>
-                    <span class="form-field__message">
-                        <svg class="form-field__message__icon">
-                            <use href="#icon-warning" />
-                        </svg>
-                        There is an error.
-                    </span>
-                </p>
-                <p class="form-field form-field--error">
-                    <input class="form-field__radio-input" id="error_field_4-2" type="radio" name="error_field_4" />
-                    <label class="form-field__label" for="error_field_4-2">
-                        <span class="form-field__radio-control" ></span>
-                        Field 4 - Option 2
-                    </label>
-                    <span class="form-field__message">
-                        <svg class="form-field__message__icon">
-                            <use href="#icon-warning" />
-                        </svg>
-                        There is an error.
-                    </span>
-                </p>
-                <p class="form-field form-field--error">
-                    <textarea class="form-field__textarea" id="error_field_5" placeholder="Field 5" rows="10"></textarea>
-                    <label class="form-field__label" for="error_field_5">Field 5</label>
-                    <span class="form-field__message">
-                        <svg class="form-field__message__icon">
-                            <use href="#icon-warning" />
-                        </svg>
-                        There is an error.
-                    </span>
-                </p>
-                <p class="form-field form-field--error">
-                    <label class="form-field__label" for="error_field_6">Field 6</label>
-                    <span class="form-field__select-container">
-                        <select class="form-field__select-input" id="error_field_6">
-                            <option disabled value="-">-</option>
-                            <option value="">Option 1</option>
-                            <option value="">Option 2</option>
-                            <option value="">Option 3</option>
-                        </select>
-                        <span class="form-field__select-arrow"></span>
                     </span>
                     <span class="form-field__message">
                         <svg class="form-field__message__icon">
@@ -460,15 +458,49 @@
                     </span>
                 </p>
                 <p class="form-field form-field--error">
-                    <input class="form-field__checkbox-input" id="error_field_7" type="checkbox" />
-                    <label class="form-field__label" for="error_field_7">
-                        <span class="form-field__checkbox-control">
-                            <svg role="img">
-                                <use href="#icon-check"></use>
-                            </svg>
-                        </span>
-                        Field 7 (Checkbox)
-                    </label>
+                    <span class="form-field__box">
+                      <textarea class="form-field__textarea" id="error_field_5" placeholder="Field 5" rows="10"></textarea>
+                      <label class="form-field__label" for="error_field_5">Field 5</label>
+                    </span>
+                    <span class="form-field__message">
+                        <svg class="form-field__message__icon">
+                            <use href="#icon-warning" />
+                        </svg>
+                        There is an error.
+                    </span>
+                </p>
+                <p class="form-field form-field--error">
+                    <span class="form-field__box">
+                      <label class="form-field__label" for="error_field_6">Field 6</label>
+                      <span class="form-field__select-container">
+                          <select class="form-field__select-input" id="error_field_6">
+                              <option disabled value="-">-</option>
+                              <option value="">Option 1</option>
+                              <option value="">Option 2</option>
+                              <option value="">Option 3</option>
+                          </select>
+                          <span class="form-field__select-arrow"></span>
+                      </span>
+                    </span>
+                    <span class="form-field__message">
+                        <svg class="form-field__message__icon">
+                            <use href="#icon-warning" />
+                        </svg>
+                        There is an error.
+                    </span>
+                </p>
+                <p class="form-field form-field--error">
+                    <span class="form-field__box">
+                      <input class="form-field__checkbox-input" id="error_field_7" type="checkbox" />
+                      <label class="form-field__label" for="error_field_7">
+                          <span class="form-field__checkbox-control">
+                              <svg role="img">
+                                  <use href="#icon-check"></use>
+                              </svg>
+                          </span>
+                          Field 7 (Checkbox)
+                      </label>
+                    </span>
                     <span class="form-field__message">
                         <svg class="form-field__message__icon">
                             <use href="#icon-warning" />


### PR DESCRIPTION
## Purpose

In order to improve user experience, we want to display error messages into the `AddressForm` component. If we retrieve basically error message generated by yup, we get only english messages so in our cases we have to [customize errors returned by yup](https://github.com/jquense/yup/tree/pre-v1#using-a-custom-locale-dictionary) to be able to use `react-intl` to manage error message translations.

Furthermore, some error messages can be long, so we must be able to display those messages without breaking the layout that's why we revamp a little bit form fields to be able to display multilines messages.


## Proposal

- [x] Update form fields to accept multi lines messages
- [x] Display error messages into `AddressForm`
