### PR TITLE
Feature/joanie handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- JoanieBackend to identify course runs managed by Joanie
 - Add Dashboard router
 - Add generic dashboard component
 - Add dashboard components for Order, Enrollment

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,27 @@ $ make migrate
 
 ## Unreleased
 
+## 2.16.x to 2.17.x
+
+- Richie is now able to delegate course enrollment to Joanie which will then synchronize its
+  course runs with Richie and provide advanced enrollment, ecommerce and multi-LMS features.
+  To set up this feature, you can add to `JOANIE_BACKEND` setting the following properties:
+  ```python
+  JOANIE_BACKEND = {
+    # ...
+    "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+    "JS_BACKEND": "joanie",
+    # The regex to match a resource that can be handle by the lms.joanie.JoanieBackend interface
+    "COURSE_REGEX": r"^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",
+    # The regex to match a resource that can be handle by the lms.joanie.JoanieBackend interface
+    "JS_COURSE_REGEX": r"^.*/api/(course-runs|products)/(.*)/?$",
+    # A list of course run properties to not update
+    "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
+    # The synchronization mode ("manual", "sync_to_public" or "sync_to_draft") 
+    "DEFAULT_COURSE_RUN_SYNC_MODE": "sync_to_public",
+  }
+  ```
+
 ## 2.15.x to 2.16.x
 
 - The way filters are configured has changed. There is now a separate setting

--- a/docs/joanie-connection.md
+++ b/docs/joanie-connection.md
@@ -7,18 +7,35 @@ sidebar_label: Joanie Connection
 
 ## Settings
 
-All settings related to Joanie have to be declared in the `JOANIE` dictionary
+All settings related to Joanie have to be declared in the `JOANIE_BACKEND` dictionary
 within `settings.py`.
-To enable Joanie, the minimal configuration requires one property:
+To enable Joanie, the minimal configuration requires following properties:
 
