### PR TITLE
Doc/cookiecutter use checkout argument

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,11 @@ generate-version-file: &generate-version-file
         "$CIRCLE_PROJECT_REPONAME" \
         "$CIRCLE_BUILD_URL" > sandbox/version.json
 
-version: 2
+version: 2.1
+parameters:
+  nightly-round:
+    type: boolean
+    default: false
 
 aliases:
   - &checkout_fun
@@ -808,11 +812,15 @@ jobs:
           command: |
             mkdir -p fun-richie-site-factory/data/media/${RICHIE_SITE}
             mkdir -p fun-richie-site-factory/data/db/${RICHIE_SITE}
-      - run:
-          name: Tweak requirement files to install the branch richie version instead of the released one
-          command: |
-            sed -i 's@"richie-education":.*@"richie-education": "https://gitpkg.now.sh/openfun/richie/src/frontend?'"${CIRCLE_BRANCH}"'"@' fun-richie-site-factory/sites/${RICHIE_SITE}/src/frontend/package.json
-            sed -i 's@richie==.*@git+https://github.com/openfun/richie.git\@'"${CIRCLE_BRANCH}"'#egg=richie@' fun-richie-site-factory/sites/${RICHIE_SITE}/requirements/base.txt
+      - when:
+          condition:
+            not: << pipeline.parameters.nightly-round >>
+          steps:
+            - run:
+                name: Tweak requirement files to install the branch richie version instead of the released one
+                command: |
+                  sed -i 's@"richie-education":.*@"richie-education": "https://gitpkg.now.sh/openfun/richie/src/frontend?'"${CIRCLE_BRANCH}"'"@' fun-richie-site-factory/sites/${RICHIE_SITE}/src/frontend/package.json
+                  sed -i 's@richie==.*@git+https://github.com/openfun/richie.git\@'"${CIRCLE_BRANCH}"'#egg=richie@' fun-richie-site-factory/sites/${RICHIE_SITE}/requirements/base.txt
       - run:
           name: Build front
           command: |
@@ -939,9 +947,11 @@ jobs:
             cd ./website && yarn install && GIT_USER=funmoocbot CI_PULL_REQUEST="" CIRCLE_PULL_REQUEST="" yarn run deploy
 
 workflows:
-  version: 2
-
   richie:
+    # Do not trigger this workflow on schedule trigger
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       # Front-end jobs
       #
@@ -1154,3 +1164,10 @@ workflows:
           filters:
             tags:
               only: /.*/
+
+  nightly-round:
+    # This workflow is triggered each working days at 3:00am UTC.
+    when:
+      equal: [ "Nightly round", << pipeline.schedule.name >> ]
+    jobs:
+      - cookiecutter-bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,9 @@ jobs:
             cat cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/base.txt | grep "richie==${BACKEND_VERSION}$"
             # In the cookiecutter site template frontend
             cat cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json | grep "\"richie-education\": \"${BACKEND_VERSION}\"$"
+            # In the cookiecutter documentation
+            cat docs/cookiecutter.md | grep "cookiecutter gh:openfun/richie --directory cookiecutter  --checkout v${BACKEND_VERSION}"
+            cat docs/cookiecutter.md | grep "fundocker/cookiecutter gh:openfun/richie --directory cookiecutter --checkout v${BACKEND_VERSION}"
             # In the e2e tests
             cat tests_e2e/package.json | grep "\"version\": \"${BACKEND_VERSION}\",$"
             # In the website

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,12 +778,12 @@ jobs:
           version: 19.03.13
       - checkout
       - run:
-         name: Is a release branch
+         name: Is a release or master branch
          command: |
-           # We want to run this job only on release branch, to guess that
+           # We want to run this job only on release or master branch, to guess that
            # we check if a new release entry has been added into the CHANGELOG
            # If there is no new release entry, git diff returns a 0 exit code
-           if git diff --quiet -G"^## \[[0-9.]*\]$" origin/master..HEAD CHANGELOG.md; then
+           if [ "$CIRCLE_BRANCH" != "master" ] & git diff --quiet -G"^## \[[0-9.]*\]$" origin/master..HEAD CHANGELOG.md; then
              # So we can gracefully exit the job
              circleci-agent step halt
            fi

--- a/docs/cookiecutter.md
+++ b/docs/cookiecutter.md
@@ -25,7 +25,7 @@ If you chose to install Cookiecutter, you can now run it against our
 [template][2] as follows:
 
 ```bash
-cookiecutter gh:openfun/richie --directory cookiecutter
+cookiecutter gh:openfun/richie --directory cookiecutter  --checkout v2.17.0
 ```
 
 If you didn't want to install it on your machine, we provide a Docker image
@@ -33,7 +33,7 @@ built with our [own repository][4] that you can use as follows:
 
 ```bash
 docker run --rm -it -u $(id -u):$(id -g) -v $PWD:/app \
-fundocker/cookiecutter gh:openfun/richie --directory cookiecutter
+fundocker/cookiecutter gh:openfun/richie --directory cookiecutter --checkout v2.17.0
 ```
 
 The `--directory` option is to indicate that our Cookiecutter template is in


### PR DESCRIPTION
## Purpose

Currently our cookiecutter template is broken. The PR #1826 seems to fix the issue but this error highlights a weakness in our workflow. Indeed, anyone reading our cookiecutter documentation will fetch template from master branch and currently we are not able to check if the template is working properly on this branch.

So to prevent this kind of error, I suggest two improvements : 
- Upgrade cookiecutter documentation by adding `--checkout` argument sets with the latest tag release in commands to fetch cookiecutter template from the latest release instead of master.
- Run `cookiecutter-bootstrap` on master branch to be aware if cookiecutter template is broken on this branch.


## Proposal

- [x] Upgrade cookiecutter documentation 
- [x] Run cookiecutter-bootstrap against master branch.
