### PR TITLE
♻️(search) refactor the way filters are being configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Refactor filter definition methods to simplify writing custom filters
 - Improve filters configuration to allow easier customization
 - CKEditor basic configuration should allow to include target on anchors
   for course fields: assessment, format and prerequisites.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Improve filters configuration to allow easier customization
 - CKEditor basic configuration should allow to include target on anchors
   for course fields: assessment, format and prerequisites.
 - Allow form messages to go on multiple lines

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,13 @@ $ make migrate
 
 ## Unreleased
 
+## 2.15.x to 2.16.x
+
+- The way filters are configured has changed. There is now a separate setting
+  `RICHIE_FILTERS_PRESENTATION` to easily define which filters are displayed and in which order.
+  If you need to customize more than the list and order of the search filters, the
+  `RICHIE_FILTERS_CONFIGURATION` still exists and has a new simplified format.
+
 ## 2.14.x to 2.15.x
 
 - On frontend, the API interface `base` has been renamed into `dummy`.

--- a/docs/cookiecutter.md
+++ b/docs/cookiecutter.md
@@ -90,11 +90,16 @@ committing it and pushing it to a new git repository.
 
 ## Theming
 
-Probably you want to change the default theme. The cookiecutter adds an extra scss frontend folder with a couple of templates where you can use to change the default styling of the site.
+You probably want to change the default theme. The cookiecutter adds an extra scss frontend folder with a couple of templates that you can use to change the default styling of the site.
 * `sites/<site>/src/frontend/scss/extras/colors/_palette.scss`
 * `sites/<site>/src/frontend/scss/extras/colors/_theme.scss`
 
 To change the default logo of the site, you need to create the folder `sites/<site>/src/backend/base/static/richie/images` and then override the new `logo.png` picture.
+
+For more advanced customization, refer to our recipes:
+
+* [How to customize search filters](filters-customization.md)
+* [How to override frontend components in Richie](frontend-overrides.md)
 
 ## Update your Richie site factory
 

