### PR TITLE
Refactor resources to make use of a new useResources hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Use versionned Joanie api routes
 - Migrate to React 18 and React-Query v4
+- Migrate to useResources hooks
 
 ### Fixed
 

--- a/src/frontend/js/components/DashboardAddressesManagement/DashboardEditAddressLoader.tsx
+++ b/src/frontend/js/components/DashboardAddressesManagement/DashboardEditAddressLoader.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom';
 import Banner, { BannerType } from 'components/Banner';
 import { DashboardEditAddress } from 'components/DashboardAddressesManagement/DashboardEditAddress';
 import { Spinner } from 'components/Spinner';
-import { useAddresses } from 'hooks/useAddresses';
+import { useAddress } from 'hooks/useAddresses';
 import { DashboardPaths } from 'utils/routers/dashboard';
 import { useDashboardNavigate } from 'utils/routers/dashboard/useDashboardRouter';
 import { useBreadcrumbsPlaceholders } from 'hooks/useBreadcrumbsPlaceholders';
@@ -15,20 +15,19 @@ export const DashboardEditAddressLoader = () => {
   const navigate = useDashboardNavigate();
   const {
     states: { error, isLoading },
-    ...addresses
-  } = useAddresses(params.addressId);
-
+    ...address
+  } = useAddress(params.addressId);
   useBreadcrumbsPlaceholders({
-    addressTitle: addresses?.items[0]?.title,
+    addressTitle: address.item?.title,
   });
 
   return (
     <>
       {isLoading && <Spinner />}
       {error && <Banner message={error} type={BannerType.ERROR} />}
-      {addresses.items.length > 0 && (
+      {address.item && (
         <DashboardEditAddress
-          address={addresses.items[0]}
+          address={address.item}
           onSettled={() => {
             navigate(DashboardPaths.PREFERENCES);
           }}

--- a/src/frontend/js/components/DashboardCreditCardsManagement/DashboardEditCreditCard.spec.tsx
+++ b/src/frontend/js/components/DashboardCreditCardsManagement/DashboardEditCreditCard.spec.tsx
@@ -341,6 +341,8 @@ describe('<DahsboardEditCreditCard/>', () => {
     });
     expect(fetchMock.called(updateUrl, { method: 'put' })).toBe(true);
 
-    await expectBannerError('An error occurred: Internal Server Error. Please retry later.');
+    await expectBannerError(
+      'An error occurred while updating the credit card. Please retry later.',
+    );
   });
 });

--- a/src/frontend/js/components/DashboardCreditCardsManagement/DashboardEditCreditCardLoader.tsx
+++ b/src/frontend/js/components/DashboardCreditCardsManagement/DashboardEditCreditCardLoader.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useDashboardNavigate } from 'utils/routers/dashboard/useDashboardRouter';
-import { useCreditCards } from 'hooks/useCreditCards';
+import { useCreditCard } from 'hooks/useCreditCards';
 import { Spinner } from 'components/Spinner';
 import Banner, { BannerType } from 'components/Banner';
 import { DashboardEditCreditCard } from 'components/DashboardCreditCardsManagement/DashboardEditCreditCard';
@@ -15,11 +15,11 @@ export const DashboardEditCreditCardLoader = () => {
   const navigate = useDashboardNavigate();
   const {
     states: { error, isLoading },
-    ...creditCards
-  } = useCreditCards(params.creditCardId);
+    ...creditCard
+  } = useCreditCard(params.creditCardId);
 
   useBreadcrumbsPlaceholders({
-    creditCardTitle: creditCards?.items[0]?.title ?? '',
+    creditCardTitle: creditCard.item?.title ?? '',
   });
 
   if (isLoading) {
@@ -28,10 +28,10 @@ export const DashboardEditCreditCardLoader = () => {
   if (error) {
     return <Banner message={error} type={BannerType.ERROR} />;
   }
-  if (creditCards.items.length > 0) {
+  if (creditCard.item) {
     return (
       <DashboardEditCreditCard
-        creditCard={creditCards.items[0]}
+        creditCard={creditCard.item}
         onSettled={() => navigate(DashboardPaths.PREFERENCES)}
       />
     );

--- a/src/frontend/js/components/DashboardCreditCardsManagement/index.spec.tsx
+++ b/src/frontend/js/components/DashboardCreditCardsManagement/index.spec.tsx
@@ -422,6 +422,6 @@ describe('<DashboardCreditCardsManagement/>', () => {
       );
     });
 
-    await expectBannerError('An error occurred: Internal Server Error. Please retry later.');
+    await expectBannerError('An error occurred while fetching credit cards. Please retry later.');
   });
 });

--- a/src/frontend/js/components/PaymentButton/index.tsx
+++ b/src/frontend/js/components/PaymentButton/index.tsx
@@ -117,23 +117,27 @@ const PaymentButton = ({ product, billingAddress, creditCard, onSuccess }: Payme
       let paymentInfos = payment;
 
       if (!paymentInfos) {
-        try {
-          const order = await orderManager.methods.create({
+        orderManager.methods.create(
+          {
             billing_address: billingAddress!,
             ...(creditCard && { credit_card_id: creditCard }),
             course: courseCode,
             product: product.id,
-          });
-          paymentInfos = {
-            ...order.payment_info!,
-            order_id: order.id,
-          };
-        } catch {
-          setState(ComponentStates.ERROR);
-        }
+          },
+          {
+            onSuccess: (order) => {
+              paymentInfos = {
+                ...order.payment_info,
+                order_id: order.id,
+              };
+              setPayment(paymentInfos);
+            },
+            onError: () => {
+              setState(ComponentStates.ERROR);
+            },
+          },
+        );
       }
-
-      setPayment(paymentInfos);
     }
   };
 

--- a/src/frontend/js/hooks/useAddressesManagement.tsx
+++ b/src/frontend/js/hooks/useAddressesManagement.tsx
@@ -2,7 +2,6 @@ import { defineMessages, useIntl } from 'react-intl';
 import { MutateOptions } from '@tanstack/react-query';
 import { useAddresses } from 'hooks/useAddresses';
 import * as Joanie from 'types/Joanie';
