### PR TITLE
🚨(frontend) enable rule to sort imports

### DIFF
--- a/src/frontend/.eslintrc.json
+++ b/src/frontend/.eslintrc.json
@@ -42,6 +42,13 @@
     "import/extensions": "off",
     "import/no-cycle": ["off"],
     "import/no-dynamic-require": "off",
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+        "alphabetize": { "order": "ignore" }
+      }
+    ],
     "import/prefer-default-export": "off",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/label-has-associated-control": "warn",
@@ -76,6 +83,7 @@
     "react/style-prop-object": ["error", { "allow": ["FormattedNumber"] }]
   },
   "settings": {
-    "polyfills": ["fetch", "Promise"]
+    "polyfills": ["fetch", "Promise"],
+    "import/resolver": "webpack"
   }
 }

--- a/src/frontend/js/components/AddressesManagement/AddressForm.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm.spec.tsx
@@ -1,9 +1,9 @@
 import { act } from '@testing-library/react-hooks';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
-import * as mockFactories from 'utils/test/factories';
-import { AddressFactory } from 'utils/test/factories';
 import countries from 'i18n-iso-countries';
 import { IntlProvider } from 'react-intl';
+import * as mockFactories from 'utils/test/factories';
+import { AddressFactory } from 'utils/test/factories';
 import { Address } from 'types/Joanie';
 import { ErrorKeys } from './validationSchema';
 import AddressForm from './AddressForm';

--- a/src/frontend/js/components/AddressesManagement/index.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.spec.tsx
@@ -4,9 +4,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from '@testing-library/react-hooks';
 import fetchMock from 'fetch-mock';
-import * as mockFactories from 'utils/test/factories';
 import { IntlProvider } from 'react-intl';
 import { QueryClientProvider } from 'react-query';
+import * as mockFactories from 'utils/test/factories';
 import { SessionProvider } from 'data/SessionProvider';
 import { REACT_QUERY_SETTINGS, RICHIE_USER_TOKEN } from 'settings';
 import type * as Joanie from 'types/Joanie';

--- a/src/frontend/js/components/DashboardItem/DashboardItemEnrollment.spec.tsx
+++ b/src/frontend/js/components/DashboardItem/DashboardItemEnrollment.spec.tsx
@@ -1,9 +1,9 @@
 import { IntlProvider } from 'react-intl';
-import { DashboardItemEnrollment } from 'components/DashboardItem/DashboardItemEnrollment';
 import { render, screen } from '@testing-library/react';
+import * as faker from 'faker';
+import { DashboardItemEnrollment } from 'components/DashboardItem/DashboardItemEnrollment';
 import { Enrollment } from 'types/Joanie';
 import { JoanieCourseRunFactory, JoanieEnrollmentFactory } from 'utils/test/factories';
