### PR TITLE
🐛(frontend) fix courses badges css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix courses badges css.
+
 ## [2.17.0]
 
 ### Added

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -138,9 +138,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     }
 
     img {
-      @include sv-flex(0, 0, 1.6rem);
       margin: 0 0.5rem 0 0;
-      order: 1;
     }
   }
 


### PR DESCRIPTION
This bug was revealed by the 0bb70196c7c42bb3bceab4e06d60baadff8dc207 commit, by transforming all buttons to flex containers some css line that were not getting took into account before went to life resulting in this bug. So that means the existing code worked but ... by chance.