-import { HttpError } from 'utils/errors/HttpError';
 import { confirm } from 'utils/indirection/window';
 
 const messages = defineMessages({
@@ -59,7 +58,7 @@ export function useAddressesManagement() {
    * @param {Joanie.Address} address
    * @param {AddressesMutateOptions} options
    */
-  const remove = (address: Joanie.Address, options?: MutateOptions<void, HttpError, string>) => {
+  const remove = (address: Joanie.Address, options?: MutateOptions) => {
     if (address.is_main) {
       addresses.methods.setError(intl.formatMessage(messages.errorCannotRemoveMain));
       return;

--- a/src/frontend/js/hooks/useCreditCards/index.spec.tsx
+++ b/src/frontend/js/hooks/useCreditCards/index.spec.tsx
@@ -4,10 +4,11 @@ import fetchMock from 'fetch-mock';
 import { PropsWithChildren } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import * as mockFactories from 'utils/test/factories';
-import { useCreditCards } from 'hooks/useCreditCards/index';
+import { useCreditCard, useCreditCards } from 'hooks/useCreditCards/index';
 import { SessionProvider } from 'data/SessionProvider';
 import { Deferred } from 'utils/test/deferred';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { CreditCard } from '../../types/Joanie';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -70,10 +71,10 @@ describe('useCreditCards', () => {
 
   it('retrieves a specific credit card', async () => {
     const creditCards = mockFactories.CreditCardFactory.generate(5);
-    const creditCard = creditCards[3];
+    const creditCard: CreditCard = creditCards[3];
     const responseDeferred = new Deferred();
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', responseDeferred.promise);
-    const { result } = renderHook(() => useCreditCards(creditCard.id), {
+    const { result } = renderHook(() => useCreditCard(creditCard.id), {
       wrapper: Wrapper,
     });
 
@@ -83,7 +84,7 @@ describe('useCreditCards', () => {
     expect(result.current.states.updating).toBe(false);
     expect(result.current.states.isLoading).toBe(true);
     expect(result.current.states.error).toBe(undefined);
-    expect(result.current.items).toEqual([]);
+    expect(result.current.item).toEqual(undefined);
 
     responseDeferred.resolve(creditCards);
 
@@ -93,6 +94,6 @@ describe('useCreditCards', () => {
     expect(result.current.states.updating).toBe(false);
     expect(result.current.states.isLoading).toBe(false);
     expect(result.current.states.error).toBe(undefined);
-    expect(JSON.stringify(result.current.items)).toBe(JSON.stringify([creditCard]));
+    expect(JSON.stringify(result.current.item)).toBe(JSON.stringify(creditCard));
   });
 });

--- a/src/frontend/js/hooks/useCreditCards/index.ts
+++ b/src/frontend/js/hooks/useCreditCards/index.ts
@@ -1,19 +1,29 @@
-import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
-import { defineMessages, useIntl } from 'react-intl';
-import { REACT_QUERY_SETTINGS } from 'settings';
-import { useJoanieApi } from 'data/JoanieApiProvider';
-import { useSessionQuery } from 'utils/react-query/useSessionQuery';
-import { useSessionMutation } from 'utils/react-query/useSessionMutation';
-import { Maybe } from 'types/utils';
+import { defineMessages } from 'react-intl';
 import { CreditCard } from 'types/Joanie';
 
+import { useJoanieApi } from '../../data/JoanieApiProvider';
+import { useResource, useResources, UseResourcesProps } from '../useResources';
+
 const messages = defineMessages({
-  error: {
-    id: 'hooks.useCreditCards.error',
-    description:
-      'Error message shown to the user when credit card creation/update/deletion request fails.',
-    defaultMessage: 'An error occurred: {error}. Please retry later.',
+  errorUpdate: {
+    id: 'hooks.useCreditCards.errorUpdate',
+    description: 'Error message shown to the user when credit card update request fails.',
+    defaultMessage: 'An error occurred while updating the credit card. Please retry later.',
+  },
+  errorGet: {
+    id: 'hooks.useCreditCards.errorSelect',
+    description: 'Error message shown to the user when credit cards fetch request fails.',
+    defaultMessage: 'An error occurred while fetching credit cards. Please retry later.',
+  },
+  errorDelete: {
+    id: 'hooks.useCreditCards.errorDelete',
+    description: 'Error message shown to the user when credit card deletion request fails.',
+    defaultMessage: 'An error occurred while deleting the credit card. Please retry later.',
+  },
+  errorCreate: {
+    id: 'hooks.useCreditCards.errorCreate',
+    description: 'Error message shown to the user when credit card creation request fails.',
+    defaultMessage: 'An error occurred while creating the credit card. Please retry later.',
   },
   errorNotFound: {
     id: 'hooks.useCreditCards.errorNotFound',
@@ -25,100 +35,13 @@ const messages = defineMessages({
 /**
  * Joanie Api hook to retrieve/create/update/delete credit cards
  * owned by the authenticated user.
- *
  */
-export const useCreditCards = (id?: string) => {
-  const API = useJoanieApi();
-  const queryClient = useQueryClient();
-  const [data, setData] = useState<CreditCard[]>([]);
-  const [error, setError] = useState<Maybe<string>>();
-  const intl = useIntl();
-
-  const onError = (e: Error) => {
-    setError(intl.formatMessage(messages.error, { error: e.message }));
-  };
-
-  const [readHandler, queryKey] = useSessionQuery(
-    ['credit-cards'],
-    () => API.user.creditCards.get(),
-    {
-      onError,
-    },
-  );
-
-  const prefetch = async () => {
-    await queryClient.prefetchQuery(queryKey, () => API.user.creditCards.get(), {
-      staleTime: REACT_QUERY_SETTINGS.staleTimes.sessionItems,
-    });
-  };
-
-  const filter = () => {
-    if (!readHandler.data) {
-      setData([]);
-      return;
-    }
-    if (!id) {
-      setData(readHandler.data);
-      return;
-    }
-    const creditCard = readHandler.data!.find((a) => a.id === id);
-    if (!creditCard) {
-      setError(intl.formatMessage(messages.errorNotFound));
-      setData([]);
-      return;
-    }
-    setData([creditCard!]);
-  };
-
-  useEffect(() => {
-    filter();
-  }, [readHandler.data]);
-
-  const invalidate = async () => {
-    await queryClient.invalidateQueries(queryKey);
-  };
-
-  const onSuccess = async () => {
-    setError(undefined);
-    await invalidate();
-  };
-
-  const writeHandlers = {
-    create: useSessionMutation(API.user.creditCards.create, {
-      onSuccess,
-      onError,
-    }),
-    update: useSessionMutation(API.user.creditCards.update, {
-      onSuccess,
-      onError,
-    }),
-    delete: useSessionMutation(API.user.creditCards.delete, {
-      onSuccess,
-      onError,
-    }),
-  };
-
-  return {
-    items: data,
-    methods: {
-      invalidate,
-      prefetch,
-      refetch: readHandler.refetch,
-      create: writeHandlers.create.mutate,
-      update: writeHandlers.update.mutate,
-      delete: writeHandlers.delete.mutate,
-      setError,
-    },
-    states: {
-      fetching: readHandler.isLoading,
-      creating: writeHandlers.create.isLoading,
-      deleting: writeHandlers.delete.isLoading,
-      updating: writeHandlers.update.isLoading,
-      isLoading:
-        Object.values(writeHandlers).reduce((previous, current) => {
-          return previous || current.isLoading;
-        }, false) || readHandler.isLoading,
-      error,
-    },
-  };
+const props: UseResourcesProps<CreditCard> = {
+  queryKey: ['creditCards'],
+  apiInterface: () => useJoanieApi().user.creditCards,
+  omniscient: true,
+  session: true,
+  messages,
 };
+export const useCreditCards = useResources<CreditCard>(props);
+export const useCreditCard = useResource<CreditCard>(props);

--- a/src/frontend/js/hooks/useCreditCardsManagement.tsx
+++ b/src/frontend/js/hooks/useCreditCardsManagement.tsx
@@ -3,7 +3,6 @@ import { MutateOptions } from '@tanstack/react-query';
 import { useCreditCards } from 'hooks/useCreditCards';
 import { CreditCard } from 'types/Joanie';
 import { confirm } from 'utils/indirection/window';
-import { HttpError } from 'utils/errors/HttpError';
 
 const messages = defineMessages({
   errorCannotRemoveMain: {
@@ -23,7 +22,7 @@ export const useCreditCardsManagement = () => {
   const intl = useIntl();
   const creditCards = useCreditCards();
 
-  const safeDelete = (creditCard: CreditCard, options?: MutateOptions<void, HttpError, string>) => {
+  const safeDelete = (creditCard: CreditCard, options?: MutateOptions) => {
     if (creditCard.is_main) {
       creditCards.methods.setError(intl.formatMessage(messages.errorCannotRemoveMain));
       return;

--- a/src/frontend/js/hooks/useOrders.ts
+++ b/src/frontend/js/hooks/useOrders.ts
@@ -1,51 +1,27 @@
-import { useQueryClient } from '@tanstack/react-query';
 import { useJoanieApi } from 'data/JoanieApiProvider';
-import { REACT_QUERY_SETTINGS } from 'settings';
-import useLocalizedQueryKey from 'utils/react-query/useLocalizedQueryKey';
 import { useSessionMutation } from 'utils/react-query/useSessionMutation';
-import { useSessionQuery } from 'utils/react-query/useSessionQuery';
+import { API, Order } from '../types/Joanie';
+import {
+  QueryOptions,
+  ResourcesQuery,
+  useResourcesCustom,
+  UseResourcesProps,
+} from './useResources';
 
-/**
- * Joanie Api hook to retrieve/create/abort an order owned by the authenticated user.
- */
-export const useOrders = () => {
-  const API = useJoanieApi();
-  const baseQueryKey = useLocalizedQueryKey(['orders']);
-  const queryClient = useQueryClient();
-
-  const [readHandler, queryKey] = useSessionQuery(baseQueryKey, () => API.user.orders.get());
-
-  const prefetch = async () => {
-    await queryClient.prefetchQuery(queryKey, () => API.user.orders.get(), {
-      staleTime: REACT_QUERY_SETTINGS.staleTimes.sessionItems,
-    });
-  };
-
-  const invalidate = async () => {
-    // Invalidate all order's queries no matter the locale
-    const unlocalizedQueryKey = queryKey.slice(0, -1);
-    await queryClient.invalidateQueries(unlocalizedQueryKey);
-  };
-
-  const creationHandler = useSessionMutation(API.user.orders.create, {
-    onSuccess: invalidate,
-  });
-
-  const abortHandler = useSessionMutation(API.user.orders.abort);
-
+const props: UseResourcesProps<Order, ResourcesQuery, API['user']['orders']> = {
+  queryKey: ['orders'],
+  apiInterface: () => useJoanieApi().user.orders,
+  omniscient: true,
+  session: true,
+};
+export const useOrders = (filters?: ResourcesQuery, queryOptions?: QueryOptions<Order>) => {
+  const custom = useResourcesCustom({ ...props, filters, queryOptions });
+  const abortHandler = useSessionMutation(useJoanieApi().user.orders.abort);
   return {
-    items: readHandler.data?.results,
+    ...custom,
     methods: {
+      ...custom.methods,
       abort: abortHandler.mutateAsync,
-      create: creationHandler.mutateAsync,
-      invalidate,
-      prefetch,
-      refetch: readHandler.refetch,
-    },
-    states: {
-      fetching: readHandler.isLoading,
-      creating: creationHandler.isLoading,
-      aborting: abortHandler.isLoading,
     },
   };
 };

--- a/src/frontend/js/hooks/useResources/index.spec.tsx
+++ b/src/frontend/js/hooks/useResources/index.spec.tsx
@@ -1,0 +1,463 @@
+import fetchMock from 'fetch-mock';
+import { createSpec, faker } from '@helpscout/helix';
+import { PropsWithChildren } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from 'react-intl';
+import { act, fireEvent, renderHook, screen, waitFor } from '@testing-library/react';
+import { stringify } from 'query-string';
+import * as mockFactories from 'utils/test/factories';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { Deferred } from 'utils/test/deferred';
+import { SessionProvider, useSession } from 'data/SessionProvider';
+import { Maybe } from 'types/utils';
+import { ResourcesQuery, useResource, useResources, UseResourcesProps } from './index';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockFactories
+    .ContextFactory({
+      authentication: { backend: 'fonzie', endpoint: 'https://demo.endpoint' },
+      joanie_backend: { endpoint: 'https://joanie.endpoint' },
+    })
+    .generate(),
+}));
+
+interface Todo {
+  id: string;
+  name: string;
+}
+interface TodoQuery extends ResourcesQuery {
+  name?: string;
+}
+
+export const TodoFactory = createSpec({
+  id: faker.datatype.uuid(),
+  name: faker.random.words(1, 3),
+});
+
+const API = {
+  todos: {
+    get: async (filters?: TodoQuery): Promise<Todo[]> => {
+      let url = 'https://example.com/api/todos';
+      const { id, ...restFilters } = filters || {};
+      const queryParameters = stringify(restFilters);
+      if (id) {
+        url = `${url}/${id}`;
+      }
+      if (queryParameters) {
+        url = `${url}?${queryParameters}`;
+      }
+      return fetch(url).then((response) => response.json());
+    },
+    update: async (payload: Todo) => {
+      return fetch(`https://example.com/api/todos/${payload.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      }).then((response) => response.json());
+    },
+  },
+};
+
+const Wrapper = ({ children }: PropsWithChildren) => {
+  return (
+    <QueryClientProvider client={createTestQueryClient({ user: true })}>
+      <IntlProvider locale="en">
+        <SessionProvider>{children}</SessionProvider>
+      </IntlProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe('useResources (omniscient)', () => {
+  const props: UseResourcesProps<Todo, TodoQuery> = {
+    queryKey: ['todos'],
+    apiInterface: () => API.todos,
+    omniscient: true,
+    omniscientFiltering: (data, filters) => {
+      return data.filter((todo) => {
+        if (filters.name) {
+          return todo.name.startsWith(filters.name);
+        }
+        return true;
+      });
+    },
+  };
+
+  const useTodos = useResources(props);
+  const useTodo = useResource(props);
+
+  beforeEach(() => {
+    fetchMock.get('https://joanie.endpoint/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it('loads todos', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    const responseDeferred = new Deferred();
+    fetchMock.get('https://example.com/api/todos', responseDeferred.promise);
+
+    const { result } = renderHook(() => useTodos(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.states.isLoading).toBe(true));
+    expect(result.current.states.fetching).toBe(true);
+    expect(result.current.items).toEqual([]);
+
+    responseDeferred.resolve(todos);
+
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(result.current.states.fetching).toBe(false);
+    expect(JSON.stringify(result.current.items)).toBe(JSON.stringify(todos));
+  });
+
+  it('loads todos with filtering', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    const todosToFind = [todos[2], todos[3]];
+    todosToFind.forEach((todo) => {
+      todo.name = 'Find me ' + todo.name;
+    });
+    const responseDeferred = new Deferred();
+    fetchMock.get('https://example.com/api/todos', responseDeferred.promise);
+
+    const { result, rerender } = renderHook((filters?: TodoQuery) => useTodos(filters), {
+      wrapper: Wrapper,
+    });
+
+    // Loads without filters the first time.
+    expect(result.current.states.isLoading).toBe(true);
+    expect(result.current.states.fetching).toBe(true);
+    expect(result.current.items).toEqual([]);
+
+    responseDeferred.resolve(todos);
+
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(result.current.states.fetching).toBe(false);
+    expect(JSON.stringify(result.current.items)).toBe(JSON.stringify(todos));
+
+    // Filter todos with name starting with "Find me".
+    rerender({ name: 'Find me' });
+    await waitFor(() =>
+      expect(JSON.stringify(result.current.items)).toBe(JSON.stringify(todosToFind)),
+    );
+
+    // Changing filter to something that will give an empty result to verify that filtering is
+    // updated.
+    rerender({ name: '$^^``sd' });
+    await waitFor(() => expect(result.current.items.length).toBe(0));
+  });
+
+  it('invalidates after mutation', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    const todo = todos[0];
+
+    const mutatedTodos = [{ ...todo, name: 'My super new task' }, ...todos.slice(1)];
+    const responseDeferred = new Deferred();
+    fetchMock.get('https://example.com/api/todos', todos);
+    fetchMock.put('https://example.com/api/todos/' + todo.id, responseDeferred.promise);
+
+    expect(fetchMock.called('https://example.com/api/todos')).toBe(false);
+    const { result } = renderHook(() => useTodos(), {
+      wrapper: Wrapper,
+    });
+
+    // The get method is not deferred so everything is loaded synchronously.
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(result.current.states.fetching).toBe(false);
+    expect(JSON.stringify(result.current.items)).toBe(JSON.stringify(todos));
+    expect(fetchMock.called('https://example.com/api/todos')).toBe(true);
+
+    // Trigger a mutation.
+    result.current.methods.update({ ...todo, name: 'My super new task' });
+
+    // As the mutation is deferred, the state is still loading.
+    await waitFor(() => expect(result.current.states.isLoading).toBe(true));
+    expect(result.current.states.updating).toBe(true);
+
+    // Update the get mock to return the mutated todos.
+    fetchMock.get('https://example.com/api/todos', mutatedTodos, { overwriteRoutes: true });
+    responseDeferred.resolve(true);
+
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(result.current.states.updating).toBe(false);
+    // The items are updated. Confirming that the mutation was triggered a new get request.
+    expect(JSON.stringify(result.current.items)).toBe(JSON.stringify(mutatedTodos));
+  });
+
+  it('loads a specific todo', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    const responseDeferred = new Deferred();
+    fetchMock.get('https://example.com/api/todos', responseDeferred.promise);
+
+    const expectedTodo = pickRandomlyFromArray(todos);
+    const { result } = renderHook(() => useTodo(expectedTodo.id), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.states.isLoading).toBe(true);
+    expect(result.current.states.fetching).toBe(true);
+    expect(result.current.item).toBe(undefined);
+
+    responseDeferred.resolve(todos);
+
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(result.current.states.fetching).toBe(false);
+    expect(JSON.stringify(result.current.item)).toBe(JSON.stringify(expectedTodo));
+  });
+
+  it('waits for id to be defined before fetching', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    fetchMock.get('https://example.com/api/todos', todos);
+
+    const expectedTodo = pickRandomlyFromArray(todos);
+    const { result, rerender } = renderHook(
+      (initialProps: Maybe<string>) => useTodo(initialProps),
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(result.current.states.isLoading).toBe(true);
+    expect(result.current.item).toBe(undefined);
+    expect(fetchMock.called('https://example.com/api/todos')).toBe(false);
+
+    rerender(expectedTodo.id);
+
+    await waitFor(() =>
+      expect(JSON.stringify(result.current.item)).toBe(JSON.stringify(expectedTodo)),
+    );
+    expect(fetchMock.lastUrl()).toBe('https://example.com/api/todos');
+    expect(result.current.states.isLoading).toBe(false);
+    expect(result.current.states.fetching).toBe(false);
+  });
+
+  it('fails to load a specific todo', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    const responseDeferred = new Deferred();
+    fetchMock.get('https://example.com/api/todos', responseDeferred.promise);
+
+    const { result } = renderHook(() => useTodo('-1'), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.states.isLoading).toBe(true);
+    expect(result.current.states.fetching).toBe(true);
+    expect(result.current.item).toBe(undefined);
+    expect(result.current.states.error).toBe(undefined);
+
+    responseDeferred.resolve(todos);
+
+    await waitFor(() => expect(result.current.states.error).toBe('Cannot find the resource.'));
+    expect(result.current.item).toBe(undefined);
+  });
+});
+
+describe('useResource (omniscient) with session', () => {
+  const props: UseResourcesProps<Todo, TodoQuery> = {
+    queryKey: ['todos'],
+    apiInterface: () => API.todos,
+    session: true,
+    omniscient: true,
+    omniscientFiltering: (data, filters) => {
+      return data.filter((todo) => {
+        if (filters.name) {
+          return todo.name.startsWith(filters.name);
+        }
+        return true;
+      });
+    },
+  };
+
+  const useTodos = useResources(props);
+
+  beforeEach(() => {
+    fetchMock.get('https://joanie.endpoint/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
+    fetchMock.get('https://demo.endpoint/logout', 200);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it('re-fetches todos on user logout', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    fetchMock.get('https://example.com/api/todos', todos);
+
+    const LogoutComponent = () => {
+      const session = useSession();
+      return <button onClick={session.destroy}>Logout</button>;
+    };
+
+    const { result } = renderHook(() => useTodos(), {
+      wrapper: (wrapperProps: PropsWithChildren) => {
+        return Wrapper({
+          children: (
+            <>
+              <LogoutComponent />
+              {wrapperProps.children}
+            </>
+          ),
+        });
+      },
+    });
+
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.items.length).toBe(5));
+
+    const button = screen.getByRole('button', { name: 'Logout' });
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // isLoading true means that the query is disabled, because no user is in session.
+    await waitFor(() => expect(result.current.states.isLoading).toBe(true));
+    // Expect data to be cleared.
+    await waitFor(() => expect(result.current.items.length).toBe(0));
+  });
+});
+
+describe('useResource (non-omniscient)', () => {
+  const props: UseResourcesProps<Todo, TodoQuery> = {
+    queryKey: ['todos'],
+    apiInterface: () => API.todos,
+  };
+
+  const useTodos = useResources(props);
+  const useTodo = useResource(props);
+
+  beforeEach(() => {
+    fetchMock.get('https://joanie.endpoint/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it('triggers a new requests each time the filters change', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    fetchMock.get('https://example.com/api/todos', todos);
+    fetchMock.get('https://example.com/api/todos?name=e', todos);
+    fetchMock.get('https://example.com/api/todos?name=ef', todos);
+
+    expect(fetchMock.called('https://example.com/api/todos')).toBe(false);
+    expect(fetchMock.called('https://example.com/api/todos?name=e')).toBe(false);
+    expect(fetchMock.called('https://example.com/api/todos?name=ef')).toBe(false);
+
+    const { result, rerender } = renderHook((initialProps?: TodoQuery) => useTodos(initialProps), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(fetchMock.called('https://example.com/api/todos')).toBe(true);
+    expect(fetchMock.called('https://example.com/api/todos?name=e')).toBe(false);
+    expect(fetchMock.called('https://example.com/api/todos?name=ef')).toBe(false);
+
+    rerender({ name: 'e' });
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(fetchMock.called('https://example.com/api/todos')).toBe(true);
+    expect(fetchMock.called('https://example.com/api/todos?name=e')).toBe(true);
+    expect(fetchMock.called('https://example.com/api/todos?name=ef')).toBe(false);
+
+    rerender({ name: 'ef' });
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(fetchMock.called('https://example.com/api/todos')).toBe(true);
+    expect(fetchMock.called('https://example.com/api/todos?name=e')).toBe(true);
+    expect(fetchMock.called('https://example.com/api/todos?name=ef')).toBe(true);
+  });
+
+  it('handles API errors', async () => {
+    const responseDeferred = new Deferred();
+    fetchMock.get('https://example.com/api/todos', responseDeferred.promise);
+
+    const { result } = renderHook(() => useTodos(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.states.isLoading).toBe(true);
+    expect(result.current.states.fetching).toBe(true);
+    expect(result.current.states.error).toBe(undefined);
+    expect(result.current.items).toEqual([]);
+
+    responseDeferred.reject({
+      status: 500,
+      body: 'Bad request',
+    });
+
+    await waitFor(() => expect(result.current.states.isLoading).toBe(false));
+    expect(result.current.states.fetching).toBe(false);
+    expect(result.current.states.error).toEqual(
+      'An error occurred while fetching resources. Please retry later.',
+    );
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('retrieves a todo through provided filters', async () => {
+    const todo: Todo = TodoFactory.generate();
+    const responseDeferred = new Deferred();
+    fetchMock.get(
+      `https://example.com/api/todos/${todo.id}?name=${todo.name}`,
+      responseDeferred.promise,
+    );
+
+    const { result } = renderHook(() => useTodo(todo.id, { name: todo.name }), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.states.fetching).toBe(true);
+    expect(result.current.states.isLoading).toBe(true);
+    expect(result.current.item).toBeUndefined();
+
+    responseDeferred.resolve(todo);
+
+    await waitFor(() => {
+      expect(result.current.states.fetching).toBe(false);
+    });
+    expect(fetchMock.called(`https://example.com/api/todos/${todo.id}?name=${todo.name}`)).toBe(
+      true,
+    );
+    expect(result.current.states.isLoading).toBe(false);
+    expect(result.current.item).toStrictEqual(todo);
+  });
+
+  it('handles PaginatedResponse', async () => {
+    const todos: Todo[] = TodoFactory.generate(5);
+    const responseDeferred = new Deferred();
+    fetchMock.get(`https://example.com/api/todos`, responseDeferred.promise);
+
+    const { result } = renderHook(() => useTodos(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.states.fetching).toBe(true);
+    expect(result.current.states.isLoading).toBe(true);
+    expect(result.current.items).toEqual([]);
+
+    responseDeferred.resolve({
+      results: todos,
+      next: '',
+      previous: '',
+      count: todos.length,
+    });
+
+    await waitFor(() => {
+      expect(result.current.states.fetching).toBe(false);
+    });
+    expect(result.current.items).toStrictEqual(todos);
+  });
+});
+
+function pickRandomlyFromArray<T>(array: T[]): T {
+  return array[Math.floor(Math.random() * array.length)];
+}

--- a/src/frontend/js/hooks/useResources/index.tsx
+++ b/src/frontend/js/hooks/useResources/index.tsx
@@ -1,0 +1,72 @@
+import type { QueryKey, UseQueryOptions } from '@tanstack/react-query';
+import { MessageDescriptor } from 'react-intl';
+import { HttpError } from 'utils/errors/HttpError';
+import { ApiResourceInterface } from 'types/Joanie';
+import { useResourcesOmniscient } from './useResourcesOmniscient';
+import { useResourcesRoot } from './useResourcesRoot';
+
+export interface ResourcesQuery {
+  id?: string;
+}
+
+export interface Resource {
+  id: string;
+}
+
+export type QueryOptions<TData extends Resource> = Omit<
+  UseQueryOptions<unknown, HttpError, TData[]>,
+  'queryKey' | 'queryFn'
+>;
+
+export interface UseResourcesProps<
+  TData extends Resource,
+  TResourceQuery extends ResourcesQuery = ResourcesQuery,
+  TApiResource extends ApiResourceInterface<TData> = ApiResourceInterface<TData>,
+> {
+  queryKey: QueryKey;
+  filters?: TResourceQuery;
+  apiInterface: () => TApiResource;
+  omniscient?: boolean;
+  omniscientFiltering?: (data: TData[], filters: TResourceQuery) => TData[];
+  session?: boolean;
+  localized?: boolean;
+  messages?: Record<string, MessageDescriptor>;
+  queryOptions?: QueryOptions<TData>;
+  frozenQueryKey?: boolean;
+}
+
+export const useResourcesCustom = <
+  TData extends Resource,
+  TResourceQuery extends ResourcesQuery = ResourcesQuery,
+  TApiResource extends ApiResourceInterface<TData> = ApiResourceInterface<TData>,
+>(
+  props: UseResourcesProps<TData, TResourceQuery, TApiResource>,
+) => {
+  if (props.omniscient) {
+    return useResourcesOmniscient(props);
+  }
+  return useResourcesRoot(props);
+};
+
+export const useResources =
+  <
+    TData extends Resource,
+    TResourceQuery extends ResourcesQuery = ResourcesQuery,
+    TApiResource extends ApiResourceInterface<TData> = ApiResourceInterface<TData>,
+  >(
+    props: UseResourcesProps<TData, TResourceQuery, TApiResource>,
+  ) =>
+  (filters?: TResourceQuery, queryOptions?: QueryOptions<TData>) => {
+    return useResourcesCustom({ ...props, filters, queryOptions });
+  };
+
+export const useResource =
+  <TData extends Resource, TResourceQuery extends ResourcesQuery = ResourcesQuery>(
+    props: UseResourcesProps<TData>,
+  ) =>
+  (id?: string, filters?: Omit<TResourceQuery, 'id'>, queryOptions?: QueryOptions<TData>) => {
+    const resources = useResources<TData>(props);
+    const res = resources({ id, ...filters }, { ...queryOptions, enabled: !!id });
+    const { items, ...subRes } = res;
+    return { ...subRes, item: items[0] };
+  };

--- a/src/frontend/js/hooks/useResources/useResourcesOmniscient.ts
+++ b/src/frontend/js/hooks/useResources/useResourcesOmniscient.ts
@@ -1,0 +1,68 @@
+import { useIntl } from 'react-intl';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ApiResourceInterface } from 'types/Joanie';
+import { messages, useResourcesRoot } from './useResourcesRoot';
+import { Resource, ResourcesQuery, UseResourcesProps } from './index';
+
+/**
+ * This hook internally wraps `useResourcesRoot` but will bulk-fetch all the whole set of resources
+ * internally, and then do a in-memory filtering on the client side.
+ *
+ * So that means changing filters will not trigger a new request to the API.
+ *
+ * @param filters
+ * @param props
+ */
+export const useResourcesOmniscient = <
+  TData extends Resource,
+  TResourceQuery extends ResourcesQuery = ResourcesQuery,
+  TApiResource extends ApiResourceInterface<TData> = ApiResourceInterface<TData>,
+>({
+  filters,
+  ...props
+}: UseResourcesProps<TData, TResourceQuery, TApiResource>) => {
+  const intl = useIntl();
+  const useResources = useResourcesRoot({ ...props, frozenQueryKey: true });
+  const [data, setData] = useState<TData[]>([]);
+  const actualMessages = useMemo(
+    () => ({ ...messages, ...props.messages }),
+    [messages, props.messages],
+  );
+  const filter = useCallback(() => {
+    if (!useResources.items) {
+      setData([]);
+      return;
+    }
+
+    const filterKeys = typeof filters === 'object' ? Object.keys(filters).length : 0;
+    if (filterKeys === 0) {
+      // Do not apply filtering.
+      setData(useResources.items);
+      return;
+    }
+
+    // Apply filtering.
+    let tmpData = useResources.items;
+    if (filters?.id) {
+      tmpData = tmpData.filter((a) => a.id === filters!.id);
+    }
+    if (props.omniscientFiltering) {
+      tmpData = props.omniscientFiltering(tmpData, filters!);
+    }
+    if (tmpData.length === 0) {
+      useResources.methods.setError(intl.formatMessage(actualMessages.errorNotFound));
+      setData([]);
+      return;
+    }
+    setData(tmpData);
+  }, [useResources.items, JSON.stringify(filters), actualMessages]);
+
+  useEffect(() => {
+    if (useResources.states.fetching) {
+      return;
+    }
+    filter();
+  }, [useResources.items, JSON.stringify(filters)]);
+
+  return { ...useResources, items: data };
+};

--- a/src/frontend/js/hooks/useResources/useResourcesRoot.ts
+++ b/src/frontend/js/hooks/useResources/useResourcesRoot.ts
@@ -1,0 +1,207 @@
+import { useMutation, useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import { useCallback, useMemo, useState } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import { MutateOptions } from '@tanstack/query-core/src/types';
+import { AddParameters, Maybe } from 'types/utils';
+import { HttpError } from 'utils/errors/HttpError';
+import { useSessionQuery } from 'utils/react-query/useSessionQuery';
+import { REACT_QUERY_SETTINGS } from 'settings';
+import { useSessionMutation } from 'utils/react-query/useSessionMutation';
+import { noop } from 'utils';
+import { ApiResourceInterface } from 'types/Joanie';
+import useLocalizedQueryKey from 'utils/react-query/useLocalizedQueryKey';
+import usePrevious from 'utils/usePrevious';
+import { Resource, ResourcesQuery, UseResourcesProps } from './index';
+
+export const messages = defineMessages({
+  errorGet: {
+    id: 'hooks.useResources.errorGet',
+    description: 'Error message shown to the user when resource fetch request fails.',
+    defaultMessage: 'An error occurred while fetching resources. Please retry later.',
+  },
+  errorNotFound: {
+    id: 'hooks.useResources.errorNotFound',
+    description: 'Error message shown to the user when no resources matches.',
+    defaultMessage: 'Cannot find the resource.',
+  },
+  errorUpdate: {
+    id: 'hooks.useResources.errorUpdate',
+    description: 'Error message shown to the user when resource update request fails.',
+    defaultMessage: 'An error occurred while updating a resource. Please retry later.',
+  },
+  errorDelete: {
+    id: 'hooks.useResources.errorDelete',
+    description: 'Error message shown to the user when resource deletion request fails.',
+    defaultMessage: 'An error occurred while deleting a resource. Please retry later.',
+  },
+  errorCreate: {
+    id: 'hooks.useResources.errorCreate',
+    description: 'Error message shown to the user when resource creation request fails.',
+    defaultMessage: 'An error occurred while creating a resource. Please retry later.',
+  },
+});
+
+type MutateFunc<TApiMethod extends Maybe<(...args: any[]) => any>> = AddParameters<
+  NonNullable<TApiMethod>,
+  [options?: MutateOptions<Awaited<ReturnType<NonNullable<TApiMethod>>>, HttpError>]
+>;
+
+const emptyArray: never[] = [];
+
+/**
+ * This hook is a wrapper around `useQuery` and `useMutation` to fetch and mutate resources.
+ *
+ * @param queryKey - The resource name ( e.g. "todos" )
+ * @param apiInterface - A callback that returns the API interface to use for this resource.
+ * @param frozenQueryKey - Indicates whether it should do a new API request when the filters change.
+ * @param filters - The filters to apply to the API request. Depends on frozenQueryKey.
+ * @param session - If true uses useSessionQuery, otherwise useQuery.
+ * @param queryOptions - Pass custom options to react-query.
+ * @param localized - Is the resource local-dependent ? If so, the query will be invalidated on locale change.
+ * @param resourceMessages - Custom messages to use for this resource.
+ */
+export const useResourcesRoot = <
+  TData extends Resource,
+  TResourceQuery extends ResourcesQuery = ResourcesQuery,
+  TApiResource extends ApiResourceInterface<TData> = ApiResourceInterface<TData>,
+>({
+  queryKey,
+  apiInterface,
+  frozenQueryKey,
+  filters,
+  session,
+  queryOptions,
+  localized,
+  messages: resourceMessages,
+}: UseResourcesProps<TData, TResourceQuery, TApiResource>) => {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<Maybe<string>>();
+  const intl = useIntl();
+
+  const actualMessages = useMemo(
+    () => ({ ...messages, ...resourceMessages }),
+    [messages, resourceMessages],
+  );
+
+  const COMMON_QUERY_KEY = frozenQueryKey ? [...queryKey] : [...queryKey, JSON.stringify(filters)];
+  const LOCALIZED_QUERY_KEY = useLocalizedQueryKey(COMMON_QUERY_KEY);
+  const QUERY_KEY = localized ? LOCALIZED_QUERY_KEY : COMMON_QUERY_KEY;
+  let ACTUAL_QUERY_KEY = QUERY_KEY;
+
+  const api = apiInterface();
+
+  const queryFn: () => Promise<any> = useCallback(
+    () => api.get(filters),
+    [api, JSON.stringify(filters)],
+  );
+  queryOptions = {
+    onError: () => setError(intl.formatMessage(actualMessages.errorGet)),
+    ...queryOptions,
+  };
+
+  if (session !== usePrevious(session)) {
+    throw new Error('session must never change value.');
+  }
+
+  let readHandler: UseQueryResult<any, HttpError>;
+  if (session) {
+    [readHandler, ACTUAL_QUERY_KEY] = useSessionQuery(QUERY_KEY, queryFn, queryOptions as any);
+  } else {
+    readHandler = useQuery(QUERY_KEY, queryFn, queryOptions);
+  }
+
+  const invalidate = async () => {
+    // Invalidate all queries related to the resource
+    await queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey.includes(queryKey[0]),
+    });
+  };
+
+  const prefetch = async () => {
+    await queryClient.prefetchQuery(ACTUAL_QUERY_KEY, queryFn, {
+      staleTime: session
+        ? REACT_QUERY_SETTINGS.staleTimes.sessionItems
+        : REACT_QUERY_SETTINGS.staleTimes.default,
+    });
+  };
+
+  const onSuccess = async () => {
+    setError(undefined);
+    await invalidate();
+  };
+
+  const mutation = (session ? useSessionMutation : useMutation) as typeof useMutation;
+
+  const writeHandlers = {
+    create: api.create
+      ? mutation(api.create, {
+          onSuccess,
+          onError: () => setError(intl.formatMessage(actualMessages.errorCreate)),
+        })
+      : undefined,
+    update: api.update
+      ? mutation(api.update, {
+          onSuccess,
+          onError: () => setError(intl.formatMessage(actualMessages.errorUpdate)),
+        })
+      : undefined,
+    delete: api.delete
+      ? mutation(api.delete, {
+          onSuccess,
+          onError: () => setError(intl.formatMessage(actualMessages.errorDelete)),
+        })
+      : undefined,
+  };
+
+  // We want to keep the same reference to the empty array to avoid potential
+  // infinite useEffect calls that use `items` as a dependency.
+  const getData = (): TData[] => {
+    if (!readHandler.data) {
+      return emptyArray;
+    }
+    // Is it a PaginatedResponse ?
+    if (
+      typeof readHandler.data === 'object' &&
+      readHandler.data.hasOwnProperty('results') &&
+      readHandler.data.hasOwnProperty('next') &&
+      readHandler.data.hasOwnProperty('previous') &&
+      readHandler.data.hasOwnProperty('count')
+    ) {
+      return readHandler.data.results;
+    }
+
+    // If a single resource has been returned by API, we wrap it in an array
+    if (!Array.isArray(readHandler.data)) {
+      return [readHandler.data];
+    }
+
+    return readHandler.data;
+  };
+
+  return {
+    items: getData(),
+    methods: {
+      invalidate,
+      prefetch,
+      refetch: readHandler.refetch,
+      create: (writeHandlers.create ? writeHandlers.create.mutate : noop) as unknown as MutateFunc<
+        TApiResource['create']
+      >,
+      update: (writeHandlers.update ? writeHandlers.update.mutate : noop) as unknown as MutateFunc<
+        TApiResource['update']
+      >,
+      delete: (writeHandlers.delete ? writeHandlers.delete.mutate : noop) as unknown as MutateFunc<
+        TApiResource['delete']
+      >,
+      setError,
+    },
+    states: {
+      fetching: readHandler.fetchStatus === 'fetching',
+      creating: writeHandlers.create?.isLoading,
+      deleting: writeHandlers.delete?.isLoading,
+      updating: writeHandlers.update?.isLoading,
+      isLoading: [...Object.values(writeHandlers), readHandler].some((value) => value?.isLoading),
+      error,
+    },
+  };
+};

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -235,7 +235,7 @@ interface APIUser {
   creditCards: {
     create(payload: Omit<CreditCard, 'id'>): Promise<CreditCard>;
     delete(id: CreditCard['id']): Promise<void>;
-    get(id: CreditCard['id']): Promise<CreditCard>;
+    get(filters?: ResourcesQuery): Promise<CreditCard>;
     get(): Promise<CreditCard[]>;
     update(payload: CreditCard): Promise<CreditCard>;
   };

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -10,7 +10,7 @@ export interface PaginatedResponse<T> {
   results: Array<T>;
 }
 
-interface PaginatedParameters {
+export interface PaginatedParameters {
   page: number;
   offset: number;
 }
@@ -243,7 +243,7 @@ interface APIUser {
     abort(payload: OrderAbortPayload): Promise<void>;
     create(payload: OrderCreationPayload): Promise<OrderWithPaymentInfo>;
     get(id: Order['id']): Promise<Nullable<Order>>;
-    get(queryParameters?: QueryParameters): Promise<PaginatedResponse<Nullable<Order>>>;
+    get(filters?: ResourcesQuery): Promise<PaginatedResponse<Nullable<Order>>>;
     invoice: {
       download(payload: { order_id: Order['id']; invoice_reference: string }): Promise<File>;
     };

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -1,5 +1,6 @@
 import type { Priority, StateCTA, StateText } from 'types';
 import type { Nullable } from 'types/utils';
+import { Resource, ResourcesQuery } from '../hooks/useResources';
 
 // - Generic
 export interface PaginatedResponse<T> {
@@ -211,6 +212,16 @@ interface EnrollmentCreationPayload {
 
 interface EnrollmentUpdatePayload extends EnrollmentCreationPayload {
   id: Enrollment['id'];
+}
+
+export interface ApiResourceInterface<
+  TData extends Resource,
+  TResourceQuery extends ResourcesQuery = ResourcesQuery,
+> {
+  get: (filters?: TResourceQuery) => any;
+  create?: (payload: any) => Promise<TData>;
+  update?: (payload: TData) => Promise<TData>;
+  delete?: (id: TData['id']) => Promise<void>;
 }
 
 interface APIUser {

--- a/src/frontend/js/types/utils.ts
+++ b/src/frontend/js/types/utils.ts
@@ -3,3 +3,8 @@ export type Maybe<T> = T | undefined;
 export type Nullable<T> = T | null;
 
 export type PropsWithTestId<Props> = Props & { 'data-testid'?: string };
+
+export type AddParameters<
+  TFunction extends (...args: readonly unknown[]) => unknown,
+  TParameters extends [...args: readonly unknown[]],
+> = (...args: [...Parameters<TFunction>, ...TParameters]) => ReturnType<TFunction>;

--- a/src/frontend/js/utils/api/joanie.ts
+++ b/src/frontend/js/utils/api/joanie.ts
@@ -14,6 +14,7 @@ import { AuthenticationApi } from 'utils/api/authentication';
 import context from 'utils/context';
 import { HttpError } from 'utils/errors/HttpError';
 import { JOANIE_API_VERSION } from 'settings';
+import { ResourcesQuery } from '../../hooks/useResources';
 
 interface CheckStatusOptions {
   fallbackValue: any;
@@ -150,10 +151,10 @@ const API = (): Joanie.API => {
   return {
     user: {
       creditCards: {
-        get: async (id?: string) => {
+        get: async (filters?: ResourcesQuery) => {
           let url;
 
-          if (id) url = ROUTES.user.creditCards.get.replace(':id', id);
+          if (filters?.id) url = ROUTES.user.creditCards.get.replace(':id', filters.id);
           else url = ROUTES.user.creditCards.get.replace(':id/', '');
 
           return fetchWithJWT(url).then(checkStatus);

--- a/src/frontend/js/utils/react-query/useSessionQuery/index.ts
+++ b/src/frontend/js/utils/react-query/useSessionQuery/index.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   QueryFunction,
   QueryKey,
   UseQueryOptions,
   UseQueryResult,
 } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'data/SessionProvider';
 import { REACT_QUERY_SETTINGS } from 'settings';
 import type { HttpError } from 'utils/errors/HttpError';


### PR DESCRIPTION
## Todo
- [x] Fix invalidation issue when editing a CD
- [x] API types
- [x] Distinction between `useCustomResources` and `useResource` to allow customization
- [x] Implement `useOmniscientResource`
- [x] Use `enabled` when `id` is `undefined` in `useResource` 
- [x] Invalidation customization
- [x] Migrate other resources