### PR TITLE
🐛(admin) order languages choices in course run admin form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - New global scroll behavior for Modal
 - Add disabled style for inputs
 
+### Fixed
+
+- Language choices should be ordered alphabetically in course run admin form
+
 ## [2.16.0]
 
 ### Fixed

--- a/src/richie/apps/courses/admin.py
+++ b/src/richie/apps/courses/admin.py
@@ -2,6 +2,7 @@
 Courses application admin
 """
 from itertools import chain
+from operator import itemgetter
 
 from django import forms
 from django.conf import settings
@@ -108,6 +109,10 @@ class CourseRunAdminForm(TranslatableModelForm):
 
         if len(course_query) < 2:
             self.fields["direct_course"].widget = forms.HiddenInput()
+
+        self.fields["languages"].choices = sorted(
+            self.fields["languages"].choices, key=itemgetter(1)
+        )
 
     def clean_direct_course(self):
         """Ensure that the user has the required permissions to change the related course page."""

--- a/tests/apps/courses/test_admin_form_course_run.py
+++ b/tests/apps/courses/test_admin_form_course_run.py
@@ -3,6 +3,7 @@ Test suite covering the admin form for the CourseRun model
 """
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
+from django.utils import translation
 
 from cms.models import PagePermission
 from cms.test_utils.testcases import CMSTestCase
@@ -239,3 +240,18 @@ class CourseRunAdminTestCase(CMSTestCase):
         self.assertIn(
             f'<option value="{snapshot.id:d}">Title 1 Snapshot</option>', html
         )
+
+    def test_admin_form_course_run_choices_languages(self):
+        """The languages field choices should be sorted alphabetically by localized values."""
+        user = UserFactory(is_staff=True, is_superuser=True)
+
+        request = RequestFactory().get("/")
+        request.user = user
+        CourseRunAdminForm.request = request
+
+        form = CourseRunAdminForm()
+        self.assertEqual(form.fields["languages"].choices[32][1], "German")
+
+        with translation.override("fr"):
+            form = CourseRunAdminForm()
+            self.assertEqual(form.fields["languages"].choices[2][1], "Allemand")


### PR DESCRIPTION
## Purpose

Languages choices should be ordered alphabetically in admin forms.

## Proposal

Ordering depends on the active language and only works if it is done directly in the form instance.

Add a test to secure the behavior.

