### PR TITLE
🐛(courses) fix course page style in edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix courses badges css.
+- Fix style in edit mode on courses with catalog visibility with
+  `course_only` or `course_and_search`.
 
 ## [2.17.0]
 

--- a/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -139,44 +139,46 @@
 
     & + #{$detail-selector}__run-descriptions {
       @if r-theme-val(course-detail, run-descriptions-divider) {
-        &::before {
+        margin-top: 4rem;
+
+        &::after {
           content: '';
           display: block;
           width: 60%;
-          margin: 2rem auto;
+          margin: 2rem 0;
+          top: -4rem;
+          left: 50%;
+          transform: translateX(-50%);
+          position: absolute;
           border-top: $onepixel solid r-theme-val(course-detail, run-descriptions-divider);
         }
       }
     }
 
     // Add CSS style only to edit mode
-    &--hidden,
-    &--course_only {
-      h3.cms-render-model::before {
-        content: '';
-        background-size: 1rem 1rem;
-        display: inline-block;
-        width: 1.5rem;
-        height: 1rem;
-        margin-left: -1.5rem;
-        background-repeat: no-repeat;
-        background-color: r-theme-val(course-detail, run-catalog-visibility-logo-color);
-      }
+    &--hidden::before,
+    &--course_only::before {
+      content: '';
+      background-size: 1rem 1rem;
+      display: inline-block;
+      width: 1.5rem;
+      height: 1rem;
+      position: absolute;
+      top: 0.25rem;
+      left: -1.5rem;
+      background-repeat: no-repeat;
+      background-color: r-theme-val(course-detail, run-catalog-visibility-logo-color);
     }
 
-    &--hidden {
-      h3.cms-render-model::before {
-        @include course-detail-run-descriptions-catalog-visibility-mask(
-          r-theme-val(course-detail, run-catalog-visibility-hidden-logo)
-        );
-      }
+    &--hidden::before {
+      @include course-detail-run-descriptions-catalog-visibility-mask(
+        r-theme-val(course-detail, run-catalog-visibility-hidden-logo)
+      );
     }
-    &--course_only {
-      h3.cms-render-model::before {
-        @include course-detail-run-descriptions-catalog-visibility-mask(
-          r-theme-val(course-detail, run-catalog-visibility-course-only-logo)
-        );
-      }
+    &--course_only::before {
+      @include course-detail-run-descriptions-catalog-visibility-mask(
+        r-theme-val(course-detail, run-catalog-visibility-course-only-logo)
+      );
     }
   }
 


### PR DESCRIPTION
Fix style in edit mode on courses with catalog visibility with `course_only` or `course_and_search`.

A course run without title and a course visibility of `course_only` or `course_and_search` didn't display the small image svg near the run. So the course editor don't know that the course run isn't going to be displayed on the course page or the course run won't be included on the search.

Before:
![image](https://user-images.githubusercontent.com/67018/203301588-7c3da40a-3917-420d-a60d-6a1721fe357f.png)

After:
![image](https://user-images.githubusercontent.com/67018/203302232-7acbad0b-830a-4a6a-aa86-c156df7bdf64.png)