-- `BASE_URL` : the endpoint at which Joanie is accessible
+- `BASE_URL`
+- `BACKEND`
+- `COURSE_REGEX`
+- `JS_COURSE_REGEX`
+
+Take a look to [LMS Backend documentation](./lms-backends.md#configuring-the-lms-handler) to get details about those properties.
 
 Add to your `settings.py`:
 
 ```python
 ...
-JOANIE = {
-  "BASE_URL": values.Value(environ_name="JOANIE_BASE_URL", environ_prefix=None)
+JOANIE_BACKEND = {
+    "BASE_URL": values.Value(environ_name="JOANIE_BASE_URL", environ_prefix=None),
+    "BACKEND": values.Value("richie.apps.courses.lms.joanie.JoanieBackend", environ_name="JOANIE_BACKEND", environ_prefix=None),
+    "JS_BACKEND": values.Value("joanie", environ_name="JOANIE_JS_BACKEND", environ_prefix=None),
+    "COURSE_REGEX": values.Value(
+        r"^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",
+        environ_name="JOANIE_COURSE_REGEX",
+        environ_prefix=None,
+    ),
+    "JS_COURSE_REGEX": values.Value(
+        r"^.*/api/(course-runs|products)/(.*)/?$",
+        environ_name="JOANIE_JS_COURSE_REGEX",
+        environ_prefix=None,
+    ),
 }
 ...
 ```

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -618,6 +618,10 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra("application", "backend")
 
+        # If a Joanie Backend has been configured, we add it into LMS_BACKENDS dict
+        if cls.JOANIE_BACKEND.get("BASE_URL") is not None:
+            cls.RICHIE_LMS_BACKENDS.append(cls.JOANIE_BACKEND)
+
 
 class Development(Base):
     """
@@ -663,7 +667,7 @@ class Test(Base):
 
 class ContinuousIntegration(Test):
     """
-    Continous Integration environment settings
+    Continuous Integration environment settings
 
     nota bene: it should inherit from the Test environment.
     """

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -299,11 +299,35 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
 
     # Joanie
     """
-    NB: Richie picks all Joanie's settings from the JOANIE namespace on the
-    settings, hence the nesting of all Joanie's values inside that prop
+    NB: Richie picks all Joanie's settings from the JOANIE_BACKEND namespace in the
+    settings, hence the nesting of all Joanie's values inside that prop.
+
+    If BASE_URL is defined, this setting is bound into RICHIE_LMS_BACKENDS to use Joanie
+    as a LMS BACKEND.
     """
-    JOANIE = {
+    JOANIE_BACKEND = {
         "BASE_URL": values.Value(environ_name="JOANIE_BASE_URL", environ_prefix=None),
+        "BACKEND": values.Value(
+            "richie.apps.courses.lms.joanie.JoanieBackend",
+            environ_name="JOANIE_BACKEND",
+            environ_prefix=None,
+        ),
+        "JS_BACKEND": values.Value(
+            "joanie", environ_name="JOANIE_JS_BACKEND", environ_prefix=None
+        ),
+        "COURSE_REGEX": values.Value(
+            r"^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",
+            environ_name="JOANIE_COURSE_REGEX",
+            environ_prefix=None,
+        ),
+        "JS_COURSE_REGEX": values.Value(
+            r"^.*/api/(course-runs|products)/(.*)/?$",
+            environ_name="JOANIE_JS_COURSE_REGEX",
+            environ_prefix=None,
+        ),
+        # Course runs synchronization
+        "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
+        "DEFAULT_COURSE_RUN_SYNC_MODE": "sync_to_public",
     }
 
     # Internationalization

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -108,7 +108,7 @@ def site_metas(request: HttpRequest):
 
     if is_joanie_enabled():
         context["FRONTEND_CONTEXT"]["context"]["joanie_backend"] = {
-            "endpoint": settings.JOANIE["BASE_URL"],
+            "endpoint": settings.JOANIE_BACKEND["BASE_URL"],
         }
 
     if getattr(settings, "RICHIE_LMS_BACKENDS", None):

--- a/src/richie/apps/core/templatetags/joanie.py
+++ b/src/richie/apps/core/templatetags/joanie.py
@@ -1,6 +1,7 @@
 """Custom template tags related to Joanie."""
 from django import template
-from django.conf import settings
+
+from richie.apps.courses.lms import LMSHandler
 
 register = template.Library()
 
@@ -8,12 +9,8 @@ register = template.Library()
 @register.simple_tag()
 def is_joanie_enabled():
     """
-    Determines if Joanie is enabled
-
-    Within settings, JOANIE can be enabled/disabled by setting the value of
-    `JOANIE.BASE_URL` with the url of joanie endpoint.
+    Determines if Joanie is enabled by checking if there is
+    an enabled lms backend with attribute `is_joanie` set to True.
     """
-    if getattr(settings, "JOANIE", None) is not None:
-        return settings.JOANIE.get("BASE_URL") is not None
 
-    return False
+    return any(getattr(lms, "is_joanie", False) for lms in LMSHandler.get_lms_classes())

--- a/src/richie/apps/courses/defaults.py
+++ b/src/richie/apps/courses/defaults.py
@@ -347,3 +347,11 @@ EFFORT_UNITS = {
 # Maximum number of archived course runs displayed by default on course detail page.
 # The additional runs can be viewed by clicking on `View more` link.
 RICHIE_MAX_ARCHIVED_COURSE_RUNS = 10
+
+# Joanie resource types
+JOANIE_RESOURCE_TYPE_COURSE_RUNS = "course-runs"
+JOANIE_RESOURCE_TYPE_PRODUCTS = "products"
+JOANIE_RESOURCE_TYPES = [
+    JOANIE_RESOURCE_TYPE_COURSE_RUNS,
+    JOANIE_RESOURCE_TYPE_PRODUCTS,
+]

--- a/src/richie/apps/courses/lms/__init__.py
+++ b/src/richie/apps/courses/lms/__init__.py
@@ -24,6 +24,7 @@ class LMSHandler:
         if url is None:
             return None
 
+        # First check if it matches a configured LMS
         for lms_configuration in settings.RICHIE_LMS_BACKENDS:
             if re.match(lms_configuration.get("COURSE_REGEX", r".*"), url):
                 return import_string(lms_configuration["BACKEND"])(lms_configuration)

--- a/src/richie/apps/courses/lms/__init__.py
+++ b/src/richie/apps/courses/lms/__init__.py
@@ -13,6 +13,17 @@ class LMSHandler:
     """
 
     @staticmethod
+    def get_lms_classes():
+        """
+        Return all enabled LMS classes.
+        """
+
+        return {
+            import_string(lms_configuration["BACKEND"])
+            for lms_configuration in settings.RICHIE_LMS_BACKENDS
+        }
+
+    @staticmethod
     def select_lms(url):
         """
         Select and return the first LMS backend matching the url passed in argument.

--- a/src/richie/apps/courses/lms/base.py
+++ b/src/richie/apps/courses/lms/base.py
@@ -4,6 +4,7 @@ Base backend to connect richie with an LMS
 from django.conf import settings
 
 from ..models.course import CourseRunSyncMode
+from ..serializers import SyncCourseRunSerializer
 
 
 class BaseLMSBackend:
@@ -15,6 +16,18 @@ class BaseLMSBackend:
         """Attach configuration to the backend instance."""
         super().__init__(*args, **kwargs)
         self.configuration = configuration
+
+    def clean_course_run_data(self, data):
+        """
+        Clean course run data. By default, it does nothing, but it aims to be overridden
+        by child class if there is a need to transform data payload before using it.
+        """
+        return data
+
+    @staticmethod
+    def get_course_run_serializer(data, partial=False):
+        """Prepare data and return a bound serializer."""
+        return SyncCourseRunSerializer(data=data, partial=partial)
 
     @property
     def default_course_run_sync_mode(self):

--- a/src/richie/apps/courses/lms/edx.py
+++ b/src/richie/apps/courses/lms/edx.py
@@ -7,7 +7,6 @@ import re
 import requests
 from requests.auth import AuthBase
 
-from ..serializers import SyncCourseRunSerializer
 from .base import BaseLMSBackend
 
 logger = logging.getLogger(__name__)
@@ -87,8 +86,3 @@ class EdXLMSBackend(BaseLMSBackend):
         except KeyError:
             pass
         return data
-
-    @staticmethod
-    def get_course_run_serializer(data, partial=False):
-        """Prepare data and return a bound serializer."""
-        return SyncCourseRunSerializer(data=data, partial=partial)

--- a/src/richie/apps/courses/lms/joanie.py
+++ b/src/richie/apps/courses/lms/joanie.py
@@ -1,0 +1,39 @@
+"""
+Backend to connect Richie with Joanie
+"""
+import re
+
+from .base import BaseLMSBackend
+
+
+class JoanieBackend(BaseLMSBackend):
+    """Joanie backend for Richie"""
+
+    is_joanie = True
+
+    @staticmethod
+    def extract_course_code(data):
+        """Extract the LMS course code from data dictionary."""
+        return data.get("course")
+
+    def _extract_info(self, content, capturing_group):
+        """
+        Try to extract a matched capturing group from a provided content.
+        """
+        return re.match(self.configuration["COURSE_REGEX"], content).group(
+            capturing_group
+        )
+
+    def extract_resource_type(self, resource_link):
+        """
+        Try to extract the resource type (products or course runs)
+        from the provided resource_link.
+        """
+        return self._extract_info(resource_link, "resource_type")
+
+    def extract_resource_id(self, resource_link):
+        """
+        Try to extract the resource id (products or course runs)
+        from the provided resource_link.
+        """
+        return self._extract_info(resource_link, "resource_id")

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -23,6 +23,7 @@ from cms.toolbar.utils import get_toolbar_from_request
 from cms.utils import get_site_id
 from cms.utils.plugins import get_plugins
 
+from .. import defaults
 from ..lms import LMSHandler
 
 # pylint: disable=invalid-name
@@ -225,6 +226,22 @@ def has_connected_lms(course_run):
     link to the course run.
     """
     return LMSHandler.select_lms(course_run.resource_link) is not None
+
+
+@register.filter()
+def is_joanie_product(course_run):
+    """
+    Check that the course run is managed by Joanie
+    then the resource type is equal to `products`.
+    """
+    handler = LMSHandler.select_lms(course_run.resource_link)
+
+    if not getattr(handler, "is_joanie", False):
+        return False
+
+    resource_type = handler.extract_resource_type(course_run.resource_link)
+
+    return resource_type == defaults.JOANIE_RESOURCE_TYPE_PRODUCTS
 
 
 @register.filter()

--- a/tests/apps/core/test_templates_richie_dashboard.py
+++ b/tests/apps/core/test_templates_richie_dashboard.py
@@ -9,7 +9,17 @@ from cms.test_utils.testcases import CMSTestCase
 class TemplatesRichieDashboardTestCase(CMSTestCase):
     """Testing the dashboard.html template"""
 
-    @override_settings(JOANIE={"BASE_URL": "https://joanie.test"})
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "http://localhost:8071",
+                "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+                "COURSE_REGEX": "^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",  # noqa pylint: disable=line-too-long
+                "JS_BACKEND": "joanie",
+                "JS_COURSE_REGEX": r"^.*/api/(course-runs|products)/(.*)/?$",
+            }
+        ]
+    )
     def test_templates_richie_dashboard_joanie_enabled(self):
         """
         Dashboard view should be reachable if JOANIE is enabled
@@ -19,7 +29,7 @@ class TemplatesRichieDashboardTestCase(CMSTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, r'class="richie-react richie-react--dashboard"')
 
-    @override_settings(JOANIE={})
+    @override_settings(RICHIE_LMS_BACKENDS=[])
     def test_templates_richie_dashboard_joanie_is_not_enabled(self):
         """
         Dashboard view should not be reachable if JOANIE is disabled

--- a/tests/apps/core/test_templatetags_joanie.py
+++ b/tests/apps/core/test_templatetags_joanie.py
@@ -12,24 +12,36 @@ class JoanieTemplateTagsTestCase(TestCase):
     Unit test suite to validate the behavior of the joanie template tags
     """
 
-    @override_settings(JOANIE={"BASE_URL": "https://joanie.endpoint"})
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "http://localhost:8071",
+                "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+                "COURSE_REGEX": r"^.*$",
+            }
+        ]
+    )
     def test_templatetags_is_joanie_enabled(self):
         """
-        is_joanie_enabled should return True if JOANIE.BASE_URL is not None
+        is_joanie_enabled should return True if
+        an enabled lms backend with attribute `is_joanie` set to True.
         """
         self.assertTrue(is_joanie_enabled())
 
-    @override_settings(JOANIE={})
-    def test_templatetags_is_joanie_enabled_with_no_base_url(self):
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "http://localhost:8071",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "COURSE_REGEX": r"^.*$",
+            }
+        ]
+    )
+    def test_templatetags_is_joanie_enabled_without_backend_with_is_joanie_attribute(
+        self,
+    ):
         """