--- a/docs/filters-customization.md
+++ b/docs/filters-customization.md
@@ -1,0 +1,198 @@
+---
+id: filters-customization
+title: Customizing search filters
+sidebar_label: Search filters customization
+---
+
+You may want to customize the filters on the left side bar of the search page.
+
+Richie makes it easy to choose which filters you want to display among the existing filters
+and in which order. You can also configure the existing filters to change their title or the
+way they behave. Lastly, you can completely override a filter or create your own custom filter
+from scratch.
+
+## Filters configuration
+
+Filters must first be defined in the `FILTERS_CONFIGURATION` setting. It is a dictionary defining
+for each filter, a predefined `class` in the code where the filter is implemented and the
+parameters to apply to this class when instantiating it.
+
+Let's study a few examples of filters in the default configuration:
+
+```
+FILTERS_CONFIGURATION = {
+    ...
+    "pace": {
+        "class": "richie.apps.search.filter_definitions.StaticChoicesFilterDefinition",
+        "params": {
+            "fragment_map": {
+                "self-paced": [{"bool": {"must_not": {"exists": {"field": "pace"}}}}],
+                "lt-1h": [{"range": {"pace": {"lt": 60}}}],
+                "1h-2h": [{"range": {"pace": {"gte": 60, "lte": 120}}}],
+                "gt-2h": [{"range": {"pace": {"gt": 120}}}],
+            },
+            "human_name": _("Weekly pace"),
+            "min_doc_count": 0,
+            "sorting": "conf",
+            "values": {
+                "self-paced": _("Self-paced"),
+                "lt-1h": _("Less than one hour"),
+                "1h-2h": _("One to two hours"),
+                "gt-2h": _("More than two hours"),
+            },
+        },
+    },
+    ...
+}
+```
+
+This filter uses the `StaticChoicesFilterDefinition` filter definition class and allows filtering
+on the `pace` field present in the Elasticsearch index. The `values` parameter defines 4 ranges
+and their human readable format that will appear as 4 filtering options to the user.
+
+The `fragment_map` parameter defines a fragment of the Elasticsearch query to apply on the `pace`
+field when one of these options is selected.
+
+The `human_name`parameter defines how the filter is entitled. It is defined as a lazy i18n string
+so that it can be translated.
+
+The `sorting` parameter determines how the facets are sorted in the left side panel of the filter:
+- `conf`: facets are sorted as defined in the `values` configuration parameter
+- `count`: facets are sorted according to the number of course results associated with each facet
+- `name`: facets are sorted by their name in alphabetical order
+
+The `min_doc_count` parameter defines how many associated results a facet must have at the minimum
+before it is displayed as an option for the filter.
+
+Let's study another interesting example:
+
+```
+FILTERS_CONFIGURATION = {
+    ...
+    "organizations": {
+        "class": "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
+        "params": {
+            "human_name": _("Organizations"),
+            "is_autocompletable": True,
+            "is_drilldown": False,
+            "is_searchable": True,
+            "min_doc_count": 0,
+            "reverse_id": "organizations",
+        },
+    },
+    ...
+}
+```
+
+This filter uses the `IndexableHierarchicalFilterDefinition` filter definition class and allows
+filtering on the link between course pages and other pages identified by their IDs like for
+example here `Organization` pages.
+
+In the example above, when an option is selected, results will only include the courses for which
+the `organizations` field in the index is including the ID of the selected organization page.
+
+The `reverse_id` parameter should point to a page's reverse ID (see DjangoCMS documentation) in
+the CMS. The filter will propose a filtering option for each children organization under this
+page.
+
+The `is_autocompletable` field determines whether organizations should be searched and suggested
+by the autocomplete feature (organizations must have an associated index and API endpoint for
+autocompletion carrying the same name).
+
+The `is_drilldown` parameter determines whether the filter is limited to one active value at a
+time or allows multi-facetting.
+
+The `is_searchable` field determines whether organizations filters should present a "more options"
+button in case there are more facet options in results than can be displayed (organizations must
+have an associated API endpoint for full-text search, carrying the same name).
+
+Lastly, let's look at nested filters which, as their name indicates, allow filtering on nested
+fields.
+
+For example, in the course index, one of the fields is named `course_runs` and contains a list of
+objects in the following format:
+
+```
+"course_runs": [
+    {
+        "start": "2022-09-09T09:00:00.000000",
+        "end": "2021-10-30T00:00:00.000000Z",
+        "enrollment_start": "2022-08-01T09:00:00.000000Z",
+        "enrollment_end": "2022-09-08T00:00:00.000000Z",
+        "languages": ["en", "fr"],
+    },
+    {
+        "start": "2023-03-01T09:00:00.000000",
+        "end": "2023-06-03T00:00:00.000000Z",
+        "enrollment_start": "2023-01-01T09:00:00.000000Z",
+        "enrollment_end": "2023-03-01T00:00:00.000000Z",
+        "languages": ["fr"],
+    },
+]
+```
+
+If we want to filter courses that are available in the english language, we can thus configure the
+following filter:
+
+```
+FILTERS_CONFIGURATION = {
+    ...
+    "course_runs": {
+        "class": "richie.apps.search.filter_definitions.NestingWrapper",
+        "params": {
+            "filters": {
+                "languages": {
+                    "class": "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
+                    "params": {
+                        "human_name": _("Languages"),
+                        # There are too many available languages to show them all, all the time.
+                        # Eg. 200 languages, 190+ of which will have 0 matching courses.
+                        "min_doc_count": 1,
+                    },
+                },
+            }
+        },
+    },
+    ...
+}
+```
+
+## Filters presentation
+
+Which filters are displayed in the left side bar of the search page and in which order is defined
+by the `RICHIE_FILTERS_PRESENTATION` setting.
+
+This setting is expecting a list of strings, which are the names of the filters as defined
+in the `FILTERS_CONFIGURATION` setting decribed in the previous section. If it, for example,
+contains the 3 filters presented in the previous section, we could define the following
+presentation:
+
+```
+RICHIE_FILTERS_PRESENTATION = ["organizations", "languages", "pace"]
+```
+
+## Writing your own custom filters
+
+You can write your own filters from scratch although we must warn you that it is not trivial
+because it requires a good knowledge of Elasticsearch and studying the mapping defined in the
+[courses indexer][1].
+
+A filter is a class deriving from [BaseFilterDefinition][2] and defining methods to return the
+information to display the filter and query fragments for elasticsearch:
+- `get_form_fields`: returns the form field instance that will be used to parse and validate this
+    filter's values from the querystring
+- `get_query_fragment`: returns the query fragment to use as filter in ElasticSearch
+- `get_aggs_fragment`: returns the query fragment to use to extract facets from
+    ElasticSearch aggregations
+- `get_facet_info`: returns the dynamic facet information from a filter's Elasticsearch facet
+    results. Together with the facet's static information, it will be used to display the filter
+    in its current status in the left side panel of the search page.
+
+We will not go into more details here about how filter definition classes work, but you can refer
+to the code of the existing filters as good examples of what is possible. The code, although not
+trivial, was given much care and includes many comments in an attempt to help writing new custom
+filters. Of course, don't hesitate to ask for help by
+[opening an issue](https://github.com/openfun/richie/issues)!
+
+[1]: https://github.com/openfun/richie/blob/master/src/richie/apps/search/indexers/courses.py
+[2]: https://github.com/openfun/richie/blob/master/src/richie/apps/search/filter_definitions/base.py

--- a/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.spec.tsx
@@ -7,7 +7,7 @@ import { SearchFiltersPane } from '.';
 
 jest.mock('components/SearchFilterGroup', () => ({
   SearchFilterGroup: ({ filter }: any) => (
-    <span>{`Received filter title: ${filter.human_name}`}</span>
+    <span data-testid="filter">{`Received filter title: ${filter.human_name}`}</span>
   ),
 }));
 
@@ -25,7 +25,11 @@ describe('components/SearchFiltersPane', () => {
   ];
 
   it('renders all our search filter groups', () => {
-    const { getByText } = render(
+    const shuffledNames = ['Categories', 'Organizations', 'Persons'].sort(
+      () => Math.random() - 0.5,
+    );
+
+    const { getByText, getAllByTestId } = render(
       <IntlProvider locale="en">
         <HistoryContext.Provider value={makeHistoryOf({ limit: '999', offset: '0' })}>
           <SearchFiltersPane
@@ -37,7 +41,7 @@ describe('components/SearchFiltersPane', () => {
                 is_autocompletable: true,
                 is_searchable: true,
                 name: 'categories',
-                position: 0,
+                position: shuffledNames.indexOf('Categories'),
                 values: [],
               },
               organizations: {
@@ -47,7 +51,17 @@ describe('components/SearchFiltersPane', () => {
                 is_autocompletable: true,
                 is_searchable: true,
                 name: 'organizations',
-                position: 1,
+                position: shuffledNames.indexOf('Organizations'),
+                values: [],
+              },
+              persons: {
+                base_path: '0003',
+                has_more_values: false,
+                human_name: 'Persons',
+                is_autocompletable: true,
+                is_searchable: true,
+                name: 'persons',
+                position: shuffledNames.indexOf('Persons'),
                 values: [],
               },
             }}
@@ -56,10 +70,13 @@ describe('components/SearchFiltersPane', () => {
       </IntlProvider>,
     );
 
-    // The pane's title is shown along with the filter groups
-    getByText('Filter courses');
-    getByText('Received filter title: Categories');
-    getByText('Received filter title: Organizations');
+    // The pane's title is shown along with filter groups in the order defined by their position
+    const items = getAllByTestId('filter');
+    expect(items.length).toEqual(3);
+    items.forEach((element, index) => {
+      expect(element.textContent).toContain(shuffledNames[index]);
+    });
+
     expect(getByText('Clear 0 active filters')).toHaveClass('search-filters-pane__clear--hidden');
   });
 

--- a/src/frontend/js/components/SearchFiltersPane/index.tsx
+++ b/src/frontend/js/components/SearchFiltersPane/index.tsx
@@ -30,7 +30,7 @@ export const SearchFiltersPane = ({
   filters,
   ...passThroughProps
 }: SearchFiltersPaneProps & DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>) => {
-  const filterList = filters && Object.values(filters);
+  const filterList = filters && Object.values(filters).sort((f1, f2) => f1.position - f2.position);
 
   const { courseSearchParams, dispatchCourseSearchParamsUpdate } = useCourseSearchParams();
 

--- a/src/richie/apps/search/defaults.py
+++ b/src/richie/apps/search/defaults.py
@@ -42,117 +42,98 @@ ES_STATE_WEIGHTS = getattr(settings, "RICHIE_ES_STATE_WEIGHTS", None) or [
     1,  # ARCHIVED_CLOSED
 ]
 
-FILTERS_CONFIGURATION = [
-    (
-        "richie.apps.search.filter_definitions.StaticChoicesFilterDefinition",
-        {
+DEFAULT_FILTERS_CONFIGURATION = {
+    # Note: the key is a special name that connects the filter to page objects
+    # in Richie as well as the corresponding indexer and API endpoint.
+    "new": {
+        "class": "richie.apps.search.filter_definitions.StaticChoicesFilterDefinition",
+        "params": {
             "fragment_map": {"new": [{"term": {"is_new": True}}]},
             "human_name": _("New courses"),
             "min_doc_count": 0,
-            "name": "new",
-            "position": 0,
             "sorting": "conf",
             "values": {"new": _("First session")},
         },
-    ),
-    (
-        "richie.apps.search.filter_definitions.NestingWrapper",
-        {
-            "name": "course_runs",
-            "filters": [
-                (
-                    "richie.apps.search.filter_definitions.AvailabilityFilterDefinition",
-                    {
+    },
+    "course_runs": {
+        "class": "richie.apps.search.filter_definitions.NestingWrapper",
+        "params": {
+            "filters": {
+                "availability": {
+                    "class": "richie.apps.search.filter_definitions.AvailabilityFilterDefinition",
+                    "params": {
                         "human_name": _("Availability"),
                         "is_drilldown": True,
                         "min_doc_count": 0,
-                        "name": "availability",
-                        "position": 1,
                         "sorting": "conf",
                     },
-                ),
-                (
-                    "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
-                    {
+                },
+                "languages": {
+                    "class": "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
+                    "params": {
                         "human_name": _("Languages"),
                         # There are too many available languages to show them all, all the time.
                         # Eg. 200 languages, 190+ of which will have 0 matching courses.
                         "min_doc_count": 1,
-                        "name": "languages",
-                        "position": 5,
                     },
-                ),
-            ],
+                },
+            }
         },
-    ),
-    (
-        "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
-        {
+    },
+    "subjects": {
+        "class": "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
+        "params": {
             "human_name": _("Subjects"),
             "is_autocompletable": True,
             "is_searchable": True,
             "min_doc_count": 0,
-            "name": "subjects",
-            "position": 2,
             "reverse_id": "subjects",
             "term": "categories",
         },
-    ),
-    (
-        "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
-        {
+    },
+    "levels": {
+        "class": "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
+        "params": {
             "human_name": _("Levels"),
             "is_autocompletable": True,
             "is_searchable": True,
             "min_doc_count": 0,
-            "name": "levels",
-            "position": 3,
             "reverse_id": "levels",
             "term": "categories",
         },
-    ),
-    (
-        "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
-        {
+    },
+    "organizations": {
+        "class": "richie.apps.search.filter_definitions.IndexableHierarchicalFilterDefinition",
+        "params": {
             "human_name": _("Organizations"),
             "is_autocompletable": True,
             "is_searchable": True,
             "min_doc_count": 0,
-            # Note: this is a special name that connects the filter to Organization objects
-            # in Richie as well was the corresponding indexer and API endpoint.
-            "name": "organizations",
-            "position": 4,
             "reverse_id": "organizations",
         },
-    ),
-    (
-        "richie.apps.search.filter_definitions.IndexableFilterDefinition",
-        {
+    },
+    "persons": {
+        "class": "richie.apps.search.filter_definitions.IndexableFilterDefinition",
+        "params": {
             "human_name": _("Persons"),
             "is_autocompletable": True,
             "is_searchable": True,
             "min_doc_count": 0,
-            # Note: this is a special name that connects the filter to Person objects
-            # in Richie as well was the corresponding indexer and API endpoint.
-            "name": "persons",
-            "position": 5,
             "reverse_id": "persons",
         },
-    ),
-    (
-        "richie.apps.search.filter_definitions.IndexableFilterDefinition",
-        {
+    },
+    "licences": {
+        "class": "richie.apps.search.filter_definitions.IndexableFilterDefinition",
+        "params": {
             "human_name": _("Licences"),
             "is_autocompletable": True,
             "is_searchable": True,
             "min_doc_count": 0,
-            "name": "licences",
-            "position": 6,
         },
-    ),
-    (
-        "richie.apps.search.filter_definitions.StaticChoicesFilterDefinition",
-        {
+    },
+    "pace": {
+        "class": "richie.apps.search.filter_definitions.StaticChoicesFilterDefinition",
+        "params": {
             "fragment_map": {
                 "self-paced": [{"bool": {"must_not": {"exists": {"field": "pace"}}}}],
                 "lt-1h": [{"range": {"pace": {"lt": 60}}}],
@@ -161,8 +142,6 @@ FILTERS_CONFIGURATION = [
             },
             "human_name": _("Weekly pace"),
             "min_doc_count": 0,
-            "name": "pace",
-            "position": 7,
             "sorting": "conf",
             "values": {
                 "self-paced": _("Self-paced"),
@@ -171,5 +150,26 @@ FILTERS_CONFIGURATION = [
                 "gt-2h": _("More than two hours"),
             },
         },
-    ),
-]
+    },
+}
+
+FILTERS_CONFIGURATION = getattr(
+    settings, "RICHIE_FILTERS_CONFIGURATION", DEFAULT_FILTERS_CONFIGURATION
+)
+
+
+FILTERS_PRESENTATION = getattr(
+    settings,
+    "RICHIE_FILTERS_PRESENTATION",
+    [
+        "new",
+        "availability",
+        "subjects",
+        "levels",
+        "organizations",
+        "languages",
+        "persons",
+        "licences",
+        "pace",
+    ],
+)

--- a/src/richie/apps/search/filter_definitions/__init__.py
+++ b/src/richie/apps/search/filter_definitions/__init__.py
@@ -1,5 +1,4 @@
 """Make all filter definitions available from richie.apps.search.filter_definitions."""
-from django.conf import settings
 from django.utils.module_loading import import_string
 
 # pylint: disable=unused-import
@@ -14,8 +13,6 @@ from .courses import (  # noqa
 )
 
 FILTERS = {
-    params["name"]: import_string(path)(**params)
-    for path, params in getattr(
-        settings, "RICHIE_FILTERS_CONFIGURATION", FILTERS_CONFIGURATION
-    )
+    name: import_string(values["class"])(name, **values["params"])
+    for name, values in FILTERS_CONFIGURATION.items()
 }

--- a/src/richie/apps/search/filter_definitions/base.py
+++ b/src/richie/apps/search/filter_definitions/base.py
@@ -32,7 +32,6 @@ class BaseFilterDefinition:
         is_drilldown=False,
         is_searchable=False,
         min_doc_count=0,
-        position=0,
         sorting=FACET_SORTING_DEFAULT,
     ):
         """Set common attributes with sensible defaults (only name is required)."""
@@ -43,7 +42,6 @@ class BaseFilterDefinition:
         self.is_drilldown = is_drilldown
         self.is_searchable = is_searchable
         self.min_doc_count = min_doc_count
-        self.position = position
         self.sorting = sorting
 
     def get_form_fields(self):
@@ -139,7 +137,6 @@ class BaseFilterDefinition:
                         "is_searchable": False,
                         "is_drilldown": False,
                         "name": "languages",
-                        "position": 5,
                     }
                 }
 
@@ -174,7 +171,6 @@ class BaseFilterDefinition:
                         "is_searchable": False,
                         "is_drilldown": False,
                         "name": "languages",
-                        "position": 5,
                         "values": [
                             {"key": "en", "human_name": "English", "count": 3},
                             {"key": "fr", "human_name": "French", "count": 2},
@@ -243,7 +239,6 @@ class BaseChoicesFilterDefinition(BaseFilterDefinition):
                 "is_drilldown": self.is_drilldown,
                 "is_searchable": self.is_searchable,
                 "name": self.name,
-                "position": self.position,
             }
         }
 
@@ -292,8 +287,7 @@ class BaseChoicesFilterDefinition(BaseFilterDefinition):
         if sorting == self.SORTING_NAME:
             # Alphabetical ascending sorting
             values = sorted(
-                values,
-                key=lambda value: (value["human_name"], value["count"] * -1),
+                values, key=lambda value: (value["human_name"], value["count"] * -1)
             )
         elif sorting == self.SORTING_CONF:
             # Respect the order set in filter definitions
@@ -303,8 +297,7 @@ class BaseChoicesFilterDefinition(BaseFilterDefinition):
         elif sorting == self.SORTING_COUNT:
             # Sorting by descending facet count
             values = sorted(
-                values,
-                key=lambda value: (value["count"] * -1, value["human_name"]),
+                values, key=lambda value: (value["count"] * -1, value["human_name"])
             )
         else:
             raise ImproperlyConfigured(
@@ -366,10 +359,10 @@ class NestingWrapper(BaseFilterDefinition):
         super().__init__(name)
         self.path = path or name
         self.filter_definitions = {
-            params["name"]: import_string(dotted_path)(
-                term=f"{self.path:s}.{params['name']:s}", **params
+            name: import_string(values["class"])(
+                name, term=f"{self.path:s}.{name:s}", **values["params"]
             )
-            for dotted_path, params in filters
+            for name, values in filters.items()
         }
 
     def get_form_fields(self):

--- a/src/richie/apps/search/filter_definitions/base.py
+++ b/src/richie/apps/search/filter_definitions/base.py
@@ -57,7 +57,7 @@ class BaseFilterDefinition:
 
     def get_query_fragment(self, data):
         """
-        Build the query fragment to use in the ElasticSearch filter & aggregations.
+        Build the query fragment to use in the ElasticSearch query.
 
         Arguments:
         ----------
@@ -84,7 +84,7 @@ class BaseFilterDefinition:
 
     def get_aggs_fragment(self, queries, *args, **kwargs):
         """
-        Build the aggregations fragment to use to extract facets from ElasticSearch.
+        Build the aggregations fragment to use to extract facets from ElasticSearch aggregations.
 
         Arguments:
         ----------

--- a/src/richie/apps/search/filter_definitions/courses.py
+++ b/src/richie/apps/search/filter_definitions/courses.py
@@ -250,7 +250,6 @@ class IndexableFilterDefinition(TermsQueryMixin, BaseFilterDefinition):
                 "is_drilldown": self.is_drilldown,
                 "is_searchable": self.is_searchable,
                 "name": self.name,
-                "position": self.position,
             }
         }
 
@@ -442,9 +441,9 @@ class StaticChoicesFilterDefinition(
     A filter definition for static choices ie that can be defined from the project settings.
     """
 
-    def __init__(self, values, fragment_map, *args, **kwargs):
+    def __init__(self, name, values, fragment_map, *args, **kwargs):
         """Record values and fragment map as attributes."""
-        super().__init__(*args, **kwargs)
+        super().__init__(name, *args, **kwargs)
         self.values = values
         self.fragment_map = fragment_map
 

--- a/src/richie/apps/search/views.py
+++ b/src/richie/apps/search/views.py
@@ -9,6 +9,7 @@ from django.views.decorators.cache import cache_page
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
+from .defaults import FILTERS_PRESENTATION
 from .filter_definitions import FILTERS
 
 
@@ -37,10 +38,13 @@ def filter_definitions(request, version):
     Make available on an API route the static parts of filter definitions.
     This is useful to some frontend components that need them to configure themselves.
     """
-    return Response(
-        {
-            name: faceted_definition
-            for filter in FILTERS.values()
-            for name, faceted_definition in filter.get_static_definitions().items()
-        }
-    )
+    filters = {
+        name: faceted_definition
+        for filter in FILTERS.values()
+        for name, faceted_definition in filter.get_definition().items()
+        if name in FILTERS_PRESENTATION
+    }
+    for name in filters:
+        filters[name]["position"] = FILTERS_PRESENTATION.index(name)
+
+    return Response(filters)

--- a/src/richie/apps/search/viewsets/courses.py
+++ b/src/richie/apps/search/viewsets/courses.py
@@ -72,10 +72,16 @@ class CoursesViewSet(AutocompleteMixin, ViewSet):
             ]
 
         if form_class.FILTERS in scope or not scope:
-            filters = {
-                name: faceted_definition
+            filters_definition = {
+                name: definition
                 for filter in FILTERS.values()
-                for name, faceted_definition in filter.get_faceted_definitions(
+                for name, definition in filter.get_definition().items()
+                if name in FILTERS_PRESENTATION
+            }
+            filters = {
+                name: {**filters_definition[name], **faceted_definition}
+                for filter in FILTERS.values()
+                for name, faceted_definition in filter.get_facet_info(
                     course_query_response["aggregations"]["all_courses"],
                     data=params_form.cleaned_data,
                 ).items()

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -876,7 +876,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "is_drilldown": False,
                         "is_searchable": True,
                         "name": "licences",
-                        "position": 6,
+                        "position": 7,
                         "values": [
                             {
                                 "count": 2,
@@ -948,7 +948,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "is_drilldown": False,
                         "is_searchable": True,
                         "name": "persons",
-                        "position": 5,
+                        "position": 6,
                         "values": [
                             {
                                 "count": 2,
@@ -965,7 +965,7 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "is_drilldown": False,
                         "is_searchable": False,
                         "name": "pace",
-                        "position": 7,
+                        "position": 8,
                         "values": [
                             {
                                 "count": 1,

--- a/tests/apps/search/test_query_courses_facets.py
+++ b/tests/apps/search/test_query_courses_facets.py
@@ -1103,7 +1103,8 @@ class FacetsCoursesQueryTestCase(TestCase):
         FILTERS,
         {
             "subjects": IndexableHierarchicalFilterDefinition(
-                **{**FILTERS_CONFIGURATION[2][1], "min_doc_count": 2}
+                "subjects",
+                **{**FILTERS_CONFIGURATION["subjects"]["params"], "min_doc_count": 2},
             )
         },
     )
@@ -1170,7 +1171,8 @@ class FacetsCoursesQueryTestCase(TestCase):
         FILTERS,
         {
             "subjects": IndexableHierarchicalFilterDefinition(
-                **{**FILTERS_CONFIGURATION[2][1], "min_doc_count": 2}
+                "subjects",
+                **{**FILTERS_CONFIGURATION["subjects"]["params"], "min_doc_count": 2},
             )
         },
     )
@@ -1233,21 +1235,17 @@ class FacetsCoursesQueryTestCase(TestCase):
         FILTERS,
         {
             "course_runs": NestingWrapper(
-                **{
-                    "name": "course_runs",
-                    "filters": [
-                        (
-                            "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
-                            {
-                                "human_name": "Languages",
-                                "min_doc_count": 2,
-                                "name": "languages",
-                                "position": 5,
-                                "sorting": "count",
-                            },
-                        )
-                    ],
-                }
+                "course_runs",
+                filters={
+                    "languages": {
+                        "class": "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
+                        "params": {
+                            "human_name": "Languages",
+                            "min_doc_count": 2,
+                            "sorting": "count",
+                        },
+                    }
+                },
             )
         },
     )
@@ -1285,21 +1283,17 @@ class FacetsCoursesQueryTestCase(TestCase):
         FILTERS,
         {
             "course_runs": NestingWrapper(
-                **{
-                    "name": "course_runs",
-                    "filters": [
-                        (
-                            "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
-                            {
-                                "human_name": "Languages",
-                                "min_doc_count": 2,
-                                "name": "languages",
-                                "position": 5,
-                                "sorting": "count",
-                            },
-                        )
-                    ],
-                }
+                "course_runs",
+                filters={
+                    "languages": {
+                        "class": "richie.apps.search.filter_definitions.LanguagesFilterDefinition",
+                        "params": {
+                            "human_name": "Languages",
+                            "min_doc_count": 2,
+                            "sorting": "count",
+                        },
+                    },
+                },
             )
         },
     )

--- a/tests/apps/search/test_views_filter_definitions.py
+++ b/tests/apps/search/test_views_filter_definitions.py
@@ -146,7 +146,7 @@ class FilterDefinitionsViewTestCase(CMSTestCase):
 
     @mock.patch.object(
         FILTERS["new"],
-        "get_static_definitions",
+        "get_definition",
         return_value={
             "new": {
                 "base_path": None,
@@ -159,10 +159,10 @@ class FilterDefinitionsViewTestCase(CMSTestCase):
             }
         },
     )
-    def test_views_filter_definitions_is_cached(self, mock_get_static_definitions):
+    def test_views_filter_definitions_is_cached(self, mock_get_definition):
         """
         Make sure we don't re-build the static filter definitions with each call.
         """
         self.client.get("/api/v1.0/filter-definitions/")
         self.client.get("/api/v1.0/filter-definitions/")
-        self.assertEqual(mock_get_static_definitions.call_count, 1)
+        self.assertEqual(mock_get_definition.call_count, 1)

--- a/tests/apps/search/test_views_filter_definitions.py
+++ b/tests/apps/search/test_views_filter_definitions.py
@@ -103,7 +103,7 @@ class FilterDefinitionsViewTestCase(CMSTestCase):
                     "is_drilldown": False,
                     "is_searchable": True,
                     "name": "licences",
-                    "position": 6,
+                    "position": 7,
                 },
                 "organizations": {
                     "base_path": "0001",
@@ -130,7 +130,7 @@ class FilterDefinitionsViewTestCase(CMSTestCase):
                     "is_drilldown": False,
                     "is_searchable": True,
                     "name": "persons",
-                    "position": 5,
+                    "position": 6,
                 },
                 "pace": {
                     "base_path": None,
@@ -139,7 +139,7 @@ class FilterDefinitionsViewTestCase(CMSTestCase):
                     "is_drilldown": False,
                     "is_searchable": False,
                     "name": "pace",
-                    "position": 7,
+                    "position": 8,
                 },
             },
         )

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -254,7 +254,7 @@ class CoursesViewsetsTestCase(CMSTestCase):
                         "is_drilldown": False,
                         "is_searchable": True,
                         "name": "licences",
-                        "position": 6,
+                        "position": 7,
                         "values": [
                             {"count": 66, "human_name": "Licence 42", "key": "42"},
                             {"count": 13, "human_name": "Licence 41", "key": "41"},
@@ -295,7 +295,7 @@ class CoursesViewsetsTestCase(CMSTestCase):
                         "is_drilldown": False,
                         "is_searchable": True,
                         "name": "persons",
-                        "position": 5,
+                        "position": 6,
                         "values": [
                             {"count": 11, "human_name": "Person 31", "key": "31"},
                             {"count": 7, "human_name": "Person 32", "key": "32"},
@@ -310,7 +310,7 @@ class CoursesViewsetsTestCase(CMSTestCase):
                         "is_drilldown": False,
                         "is_searchable": False,
                         "name": "pace",
-                        "position": 7,
+                        "position": 8,
                         "values": [],
                     },
                     "subjects": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,10 +2,11 @@
   "docs": {
     "Getting started": ["discover", "cookiecutter"],
     "Recipes": [
+      "filters-customization",
       "django-react-interop",
       "building-the-frontend",
-      "internationalization",
       "frontend-overrides",
+      "internationalization",
       "lms-connection",
       "web-analytics"
     ],


### PR DESCRIPTION
## Purpose

It was not easy to define the list of filters to display and their order.

PR https://github.com/openfun/richie/pull/1765 addressed this issue by introducing new settings, one per filter. 

This PR is an attempt to further simplify filters configuration and avoid adding too many settings, the existence of which is tied to what is defined in `FILTERS_CONFIGURATION`.

## Proposal

Introduce a new setting `FILTERS_PRESENTATION` and simplify the format of the existing `FILTERS_CONFIGURATION` setting.

With this new setting, it is easier to define which filters are displayed and their order.
Filter definitions became a dictionary which also makes it easier than previous list of tuples.

This requires upgrade attention only for sites that have customized their filters.

Now that filters configuration is easier, I added a documentation to explain what is possible.
