### PR TITLE
✅(frontend) fix flaky tests

### DIFF
--- a/src/frontend/js/components/DashboardCreditCardsManagement/index.spec.tsx
+++ b/src/frontend/js/components/DashboardCreditCardsManagement/index.spec.tsx
@@ -113,9 +113,10 @@ describe('<DashboardCreditCardsManagement/>', () => {
   });
 
   it('renders the correct label for an expiration date that will soon expire', async () => {
-    const limit = new Date();
-    limit.setMonth(limit.getMonth() + 1);
-    const date = faker.date.future(0.2, limit);
+    const offset = new Date();
+    offset.setMonth(offset.getMonth() + 1);
+    offset.setDate(1);
+    const date = faker.date.future(2 / 12, offset);
     const creditCard: CreditCard = {
       ...mockFactories.CreditCardFactory.generate(),
       expiration_month: date.getMonth() + 1,


### PR DESCRIPTION
## Purpose

The DashboardCreditCardsManagement test suite was flaky. In some case the test in charge to check if the right class is displayed when a credit card soon expire could generate an expiration date in the wrong interval.


## Proposal

- [x] Remove flaky test