-        is_joanie_enabled should return False if JOANIE["BASE_URL"] is not defined.
-        """
-        self.assertFalse(is_joanie_enabled())
-
-    @override_settings(JOANIE=None)
-    def test_templatetags_is_joanie_enabled_not_defined(self):
-        """
-        is_joanie_enabled should return False if JOANIE is not defined within
-        setting
+        is_joanie_enabled should return False if there is
+        any enabled lms backend with attribute `is_joanie` set to True.
         """
         self.assertFalse(is_joanie_enabled())

--- a/tests/apps/courses/lms/test_get_lms_classes.py
+++ b/tests/apps/courses/lms/test_get_lms_classes.py
@@ -1,0 +1,41 @@
+"""Test suite for the Get LMS Classes function."""
+from unittest import TestCase
+
+from django.test import override_settings
+
+from richie.apps.courses.lms import LMSHandler
+from richie.apps.courses.lms.base import BaseLMSBackend
+from richie.apps.courses.lms.edx import EdXLMSBackend
+from richie.apps.courses.lms.joanie import JoanieBackend
+
+
+class GetLMSClassesTestCase(TestCase):
+    """Test suite for the Get LMS Classes function."""
+
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "BASE_URL": "https://edx.org",
+            },
+            {
+                "COURSE_REGEX": r"^.*/moocs/(?P<course_id>.*)",
+                "BACKEND": "richie.apps.courses.lms.base.BaseLMSBackend",
+                "BASE_URL": "https://www.example.com",
+            },
+            {
+                "BASE_URL": "https://www.joanie.org",
+                "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+                "COURSE_REGEX": "^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",  # noqa pylint: disable=line-too-long
+            },
+        ]
+    )
+    def test_get_lms_classes(self):
+        """
+        The "get_lms_classes" util function should return
+        a set of all enabled backend classes.
+        """
+        classes = LMSHandler.get_lms_classes()
+
+        self.assertSetEqual(classes, {BaseLMSBackend, JoanieBackend, EdXLMSBackend})

--- a/tests/apps/courses/lms/test_lms_select.py
+++ b/tests/apps/courses/lms/test_lms_select.py
@@ -5,6 +5,7 @@ from django.test.utils import override_settings
 from richie.apps.courses.lms import LMSHandler
 from richie.apps.courses.lms.base import BaseLMSBackend
 from richie.apps.courses.lms.edx import EdXLMSBackend
+from richie.apps.courses.lms.joanie import JoanieBackend
 
 
 class LMSSelectTestCase(TestCase):
@@ -22,13 +23,13 @@ class LMSSelectTestCase(TestCase):
                 "BACKEND": "richie.apps.courses.lms.base.BaseLMSBackend",
                 "BASE_URL": "https://edx.org",
             },
-        ]
+        ],
     )
     def test_lms_select(self):
         """
         The "select_lms" util function should return a backend instance with its configuration