-import * as faker from 'faker';
 import { DEFAULT_DATE_FORMAT } from 'utils/useDateFormat';
 
 describe('<DashboardItemEnrollment/>', () => {

--- a/src/frontend/js/components/DashboardItem/DashboardItemEnrollmentFooter.tsx
+++ b/src/frontend/js/components/DashboardItem/DashboardItemEnrollmentFooter.tsx
@@ -1,5 +1,5 @@
-import { Enrollment } from 'types/Joanie';
 import { FormattedMessage } from 'react-intl';
+import { Enrollment } from 'types/Joanie';
 import { Icon } from 'components/Icon';
 import { Button } from 'components/Button';
 import useDateFormat from 'utils/useDateFormat';

--- a/src/frontend/js/components/DashboardItem/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/components/DashboardItem/DashboardItemOrder.spec.tsx
@@ -1,13 +1,13 @@
+import { getByRole, getByText, render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import faker from 'faker';
 import {
   JoanieCourseRunFactory,
   JoanieEnrollmentFactory,
   OrderFactory,
 } from 'utils/test/factories';
-import { getByRole, getByText, render, screen } from '@testing-library/react';
-import { IntlProvider } from 'react-intl';
 import { DashboardItemOrder } from 'components/DashboardItem/DashboardItemOrder';
 import { Order } from 'types/Joanie';
-import faker from 'faker';
 import { DEFAULT_DATE_FORMAT } from 'utils/useDateFormat';
 
 describe('<DashboardItemOrder/>', () => {

--- a/src/frontend/js/components/DashboardItem/DashboardItemOrder.tsx
+++ b/src/frontend/js/components/DashboardItem/DashboardItemOrder.tsx
@@ -1,8 +1,8 @@
+import { FormattedMessage, useIntl } from 'react-intl';
 import { Button } from 'components/Button';
 import { DashboardItemEnrollmentFooter } from 'components/DashboardItem/DashboardItemEnrollmentFooter';
 import { DashboardSubItem } from 'components/DashboardItem/DashboardSubItem';
 import { Icon } from 'components/Icon';
-import { FormattedMessage, useIntl } from 'react-intl';
 import { Enrollment, Order, OrderState } from 'types/Joanie';
 import { StringHelper } from 'utils/StringHelper';
 import { DashboardSubItemsList } from './DashboardSubItemsList';

--- a/src/frontend/js/components/Form/CheckboxField.stories.tsx
+++ b/src/frontend/js/components/Form/CheckboxField.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { CheckboxField as Base } from './index';
 import { defaultConfig } from './Field.stories';
+import { CheckboxField as Base } from './index';
 
 export default {
   title: 'Components/Inputs',

--- a/src/frontend/js/components/Form/RadioField.stories.tsx
+++ b/src/frontend/js/components/Form/RadioField.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { RadioField as Base } from './index';
 import { defaultConfig } from './Field.stories';
+import { RadioField as Base } from './index';
 
 export default {
   title: 'Components/Inputs',

--- a/src/frontend/js/components/Form/SelectField.stories.tsx
+++ b/src/frontend/js/components/Form/SelectField.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { SelectField as Base } from './index';
 import { defaultConfig } from './Field.stories';
+import { SelectField as Base } from './index';
 
 export default {
   title: 'Components/Inputs',

--- a/src/frontend/js/components/Form/TextAreaField.stories.tsx
+++ b/src/frontend/js/components/Form/TextAreaField.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { TextareaField as Base } from './index';
 import { defaultConfig } from './Field.stories';
+import { TextareaField as Base } from './index';
 
 export default {
   title: 'Components/Inputs',

--- a/src/frontend/js/components/Form/TextField.stories.tsx
+++ b/src/frontend/js/components/Form/TextField.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { TextField as Base } from './index';
 import { defaultConfig } from './Field.stories';
+import { TextField as Base } from './index';
 
 export default {
   title: 'Components/Inputs',

--- a/src/frontend/js/data/CourseCodeProvider/index.spec.tsx
+++ b/src/frontend/js/data/CourseCodeProvider/index.spec.tsx
@@ -1,7 +1,7 @@
-import type { CourseCodeProviderProps } from 'data/CourseCodeProvider/index';
-import { CourseCodeProvider, useCourseCode } from 'data/CourseCodeProvider/index';
 import type { PropsWithChildren } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
+import type { CourseCodeProviderProps } from 'data/CourseCodeProvider/index';
+import { CourseCodeProvider, useCourseCode } from 'data/CourseCodeProvider/index';
 import { noop } from 'utils';
 
 describe('useCourseCode', () => {

--- a/src/frontend/js/data/SessionProvider/BaseSessionProvider.tsx
+++ b/src/frontend/js/data/SessionProvider/BaseSessionProvider.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useCallback, useEffect, useMemo } from 'react';
-import { AuthenticationApi } from 'utils/api/authentication';
 import { useQuery, useQueryClient } from 'react-query';
+import { AuthenticationApi } from 'utils/api/authentication';
 import { Nullable } from 'types/utils';
 import { User } from 'types/User';
 import { REACT_QUERY_SETTINGS } from 'settings';

--- a/src/frontend/js/data/SessionProvider/JoanieSessionProvider.spec.tsx
+++ b/src/frontend/js/data/SessionProvider/JoanieSessionProvider.spec.tsx
@@ -2,13 +2,13 @@ import fetchMock from 'fetch-mock';
 import { IntlProvider } from 'react-intl';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { act, render, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { PropsWithChildren } from 'react';
 import { ContextFactory as mockContextFactory, FonzieUserFactory } from 'utils/test/factories';
 import createQueryClient from 'utils/react-query/createQueryClient';
 import { Deferred } from 'utils/test/deferred';
 import { REACT_QUERY_SETTINGS, RICHIE_USER_TOKEN } from 'settings';
-import { renderHook } from '@testing-library/react-hooks';
 import { useSession } from 'data/SessionProvider/index';
-import { PropsWithChildren } from 'react';
 import JoanieSessionProvider from './JoanieSessionProvider';
 
 jest.mock('utils/errors/handle');

--- a/src/frontend/js/data/SessionProvider/no-authentication.spec.tsx
+++ b/src/frontend/js/data/SessionProvider/no-authentication.spec.tsx
@@ -1,8 +1,8 @@
-import { ContextFactory as mockContextFactory } from 'utils/test/factories';
 import { renderHook } from '@testing-library/react-hooks';
+import { render, screen } from '@testing-library/react';
+import { ContextFactory as mockContextFactory } from 'utils/test/factories';
 import { handle as mockHandle } from 'utils/errors/handle';
 import { noop } from 'utils';
-import { render, screen } from '@testing-library/react';
 import { SessionProvider, useSession } from '.';
 
 jest.mock('utils/errors/handle');

--- a/src/frontend/js/data/useCourseSearch/index.spec.tsx
+++ b/src/frontend/js/data/useCourseSearch/index.spec.tsx
@@ -2,12 +2,12 @@ import { act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { PropsWithChildren } from 'react';
 import { QueryClientProvider } from 'react-query';
+import { IntlProvider } from 'react-intl';
 import createQueryClient from 'utils/react-query/createQueryClient';
 
 import { fetchList } from 'data/getResourceList';
 import { APIListRequestParams } from 'types/api';
 import { Deferred } from 'utils/test/deferred';
-import { IntlProvider } from 'react-intl';
 import { useCourseSearch } from '.';
 
 jest.mock('utils/context', () => jest.fn());

--- a/src/frontend/js/data/useFilterValue/index.spec.tsx
+++ b/src/frontend/js/data/useFilterValue/index.spec.tsx
@@ -1,8 +1,8 @@
 import { stringify } from 'query-string';
 import { PropsWithChildren } from 'react';
 
-import { CourseSearchParamsAction } from 'data/useCourseSearchParams';
 import { renderHook } from '@testing-library/react-hooks';
+import { CourseSearchParamsAction } from 'data/useCourseSearchParams';
 import { History, HistoryContext } from 'data/useHistory';
 import { FacetedFilterDefinition, FilterValue } from 'types/filters';
 import { useFilterValue } from '.';

--- a/src/frontend/js/data/useStaticFilters/index.spec.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.spec.tsx
@@ -2,10 +2,10 @@ import { act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import fetchMock from 'fetch-mock';
 
-import { FilterDefinition } from 'types/filters';
-import { Deferred } from 'utils/test/deferred';
 import { IntlProvider } from 'react-intl';
 import { PropsWithChildren } from 'react';
+import { FilterDefinition } from 'types/filters';
+import { Deferred } from 'utils/test/deferred';
 import { useStaticFilters } from '.';
 
 describe('data/useStaticFilters', () => {

--- a/src/frontend/js/data/useStaticFilters/index.tsx
+++ b/src/frontend/js/data/useStaticFilters/index.tsx
@@ -1,9 +1,9 @@
 import { useRef, useState } from 'react';
 
+import { defineMessages, useIntl } from 'react-intl';
 import { FilterDefinition, StaticFilterDefinitions } from 'types/filters';
 import { Nullable } from 'types/utils';
 import { useAsyncEffect } from 'utils/useAsyncEffect';
-import { defineMessages, useIntl } from 'react-intl';
 
 // Our search and autosuggestion pipeline operated based on filter definitions. Obviously, we can't filters
 // courses by courses, but we still need a filter-definition-like config to run courses autocompletion.

--- a/src/frontend/js/hooks/useCourse.ts
+++ b/src/frontend/js/hooks/useCourse.ts
@@ -2,9 +2,9 @@
  * Joanie hook to retrieve information about a course
  *
  */
+import { useQuery, useQueryClient } from 'react-query';
 import { useJoanieApi } from 'data/JoanieApiProvider';
 import useLocalizedQueryKey from 'utils/react-query/useLocalizedQueryKey';
-import { useQuery, useQueryClient } from 'react-query';
 import { REACT_QUERY_SETTINGS } from 'settings';
 import { useSession } from 'data/SessionProvider';
 

--- a/src/frontend/js/hooks/useStepManager/index.ts
+++ b/src/frontend/js/hooks/useStepManager/index.ts
@@ -1,5 +1,5 @@
-import { type IconType } from 'components/Icon';
 import { useEffect, useMemo, useState } from 'react';
+import { type IconType } from 'components/Icon';
 import { type Nullable } from 'types/utils';
 
 export interface Step<Keys extends PropertyKey = PropertyKey> {

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -9,12 +9,11 @@
 // regardless of their use throughout the Richie codebase itself.
 import 'core-js/modules/es.array.iterator';
 import 'core-js/modules/es.promise';
-import ReactDOM from 'react-dom';
 import { IntlProvider } from 'react-intl';
 import { QueryClientProvider } from 'react-query';
 import countries from 'i18n-iso-countries';
+import ReactDOM from 'react-dom';
 import createQueryClient from 'utils/react-query/createQueryClient';
-
 import { Root } from 'components/Root';
 import { handle } from 'utils/errors/handle';
 

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.spec.ts
@@ -1,6 +1,6 @@
 import fetchMock from 'fetch-mock';
-import { ContextFactory as mockContextFactory } from 'utils/test/factories';
 import faker from 'faker';
+import { ContextFactory as mockContextFactory } from 'utils/test/factories';
 import { handle } from 'utils/errors/handle';
 import context from 'utils/context';
 import API from './openedx-hawthorn';

--- a/src/frontend/js/utils/api/web-analytics/google_analytics.spec.ts
+++ b/src/frontend/js/utils/api/web-analytics/google_analytics.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ContextFactory as mockContextFactory } from 'utils/test/factories';
-import WebAnalyticsAPIHandler from '.';
 import GoogleAnalyticsApi from './google_analytics';
+import WebAnalyticsAPIHandler from '.';
 
 jest.mock('utils/context', () => ({
   __esModule: true,

--- a/src/frontend/js/utils/api/web-analytics/google_tag_manager.spec.ts
+++ b/src/frontend/js/utils/api/web-analytics/google_tag_manager.spec.ts
@@ -1,6 +1,6 @@
 import { ContextFactory as mockContextFactory } from 'utils/test/factories';
-import WebAnalyticsAPIHandler from '.';
 import GoogleTagManagerApi from './google_tag_manager';
+import WebAnalyticsAPIHandler from '.';
 
 jest.mock('utils/context', () => ({
   __esModule: true,

--- a/src/frontend/js/utils/react-query/useSessionMutation/index.spec.tsx
+++ b/src/frontend/js/utils/react-query/useSessionMutation/index.spec.tsx
@@ -1,6 +1,8 @@
 import { hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import fetchMock from 'fetch-mock';
 import { renderHook } from '@testing-library/react-hooks';
+import { PropsWithChildren } from 'react';
+import { waitFor } from '@testing-library/react';
 import {
   ContextFactory as mockContextFactory,
   PersistedClientFactory,
@@ -10,8 +12,6 @@ import BaseSessionProvider from 'data/SessionProvider/BaseSessionProvider';
 import createQueryClient from 'utils/react-query/createQueryClient';
 import { useSession } from 'data/SessionProvider';
 import { checkStatus } from 'utils/api/joanie';
-import { PropsWithChildren } from 'react';
-import { waitFor } from '@testing-library/react';
 import { useSessionMutation } from '.';
 
 jest.mock('utils/context', () => ({

--- a/src/frontend/js/utils/react-query/useSessionQuery/index.spec.tsx
+++ b/src/frontend/js/utils/react-query/useSessionQuery/index.spec.tsx
@@ -1,6 +1,8 @@
 import { hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import fetchMock from 'fetch-mock';
 import { renderHook } from '@testing-library/react-hooks';
+import { PropsWithChildren } from 'react';
+import { waitFor } from '@testing-library/react';
 import {
   ContextFactory as mockContextFactory,
   PersistedClientFactory,
@@ -9,8 +11,6 @@ import {
 import BaseSessionProvider from 'data/SessionProvider/BaseSessionProvider';
 import createQueryClient from 'utils/react-query/createQueryClient';
 import { checkStatus } from 'utils/api/joanie';
-import { PropsWithChildren } from 'react';
-import { waitFor } from '@testing-library/react';
 import { useSession } from 'data/SessionProvider';
 import { useSessionQuery } from '.';
 

--- a/src/frontend/js/utils/react-query/useSessionQuery/index.ts
+++ b/src/frontend/js/utils/react-query/useSessionQuery/index.ts
@@ -1,12 +1,12 @@
 import type { QueryFunction, QueryKey } from 'react-query/types/core/types';
 import type { UseQueryOptions, UseQueryResult } from 'react-query/types/react/types';
+import { useQuery, useQueryClient } from 'react-query';
+import { useMemo } from 'react';
 import type { HttpError } from 'utils/errors/HttpError';
 import type { TSessionQueryKey } from 'utils/react-query/useSessionKey';
 import useSessionQueryKey from 'utils/react-query/useSessionKey';
-import { useQuery, useQueryClient } from 'react-query';
 import { useSession } from 'data/SessionProvider';
 import { REACT_QUERY_SETTINGS } from 'settings';
-import { useMemo } from 'react';
 
 /**
  * Hook to use when the query relies on the current session. In this way, the queryKey

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -86,6 +86,7 @@
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-airbnb-typescript": "17.0.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-import-resolver-webpack": "0.13.2",
     "eslint-plugin-compat": "4.0.2",
     "eslint-plugin-formatjs": "4.3.2",
     "eslint-plugin-import": "2.26.0",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -4913,6 +4913,11 @@ array-find-index@^1.0.1:
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==
 
+array-find@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
+  integrity sha512-kO/vVCacW9mnpn3WPWbTVlEnOabK2L7LWi2HViURtCM46y1zb6I8UMjx4LgbiqadTgHnLInUronwn3ampNTJtQ==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -6847,6 +6852,15 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.5"
 
+enhanced-resolve@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz#4d6e689b3725f86090927ccc86cd9f1635b89e2e"
+  integrity sha512-kxpoMgrdtkXZ5h0SeraBS1iRntpTpQ3R8ussdb38+UAFnMGX5DDyJXePm+OCHOcoXvHDw7mc2erbJBpDnl7TPw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.2.0"
+    tapable "^0.1.8"
+
 enhanced-resolve@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
@@ -7088,6 +7102,23 @@ eslint-import-resolver-node@^0.3.6:
   dependencies:
     debug "^3.2.7"
     resolve "^1.20.0"
+
+eslint-import-resolver-webpack@0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz#fc813df0d08b9265cc7072d22393bda5198bdc1e"
+  integrity sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==
+  dependencies:
+    array-find "^1.0.0"
+    debug "^3.2.7"
+    enhanced-resolve "^0.9.1"
+    find-root "^1.1.0"
+    has "^1.0.3"
+    interpret "^1.4.0"
+    is-core-module "^2.7.0"
+    is-regex "^1.1.4"
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+    semver "^5.7.1"
 
 eslint-module-utils@^2.7.3:
   version "2.7.3"
@@ -7679,6 +7710,11 @@ find-cache-dir@^3.3.1:
     commondir "^1.0.1"
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -8589,6 +8625,11 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+interpret@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
 interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
@@ -8730,7 +8771,7 @@ is-core-module@^2.2.0, is-core-module@^2.8.1:
   dependencies:
     has "^1.0.3"
 
-is-core-module@^2.9.0:
+is-core-module@^2.7.0, is-core-module@^2.9.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
   integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
@@ -10163,6 +10204,11 @@ memoizerific@^1.11.3:
   integrity sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==
   dependencies:
     map-or-similar "^1.5.0"
+
+memory-fs@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
+  integrity sha512-+y4mDxU4rvXXu5UDSGCGNiesFmwCHuefGMoPCO1WYucNYj7DsLqrFaa2fXVI0H+NNiPTwwzKwspn9yTZqUGqng==
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -13006,6 +13052,11 @@ synchronous-promise@^2.0.15:
   version "2.0.16"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.16.tgz#669b75e86b4295fdcc1bb0498de9ac1af6fd51a9"
   integrity sha512-qImOD23aDfnIDNqlG1NOehdB9IYsn1V9oByPjKY1nakv2MQYCEMyX033/q+aEtYCpmYK1cv2+NTmlH+ra6GA5A==
+
+tapable@^0.1.8:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
+  integrity sha512-jX8Et4hHg57mug1/079yitEKWGB3LCwoxByLsNim89LABq8NqgiX+6iYVOsq0vX8uJHkU+DZ5fnq95f800bEsQ==
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
## Purpose

In order to improve code structure we would like to sort imports as follows "builtin", "external", "internal", "parent", "sibling", "index". The eslint import plugin allow to do that. We also have to install a plugin to resolve webpack alias as internal imports.

## Proposal

- [x] Enable eslint `import/order` rule