### PR TITLE
👷(ci) update gitmojis json url

### DIFF
--- a/gitlint/gitlint_emoji.py
+++ b/gitlint/gitlint_emoji.py
@@ -28,7 +28,7 @@ class GitmojiTitle(LineRule):
         title contains one of them.
         """
         gitmojis = requests.get(
-            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/src/data/gitmojis.json"
+            "https://raw.githubusercontent.com/carloscuesta/gitmoji/master/packages/gitmojis/src/gitmojis.json"
         ).json()["gitmojis"]
         emojis = [item["emoji"] for item in gitmojis]
         pattern = r"^({:s})\(.*\)\s[a-z].*$".format("|".join(emojis))


### PR DESCRIPTION
The repostiory containing the list of valid emojis just got transformed into a monorepo causing the old url to be obsolete.