-        or raise an ImproperlyConfigurer error if the url does not match any backend or is blank or
-        any course id can be extract from the resource_link.
+        or None if the url does not match any backend or is blank or any course id
+        can be extract from the resource_link.
         """
         backend = LMSHandler.select_lms("https://www.example.com/moocs/123")
         self.assertEqual(type(backend), EdXLMSBackend)
@@ -39,6 +40,37 @@ class LMSSelectTestCase(TestCase):
         self.assertEqual(backend.configuration["BASE_URL"], "https://edx.org")
 
         self.assertIsNone(LMSHandler.select_lms("https://edx.org/wrong-path/123"))
+
+        self.assertIsNone(LMSHandler.select_lms("https://unknown.io/course/123"))
+
+        self.assertIsNone(LMSHandler.select_lms(None))
+
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "https://www.example.com",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "COURSE_REGEX": r"^.*/moocs/(?P<course_id>.*)",
+            },
+            {
+                "BASE_URL": "https://www.joanie.org",
+                "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+                "COURSE_REGEX": "^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",  # noqa pylint: disable=line-too-long
+            },
+        ],
+    )
+    def test_lms_select_with_joanie(self):
+        """
+        The "select_lms" util function should return JoanieBackend when a resource_link
+        match JOANIE.COURSE_REGEX
+        """
+        backend = LMSHandler.select_lms("https://www.example.com/moocs/123")
+        self.assertEqual(type(backend), EdXLMSBackend)
+        self.assertEqual(backend.configuration["BASE_URL"], "https://www.example.com")
+
+        backend = LMSHandler.select_lms("https://www.joanie.org/api/products/123")
+        self.assertEqual(type(backend), JoanieBackend)
+        self.assertEqual(backend.configuration["BASE_URL"], "https://www.joanie.org")
 
         self.assertIsNone(LMSHandler.select_lms("https://unknown.io/course/123"))
 

--- a/tests/apps/courses/test_api_course_run_sync.py
+++ b/tests/apps/courses/test_api_course_run_sync.py
@@ -1,0 +1,1010 @@
+"""
+Tests for CourseRun API endpoints in the courses app.
+"""
+# pylint: disable=too-many-lines
+from unittest import mock
+
+from django.conf import settings
+from django.test import override_settings
+
+from cms.constants import PUBLISHER_STATE_DEFAULT, PUBLISHER_STATE_DIRTY
+from cms.models import Page, Title
+from cms.signals import post_publish
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.courses.factories import CourseFactory, CourseRunFactory
+from richie.apps.courses.models import Course, CourseRun
+from richie.apps.courses.serializers import SyncCourseRunSerializer
+
+
+# pylint: disable=too-many-public-methods
+@mock.patch.object(post_publish, "send", wraps=post_publish.send)
+@override_settings(RICHIE_COURSE_RUN_SYNC_SECRETS=["shared secret"])
+class SyncCourseRunApiTestCase(CMSTestCase):
+    """Test calls to sync a course run via API endpoint."""
+
+    # To update the http authorizations add this next statements before the first assert
+    # from richie.apps.courses.utils import get_signature
+    # print (get_signature(self.client._encode_json(data, "application/json"), "shared secret"))
+
+    def test_api_course_run_sync_missing_signature(self, mock_signal):
+        """The course run synchronization API endpoint requires a signature."""
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+        }
+
+        mock_signal.reset_mock()
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync", data, content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json(), "Missing authentication.")
+        self.assertEqual(CourseRun.objects.count(), 0)
+        self.assertEqual(Course.objects.count(), 0)
+        self.assertFalse(mock_signal.called)
+
+    def test_api_course_run_sync_invalid_signature(self, mock_signal):
+        """The course run synchronization API endpoint requires a valid signature."""
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+        }
+
+        mock_signal.reset_mock()
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=("invalid authorization"),
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), "Invalid authentication.")
+        self.assertEqual(CourseRun.objects.count(), 0)
+        self.assertEqual(Course.objects.count(), 0)
+        self.assertFalse(mock_signal.called)
+
+    def test_api_course_run_sync_missing_resource_link(self, mock_signal):
+        """
+        If the data submitted is missing a resource link, it should return a 400 error.
+        """
+        # Data with missing resource link => invalid
+        data = {
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+        }
+
+        mock_signal.reset_mock()
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 acee4804ff21eabe366ff6e04495591dfe32dffa7f1cd2d48c0f44beb9d5aa0d"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(), {"resource_link": ["This field is required."]}
+        )
+        self.assertEqual(CourseRun.objects.count(), 0)
+        self.assertEqual(Course.objects.count(), 0)
+        self.assertFalse(mock_signal.called)
+
+    def test_api_course_run_sync_invalid_field(self, mock_signal):
+        """
+        If the submitted data is invalid, the course run synchronization view should return
+        a 400 error.
+        """
+        # Data with invalid start date value
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "start": 1,
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+        }
+
+        mock_signal.reset_mock()
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 38af01f97c1b6d078662de52a4785df7c09a16b426659af56f722f68c2035f95"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "start": [
+                    (
+                        "Datetime has wrong format. Use one of these formats instead: "
+                        "YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]."
+                    )
+                ]
+            },
+        )
+        self.assertEqual(CourseRun.objects.count(), 0)
+        self.assertEqual(Course.objects.count(), 0)
+        self.assertFalse(mock_signal.called)
+
+    def test_api_course_run_sync_create_unknown_course(self, mock_signal):
+        """
+        If the submitted data is not related to an existing course run and the related course
+        can't be found, the course run synchronization view should return a 400 error.
+        """
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+        }
+
+        mock_signal.reset_mock()
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 338f7c262254e8220fea54467526f8f1f4562ee3adf1e3a71abaf23a20b739e4"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"resource_link": ["Unknown course: DEMOX."]})
+        self.assertEqual(CourseRun.objects.count(), 0)
+        self.assertEqual(Course.objects.count(), 0)
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
+    )
+    def test_api_course_run_sync_create_sync_to_public_draft_course(self, mock_signal):
+        """
+        If the submitted data is not related to an existing course run, a new course run should
+        be created. If the related course is draft, the synchronization is limited to the draft
+        course run and the course is not marked dirty (it will already be IRL...).
+
+        Demonstrate calculating the signature.
+        """
+        course = CourseFactory(code="DemoX", should_publish=False)
+        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 46782,
+            "catalog_visibility": "course_and_search",
+        }
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        authorization = (
+            "SIG-HMAC-SHA256 "
+            "5bdfb326b35fccaef9961e03cf617c359c86ffbb6c64e0f7e074aa011e8af9d6"
+        )
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=authorization,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check the new draft course run
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
+    )
+    def test_api_course_run_sync_create_sync_to_public_published_course(
+        self, mock_signal
+    ):
+        """
+        If the submitted data is not related to an existing course run, a new course run should
+        be created. If the related course has a public counterpart, the synchronization is
+        applied a draft and a public course run.
+        """
+        course = CourseFactory(code="DemoX", should_publish=True)
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 324,
+            "catalog_visibility": "course_and_search",
+        }
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 8e232f3a6071a10cded2740bdc71aed06aa637719d28f968c7b7d35eccd765f7"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 2)
+
+        # Check the new draft course run
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, data)
+
+        # Check the new public course run
+        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
+        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
+        self.assertEqual(public_serializer.data, data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.assert_called_once_with(
+            sender=Page, instance=course.extended_object, language=None
+        )
+
+    @override_settings(
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_draft", TIME_ZONE="utc"
+    )
+    def test_api_course_run_sync_create_sync_to_draft(self, mock_signal):
+        """
+        If the submitted data is not related to an existing course run, a new course run should
+        be created. In "sync_to_draft" mode, the synchronization should be limited to the draft
+        course run, even if the related course is published.
+        """
+        course = CourseFactory(code="DemoX", should_publish=True)
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 47892,
+            "catalog_visibility": "course_and_search",
+        }
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 bb453816becb5df16949b915dd577a2cabf734e4429bfbd3bdb727bde39c58b7"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check the new draft course run
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DIRTY,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(TIME_ZONE="utc")
+    def test_api_course_run_sync_create_partial_required(self, mock_signal):
+        """
+        If the submitted data is not related to an existing course run and some required fields
+        are missing, it should raise a 400.
+        """
+        course = CourseFactory(code="DemoX", should_publish=True)
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "end": "2021-03-14T09:31:59.417895Z",
+        }
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 1de9b46133a91eec3515d0df40f586b642cff16b79aa9d5fe4f7679a33767967"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"languages": ["This field is required."]})
+        self.assertEqual(CourseRun.objects.count(), 0)
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(TIME_ZONE="utc")
+    def test_api_course_run_sync_create_partial_not_required(self, mock_signal):
+        """
+        If the submitted data is not related to an existing course run and some optional fields
+        are missing, it should create the course run.
+        """
+        course = CourseFactory(code="DemoX")
+        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 45,
+            "catalog_visibility": "course_and_search",
+        }
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 723d3312759b6755bc8bbe05a9c2c719d2b4a3bdf381e2036a93119bf192aeda"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check the new draft course run
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        data.update({"start": None, "end": None, "enrollment_start": None})
+        self.assertEqual(draft_serializer.data, data)
+
+        # The page is not marked dirty because the course run is to be scheduled
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        self.assertFalse(mock_signal.called)
+
+    def test_api_course_run_sync_existing_published_manual(self, mock_signal):
+        """
+        If a course run exists in "manual" sync mode (draft and public versions), it should not
+        be updated and course runs should not be created.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX")
+        course_run = CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="manual"
+        )
+        course.extended_object.publish("en")
+        course.refresh_from_db()
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        origin_data = SyncCourseRunSerializer(instance=course_run).data
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 338f7c262254e8220fea54467526f8f1f4562ee3adf1e3a71abaf23a20b739e4"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 2)
+
+        # Check that the existing draft course run was not updated
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, origin_data)
+
+        # Check that the existing public course run was not updated
+        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
+        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
+        self.assertEqual(public_serializer.data, origin_data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        self.assertFalse(mock_signal.called)
+
+    def test_api_course_run_sync_existing_draft_manual(self, mock_signal):
+        """
+        If a course run exists in "manual" sync mode (only draft version), it should not
+        be updated and a new course run should not be created.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX")
+        course_run = CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="manual"
+        )
+        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        origin_data = SyncCourseRunSerializer(instance=course_run).data
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 338f7c262254e8220fea54467526f8f1f4562ee3adf1e3a71abaf23a20b739e4"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check that the existing draft course run was not updated
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, origin_data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(TIME_ZONE="utc")
+    def test_api_course_run_sync_existing_published_sync_to_public(self, mock_signal):
+        """
+        If a course run exists in "sync_to_public" mode (draft and public versions),
+        it should be updated, draft and public versions.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX")
+        CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="sync_to_public"
+        )
+        course.extended_object.publish("en")
+        course.refresh_from_db()
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 15682,
+            "catalog_visibility": "course_and_search",
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 25de22f3674a207a2bd3923dcc5e302a21c9aac8eee7c835f084349da69d0472"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 2)
+
+        # Check that the existing draft course run was updated
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, data)
+
+        # Check that the existing public course run was updated
+        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
+        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
+        self.assertEqual(public_serializer.data, data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.assert_called_once_with(
+            sender=Page, instance=course.extended_object, language=None
+        )
+
+    @override_settings(TIME_ZONE="utc")
+    def test_api_course_run_sync_existing_draft_sync_to_public(self, mock_signal):
+        """
+        If a course run exists in "sync_to_public" mode (only draft version), and the course
+        does not exist in public version, the draft course run should be updated and the
+        related course should not be marked dirty (it will already be IRL...).
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX")
+        CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="sync_to_public"
+        )
+        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 2042,
+            "catalog_visibility": "course_and_search",
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 6f85261b995a8ca78b5610cfe47fd6a0e321f26c671b606d12225bbea72fc8f0"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check that the draft course run was updated
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(TIME_ZONE="utc")
+    def test_api_course_run_sync_existing_draft_with_public_course_sync_to_public(
+        self, mock_signal
+    ):
+        """
+        If a course run exists in "sync_to_public" mode (only draft version),
+        but the course exists in public version, it should be updated, and a new public
+        version should be created.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX", should_publish=True)
+        CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="sync_to_public"
+        )
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 103123,
+            "catalog_visibility": "course_and_search",
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 262963565518c85901059500b274568a4d5583d507c375604e9845083d5d7095"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 2)
+
+        # Check that the draft course run was updated
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, data)
+
+        # Check that a new public course run was created
+        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
+        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
+        self.assertEqual(public_serializer.data, data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.assert_called_once_with(
+            sender=Page, instance=course.extended_object, language=None
+        )
+
+    @override_settings(TIME_ZONE="utc")
+    def test_api_course_run_sync_existing_published_sync_to_draft(self, mock_signal):
+        """
+        If a course run exists in "sync_to_draft" mode (draft and public versions),
+        only the draft version should be udpated and the related course page should
+        be marked dirty.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX")
+        course_run = CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="sync_to_draft"
+        )
+        course.extended_object.publish("en")
+        course.refresh_from_db()
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        origin_data = SyncCourseRunSerializer(instance=course_run).data
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 542,
+            "catalog_visibility": "course_and_search",
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 db30268ee706fd147c6f04567faa88ed84fd06f08dbc944fff6c0a4973b06599"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 2)
+
+        # Check that the draft course run was updated
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, data)
+
+        # Check that the public course run was NOT updated
+        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
+        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
+        self.assertEqual(public_serializer.data, origin_data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DIRTY,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(TIME_ZONE="utc")
+    def test_api_course_run_sync_existing_draft_sync_to_draft(self, mock_signal):
+        """
+        If a course run exists in "sync_to_draft" mode (only draft version),
+        the draft version should be udpated, the related course page should
+        be marked dirty and no public version should be created.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX", should_publish=True)
+        CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="sync_to_draft"
+        )
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 986,
+            "catalog_visibility": "course_and_search",
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 3bed4a7b1595f49957bd949ed0192d5f1416d4f6a1c409fc8b03b1a1ebad0f39"
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check that the draft course run was updated
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+        self.assertEqual(draft_serializer.data, data)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DIRTY,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(TIME_ZONE="utc")
+    def test_api_course_run_sync_existing_partial(self, mock_signal):
+        """
+        If a course run exists, it can be partially updated and the other fields should not
+        be altered.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX")
+        course_run = CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="sync_to_draft"
+        )
+        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        origin_data = SyncCourseRunSerializer(instance=course_run).data
+        data = {"resource_link": link, "end": "2021-03-14T09:31:59.417895Z"}
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 1de9b46133a91eec3515d0df40f586b642cff16b79aa9d5fe4f7679a33767967"
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check that the draft course run was updated
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+
+        self.assertEqual(draft_serializer.data["end"], data["end"])
+        for field in draft_serializer.fields:
+            if field == "end":
+                continue
+            self.assertEqual(draft_serializer.data[field], origin_data[field])
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DIRTY,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(
+        TIME_ZONE="utc",
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "http://localhost:8073",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages", "start"],
+                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
+                "JS_BACKEND": "dummy",
+                "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
+            }
+        ],
+    )
+    def test_api_course_run_sync_update_with_no_update_fields(self, mock_signal):
+        """
+        If a course run exists and LMS Backend has course run protected fields,
+        these fields should not be updated.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX")
+        course_run = CourseRunFactory(
+            direct_course=course, resource_link=link, sync_mode="sync_to_draft"
+        )
+        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+        mock_signal.reset_mock()
+
+        origin_data = SyncCourseRunSerializer(instance=course_run).data
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 12345,
+            "catalog_visibility": "course_and_search",
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 13433eb9159326b7d0f38ea86ab1ef8510ac4bc643d997d2ad01e349bee15570"
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check that the draft course run was updated except protected fields
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+
+        no_update_fields = getattr(settings, "RICHIE_LMS_BACKENDS")[0].get(
+            "COURSE_RUN_SYNC_NO_UPDATE_FIELDS"
+        )
+        for field in draft_serializer.fields:
+            if field in no_update_fields:
+                self.assertEqual(draft_serializer.data[field], origin_data[field])
+            else:
+                self.assertEqual(draft_serializer.data[field], data[field])
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DIRTY,
+        )
+        self.assertFalse(mock_signal.called)
+
+    @override_settings(
+        TIME_ZONE="utc",
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "http://localhost:8073",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages", "start"],
+                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
+                "JS_BACKEND": "dummy",
+                "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
+            }
+        ],
+    )
+    def test_api_course_run_sync_create_with_no_update_fields(self, mock_signal):
+        """
+        If a course run does not exist and LMS Backend has course run protected fields,
+        these fields should still be used to create the course run.
+        """
+        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        course = CourseFactory(code="DemoX")
+        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
+        mock_signal.reset_mock()
+
+        data = {
+            "resource_link": link,
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 12345,
+            "catalog_visibility": "course_and_search",
+        }
+
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=(
+                "SIG-HMAC-SHA256 13433eb9159326b7d0f38ea86ab1ef8510ac4bc643d997d2ad01e349bee15570"
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)
+
+        # Check that the draft course run was created
+        draft_course_run = CourseRun.objects.get(direct_course=course)
+        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
+
+        for field, value in data.items():
+            self.assertEqual(draft_serializer.data[field], value)
+
+        self.assertFalse(mock_signal.called)

