### PR TITLE
✨(search) allows different search and courses page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add `RICHIE_SEARCH_REVERSE_ID` setting that allows to have different search
+  page and courses parent page.
 - Add Dashboard router
 - Add generic dashboard component
 - Add dashboard components for Order, Enrollment

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
@@ -270,6 +270,13 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         environ_prefix=None,
     )
 
+    # Configure course search page reverse id
+    RICHIE_SEARCH_REVERSE_ID = values.Value(
+        "courses",
+        environ_name="RICHIE_SEARCH_REVERSE_ID",
+        environ_prefix=None,
+    )
+
     # Internationalization
     TIME_ZONE = "Europe/Paris"
     USE_I18N = True

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -554,6 +554,13 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         environ_prefix=None,
     )
 
+    # Configure course search page reverse id
+    RICHIE_SEARCH_REVERSE_ID = values.Value(
+        "courses",
+        environ_name="RICHIE_SEARCH_REVERSE_ID",
+        environ_prefix=None,
+    )
+
     @classmethod
     def _get_environment(cls):
         """Environment in which the application is launched."""

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -54,6 +54,11 @@ def site_metas(request: HttpRequest):
         **WebAnalyticsContextProcessor().context_processor(request),
     }
 
+    # Add a context variable with the reverse id of the search course page.
+    context["RICHIE_SEARCH_REVERSE_ID"] = getattr(
+        settings, "RICHIE_SEARCH_REVERSE_ID", "courses"
+    )
+
     if getattr(settings, "CDN_DOMAIN", None):
         context["CDN_DOMAIN"] = settings.CDN_DOMAIN
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -108,7 +108,7 @@
                             <div class="topbar__menu topbar__menu--aside">
                                 {% block topbar_searchbar %}
                                 <div class="topbar__search richie-react richie-react--root-search-suggest-field"
-                                    data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}"}'></div>
+                                    data-props='{"courseSearchPageUrl": "{% page_url RICHIE_SEARCH_REVERSE_ID %}"}'></div>
                                 {% endblock topbar_searchbar %}
                                 <ul class="topbar__list topbar__list--controls">
                                     {% block userlogin %}

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -130,13 +130,13 @@
                                 {% include "richie/pagination.html" with label=_("Courses pagination") %}
                                 <div class="button-caesura">
                                 {% if category.get_meta_category %}
-                                    <a href="{% page_url 'courses' %}?{{ category.get_meta_category.extended_object.reverse_id }}={{ category.get_es_id }}" class="category-detail__see-more">
+                                    <a href="{% page_url RICHIE_SEARCH_REVERSE_ID %}?{{ category.get_meta_category.extended_object.reverse_id }}={{ category.get_es_id }}" class="category-detail__see-more">
                                     {% blocktrans with category_title=category.extended_object.get_title %}
                                         See all courses related to {{ category_title }}
                                     {% endblocktrans %}
                                     </a>
                                 {% else %}
-                                    <a href="{% page_url 'courses' %}" class="category-detail__see-more">
+                                    <a href="{% page_url RICHIE_SEARCH_REVERSE_ID %}" class="category-detail__see-more">
                                     {% trans "See all courses" %}
                                     </a>
                                 {% endif %}

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -124,7 +124,7 @@
                         {% if paginator.num_pages > 1 %}
                             {% include "richie/pagination.html" with label=_("Related courses pagination") %}
                             <div class="button-caesura">
-                                <a href="{% page_url 'courses' %}?organizations={{ organization.get_es_id }}" class="organization-detail__see-more">
+                                <a href="{% page_url RICHIE_SEARCH_REVERSE_ID %}?organizations={{ organization.get_es_id }}" class="organization-detail__see-more">
                                     {% blocktrans with organization_title=organization.extended_object.get_title %}
                                         See all courses related to {{ organization_title }}
                                     {% endblocktrans %}

--- a/src/richie/apps/courses/templates/courses/cms/person_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/person_detail.html
@@ -133,7 +133,7 @@
                             {% if paginator.num_pages > 1 %}
                                 {% include "richie/pagination.html" with label=_("Courses pagination") %}
                                 <div class="button-caesura">
-                                    <a href="{% page_url 'courses' %}?persons={{ person.extended_object_id }}" class="person-detail__see-more">
+                                    <a href="{% page_url RICHIE_SEARCH_REVERSE_ID %}?persons={{ person.extended_object_id }}" class="person-detail__see-more">
                                     {% blocktrans with person_title=person.extended_object.get_title %}
                                         See all courses related to {{ person_title }}
                                     {% endblocktrans %}

--- a/src/richie/plugins/large_banner/templates/richie/large_banner/hero-intro.html
+++ b/src/richie/plugins/large_banner/templates/richie/large_banner/hero-intro.html
@@ -18,9 +18,9 @@
                 </p>
 
                 <div class="richie-react richie-react--root-search-suggest-field"
-                    data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}"}'></div>
+                    data-props='{"courseSearchPageUrl": "{% page_url RICHIE_SEARCH_REVERSE_ID %}"}'></div>
 
-                <a class="hero-intro__cta" href="{% page_url 'courses' %}">
+                <a class="hero-intro__cta" href="{% page_url RICHIE_SEARCH_REVERSE_ID %}">
                     {% trans "Explore our catalog" %}
                 </a>
             </div>

--- a/tests/apps/courses/test_templates_organization_detail.py
+++ b/tests/apps/courses/test_templates_organization_detail.py
@@ -283,9 +283,12 @@ class OrganizationCMSTestCase(CMSTestCase):
     @mock.patch(
         "cms.templatetags.cms_tags.PageUrl.get_value", return_value="/the/courses/"
     )
-    @override_settings(RICHIE_GLIMPSE_PAGINATION={"courses": 2})
+    @override_settings(
+        RICHIE_GLIMPSE_PAGINATION={"courses": 2},
+        RICHIE_SEARCH_REVERSE_ID="overall-search",
+    )
     def test_templates_organization_detail_cms_published_content_max_courses(
-        self, _mock_page_url
+        self, mock_page_url
     ):
         """
         Make sure the organization detail page does not display too many courses, even when a large
@@ -313,6 +316,10 @@ class OrganizationCMSTestCase(CMSTestCase):
         self.assertContains(response, courses[0].extended_object.get_title())
         self.assertContains(response, courses[1].extended_object.get_title())
         self.assertNotContains(response, courses[2].extended_object.get_title())
+
+        # Check if `RICHIE_SEARCH_REVERSE_ID` setting value is used has reverse id
+        # to find course page search
+        self.assertEqual("overall-search", mock_page_url.call_args[1]["page_lookup"])
 
         # There is a link to view more related courses directly in the Search view
         self.assertContains(


### PR DESCRIPTION
Add `RICHIE_SEARCH_REVERSE_ID` setting that allows to have different search page and courses parent page.
Closes #1810
