### PR TITLE
🐛(course) allow to include anchor target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- CKEditor basic configuration should allow to include target on anchors
+  for course fields: assessment, format and prerequisites.
 - Allow form messages to go on multiple lines
 - On the search page, improve accessibility of the filters pane when using a
   small screen

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -434,7 +434,7 @@ CKEDITOR_BASIC_CONFIGURATION = {
     "toolbarCanCollapse": False,
     "contentsCss": "/static/css/ckeditor.css",
     # Only enable following tag definitions
-    "allowedContent": ["p", "b", "i", "a[href]"],
+    "allowedContent": ["p", "b", "i", "a[href,target]"],
     # Enabled showblocks as default behavior
     "startupOutlineBlocks": True,
     # Default toolbar configurations for djangocms_text_ckeditor


### PR DESCRIPTION
CKEditor basic configuration should allow to include target on anchors for course fields: assessment, format and prerequisites.
Resolves #1764

The business problem is that we need to include an anchor on the prerequisites, for an external stuff, but it should open it as a new tab (`target=_blank`), so the user doesn't simply leave the Richie site.

Screen capture:
![image](https://user-images.githubusercontent.com/67018/188179985-76b2ab70-fa0f-421a-b9f0-791cbdf276da.png)