--- a/tests/apps/courses/test_api_course_run_sync_edx.py
+++ b/tests/apps/courses/test_api_course_run_sync_edx.py
@@ -1,194 +1,45 @@
 """
-Tests for CourseRun API endpoints in the courses app.
+Tests for CourseRun API endpoints in the courses app with EDX LMS.
 """
 # pylint: disable=too-many-lines
-import json
 from unittest import mock
 
-from django.conf import settings
 from django.test import override_settings
 
-from cms.constants import PUBLISHER_STATE_DEFAULT, PUBLISHER_STATE_DIRTY
-from cms.models import Page, Title
+from cms.constants import PUBLISHER_STATE_DEFAULT
+from cms.models import Title
 from cms.signals import post_publish
 from cms.test_utils.testcases import CMSTestCase
 
 from richie.apps.courses.factories import CourseFactory, CourseRunFactory
-from richie.apps.courses.lms.edx import SyncCourseRunSerializer
-from richie.apps.courses.models import Course, CourseRun, CourseRunCatalogVisibility
+from richie.apps.courses.models import CourseRun, CourseRunCatalogVisibility
 
 
 # pylint: disable=too-many-public-methods
 @mock.patch.object(post_publish, "send", wraps=post_publish.send)
 @override_settings(RICHIE_COURSE_RUN_SYNC_SECRETS=["shared secret"])
-class SyncCourseRunApiTestCase(CMSTestCase):
-    """Test calls to sync a course run via API endpoint."""
+@override_settings(
+    TIME_ZONE="utc",
+    RICHIE_LMS_BACKENDS=[
+        {
+            "BASE_URL": "http://localhost:8073",
+            "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+            "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
+            "JS_BACKEND": "dummy",
+            "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
+        }
+    ],
+)
+class EdxSyncCourseRunApiTestCase(CMSTestCase):
+    """Test calls to sync a course run from Open EdX via API endpoint."""
 
     # To update the http authorizations add this next statements before the first assert
     # from richie.apps.courses.utils import get_signature
     # print (get_signature(self.client._encode_json(data, "application/json"), "shared secret"))
 
