### PR TITLE
♻️(frontend) refactor modal component ( UX / DX ) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Modal component refactor for homogeneous use
+- New global scroll behavior for Modal
+
 ## [2.16.0]
 
 ### Fixed

--- a/src/frontend/.storybook/preview.tsx
+++ b/src/frontend/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useAsyncEffect } from "../js/utils/useAsyncEffect";
+import { IntlProvider } from 'react-intl';
 
 export const parameters = {
   actions: {argTypesRegex: "^on[A-Z].*"},
@@ -31,8 +32,10 @@ const IconsWrapper = props => {
 
 export const decorators = [
   (Story) => (
-    <IconsWrapper>
-      <Story/>
-    </IconsWrapper>
+    <IntlProvider locale="en">
+      <IconsWrapper>
+        <Story/>
+      </IconsWrapper>
+    </IntlProvider>
   ),
 ];

--- a/src/frontend/js/components/Modal/_styles.scss
+++ b/src/frontend/js/components/Modal/_styles.scss
@@ -5,18 +5,14 @@
   color: r-theme-val(modal, base-color);
   left: 0;
   margin: 3rem auto;
-  max-height: calc(100% - 6rem);
   max-width: 1024px;
   outline: none;
-  overflow: auto;
-  position: absolute;
   right: 0;
   top: 0;
   width: 75vw;
 
   @include media-breakpoint-down(sm) {
     margin: 1rem auto;
-    max-height: calc(100% - 2rem);
     width: calc(100% - 2rem);
   }
 
@@ -66,9 +62,22 @@
     right: 0;
     top: 0;
     z-index: 300;
+    overflow: auto;
 
     &--transparent {
       background-color: transparent;
+    }
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: sticky;
+    top: 0;
+
+    &.filled {
+      background-color: r-theme-val(modal, base-background);
     }
   }
 }

--- a/src/frontend/js/components/Modal/_styles.scss
+++ b/src/frontend/js/components/Modal/_styles.scss
@@ -76,7 +76,16 @@
     position: sticky;
     top: 0;
 
-    &.filled {
+    h2 {
+      font-family: $r-font-family-hind;
+      display: block;
+      margin: 0;
+      padding: 1rem;
+      font-size: 1.1rem;
+      font-weight: $font-weight-boldest;
+    }
+
+    &--filled {
       background-color: r-theme-val(modal, base-background);
     }
   }

