### PR TITLE
💚(cookiecutter) exec cookiecutter-bootstrap job only on release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -773,6 +773,17 @@ jobs:
       # Activate docker-in-docker
       - setup_remote_docker:
           version: 19.03.13
+      - checkout
+      - run:
+         name: Is a release branch
+         command: |
+           # We want to run this job only on release branch, to guess that
+           # we check if a new release entry has been added into the CHANGELOG
+           # If there is no new release entry, git diff returns a 0 exit code
+           if git diff --quiet -G"^## \[[0-9.]*\]$" origin/master..HEAD CHANGELOG.md; then
+             # So we can gracefully exit the job
+             circleci-agent step halt
+           fi
       - run:
           name: Install cookiecutter
           command: pip install cookiecutter


### PR DESCRIPTION
## Purpose

Currently, `cookiecutter-bootstrap` job runs on every branch and currently this job failed when PRs are created from forks.
Furthermore it appears this is relevant to run `cookiecutter-bootstrap` job only on release branch, so we add a step to this job which is in charge to check if the workflow concerned this kind of branch. If this is not the case, the job is exited gracefully.


## Proposal

- [x] Exit gracefully `cookiecutter-bootstrap` job if the branch is not a release branch. 
