### PR TITLE
🐛(frontend) show message when a product without any course run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Show error message when user tries to enroll or unenroll to a
+- Display a message in the sales tunnel when at least one course has no course
+  runs, to say that this product is not currently available for sale. 
+- Show error message when user tries to enroll or unroll to a
   course run and the requests fails
 - Fix courses badges css.
 - Fix style in edit mode on courses with catalog visibility with

--- a/src/frontend/js/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/components/CourseProductItem/_styles.scss
@@ -95,6 +95,10 @@
   &__footer {
     padding: 0 0.875rem 1rem 0.875rem;
 
+    .product-item__no-course-run {
+      text-align: center;
+      color: r-theme-val(product-item, button-background);
+    }
     .product-item__cta {
       @include button-base(
         $font-color: r-theme-val(product-item, button-color),

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -136,6 +136,28 @@ describe('SaleTunnel', () => {
     rafSpy.mockRestore();
   });
 
+  it('render a sale tunnel with one course has no course runs', async () => {
+    const product = ProductFactory.generate();
+    product.target_courses[0].course_runs = [];
+    fetchMock
+      .get(`https://joanie.test/api/v1.0/products/${product.id}/`, product)
+      .get('https://joanie.test/api/v1.0/addresses/', [])
+      .get('https://joanie.test/api/v1.0/credit-cards/', [])
+      .get('https://joanie.test/api/v1.0/orders/', []);
+
+    await act(async () => {
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <SaleTunnel courseCode="00000" product={product} />
+        </Wrapper>,
+      );
+    });
+
+    await screen.findByText(
+      'At least one course has no course runs, this product is not currently available for sale',
+    );
+  });
+
   it('renders a sale tunnel with a close button', async () => {
     const product = ProductFactory.generate();
 

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { Modal } from 'components/Modal';
 import { SaleTunnelStepPayment } from 'components/SaleTunnelStepPayment';
@@ -32,6 +32,12 @@ const messages = defineMessages({
     description: "Label displayed inside the product's CTA when user is not logged in",
     id: 'components.SaleTunnel.loginToPurchase',
   },
+  noCourseRunToPurchase: {
+    defaultMessage:
+      'At least one course has no course runs, this product is not currently available for sale',
+    description: "Label displayed inside the product's when there is no courseRun",
+    id: 'components.SaleTunnel.noCourseRunToPurchase',
+  },
   callToActionDescription: {
     defaultMessage: 'Purchase {product}',
     description:
@@ -56,6 +62,7 @@ type Props = {
 
 const SaleTunnel = ({ product, courseCode }: Props) => {
   const intl = useIntl();
+
   const manifest: Manifest<TunnelSteps, 'resume'> = {
     start: 'validation',
     steps: {
@@ -86,6 +93,11 @@ const SaleTunnel = ({ product, courseCode }: Props) => {
   const productQuery = useProduct(product.id);
   const ordersQuery = useOrders({ product: product.id, course: courseCode });
   const [isOpen, setIsOpen] = useState(false);
+
+  const oneCourseHasNoCourseRun = useMemo(() => {
+    return product.target_courses.some(({ course_runs }) => course_runs.length === 0);
+  }, [product]);
+
   const modalRef = useRef<HTMLDivElement | null>(null);
 
   const handleModalClose = () => {
@@ -114,6 +126,14 @@ const SaleTunnel = ({ product, courseCode }: Props) => {
           values={{ product: <span className="offscreen">&quot;{product.title}&quot;</span> }}
         />
       </button>
+    );
+  }
+
+  if (oneCourseHasNoCourseRun) {
+    return (
+      <p className="product-item__no-course-run">
+        <FormattedMessage {...messages.noCourseRunToPurchase} />
+      </p>
     );
   }
 


### PR DESCRIPTION
## Purpose
A user is able today to buy a product with no open course runs. 

## Proposal

- [x] hide the purchase button
- [x] show message to explain why