-    def test_api_course_run_sync_missing_signature(self, mock_signal):
-        """The course run synchronization API endpoint requires a signature."""
-        data = {
-            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-        }
-
-        mock_signal.reset_mock()
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync", data, content_type="application/json"
-        )
-
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(json.loads(response.content), "Missing authentication.")
-        self.assertEqual(CourseRun.objects.count(), 0)
-        self.assertEqual(Course.objects.count(), 0)
-        self.assertFalse(mock_signal.called)
-
-    def test_api_course_run_sync_invalid_signature(self, mock_signal):
-        """The course run synchronization API endpoint requires a valid signature."""
-        data = {
-            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-        }
-
-        mock_signal.reset_mock()
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=("invalid authorization"),
-        )
-
-        self.assertEqual(response.status_code, 401)
-        self.assertEqual(json.loads(response.content), "Invalid authentication.")
-        self.assertEqual(CourseRun.objects.count(), 0)
-        self.assertEqual(Course.objects.count(), 0)
-        self.assertFalse(mock_signal.called)
-
-    def test_api_course_run_sync_missing_resource_link(self, mock_signal):
+    def test_api_course_run_sync_edx_succeed(self, mock_signal):
         """
-        If the data submitted is missing a resource link, it should return a 400 error.
-        """
-        # Data with missing resource link => invalid
-        data = {
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-        }
-
-        mock_signal.reset_mock()
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 acee4804ff21eabe366ff6e04495591dfe32dffa7f1cd2d48c0f44beb9d5aa0d"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            json.loads(response.content), {"resource_link": ["This field is required."]}
-        )
-        self.assertEqual(CourseRun.objects.count(), 0)
-        self.assertEqual(Course.objects.count(), 0)
-        self.assertFalse(mock_signal.called)
-
-    def test_api_course_run_sync_invalid_field(self, mock_signal):
-        """
-        If the submitted data is invalid, the course run synchronization view should return
-        a 400 error.
-        """
-        # Data with invalid start date value
-        data = {
-            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "start": 1,
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-        }
-
-        mock_signal.reset_mock()
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 38af01f97c1b6d078662de52a4785df7c09a16b426659af56f722f68c2035f95"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            json.loads(response.content),
-            {
-                "start": [
-                    (
-                        "Datetime has wrong format. Use one of these formats instead: "
-                        "YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]."
-                    )
-                ]
-            },
-        )
-        self.assertEqual(CourseRun.objects.count(), 0)
-        self.assertEqual(Course.objects.count(), 0)
-        self.assertFalse(mock_signal.called)
-
-    def test_api_course_run_sync_create_unknown_course(self, mock_signal):
-        """
-        If the submitted data is not related to an existing course run and the related course
-        can't be found, the course run synchronization view should return a 400 error.
-        """
-        data = {
-            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-        }
-
-        mock_signal.reset_mock()
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 338f7c262254e8220fea54467526f8f1f4562ee3adf1e3a71abaf23a20b739e4"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            json.loads(response.content), {"resource_link": ["Unknown course: DEMOX."]}
-        )
-        self.assertEqual(CourseRun.objects.count(), 0)
-        self.assertEqual(Course.objects.count(), 0)
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
-    )
-    def test_api_course_run_sync_create_sync_to_public_draft_course(self, mock_signal):
-        """
-        If the submitted data is not related to an existing course run, a new course run should
-        be created. If the related course is draft, the synchronization is limited to the draft
-        course run and the course is not marked dirty (it will already be IRL...).
-
-        Demonstrate calculating the signature.
+        A course run synchronization through Open EdX LMS should succeed.
         """
         course = CourseFactory(code="DemoX", should_publish=False)
         Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
@@ -202,12 +53,12 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             "enrollment_count": 46782,
             "catalog_visibility": "course_and_search",
         }
+        mock_signal.reset_mock()
 
         self.assertEqual(
             course.extended_object.title_set.first().publisher_state,
             PUBLISHER_STATE_DEFAULT,
         )
