### PR TITLE
♿️(templates) add label on external video players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modal component refactor for homogeneous use
 - New global scroll behavior for Modal
 - Add disabled style for inputs
+- Add a visually hidden title on video player iframes, meant to be announced
+  to screen reader users
 
 ### Fixed
 

--- a/src/richie/apps/core/templates/djangocms_video/default/video_player.html
+++ b/src/richie/apps/core/templates/djangocms_video/default/video_player.html
@@ -7,7 +7,12 @@ obsolete attribute "frameborder" and invalid "allowfullscreen" attribute value.
 {% if instance.embed_link %}
     {# show iframe if embed_link is provided #}
     <div class="aspect-ratio">
-        <iframe src="{{ instance.embed_link_with_parameters }}" {{ instance.attributes_str }} allowfullscreen></iframe>
+        <iframe
+            title="{% if instance.label %}{{ instance.label }}{% else %}{% trans "Video" %}{% endif %}"
+            src="{{ instance.embed_link_with_parameters }}"
+            {{ instance.attributes_str }}
+            allowfullscreen
+        ></iframe>
     </div>
     {% with disabled=instance.embed_link %}
         {% for plugin in instance.child_plugin_instances %}

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -540,16 +540,12 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         course = CourseFactory(fill_teaser=video_sample, should_publish=True)
 
         response = self.client.get(course.extended_object.get_absolute_url())
-
         self.assertEqual(response.status_code, 200)
-        pattern = (
-            r'<div class="subheader__teaser">'
-            r'<div class="aspect-ratio">'
-            rf'<iframe src="{video_sample.url:s}"  allowfullscreen></iframe>'
-            r"</div>"
-            r"</div>"
-        )
-        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        html = lxml.html.fromstring(response.content)
+        iframe = html.cssselect(".subheader__teaser .aspect-ratio iframe")[0]
+        self.assertIn("allowfullscreen", iframe.keys())
+        self.assertEqual(iframe.get("title"), video_sample.label)
+        self.assertEqual(iframe.get("src"), video_sample.url)
 
     def test_templates_course_detail_teaser_empty_cover_image(self):
         """
@@ -584,14 +580,11 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         response = self.client.get(course.extended_object.get_absolute_url())
 
         self.assertEqual(response.status_code, 200)
-        pattern = (
-            r'<div class="subheader__teaser">'
-            r'<div class="aspect-ratio">'
-            rf'<iframe src="{video_sample.url:s}"  allowfullscreen></iframe>'
-            r"</div>"
-            r"</div>"
-        )
-        self.assertIsNotNone(re.search(pattern, str(response.content)))
+        html = lxml.html.fromstring(response.content)
+        iframe = html.cssselect(".subheader__teaser .aspect-ratio iframe")[0]
+        self.assertIn("allowfullscreen", iframe.keys())
+        self.assertEqual(iframe.get("title"), video_sample.label)
+        self.assertEqual(iframe.get("src"), video_sample.url)
 
 
 # pylint: disable=too-many-public-methods


### PR DESCRIPTION
## Purpose

The main goal of the PR is to be a tiny more explicit about what the `iframe` elements on the website are about. This is mostly for screen reader users.

The added bonus of this PR is that it makes the website pass the RGAA test n° 2.1.

## Proposal

Add a `title` attribute on a video player `iframe` block.
