### PR TITLE
💄(course-detail) fix course run visibility state icon position

### DIFF
--- a/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
+++ b/src/frontend/scss/components/templates/courses/cms/_course_detail.scss
@@ -125,6 +125,8 @@
   }
 
   &__run-descriptions {
+    position: relative;
+
     dl {
       margin: 0;
     }


### PR DESCRIPTION
## Purpose

Recently [we fixed an issue about icon visibility state](#1832) of course detail page. It was not display when the course run had no title. As a workaround we positioned icon through `position: absolute`. But we forgot to add a `position: relative` attribute to the course run row element so all visibility icon stick to the top of the course run list element instead to stick to the top of the course run row.

### Before
<img width="410" alt="Capture d’écran 2022-12-02 à 16 18 32" src="https://user-images.githubusercontent.com/9265241/205326173-a14a865a-1290-4395-a06b-ccdbbad476f5.png">

### After
<img width="439" alt="Capture d’écran 2022-12-02 à 16 18 49" src="https://user-images.githubusercontent.com/9265241/205326187-0eb3a9e3-ed3d-4c6f-8e01-eb8d34d011b4.png">

## Proposal

- [x] Add `position: relative` to the `.course-detail__run-descriptions` elemeent