-        mock_signal.reset_mock()
 
         authorization = (
             "SIG-HMAC-SHA256 "
@@ -221,801 +72,10 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(response.json(), {"success": True})
         self.assertEqual(CourseRun.objects.count(), 1)
 
-        # Check the new draft course run
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
-    )
-    def test_api_course_run_sync_create_sync_to_public_published_course(
-        self, mock_signal
-    ):
-        """
-        If the submitted data is not related to an existing course run, a new course run should
-        be created. If the related course has a public counterpart, the synchronization is
-        applied a draft and a public course run.
-        """
-        course = CourseFactory(code="DemoX", should_publish=True)
-        data = {
-            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 324,
-            "catalog_visibility": "course_and_search",
-        }
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 8e232f3a6071a10cded2740bdc71aed06aa637719d28f968c7b7d35eccd765f7"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 2)
-
-        # Check the new draft course run
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, data)
-
-        # Check the new public course run
-        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
-        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
-        self.assertEqual(public_serializer.data, data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.assert_called_once_with(
-            sender=Page, instance=course.extended_object, language=None
-        )
-
-    @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_draft", TIME_ZONE="utc"
-    )
-    def test_api_course_run_sync_create_sync_to_draft(self, mock_signal):
-        """
-        If the submitted data is not related to an existing course run, a new course run should
-        be created. In "sync_to_draft" mode, the synchronization should be limited to the draft
-        course run, even if the related course is published.
-        """
-        course = CourseFactory(code="DemoX", should_publish=True)
-        data = {
-            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 47892,
-            "catalog_visibility": "course_and_search",
-        }
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 bb453816becb5df16949b915dd577a2cabf734e4429bfbd3bdb727bde39c58b7"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 1)
-
-        # Check the new draft course run
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DIRTY,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_create_partial_required(self, mock_signal):
-        """
-        If the submitted data is not related to an existing course run and some required fields
-        are missing, it should raise a 400.
-        """
-        course = CourseFactory(code="DemoX", should_publish=True)
-        data = {
-            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "end": "2021-03-14T09:31:59.417895Z",
-        }
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 1de9b46133a91eec3515d0df40f586b642cff16b79aa9d5fe4f7679a33767967"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            json.loads(response.content), {"languages": ["This field is required."]}
-        )
-        self.assertEqual(CourseRun.objects.count(), 0)
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_create_partial_not_required(self, mock_signal):
-        """
-        If the submitted data is not related to an existing course run and some optional fields
-        are missing, it should create the course run.
-        """
-        course = CourseFactory(code="DemoX")
-        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
-        data = {
-            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 45,
-            "catalog_visibility": "course_and_search",
-        }
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 723d3312759b6755bc8bbe05a9c2c719d2b4a3bdf381e2036a93119bf192aeda"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 1)
-
-        # Check the new draft course run
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        data.update({"start": None, "end": None, "enrollment_start": None})
-        self.assertEqual(draft_serializer.data, data)
-
-        # The page is not marked dirty because the course run is to be scheduled
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        self.assertFalse(mock_signal.called)
-
-    def test_api_course_run_sync_existing_published_manual(self, mock_signal):
-        """
-        If a course run exists in "manual" sync mode (draft and public versions), it should not
-        be updated and course runs should not be created.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX")
-        course_run = CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="manual"
-        )
-        course.extended_object.publish("en")
-        course.refresh_from_db()
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        origin_data = SyncCourseRunSerializer(instance=course_run).data
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 338f7c262254e8220fea54467526f8f1f4562ee3adf1e3a71abaf23a20b739e4"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 2)
-
-        # Check that the existing draft course run was not updated
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, origin_data)
-
-        # Check that the existing public course run was not updated
-        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
-        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
-        self.assertEqual(public_serializer.data, origin_data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        self.assertFalse(mock_signal.called)
-
-    def test_api_course_run_sync_existing_draft_manual(self, mock_signal):
-        """
-        If a course run exists in "manual" sync mode (only draft version), it should not
-        be updated and a new course run should not be created.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX")
-        course_run = CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="manual"
-        )
-        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        origin_data = SyncCourseRunSerializer(instance=course_run).data
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 338f7c262254e8220fea54467526f8f1f4562ee3adf1e3a71abaf23a20b739e4"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 1)
-
-        # Check that the existing draft course run was not updated
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, origin_data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_existing_published_sync_to_public(self, mock_signal):
-        """
-        If a course run exists in "sync_to_public" mode (draft and public versions),
-        it should be updated, draft and public versions.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX")
-        CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="sync_to_public"
-        )
-        course.extended_object.publish("en")
-        course.refresh_from_db()
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 15682,
-            "catalog_visibility": "course_and_search",
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 25de22f3674a207a2bd3923dcc5e302a21c9aac8eee7c835f084349da69d0472"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 2)
-
-        # Check that the existing draft course run was updated
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, data)
-
-        # Check that the existing public course run was updated
-        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
-        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
-        self.assertEqual(public_serializer.data, data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.assert_called_once_with(
-            sender=Page, instance=course.extended_object, language=None
-        )
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_existing_draft_sync_to_public(self, mock_signal):
-        """
-        If a course run exists in "sync_to_public" mode (only draft version), and the course
-        does not exist in public version, the draft course run should be updated and the
-        related course should not be marked dirty (it will already be IRL...).
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX")
-        CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="sync_to_public"
-        )
-        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 2042,
-            "catalog_visibility": "course_and_search",
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 6f85261b995a8ca78b5610cfe47fd6a0e321f26c671b606d12225bbea72fc8f0"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 1)
-
-        # Check that the draft course run was updated
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_existing_draft_with_public_course_sync_to_public(
-        self, mock_signal
-    ):
-        """
-        If a course run exists in "sync_to_public" mode (only draft version),
-        but the course exists in public version, it should be updated, and a new public
-        version should be created.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX", should_publish=True)
-        CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="sync_to_public"
-        )
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 103123,
-            "catalog_visibility": "course_and_search",
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 262963565518c85901059500b274568a4d5583d507c375604e9845083d5d7095"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 2)
-
-        # Check that the draft course run was updated
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, data)
-
-        # Check that a new public course run was created
-        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
-        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
-        self.assertEqual(public_serializer.data, data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.assert_called_once_with(
-            sender=Page, instance=course.extended_object, language=None
-        )
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_existing_published_sync_to_draft(self, mock_signal):
-        """
-        If a course run exists in "sync_to_draft" mode (draft and public versions),
-        only the draft version should be udpated and the related course page should
-        be marked dirty.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX")
-        course_run = CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="sync_to_draft"
-        )
-        course.extended_object.publish("en")
-        course.refresh_from_db()
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        origin_data = SyncCourseRunSerializer(instance=course_run).data
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 542,
-            "catalog_visibility": "course_and_search",
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 db30268ee706fd147c6f04567faa88ed84fd06f08dbc944fff6c0a4973b06599"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 2)
-
-        # Check that the draft course run was updated
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, data)
-
-        # Check that the public course run was NOT updated
-        public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
-        public_serializer = SyncCourseRunSerializer(instance=public_course_run)
-        self.assertEqual(public_serializer.data, origin_data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DIRTY,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_existing_draft_sync_to_draft(self, mock_signal):
-        """
-        If a course run exists in "sync_to_draft" mode (only draft version),
-        the draft version should be udpated, the related course page should
-        be marked dirty and no public version should be created.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX", should_publish=True)
-        CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="sync_to_draft"
-        )
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 986,
-            "catalog_visibility": "course_and_search",
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 3bed4a7b1595f49957bd949ed0192d5f1416d4f6a1c409fc8b03b1a1ebad0f39"
-            ),
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 1)
-
-        # Check that the draft course run was updated
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-        self.assertEqual(draft_serializer.data, data)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DIRTY,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_existing_partial(self, mock_signal):
-        """
-        If a course run exists, it can be partially updated and the other fields should not
-        be altered.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX")
-        course_run = CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="sync_to_draft"
-        )
-        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        origin_data = SyncCourseRunSerializer(instance=course_run).data
-        data = {"resource_link": link, "end": "2021-03-14T09:31:59.417895Z"}
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 1de9b46133a91eec3515d0df40f586b642cff16b79aa9d5fe4f7679a33767967"
-            ),
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 1)
-
-        # Check that the draft course run was updated
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-
-        self.assertEqual(draft_serializer.data["end"], data["end"])
-        for field in draft_serializer.fields:
-            if field == "end":
-                continue
-            self.assertEqual(draft_serializer.data[field], origin_data[field])
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DIRTY,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(
-        TIME_ZONE="utc",
-        RICHIE_LMS_BACKENDS=[
-            {
-                "BASE_URL": "http://localhost:8073",
-                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
-                "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages", "start"],
-                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
-                "JS_BACKEND": "dummy",
-                "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
-            }
-        ],
-    )
-    def test_api_course_run_sync_update_with_no_update_fields(self, mock_signal):
-        """
-        If a course run exists and LMS Backend has course run protected fields,
-        these fields should not be updated.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX")
-        course_run = CourseRunFactory(
-            direct_course=course, resource_link=link, sync_mode="sync_to_draft"
-        )
-        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DEFAULT,
-        )
-        mock_signal.reset_mock()
-
-        origin_data = SyncCourseRunSerializer(instance=course_run).data
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 12345,
-            "catalog_visibility": "course_and_search",
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 13433eb9159326b7d0f38ea86ab1ef8510ac4bc643d997d2ad01e349bee15570"
-            ),
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 1)
-
-        # Check that the draft course run was updated except protected fields
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-
-        no_update_fields = getattr(settings, "RICHIE_LMS_BACKENDS")[0].get(
-            "COURSE_RUN_SYNC_NO_UPDATE_FIELDS"
-        )
-        for field in draft_serializer.fields:
-            if field in no_update_fields:
-                self.assertEqual(draft_serializer.data[field], origin_data[field])
-            else:
-                self.assertEqual(draft_serializer.data[field], data[field])
-
-        self.assertEqual(
-            course.extended_object.title_set.first().publisher_state,
-            PUBLISHER_STATE_DIRTY,
-        )
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(
-        TIME_ZONE="utc",
-        RICHIE_LMS_BACKENDS=[
-            {
-                "BASE_URL": "http://localhost:8073",
-                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
-                "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages", "start"],
-                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
-                "JS_BACKEND": "dummy",
-                "JS_COURSE_REGEX": r"^.*/courses/(?<course_id>.*)/course/?$",
-            }
-        ],
-    )
-    def test_api_course_run_sync_create_with_no_update_fields(self, mock_signal):
-        """
-        If a course run does not exist and LMS Backend has course run protected fields,
-        these fields should still be used to create the course run.
-        """
-        link = "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
-        course = CourseFactory(code="DemoX")
-        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
-        mock_signal.reset_mock()
-
-        data = {
-            "resource_link": link,
-            "start": "2020-12-09T09:31:59.417817Z",
-            "end": "2021-03-14T09:31:59.417895Z",
-            "enrollment_start": "2020-11-09T09:31:59.417936Z",
-            "enrollment_end": "2020-12-24T09:31:59.417972Z",
-            "languages": ["en", "fr"],
-            "enrollment_count": 12345,
-            "catalog_visibility": "course_and_search",
-        }
-
-        response = self.client.post(
-            "/api/v1.0/course-runs-sync",
-            data,
-            content_type="application/json",
-            HTTP_AUTHORIZATION=(
-                "SIG-HMAC-SHA256 13433eb9159326b7d0f38ea86ab1ef8510ac4bc643d997d2ad01e349bee15570"
-            ),
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
-        self.assertEqual(CourseRun.objects.count(), 1)
-
-        # Check that the draft course run was created
-        draft_course_run = CourseRun.objects.get(direct_course=course)
-        draft_serializer = SyncCourseRunSerializer(instance=draft_course_run)
-
-        for field, value in data.items():
-            self.assertEqual(draft_serializer.data[field], value)
-
-        self.assertFalse(mock_signal.called)
-
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_enrollment_count(self, mock_signal):
+    def test_api_course_run_sync_edx_enrollment_count(self, mock_signal):
         """
         Check if the enrollment count of a course is updated
         """
@@ -1038,13 +98,12 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             ),
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(response.json(), {"success": True})
         course_run.refresh_from_db()
         self.assertEqual(course_run.enrollment_count, 865)
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_catalog_visibility_course_only(self, mock_signal):
+    def test_api_course_run_sync_edx_catalog_visibility_course_only(self, mock_signal):
         """
         Verify that the catalog visibility is updated with `course_only`
         """
@@ -1067,15 +126,14 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             ),
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(response.json(), {"success": True})
         course_run.refresh_from_db()
         self.assertEqual(
             course_run.catalog_visibility, CourseRunCatalogVisibility.COURSE_ONLY
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_catalog_visibility_course_and_search(
+    def test_api_course_run_sync_edx_catalog_visibility_course_and_search(
         self, mock_signal
     ):
         """
