### PR TITLE
🐛(frontend) fix flaky tests using random currencies

### DIFF
--- a/src/frontend/js/components/SaleTunnelStepPayment/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnelStepPayment/index.spec.tsx
@@ -84,7 +84,7 @@ describe('SaleTunnelStepPayment', () => {
     // - It should display product information (title & price)
     screen.getByRole('heading', { level: 5, name: 'You are about to purchase' });
     screen.getByText(product.title, { exact: true });
-    screen.getByText(formatter.format(product.price).replace(' ', ' '));
+    screen.getByText(formatter.format(product.price).replaceAll(' ', ' '));
   });
 
   it('should display authenticated user information', async () => {

--- a/src/frontend/js/components/SaleTunnelStepValidation/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnelStepValidation/index.spec.tsx
@@ -27,7 +27,7 @@ describe('SaleTunnelStepValidation', () => {
     });
 
     screen.getByRole('heading', { level: 3, name: product.title });
-    screen.getByText(`${formatter.format(product.price).replace(' ', ' ')} including VAT`);
+    screen.getByText(`${formatter.format(product.price).replaceAll(' ', ' ')} including VAT`);
 
     const courses = container.querySelectorAll('.product-detail-row--course');
     expect(courses).toHaveLength(product.target_courses.length);


### PR DESCRIPTION
## Purpose

Some components display prices, and we need to test price currencies are well displayed to the user. To empower our tests, price currency is randomly picked so each tests can display a different content. Thus ensure that content exists in document we try to find an element containing the formatted price using Intl.NumberFormat, but spaces seems not rendered in the same way between this method and the render method of testing-library/react. As a workaround, we replace non-breakable space by a "normal" space through `replace` method but we didn't think about currency containing several spaces. In order to fix that, we have to use `replaceAll` method instead of `replace`.


## Proposal

- [x] replace all `NBSP` by simple space
