### PR TITLE
🐛(frontend) Bug/error message course run item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Show error message when user tries to enroll or unenroll to a
+  course run and the requests fails
 - Fix courses badges css.
 - Fix style in edit mode on courses with catalog visibility with
   `course_only` or `course_and_search`.
+
 
 ### Removed
 

--- a/src/frontend/js/components/CourseProductCourseRuns/EnrollableCourseRunList.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/EnrollableCourseRunList.tsx
@@ -203,6 +203,7 @@ const EnrollableCourseRunList = ({ courseRuns, order }: Props) => {
                 values={{ enrollment_start: formatDate(selectedCourseRun.enrollment_start) }}
               />
             )}
+            {enrollment.states?.error}
           </span>
           <button className="course-runs-item__cta button--primary button--pill button--tiny">
             {loading ? (

--- a/src/frontend/js/components/CourseProductCourseRuns/EnrolledCourseRun.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/EnrolledCourseRun.tsx
@@ -70,6 +70,7 @@ const EnrolledCourseRun = ({ enrollment }: Props) => {
             {formatDate(enrollment.course_run.end)}
           </em>
         </div>
+        {states.error && <p className="course-runs-list__errors-feedback ">{states.error}</p>}
         <div className="course-runs-item">
           <a
             href={enrollment.course_run.resource_link}

--- a/src/frontend/js/components/CourseProductCourseRuns/_styles.scss
+++ b/src/frontend/js/components/CourseProductCourseRuns/_styles.scss
@@ -23,6 +23,12 @@
     @include m-o-list-group__container;
     color: r-theme-val(product-item, lighter-color);
     list-style: none;
+
+    &__errors-feedback {
+      color: r-theme-val(product-item, feedback-color);
+      padding-left: 1.5rem;
+      font-size: 0.8125rem;
+    }
   }
 
   .course-runs-item {

--- a/src/frontend/js/components/PaymentButton/_styles.scss
+++ b/src/frontend/js/components/PaymentButton/_styles.scss
@@ -1,5 +1,9 @@
 .payment-button {
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 
   &__error {
     color: r-color('firebrick6');


### PR DESCRIPTION
## Purpose

On the CourseProductItem, when user tries to enroll or unenroll to a course run, if the request fails, the user has no feedback the action is failing that is weird.


## Proposal

An error message should be display to explicitly show to the user that its action has failed.
