### PR TITLE
Cookiecutter/fix template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Add pip requests package for open edx lms backend.
+- Fix several issues about cookiecutter template
 
 ### Added
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Dockerfile
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Dockerfile
@@ -38,11 +38,7 @@ COPY ./sites/${SITE}/requirements/base.txt /builder/requirements.txt
 RUN pip install --upgrade pip
 
 RUN mkdir /install && \
-    pip install --prefix=/install -r requirements.txt \
-    # The django-cms fork includes drillable search feature,
-    # it should be removed when this feature will be officially released.
-    pip install --prefix=/install \
-    git+https://github.com/jbpenrath/django-cms@fun-3.10.0#egg=django-cms
+    pip install --prefix=/install -r requirements.txt
 
 # ---- Core application image ----
 FROM base as core

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/env.d/development.dist
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/env.d/development.dist
@@ -23,7 +23,7 @@ DB_PORT=5432
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
 EDX_JS_BACKEND=base
-EDX_JS_COURSE_REGEX=^.*/courses/(.*)/info$
+EDX_JS_COURSE_REGEX='^.*/courses/(.*)/info$'
 EDX_BASE_URL=http://localhost:8073
 
 # Authentication Backend


### PR DESCRIPTION
## Purpose

Currently, the workflow to create a project from cookiecutter is corrupted.
There are several aspects to fix :
- An incompatibility issue with docker compose > 2.17
- A dependency issue

Furthermore, as cookiecutter is crucial for newcomer to start a new project from richie, we should be aware of any problem about our template. -> **Will be address in a separate PR #1776.**


## Proposal

- [x] Fix current errors of our templates
