### PR TITLE
Fix synchronization with openedx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add generic dashboard component
 - Add dashboard components for Order, Enrollment
 - Add dashboard components for Credit Card management
+- Dashboard addresses management components
 
 ### Changed
 
-- Allow editor to enforce `inline_ratio` and `is_automatic_resizing` values for
-  a lti consumer plugin based on a lti provider
+- Allow editor to enforce `inline_ratio` and `is_automatic_resizing` values
+  for a lti consumer plugin based on a lti provider
 - Use new Joanie Enrollment resource type
 - Modal component refactor for homogeneous use
 - New global scroll behavior for Modal
@@ -30,13 +31,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix course run synchronization when no-update fields are declared (broken
+  since Richie version 2.15.0)
 - Unlocalize aspect ratio floating value rendered in lti_consumer template
   to always display value with a dot no matter active language
 - Language choices should be ordered alphabetically in course run admin form
-
-### Added
-
-- Dashboard addresses management components 
 
 ## [2.16.0]
 

--- a/src/richie/apps/courses/admin.py
+++ b/src/richie/apps/courses/admin.py
@@ -56,6 +56,7 @@ class CourseRunAdminForm(TranslatableModelForm):
             "languages",
             "enrollment_count",
             "catalog_visibility",
+            "sync_mode",
         ]
 
     def __init__(self, *args, **kwargs):
@@ -147,6 +148,7 @@ class CourseRunAdmin(FrontendEditableAdminMixin, TranslatableAdmin):
         "languages",
         "enrollment_count",
         "catalog_visibility",
+        "sync_mode",
     )
     list_display = ["id"]
     form = CourseRunAdminForm

--- a/src/richie/apps/courses/api.py
+++ b/src/richie/apps/courses/api.py
@@ -180,14 +180,14 @@ def course_runs_sync(request, version):
         )
 
     # Look for the course targeted by the resource link
-    course_number = normalize_code(lms.extract_course_number(request.data))
+    course_code = normalize_code(lms.extract_course_code(request.data))
     try:
         course = Course.objects.get(
-            code=course_number, extended_object__publisher_is_draft=True
+            code=course_code, extended_object__publisher_is_draft=True
         )
     except Course.DoesNotExist:
         return Response(
-            {"resource_link": [f"Unknown course: {course_number:s}."]}, status=400
+            {"resource_link": [f"Unknown course: {course_code:s}."]}, status=400
         )
 
     # Instantiate a new draft course run

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -695,6 +695,7 @@ class CourseRun(TranslatableModel):
         max_length=20,
         choices=CourseRunSyncMode.choices,
         default=CourseRunSyncMode.MANUAL,
+        verbose_name=_("Synchronization mode"),
     )
 
     title = TranslatedField()

--- a/tests/apps/courses/test_admin_course_run.py
+++ b/tests/apps/courses/test_admin_course_run.py
@@ -60,6 +60,7 @@ class CourseRunAdminTestCase(CMSTestCase):
         self.assertContains(response, "id_enrollment_end_", count=3)
         self.assertContains(response, "id_languages")
         self.assertContains(response, "id_enrollment_count")
+        self.assertContains(response, "id_sync_mode")
 
     # List
 
@@ -213,6 +214,7 @@ class CourseRunAdminTestCase(CMSTestCase):
         self.assertContains(response, "id_enrollment_end_", count=3)
         self.assertContains(response, "id_languages", count=2)
         self.assertContains(response, "id_enrollment_count", count=2)
+        self.assertContains(response, "id_sync_mode", count=2)
 
     def test_admin_course_run_change_view_get_superuser_public(self):
         """Public course runs should not render a change view."""
@@ -287,7 +289,7 @@ class CourseRunAdminTestCase(CMSTestCase):
 
     def test_admin_course_run_change_view_get_staff_all_permissions(self):
         """
-        Staff users with all permissions should allowed to view a course run's change view.
+        Staff users with all permissions should be allowed to view a course run's change view.
         """
         user = UserFactory(is_staff=True)
         self.client.login(username=user.username, password="password")
@@ -323,6 +325,7 @@ class CourseRunAdminTestCase(CMSTestCase):
         self.assertContains(response, "id_enrollment_end_", count=3)
         self.assertContains(response, "id_languages", count=2)
         self.assertContains(response, "id_enrollment_count", count=2)
+        self.assertContains(response, "id_sync_mode", count=2)
 
     # Add
 
@@ -343,6 +346,7 @@ class CourseRunAdminTestCase(CMSTestCase):
             "enrollment_end_0": "2015-01-23",
             "enrollment_end_1": "09:07:11",
             "catalog_visibility": "course_and_search",
+            "sync_mode": "manual",
         }
         with timezone.override(pytz.utc):
             response = self.client.post(url, data, follow=True)
@@ -445,6 +449,7 @@ class CourseRunAdminTestCase(CMSTestCase):
             "enrollment_end_1": "09:07:11",
             "enrollment_count": "5",
             "catalog_visibility": "course_and_search",
+            "sync_mode": "manual",
         }
         with timezone.override(pytz.utc):
             response = self.client.post(url, data, follow=True)
@@ -466,6 +471,7 @@ class CourseRunAdminTestCase(CMSTestCase):
             course_run.enrollment_end, datetime(2015, 1, 23, 9, 7, 11, tzinfo=pytz.utc)
         )
         check_method(course_run.enrollment_count, 5)
+        check_method(course_run.sync_mode, "manual")
         return response
 
     def test_admin_course_run_change_view_post_anonymous(self):

--- a/tests/apps/courses/test_admin_form_course_run.py
+++ b/tests/apps/courses/test_admin_form_course_run.py
@@ -35,6 +35,7 @@ class CourseRunAdminTestCase(CMSTestCase):
             "enrollment_end_0": "2015-01-23",
             "enrollment_end_1": "09:07:11",
             "catalog_visibility": "course_and_search",
+            "sync_mode": "manual",
         }
         request = RequestFactory().get("/")
         request.user = user
@@ -113,6 +114,7 @@ class CourseRunAdminTestCase(CMSTestCase):
                 "direct_course": ["This field is required."],
                 "languages": ["This field is required."],
                 "catalog_visibility": ["This field is required."],
+                "sync_mode": ["This field is required."],
             },
         )
 


### PR DESCRIPTION
### Purpose

We were having course run synchronization issues on our sites since version 2.15.0.

After investigation, it appeared that the synchronization hook was misbehaving since PR https://github.com/openfun/richie/pull/1549. Indeed the no-update fields were removed from the payload for create as well as update queries which lead to 400 errors because the fields removed are required to create a course run.

### Proposal

Split "field conversion" and "removing no-update fields" in 2 separated actions to play them only when they are respectively required.
