### PR TITLE
📌(backend) unpin python dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,22 +29,22 @@ include_package_data = True
 # `matchPackageNames` (in the "ignored python dependencies" group) within
 # renovate.json file at the root of this repository
 install_requires =
-    arrow==1.2.2
+    arrow
     Django<4
-    djangocms-file==3.0.0
-    djangocms-googlemap==2.0.0
-    djangocms-link==3.0.0
-    djangocms-picture==4.0.0
-    djangocms-text-ckeditor==5.1.1
-    djangocms-video==3.0.0
-    djangorestframework==3.13.1
+    djangocms-file
+    djangocms-googlemap
+    djangocms-link
+    djangocms-picture
+    djangocms-text-ckeditor
+    djangocms-video
+    djangorestframework
     django-autocomplete-light==3.9.4
-    django-cms==3.11.0
-    django-parler==2.3
-    django-redis==5.2.0
-    django-treebeard==4.5.1
-    dj-pagination==2.5.0
-    easy_thumbnails[svg]==2.8.3
+    django-cms>=3.11.0
+    django-parler>=2.3
+    django-redis>=4.11.0
+    django-treebeard
+    dj-pagination
+    easy_thumbnails[svg]>=2.8
     elasticsearch>=6.0.0,<7.0.0
     exrex==0.10.5
     oauthlib==3.2.0


### PR DESCRIPTION
## Purpose

We previously pinned all python dependencies to prevent some uncontrolled issues due to transparent upgrades. Unfortunately this workflow does not comply with library projects like Richie as user of this library should be able to install another version of a richie dependency and pinning all richie dependencies does not allow that that's why we have to roll back this change.


## Proposal

- [x] Rollback 798780746a996ec3bf9137acddddb590fdb79241