--- a/src/frontend/js/components/Modal/index.spec.tsx
+++ b/src/frontend/js/components/Modal/index.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
 import { Modal } from '.';
 
 describe('<Modal />', () => {
@@ -10,12 +11,14 @@ describe('<Modal />', () => {
 
   it('merges custom classNames of type string with the default classes', () => {
     render(
-      <Modal
-        isOpen={true}
-        className="custom-class"
-        bodyOpenClassName="custom-body-open-class"
-        overlayClassName="custom-overlay-class"
-      />,
+      <IntlProvider locale="en">
+        <Modal
+          isOpen={true}
+          className="custom-class"
+          bodyOpenClassName="custom-body-open-class"
+          overlayClassName="custom-overlay-class"
+        />
+      </IntlProvider>,
     );
 
     const $body = document.querySelector('body.has-opened-modal.custom-body-open-class');
@@ -29,19 +32,21 @@ describe('<Modal />', () => {
 
   it('merges custom classNames of type ReactModal.Classes with the default classes', () => {
     render(
-      <Modal
-        isOpen={true}
-        className={{
-          base: 'custom-class-base',
-          afterOpen: 'custom-class-afterOpen',
-          beforeClose: 'custom-class-beforeClose',
-        }}
-        overlayClassName={{
-          base: 'custom-overlay-class-base',
-          afterOpen: 'custom-overlay-class-afterOpen',
-          beforeClose: 'custom-overlay-class-beforeClose',
-        }}
-      />,
+      <IntlProvider locale="en">
+        <Modal
+          isOpen={true}
+          className={{
+            base: 'custom-class-base',
+            afterOpen: 'custom-class-afterOpen',
+            beforeClose: 'custom-class-beforeClose',
+          }}
+          overlayClassName={{
+            base: 'custom-overlay-class-base',
+            afterOpen: 'custom-overlay-class-afterOpen',
+            beforeClose: 'custom-overlay-class-beforeClose',
+          }}
+        />
+      </IntlProvider>,
     );
 
     const $modal = document.querySelector('.modal.custom-class-base');

--- a/src/frontend/js/components/Modal/index.spec.tsx
+++ b/src/frontend/js/components/Modal/index.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { Modal } from '.';
 
@@ -54,5 +54,44 @@ describe('<Modal />', () => {
 
     expect($modal).toBeInstanceOf(HTMLDivElement);
     expect($overlay).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('displays close button', () => {
+    render(
+      <IntlProvider locale="en">
+        <Modal isOpen={true} />
+      </IntlProvider>,
+    );
+
+    screen.getByRole('button', { name: 'Close dialog' });
+  });
+
+  it('has no close button', () => {
+    render(
+      <IntlProvider locale="en">
+        <Modal isOpen={true} hasCloseButton={false} />
+      </IntlProvider>,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Close dialog' })).toBeNull();
+  });
+
+  it('displays title', () => {
+    render(
+      <IntlProvider locale="en">
+        <Modal isOpen={true} title={<div data-testid="custom__header">Hi there</div>} />
+      </IntlProvider>,
+    );
+
+    screen.getByTestId('custom__header');
+  });
+
+  it('displays title in h2 if it is a string', () => {
+    render(
+      <IntlProvider locale="en">
+        <Modal isOpen={true} title="Hello world" />
+      </IntlProvider>,
+    );
+    screen.getByRole('heading', { level: 2, name: 'Hello world' });
   });
 });

--- a/src/frontend/js/components/Modal/index.stories.tsx
+++ b/src/frontend/js/components/Modal/index.stories.tsx
@@ -1,7 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { useState } from 'react';
 import { Modal } from './index';
-import { Icon } from '../Icon';
 
 export default {
   title: 'Components/Modal',
@@ -13,6 +12,9 @@ export default {
     shouldCloseOnEsc: {
       control: 'boolean',
     },
+    title: {
+      control: 'text',
+    },
   },
 } as ComponentMeta<typeof Modal>;
 
@@ -23,17 +25,11 @@ const Template: ComponentStory<typeof Modal> = (args) => {
     <>
       <button onClick={() => setModalIsOpen(true)}>Open modal</button>
       <Modal {...args} isOpen={modalIsOpen} onRequestClose={() => setModalIsOpen(false)}>
-        <button
-          className="modal__closeButton search-filter-group-modal__close"
-          onClick={() => setModalIsOpen(false)}
-        >
-          <span className="offscreen">Close</span>
-          <Icon
-            name="icon-cross"
-            className="modal__closeButton__icon search-filter-group-modal__close__icon"
-          />
-        </button>
-        <div style={{ padding: '20px' }}>Any content you want here.</div>
+        <div style={{ padding: '20px' }}>
+          {[...Array(50)].map(() => (
+            <div>Any content you want here.</div>
+          ))}
+        </div>
       </Modal>
     </>
   );

--- a/src/frontend/js/components/Modal/index.tsx
+++ b/src/frontend/js/components/Modal/index.tsx
@@ -1,13 +1,31 @@
-import { PropsWithChildren, useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import ReactModal from 'react-modal';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+
+const messages = defineMessages({
+  closeDialog: {
+    defaultMessage: 'Close modal',
+    description: 'Text for the button to close the modal',
+    id: 'components.Modal.closeDialog',
+  },
+});
+
+interface ModalProps extends ReactModal.Props {
+  closeButton?: boolean;
+  title?: string | ReactNode;
+}
 
 export const Modal = ({
   className,
   bodyOpenClassName,
   overlayClassName,
   children,
+  closeButton = true,
+  title,
   ...props
-}: PropsWithChildren<ReactModal.Props>) => {
+}: ModalProps) => {
+  const intl = useIntl();
+
   // As ReactModal can accept a ReactModal.Classes object or a string for some
   // class properties, we have to impletemente a little util to merge this special
   // object with the default CSS class to applied.
@@ -35,6 +53,11 @@ export const Modal = ({
     throw new Error('Failed to get #modal-exclude to enable an accessible <ReactModal />.');
   }, []);
 
+  const headerClasses = ['modal__header'];
+  if (title) {
+    headerClasses.push('filled');
+  }
+
   return (
     <ReactModal
       appElement={modalExclude}
@@ -43,6 +66,23 @@ export const Modal = ({
       overlayClassName={mergeClasses({ base: 'modal__overlay', classes: overlayClassName })}
       {...props}
     >
+      <div className={headerClasses.join(' ')}>
+        <div>{title}</div>
+        {closeButton && (
+          <button
+            className="modal__closeButton"
+            onClick={(e) => props.onRequestClose?.(e)}
+            title={intl.formatMessage(messages.closeDialog)}
+          >
+            <svg className="modal__closeButton__icon" aria-hidden="true">
+              <use href="#icon-round-close" />
+            </svg>
+            <span className="offscreen">
+              <FormattedMessage {...messages.closeDialog} />
+            </span>
+          </button>
+        )}
+      </div>
       {children}
     </ReactModal>
   );

--- a/src/frontend/js/components/Modal/index.tsx
+++ b/src/frontend/js/components/Modal/index.tsx
@@ -1,17 +1,18 @@
 import { ReactNode, useMemo } from 'react';
 import ReactModal from 'react-modal';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { StringHelper } from '../../utils/StringHelper';
 
 const messages = defineMessages({
   closeDialog: {
-    defaultMessage: 'Close modal',
+    defaultMessage: 'Close dialog',
     description: 'Text for the button to close the modal',
     id: 'components.Modal.closeDialog',
   },
 });
 
 interface ModalProps extends ReactModal.Props {
-  closeButton?: boolean;
+  hasCloseButton?: boolean;
   title?: string | ReactNode;
 }
 
@@ -20,14 +21,14 @@ export const Modal = ({
   bodyOpenClassName,
   overlayClassName,
   children,
-  closeButton = true,
+  hasCloseButton = true,
   title,
   ...props
 }: ModalProps) => {
   const intl = useIntl();
 
   // As ReactModal can accept a ReactModal.Classes object or a string for some
-  // class properties, we have to impletemente a little util to merge this special
+  // class properties, we have to implement a little util to merge this special
   // object with the default CSS class to applied.
   const mergeClasses = ({ base, classes }: { base?: string; classes?: any }) => {
     if (base && classes) {
@@ -55,7 +56,7 @@ export const Modal = ({
 
   const headerClasses = ['modal__header'];
   if (title) {
-    headerClasses.push('filled');
+    headerClasses.push('modal__header--filled');
   }
 
   return (
@@ -66,9 +67,10 @@ export const Modal = ({
       overlayClassName={mergeClasses({ base: 'modal__overlay', classes: overlayClassName })}
       {...props}
     >
-      <div className={headerClasses.join(' ')}>
-        <div>{title}</div>
-        {closeButton && (
+      <header className={headerClasses.join(' ')}>
+        {StringHelper.isString(title) && <h2>{title}</h2>}
+        {!StringHelper.isString(title) && title}
+        {hasCloseButton && (
           <button
             className="modal__closeButton"
             onClick={(e) => props.onRequestClose?.(e)}
@@ -82,7 +84,7 @@ export const Modal = ({
             </span>
           </button>
         )}
-      </div>
+      </header>
       {children}
     </ReactModal>
   );

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -191,7 +191,7 @@ describe('SaleTunnel', () => {
     screen.getByTestId('SaleTunnel__modal');
 
     // - A close button should be displayed
-    const $closeButton = screen.getByRole('button', { name: 'Close modal' });
+    const $closeButton = screen.getByRole('button', { name: 'Close dialog' });
 
     // - Go to step 2
     screen.getByRole('heading', { level: 1, name: 'SaleTunnelStepValidation Component' });

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -191,7 +191,7 @@ describe('SaleTunnel', () => {
     screen.getByTestId('SaleTunnel__modal');
 
     // - A close button should be displayed
-    const $closeButton = screen.getByRole('button', { name: 'Close the dialog' });
+    const $closeButton = screen.getByRole('button', { name: 'Close modal' });
 
     // - Go to step 2
     screen.getByRole('heading', { level: 1, name: 'SaleTunnelStepValidation Component' });

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -33,12 +33,6 @@ const messages = defineMessages({
     description: "Label displayed inside the product's CTA when user is not logged in",
     id: 'components.SaleTunnel.loginToPurchase',
   },
-  closeDialog: {
-    defaultMessage: 'Close the dialog',
-    description:
-      'ARIA label used by screenreader to inform that the close dialog button is selected',
-    id: 'components.SaleTunnel.closeDialog',
-  },
 });
 
 interface SaleTunnelProps {
@@ -107,18 +101,6 @@ const SaleTunnel = ({ product }: SaleTunnelProps) => {
         shouldCloseOnEsc={false}
         testId="SaleTunnel__modal"
       >
-        <button
-          className="modal__closeButton"
-          onClick={handleModalClose}
-          title={intl.formatMessage(messages.closeDialog)}
-        >
-          <svg className="modal__closeButton__icon" aria-hidden="true">
-            <use href="#icon-round-close" />
-          </svg>
-          <span className="offscreen">
-            <FormattedMessage {...messages.closeDialog} />
-          </span>
-        </button>
         <div className="SaleTunnel__modal-body">
           <StepBreadcrumb manifest={manifest} step={step} />
           {step === 'validation' && <SaleTunnelStepValidation product={product} next={next} />}

--- a/src/frontend/js/components/SearchFilterGroupModal/_styles.scss
+++ b/src/frontend/js/components/SearchFilterGroupModal/_styles.scss
@@ -16,14 +16,6 @@
     flex-direction: column;
     flex-grow: 1;
 
-    &__title {
-      display: block;
-      margin: 0;
-      padding: 1rem;
-      font-size: 1.1rem;
-      font-weight: $font-weight-boldest;
-    }
-
     &__input {
       width: 100%;
       padding: 0.5rem 1rem;

--- a/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.spec.tsx
@@ -427,7 +427,7 @@ describe('<SearchFilterGroupModal />', () => {
     // The modal is not rendered
     expect(screen.queryByText('Add filters for Universities')).toEqual(null);
     expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
-    expect(screen.queryByText('Close modal')).toEqual(null);
+    expect(screen.queryByText('Close dialog')).toEqual(null);
 
     // The modal is rendered
     const openButton = screen.getByText('More options');
@@ -452,7 +452,7 @@ describe('<SearchFilterGroupModal />', () => {
     screen.getByPlaceholderText('Search in Universities');
 
     // User clicks on the close button
-    const closeButton = screen.getByText('Close modal');
+    const closeButton = screen.getByText('Close dialog');
     fireEvent.click(closeButton);
 
     // The modal is not rendered any more
@@ -460,7 +460,7 @@ describe('<SearchFilterGroupModal />', () => {
       expect(screen.queryByText('Add filters for Universities')).toEqual(null);
     });
     expect(screen.queryByPlaceholderText('Search in Universities')).toEqual(null);
-    expect(screen.queryByText('Close modal')).toEqual(null);
+    expect(screen.queryByText('Close dialog')).toEqual(null);
   });
 
   it('adds the value and closes when the user clicks a filter value', async () => {

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -4,7 +4,6 @@ import { useInfiniteQuery } from 'react-query';
 
 import { Modal } from 'components/Modal';
 import { Spinner } from 'components/Spinner';
-import { Icon } from 'components/Icon';
 import { fetchList } from 'data/getResourceList';
 import { CourseSearchParamsAction, useCourseSearchParams } from 'data/useCourseSearchParams';
 import { API_LIST_DEFAULT_PARAMS } from 'settings';
@@ -151,22 +150,7 @@ const ModalContent = ({ filter, modalIsOpen, setModalIsOpen }: ModalContentProps
 
   return (
     <Fragment>
-      <button
-        className="modal__closeButton search-filter-group-modal__close"
-        onClick={() => setModalIsOpen(false)}
-      >
-        <span className="offscreen">
-          <FormattedMessage {...messages.closeButton} />
-        </span>
-        <Icon
-          name="icon-cross"
-          className="modal__closeButton__icon search-filter-group-modal__close__icon"
-        />
-      </button>
       <fieldset className="search-filter-group-modal__form">
-        <legend className="search-filter-group-modal__form__title">
-          <FormattedMessage {...messages.modalTitle} values={{ filterName: filter.human_name }} />
-        </legend>
         <input
           aria-label={intl.formatMessage(messages.inputLabel)}
           className="search-filter-group-modal__form__input"
@@ -257,8 +241,13 @@ export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) 
       <Modal
         appElement={modalExclude}
         bodyOpenClassName="has-search-filter-group-modal"
-        className="search-filter-group-modal modal--stretched"
+        className="search-filter-group-modal"
         isOpen={modalIsOpen}
+        title={
+          <legend className="search-filter-group-modal__form__title">
+            <FormattedMessage {...messages.modalTitle} values={{ filterName: filter.human_name }} />
+          </legend>
+        }
         onRequestClose={() => setModalIsOpen(false)}
       >
         <ModalContent {...{ filter, modalIsOpen, setModalIsOpen }} />

--- a/src/frontend/js/components/SearchFilterGroupModal/index.tsx
+++ b/src/frontend/js/components/SearchFilterGroupModal/index.tsx
@@ -223,6 +223,7 @@ interface SearchFilterGroupModalProps {
 
 export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
+  const intl = useIntl();
 
   const modalExclude = useMemo(() => {
     const exclude = document.getElementById('modal-exclude');
@@ -243,11 +244,7 @@ export const SearchFilterGroupModal = ({ filter }: SearchFilterGroupModalProps) 
         bodyOpenClassName="has-search-filter-group-modal"
         className="search-filter-group-modal"
         isOpen={modalIsOpen}
-        title={
-          <legend className="search-filter-group-modal__form__title">
-            <FormattedMessage {...messages.modalTitle} values={{ filterName: filter.human_name }} />
-          </legend>
-        }
+        title={intl.formatMessage(messages.modalTitle, { filterName: filter.human_name })}
         onRequestClose={() => setModalIsOpen(false)}
       >
         <ModalContent {...{ filter, modalIsOpen, setModalIsOpen }} />

--- a/src/frontend/js/utils/StringHelper/index.spec.tsx
+++ b/src/frontend/js/utils/StringHelper/index.spec.tsx
@@ -1,0 +1,19 @@
+import { StringHelper } from './index';
+
+describe('StringHelper', () => {
+  it('is a string', () => {
+    expect(StringHelper.isString('Hello')).toBe(true);
+  });
+  it('is a ReactNode', () => {
+    expect(StringHelper.isString(<div>Hello</div>)).toBe(false);
+  });
+  it('is null', () => {
+    expect(StringHelper.isString(null)).toBe(false);
+  });
+  it('is a number', () => {
+    expect(StringHelper.isString(10)).toBe(false);
+  });
+  it('is zero', () => {
+    expect(StringHelper.isString(0)).toBe(false);
+  });
+});

--- a/src/frontend/js/utils/StringHelper/index.ts
+++ b/src/frontend/js/utils/StringHelper/index.ts
@@ -1,0 +1,5 @@
+export class StringHelper {
+  static isString(input: any): boolean {
+    return typeof input === 'string' || input instanceof String;
+  }
+}


### PR DESCRIPTION
## Purpose

The modal close button wasn't included in the modal component, therefore it was required to define it each time when using the modal. So let's define a generic approach to modal close button for homogeneous UI.

Moreover, we decided to make homogeneous the behavior of the modal component, in terms in scroll and with a sticky header.