@@ -1100,15 +158,14 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             ),
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(response.json(), {"success": True})
         course_run.refresh_from_db()
         self.assertEqual(
             course_run.catalog_visibility, CourseRunCatalogVisibility.COURSE_AND_SEARCH
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_catalog_visibility_hidden(self, mock_signal):
+    def test_api_course_run_sync_edx_catalog_visibility_hidden(self, mock_signal):
         """
         Verify that the catalog visibility is updated with `hidden`
         """
@@ -1131,15 +188,14 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             ),
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(response.json(), {"success": True})
         course_run.refresh_from_db()
         self.assertEqual(
             course_run.catalog_visibility, CourseRunCatalogVisibility.HIDDEN
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_catalog_visibility_none(self, mock_signal):
+    def test_api_course_run_sync_edx_catalog_visibility_none(self, mock_signal):
         """
         Test the adaptation of the Open edX catalog visibility of the `none` value to the Richie
         `hidden`.
@@ -1163,15 +219,14 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             ),
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(response.json(), {"success": True})
         course_run.refresh_from_db()
         self.assertEqual(
             course_run.catalog_visibility, CourseRunCatalogVisibility.HIDDEN
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_catalog_visibility_both(self, mock_signal):
+    def test_api_course_run_sync_edx_catalog_visibility_both(self, mock_signal):
         """
         Test the adaptation of the Open edX catalog visibility of the `both` value to the Richie
         `course_and_search`.
@@ -1195,15 +250,14 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             ),
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(response.json(), {"success": True})
         course_run.refresh_from_db()
         self.assertEqual(
             course_run.catalog_visibility, CourseRunCatalogVisibility.COURSE_AND_SEARCH
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
-    def test_api_course_run_sync_catalog_visibility_about(self, mock_signal):
+    def test_api_course_run_sync_edx_catalog_visibility_about(self, mock_signal):
         """
         Test the adaptation of the Open edX catalog visibility of the `about` value to the Richie
         `course_only`.
@@ -1227,7 +281,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             ),
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content), {"success": True})
+        self.assertEqual(response.json(), {"success": True})
         course_run.refresh_from_db()
         self.assertEqual(
             course_run.catalog_visibility, CourseRunCatalogVisibility.COURSE_ONLY

--- a/tests/apps/courses/test_api_course_run_sync_joanie.py
+++ b/tests/apps/courses/test_api_course_run_sync_joanie.py
@@ -1,0 +1,73 @@
+"""
+Tests for CourseRun API endpoints in the courses app with EDX LMS.
+"""
+# pylint: disable=too-many-lines
+from unittest import mock
+
+from django.test import override_settings
+
+from cms.constants import PUBLISHER_STATE_DEFAULT
+from cms.models import Title
+from cms.signals import post_publish
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.courses.factories import CourseFactory
+from richie.apps.courses.models import CourseRun
+
+
+# pylint: disable=too-many-public-methods
+@mock.patch.object(post_publish, "send", wraps=post_publish.send)
+@override_settings(RICHIE_COURSE_RUN_SYNC_SECRETS=["shared secret"])
+@override_settings(
+    TIME_ZONE="utc",
+    RICHIE_LMS_BACKENDS=[
+        {
+            "BASE_URL": "http://localhost:8071",
+            "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+            "COURSE_REGEX": "^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",  # noqa pylint: disable=line-too-long
+        }
+    ],
+)
+class JoanieSyncCourseRunApiTestCase(CMSTestCase):
+    """Test calls to sync a course run from Joanie via API endpoint."""
+
+    # To update the http authorizations add this next statements before the first assert
+    # from richie.apps.courses.utils import get_signature
+    # print (get_signature(self.client._encode_json(data, "application/json"), "shared secret"))
+
+    def test_api_course_run_sync_joanie_succeed(self, mock_signal):
+        """
+        A course run synchronization through Joanie should succeed.
+        """
+        course = CourseFactory(code="DemoX", should_publish=False)
+        Title.objects.update(publisher_state=PUBLISHER_STATE_DEFAULT)
+        data = {
+            "resource_link": "http://example.joanie:8071/api/course-runs/123",
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "course": "DemoX",
+        }
+        mock_signal.reset_mock()
+
+        self.assertEqual(
+            course.extended_object.title_set.first().publisher_state,
+            PUBLISHER_STATE_DEFAULT,
+        )
+
+        authorization = (
+            "SIG-HMAC-SHA256 "
+            "98ee25a1f289f4bb1e2887455b02ff32bf1e45d64a72ac6c6f4e6feff80df0f2"
+        )
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=authorization,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -1815,7 +1815,17 @@ class RunsCourseCMSTestCase(CMSTestCase):
 
         self.assertContains(response, "No other course runs")
 
-    @override_settings(JOANIE={"ENABLED": True, "BASE_URL": "https://joanie.test"})
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "http://localhost:8071",
+                "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+                "COURSE_REGEX": "^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",  # noqa pylint: disable=line-too-long
+                "JS_BACKEND": "joanie",
+                "JS_COURSE_REGEX": r"^.*/api/(course-runs|products)/(.*)/?$",
+            }
+        ]
+    )
     def test_template_course_detail_with_joanie_enabled(self):
         """
         When Joanie is enabled, course detail template should use

--- a/tests/apps/courses/test_templatetags_extra_tags_is_joanie_product.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_is_joanie_product.py
@@ -1,0 +1,63 @@
+"""Tests for the `is_joanie_product` template filter."""
+from django.test import TestCase, override_settings
+
+from richie.apps.courses import factories
+from richie.apps.courses.lms import LMSHandler
+from richie.apps.courses.lms.joanie import JoanieBackend
+from richie.apps.courses.templatetags.extra_tags import is_joanie_product
+
+
+class IsJoanieProductFilterTestCase(TestCase):
+    """
+    Unit test suite to validate the behavior of the `is_joanie_product` template filter.
+    """
+
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "http://localhost:8071",
+                "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+                "COURSE_REGEX": "^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",  # noqa pylint: disable=line-too-long
+            }
+        ]
+    )
+    def test_course_run_is_joanie_product(self):
+        """
+        It should return True if the provided course run has a resource_link which is
+        a link to a product resource.
+        """
+        course_run = factories.CourseRunFactory(
+            resource_link="http://localhost:8071/api/products/123"
+        )
+        self.assertEqual(is_joanie_product(course_run), True)
+
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "http://localhost:8071",
+                "BACKEND": "richie.apps.courses.lms.joanie.JoanieBackend",
+                "COURSE_REGEX": "^.*/api/(?P<resource_type>(course-runs|products))/(?P<resource_id>.*)/?$",  # noqa pylint: disable=line-too-long
+            }
+        ]
+    )
+    def test_course_run_is_not_joanie_product(self):
+        """
+        It should return False if the provided course run has a resource_link which is
+        a resource managed by Joanie but not a link to a product resource.
+        """
+        course_run = factories.CourseRunFactory(
+            resource_link="http://localhost:8071/api/course-runs/123"
+        )
+        lms = LMSHandler.select_lms(course_run.resource_link)
+        self.assertIsInstance(lms, JoanieBackend)
+        self.assertEqual(is_joanie_product(course_run), False)
+
+    @override_settings(RICHIE_LMS_BACKENDS=[])
+    def test_course_run_is_joanie_product_without_joanie_enabled(self):
+        """
+        It should return False if Joanie is not enabled
+        """
+        course_run = factories.CourseRunFactory(
+            resource_link="http://localhost:8071/api/course-runs/123"
+        )
+        self.assertEqual(is_joanie_product(course_run), False)


### PR DESCRIPTION
## Purpose

Joanie will be soon able to synchronize course runs and products (interpolated as course run) into Richie. In this way, all products and course runs managed by Joanie will be indexed by Richie with ease. So from Richie, we have to implement an interface able to identify course runs managed by Joanie.



## Proposal

- [x] Implement JoanieBackend able to identify course runs managed by Joanie
- [x] Add template tag to identify course runs which are products
- [x] Write tests
- [x] Add all methods to JoanieBackend required to synchronize course runs
