### PR TITLE
🔨(bin) stop using env variable to activate sites

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/commands/generate-version-file.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/commands/generate-version-file.yml
@@ -1,7 +1,6 @@
 parameters:
     site:
         type: string
-        default: funmooc
 steps:
     - run:
         name: Create a version.json

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Dockerfile
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Dockerfile
@@ -1,7 +1,7 @@
 ARG NGINX_IMAGE_NAME=fundocker/openshift-nginx
 ARG NGINX_IMAGE_TAG=1.13
 ARG STATIC_ROOT=/data/static
-ARG SITE=funmooc
+ARG SITE
 
 # The ID of the user running in the container
 ARG DOCKER_USER=10000

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Makefile
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Makefile
@@ -1,5 +1,3 @@
-RICHIE_SITE ?= funmooc
-
 # -- Terminal colors
 COLOR_INFO    = \033[0;36m
 COLOR_RESET   = \033[0m
@@ -42,6 +40,7 @@ MANAGE = $(COMPOSE_RUN_APP) python manage.py
 default: help
 
 bootstrap: \
+  .env \
   env.d/aws \
   env.d/development \
   data/media/$(RICHIE_SITE)/.keep \
@@ -56,7 +55,7 @@ bootstrap: \
 bootstrap:  ## install development dependencies
 .PHONY: bootstrap
 
-add-site: ## add a new site to the site factory
+generate-site: ## generate a new site using cookiecutter
 	@docker run --rm -it -e LC_ALL=C.UTF-8 \
 		-u $(DOCKER_UID):$(DOCKER_GID) \
 		-v $(PWD):/app \
@@ -66,31 +65,37 @@ add-site: ## add a new site to the site factory
 			--output-dir /app/sites \
 			--config-file /app/.cookiecutter_default.yml \
 			/app/template
+.PHONY: generate-site
 
+add-site: generate-site ## add a new site to the site factory
+	@echo "RICHIE_SITE=$(shell ls -td sites/* | head -1 | cut -f2 -d'/')" > .env
 .PHONY: add-site
 
+.env: ## site should be activated
+	@bin/activate
+
 # == Docker
-build: ## build all containers
+build: .env ## build all containers
 	$(COMPOSE) build app
 	$(COMPOSE) build nginx
 	$(COMPOSE) build app-dev
 .PHONY: build
 
-reset:  ## Remove database and local files
+reset: .env ## Remove database and local files
 	$(COMPOSE) stop
 	rm -Ir data/* || exit 0
 	$(COMPOSE) rm db
 .PHONY: reset
 
-down: ## stop & remove containers
+down: .env ## stop & remove containers
 	@$(COMPOSE) down
 .PHONY: down
 
-logs: ## display app logs (follow mode)
+logs: .env ## display app logs (follow mode)
 	@$(COMPOSE) logs -f app-dev
 .PHONY: logs
 
-run: ## start the wsgi (production) or development server
+run: .env ## start the wsgi (production) or development server
 	@$(COMPOSE) up -V -d redis-sentinel
 	@$(WAIT_SENTINEL)
 	@$(COMPOSE) up -d nginx
@@ -98,51 +103,51 @@ run: ## start the wsgi (production) or development server
 	@$(WAIT_DB)
 .PHONY: run
 
-stop: ## stop the development server
+stop: .env ## stop the development server
 	@$(COMPOSE) stop
 .PHONY: stop
 
-info:  ## get activated site info
-	@echo "RICHIE_SITE: $(COLOR_INFO)$(RICHIE_SITE)$(COLOR_RESET)"
+info: .env ## get activated site info
+	@cat .env
 .PHONY: info
 
 # == Frontend
 build-front: install-front build-ts build-sass ## build front-end application
 .PHONY: build-front
 
-build-sass: ## build Sass files to css
+build-sass: .env ## build Sass files to css
 	@$(YARN) build-sass
 .PHONY: build-sass
 
-build-sass-production: ## build Sass files to css (production mode)
+build-sass-production: .env ## build Sass files to css (production mode)
 	@$(YARN) build-sass-production
 .PHONY: build-sass-production
 
-build-ts: ## build ts(x) files to js
+build-ts: .env ## build ts(x) files to js
 	@$(YARN) build-ts
 .PHONY: build-ts
 
-build-ts-production: ## build ts(x) files to js (production mode)
+build-ts-production: .env ## build ts(x) files to js (production mode)
 	@$(YARN) build-ts-production
 .PHONY: build-ts-production
 
-install-front: ## install front-end dependencies
+install-front: .env ## install front-end dependencies
 	@$(YARN) install
 .PHONY: install-front
 
-install-front-production: ## install front-end dependencies (production mode)
+install-front-production: .env ## install front-end dependencies (production mode)
 	@$(YARN) install --frozen-lockfile
 .PHONY: install-front-production
 
-lint-front-prettier: ## run prettier linter over ts(x) & scss files
+lint-front-prettier: .env ## run prettier linter over ts(x) & scss files
 	@$(YARN) prettier
 .PHONY: lint-front-prettier
 
-lint-front-prettier-write: ## run prettier over ts(x) & scss files -- beware! overwrites files
+lint-front-prettier-write: .env ## run prettier over ts(x) & scss files -- beware! overwrites files
 	@$(YARN) prettier-write
 .PHONY: lint-front-prettier-write
 
-lint-front-eslint: ## run eslint over ts files
+lint-front-eslint: .env ## run eslint over ts files
 	@$(YARN) lint
 .PHONY: lint-front-eslint
 
@@ -152,15 +157,15 @@ lint-front: \
 	lint-front-eslint
 .PHONY: lint-front
 
-test-back: ## run back-end tests
+test-back: .env ## run back-end tests
 	bin/pytest
 .PHONY: test-back
 
-watch-sass: ## watch changes in Sass files
+watch-sass: .env ## watch changes in Sass files
 	@$(YARN) watch-sass
 .PHONY: watch-sass
 
-watch-ts: ## watch changes in js files
+watch-ts: .env ## watch changes in js files
 	@$(YARN) watch-ts
 .PHONY: watch-ts
 
@@ -169,11 +174,11 @@ env.d/aws:
 	cp env.d/aws.dist env.d/aws
 
 # == Django
-check: ## perform django checks
+check: .env ## perform django checks
 	@$(MANAGE) check
 .PHONY: check
 
-demo-site: ## create a demo site
+demo-site: .env ## create a demo site
 	@$(COMPOSE) up -d db
 	@$(WAIT_DB)
 	@$(MANAGE) flush
@@ -181,7 +186,7 @@ demo-site: ## create a demo site
 	@${MAKE} search-index
 .PHONY: demo-site
 
-init: ## create base site structure
+init: .env ## create base site structure
 	@$(MANAGE) richie_init
 	@${MAKE} search-index
 .PHONY: init
@@ -197,37 +202,37 @@ lint-back: \
   lint-back-raincoat
 .PHONY: lint-back
 
-lint-back-black: ## lint back-end python sources with black
+lint-back-black: .env ## lint back-end python sources with black
 	@echo 'lint:black started…'
 	@$(COMPOSE_TEST_RUN_APP) black .
 .PHONY: lint-back-black
 
-lint-back-flake8: ## lint back-end python sources with flake8
+lint-back-flake8: .env ## lint back-end python sources with flake8
 	@echo 'lint:flake8 started…'
 	@$(COMPOSE_TEST_RUN_APP) flake8
 .PHONY: lint-back-flake8
 
-lint-back-isort: ## automatically re-arrange python imports in back-end code base
+lint-back-isort: .env ## automatically re-arrange python imports in back-end code base
 	@echo 'lint:isort started…'
 	@$(COMPOSE_TEST_RUN_APP) isort --atomic .
 .PHONY: lint-back-isort
 
-lint-back-pylint: ## lint back-end python sources with pylint
+lint-back-pylint: .env ## lint back-end python sources with pylint
 	@echo 'lint:pylint started…'
 	@$(COMPOSE_TEST_RUN_APP) pylint .
 .PHONY: lint-back-pylint
 
-lint-back-raincoat: ## lint back-end python sources with raincoat
+lint-back-raincoat: .env ## lint back-end python sources with raincoat
 	@echo 'lint:raincoat started…'
 	@$(COMPOSE_TEST_RUN_APP) raincoat
 .PHONY: lint-back-raincoat
 
-lint-back-bandit: ## lint back-end python sources with bandit
+lint-back-bandit: .env ## lint back-end python sources with bandit
 	@echo 'lint:bandit started…'
 	@$(COMPOSE_TEST_RUN_APP) bandit -qr .
 .PHONY: lint-back-bandit
 
-import-fixtures:  ## import fixtures
+import-fixtures: .env ## import fixtures
 	@$(MANAGE) import_fixtures -v3
 .PHONY: import-fixtures
 
@@ -237,48 +242,48 @@ i18n: \
 	i18n-front
 .PHONY: i18n
 
-i18n-back: ## create/update .po files and compile .mo files used for i18n
+i18n-back: .env ## create/update .po files and compile .mo files used for i18n
 	@$(MANAGE) makemessages --keep-pot --all
 	@echo 'Reactivating obsolete strings (allow overriding strings defined in dependencies)'
 	@$(COMPOSE_RUN_APP) find ./ -type f -name django.po -exec sed -i 's/#~ //g' {} \;
 	@$(MANAGE) compilemessages
 .PHONY: i18n-back
 
-i18n-front: ## Extract and compile translation files used for react-intl
+i18n-front: .env ## Extract and compile translation files used for react-intl
 	@$(YARN) extract-translations
 	@$(YARN) compile-translations
 .PHONY: i18n-front
 
-migrate: ## perform database migrations
+migrate: .env ## perform database migrations
 	@$(COMPOSE) up -d db
 	@$(WAIT_DB)
 	@$(MANAGE) migrate
 .PHONY: migrate
 
-search-index: ## (re)generate the Elasticsearch index
+search-index: .env ## (re)generate the Elasticsearch index
 	@$(COMPOSE) up -d elasticsearch
 	@$(WAIT_ES)
 	@$(MANAGE) bootstrap_elasticsearch
 .PHONY: search-index
 
-superuser: ## create a DjangoCMS superuser
+superuser: .env ## create a DjangoCMS superuser
 	@$(COMPOSE) up -d db
 	@$(WAIT_DB)
 	@$(MANAGE) createsuperuser
 .PHONY: superuser
 
 # == CI
-ci-check: ## run django check management command on productin image
+ci-check: .env ## run django check management command on productin image
 	$(COMPOSE_RUN) app python manage.py check
 .PHONY: ci-check
 
-ci-migrate: ## run django migrate command on production image
+ci-migrate: .env ## run django migrate command on production image
 	@$(COMPOSE) up -d db
 	@$(WAIT_DB)
 	$(COMPOSE_RUN) app python manage.py migrate
 .PHONY: ci-migrate
 
-ci-run: ## start the wsgi server (and linked services)
+ci-run: .env ## start the wsgi server (and linked services)
 	@$(COMPOSE) up -d app
 	# As we use a remote docker environment, we should explicitly use the same
 	# network to check containers status
@@ -287,7 +292,7 @@ ci-run: ## start the wsgi server (and linked services)
 	docker run --network container:fun_elasticsearch_1 --rm jwilder/dockerize -wait tcp://localhost:9200 -timeout 60s
 .PHONY: ci-run
 
-ci-version: ## check version file bundled in the docker image
+ci-version: .env ## check version file bundled in the docker image
 	$(COMPOSE_RUN) --no-deps app cat version.json
 .PHONY: ci-version
 
@@ -296,12 +301,12 @@ clean: ## restore repository state as it was freshly cloned
 	git clean -idx
 .PHONY: clean
 
-data/media/$(RICHIE_SITE)/.keep:
+data/media/$(RICHIE_SITE)/.keep: .env
 	@echo 'Preparing media volume...'
 	@mkdir -p data/media/$(RICHIE_SITE)
 	@touch data/media/$(RICHIE_SITE)/.keep
 
-data/db/$(RICHIE_SITE):
+data/db/$(RICHIE_SITE): .env
 	@echo 'Preparing db volume...'
 	@mkdir -p data/db/$(RICHIE_SITE)
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/_config.sh
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/_config.sh
@@ -3,9 +3,6 @@
 PROJECT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/..
 SITES_DIRECTORY="sites"
 
-# Set default active site
-RICHIE_SITE="${RICHIE_SITE:-funmooc}"
-
 # console colors
 declare -r COLOR_INFO="\033[0;36m"
 declare -r COLOR_RESET="\033[0m"
@@ -14,4 +11,3 @@ export COLOR_INFO
 export COLOR_RESET
 export PROJECT_DIRECTORY
 export SITES_DIRECTORY
-export RICHIE_SITE

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/activate
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/activate
@@ -18,6 +18,17 @@ read -r -a sites <<< "$(
 )"
 n_sites=${#sites[@]}
 
+if [[ n_sites -eq 0 ]]; then
+    (>&2 echo "You should first add a site to the project by running: make add-site")
+    exit 10
+fi
+
+if [[ n_sites -eq 1 ]]; then
+    # If there is only one site, just activate it
+    echo "RICHIE_SITE=${sites[0]}" > .env
+    exit 0
+fi
+
 prompt="Select an available site to activate:\\n"
 for (( i=0; i<n_sites; i++ )); do
     prompt+="[$((i+1))] ${sites[$i]}"
@@ -38,11 +49,5 @@ if [[ ${choice} -le 0 ]]; then
     choice=${default}
 fi
 
-RICHIE_SITE="${sites[$((choice-1))]}"
-
-if [[ "${BASH_SOURCE[0]}" != "${0}" ]] ; then
-    export RICHIE_SITE
-else
-    echo -e "\\n# Copy/paste ${RICHIE_SITE} activation command:"
-    echo "export RICHIE_SITE=${RICHIE_SITE}"
-fi
+# Activate the chosen site
+echo "RICHIE_SITE=${sites[$((choice-1))]}" > .env

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/add-site
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/add-site
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
-
-docker run --rm -it -e LC_ALL=C.UTF-8 \
-    -v ${PWD}:/srv/app -w /srv/app \
-    cookiecutter/cookiecutter \
-    -o /srv/app/sites /srv/app/site_template

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -4,13 +4,13 @@ services:
   db:
     image: postgres:9.6
     environment:
-      - POSTGRES_DB=richie_${RICHIE_SITE:-funmooc}
+      - POSTGRES_DB=richie_${RICHIE_SITE:?}
     env_file:
       - "env.d/development"
     ports:
       - "5440:5432"
     volumes:
-      - ./data/db/${RICHIE_SITE:-funmooc}:/var/lib/postgresql/data
+      - ./data/db/${RICHIE_SITE:?}:/var/lib/postgresql/data
 
   elasticsearch:
     image: fundocker/openshift-elasticsearch:6.6.2
@@ -27,13 +27,13 @@ services:
       target: development
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
-        SITE: ${RICHIE_SITE:-funmooc}
-    image: "${RICHIE_SITE:-funmooc}:development"
+        SITE: ${RICHIE_SITE:?}
+    image: "${RICHIE_SITE:?}:development"
     environment:
-      - DB_NAME=richie_${RICHIE_SITE:-funmooc}
-      - DJANGO_SETTINGS_MODULE=${RICHIE_SITE:-funmooc}.settings
+      - DB_NAME=richie_${RICHIE_SITE:?}
+      - DJANGO_SETTINGS_MODULE=${RICHIE_SITE:?}.settings
       - DJANGO_CONFIGURATION=Development
-      - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:-funmooc}
+      - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:?}
     env_file: env.d/development
     networks:
       - default
@@ -41,8 +41,8 @@ services:
     ports:
       - "8070:8000"
     volumes:
-      - "./sites/${RICHIE_SITE:-funmooc}/src/backend:/app"
-      - "./data/media/${RICHIE_SITE:-funmooc}:/data/media"
+      - "./sites/${RICHIE_SITE:?}/src/backend:/app"
+      - "./data/media/${RICHIE_SITE:?}:/data/media"
     depends_on:
       - "db"
       - "elasticsearch"
@@ -55,21 +55,21 @@ services:
       target: production
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
-        SITE: ${RICHIE_SITE:-funmooc}
+        SITE: ${RICHIE_SITE:?}
     # We tag our images with the current commit sha1 in the CI to make them
     # unique and avoid collisions in parallel builds.
-    image: "${RICHIE_SITE:-funmooc}:production"
+    image: "${RICHIE_SITE:?}:production"
     environment:
-      - DB_NAME=richie_${RICHIE_SITE:-funmooc}
-      - DJANGO_SETTINGS_MODULE=${RICHIE_SITE:-funmooc}.settings
+      - DB_NAME=richie_${RICHIE_SITE:?}
+      - DJANGO_SETTINGS_MODULE=${RICHIE_SITE:?}.settings
       - DJANGO_CONFIGURATION=ContinuousIntegration
-      - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:-funmooc}
+      - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:?}
     env_file: env.d/development
     networks:
       - default
       - lms_outside
     volumes:
-      - ./data/media/${RICHIE_SITE:-funmooc}:/data/media
+      - ./data/media/${RICHIE_SITE:?}:/data/media
     depends_on:
       - "db"
       - "elasticsearch"
@@ -84,13 +84,13 @@ services:
         DOCKER_USER: ${DOCKER_USER:-1000}
         NGINX_IMAGE_NAME: ${NGINX_IMAGE_NAME:-fundocker/openshift-nginx}
         NGINX_IMAGE_TAG: ${NGINX_IMAGE_TAG:-1.13}
-        SITE: ${RICHIE_SITE:-funmooc}
-    image: "${RICHIE_SITE:-funmooc}-nginx:production"
+        SITE: ${RICHIE_SITE:?}
+    image: "${RICHIE_SITE:?}-nginx:production"
     ports:
       - "8081:8081"
     volumes:
       - ./docker/files/etc/nginx/conf.d:/etc/nginx/conf.d:ro
-      - ./data/media/${RICHIE_SITE:-funmooc}:/data/media:ro
+      - ./data/media/${RICHIE_SITE:?}:/data/media:ro
     depends_on:
       - app
 
@@ -102,7 +102,7 @@ services:
     working_dir: /app/src/frontend
     user: ${DOCKER_USER:-1000}
     volumes:
-      - ./sites/${RICHIE_SITE:-funmooc}:/app
+      - ./sites/${RICHIE_SITE:?}:/app
 
   terraform-state:
     image: hashicorp/terraform:latest
@@ -115,14 +115,14 @@ services:
   terraform:
     image: hashicorp/terraform:0.12.31
     environment:
-      - TF_VAR_SITE=${RICHIE_SITE:-funmooc}
+      - TF_VAR_SITE=${RICHIE_SITE:?}
       - TF_DATA_DIR=/config
     env_file: env.d/aws
     user: ${DOCKER_USER:-1000}
     working_dir: /app
     volumes:
       - ./aws:/app
-      - ./sites/${RICHIE_SITE:-funmooc}/aws:/config
+      - ./sites/${RICHIE_SITE:?}/aws:/config
 
   redis-sentinel:
     image: docker.io/bitnami/redis-sentinel:6.0-debian-10

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker/files/usr/local/bin/entrypoint
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker/files/usr/local/bin/entrypoint
@@ -14,7 +14,7 @@
 # To pass environment variables, you can either use the -e option of the docker
 # run command:
 #
-#     docker run --rm -e USER_NAME=foo -e HOME='/home/foo' funmooc:latest python manage.py migrate
+#     docker run --rm -e USER_NAME=foo -e HOME='/home/foo' foo:latest python manage.py migrate
 #
 # or define new variables in an environment file to use with docker or
 # docker-compose:
@@ -23,7 +23,7 @@
 #     USER_NAME=foo
 #     HOME=/home/foo
 #
-#     docker run --rm --env-file env.d/development funmooc:latest python manage.py migrate
+#     docker run --rm --env-file env.d/development foo:latest python manage.py migrate
 #
 
 echo "🐳(entrypoint) creating user running in the container..."

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docs/aws.md
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docs/aws.md
@@ -83,9 +83,9 @@ $ bin/terraform init
 ```
 
 Now that your terraform project is initialized, you will be able to create S3
-buckets for static and media files in various environments (see the [project's
-settings](../src/backend/funmooc/settings.py)). To achieve this, we will use
-Terraform workspaces with the following paradigm:
+buckets for static and media files in various environments (see the project's
+settings). To achieve this, we will use Terraform workspaces with the
+following paradigm:
 
 _One workspace should be dedicated to one environment_.
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/base/tests/test_cache.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/base/tests/test_cache.py
@@ -1,4 +1,4 @@
-"""Test funmooc cache plugin"""
+"""Test site cache plugin"""
 
 import datetime
 from unittest import mock

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/wsgi.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/wsgi.py
@@ -1,5 +1,5 @@
 """
-WSGI config for the funmooc project.
+WSGI config for the site project.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 


### PR DESCRIPTION
## Purpose

The developper experience was not good as we had to run `bin/activate` and then export a variable. Many users forgot to export the variable expecting the activate script to do what it claims to do...

## Proposal

We now use the `.env` file to record the active site (similar to what is done for workspaces in Terraform). This allows a much better DX as running `bin/activate` now effectively activates the site.

We further improved DX by automatically activating the site without any prompt when there is only one site.