### PR TITLE
💚(ci) fix cookiecutter-bootstrap job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -787,7 +787,7 @@ jobs:
            # We want to run this job only on release or master branch, to guess that
            # we check if a new release entry has been added into the CHANGELOG
            # If there is no new release entry, git diff returns a 0 exit code
-           if [ "$CIRCLE_BRANCH" != "master" ] & git diff --quiet -G"^## \[[0-9.]*\]$" origin/master..HEAD CHANGELOG.md; then
+           if [ "$CIRCLE_BRANCH" != "master" ] && git diff --quiet -G"^## \[[0-9.]*\]$" origin/master..HEAD CHANGELOG.md; then
              # So we can gracefully exit the job
              circleci-agent step halt
            fi


### PR DESCRIPTION
## Purpose

The condition statement to determine if the job should run contained a wrong operator. There was only one `&` but to create an and operator we must use `&&` operator.

## Proposal

- [x] Fix cookiecutter-bootstrap job
