### PR TITLE
Fix/sale tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Prevent product course run enrollment when user owns the product
+  through an invalid order
 - Display a message in the sales tunnel when at least one course has no course
   runs, to say that this product is not currently available for sale. 
 - Show error message when user tries to enroll or unroll to a

--- a/src/frontend/js/components/CourseProductCourseRuns/EnrollableCourseRunList.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/EnrollableCourseRunList.tsx
@@ -70,7 +70,7 @@ const EnrollableCourseRunList = ({ courseRuns, order }: Props) => {
   const enrollment = useEnrollments();
   const loading = enrollment.states.creating || enrollment.states.updating;
   const canSubmit = selectedCourseRun && !selectedCourseRunIsNotOpened;
-  const showFeedback = !loading && submitted && !canSubmit;
+  const showFeedback = (!loading && submitted && !canSubmit) || enrollment.states.error;
 
   const handleChange = () => {
     const form = formRef.current;
@@ -97,6 +97,7 @@ const EnrollableCourseRunList = ({ courseRuns, order }: Props) => {
       // we use an attribute selector and not an id selector because the CSS engine
       // doesn't understand id selectors beginning with digits
       formRef.current?.querySelector<HTMLElement>(`[id="${order.id}-feedback"]`)?.focus();
+      return;
     }
 
     if (selectedCourseRun) {
@@ -194,16 +195,19 @@ const EnrollableCourseRunList = ({ courseRuns, order }: Props) => {
         </ol>
         <div className="course-runs-item course-runs-item--submit">
           <span id={`${order.id}-feedback`} className="course-runs-item__feedback" tabIndex={-1}>
-            {showFeedback && !selectedCourseRun && (
-              <FormattedMessage {...messages.selectCourseRun} />
-            )}
-            {showFeedback && selectedCourseRun && selectedCourseRunIsNotOpened && (
-              <FormattedMessage
-                {...messages.enrollmentNotYetOpened}
-                values={{ enrollment_start: formatDate(selectedCourseRun.enrollment_start) }}
-              />
-            )}
-            {enrollment.states?.error}
+            {showFeedback &&
+              (selectedCourseRun ? (
+                selectedCourseRunIsNotOpened ? (
+                  <FormattedMessage
+                    {...messages.enrollmentNotYetOpened}
+                    values={{ enrollment_start: formatDate(selectedCourseRun.enrollment_start) }}
+                  />
+                ) : (
+                  enrollment.states?.error
+                )
+              ) : (
+                <FormattedMessage {...messages.selectCourseRun} />
+              ))}
           </span>
           <button className="course-runs-item__cta button--primary button--pill button--tiny">
             {loading ? (

--- a/src/frontend/js/components/CourseProductItem/CourseRunItem.spec.tsx
+++ b/src/frontend/js/components/CourseProductItem/CourseRunItem.spec.tsx
@@ -1,5 +1,5 @@
 import faker from 'faker';
-import { waitFor, screen, getByText, render } from '@testing-library/react';
+import { screen, getByText, render } from '@testing-library/react';
 import { OrderFactory } from 'utils/test/factories';
 import type { CourseRun, Order } from 'types/Joanie';
 import { OrderState } from 'types/Joanie';

--- a/src/frontend/js/components/CourseProductItem/CourseRunItem.spec.tsx
+++ b/src/frontend/js/components/CourseProductItem/CourseRunItem.spec.tsx
@@ -1,0 +1,36 @@
+import faker from 'faker';
+import { waitFor, screen, getByText, render } from '@testing-library/react';
+import { OrderFactory } from 'utils/test/factories';
+import type { CourseRun, Order } from 'types/Joanie';
+import { OrderState } from 'types/Joanie';
+import CourseRunItem from './CourseRunItem';
+
+jest.mock('components/CourseProductCourseRuns', () => ({
+  CourseRunList: ({ courseRuns }: { courseRuns: CourseRun[] }) => (
+    <div data-testid={`CourseRunList-${courseRuns.map(({ id }) => id).join('-')}`} />
+  ),
+}));
+
+describe('CourseRunItem', () => {
+  it('does not allow user which purchase the product to enroll to course if order state is not validated', async () => {
+    const order: Order = OrderFactory.afterGenerate((o: Order) => ({
+      ...o,
+      state: faker.helpers.randomize([OrderState.CANCELED, OrderState.PENDING]),
+    })).generate();
+    const targetCourse = order.target_courses[0];
+
+    render(<CourseRunItem targetCourse={targetCourse} order={order} />);
+
+    // - It should render CourseRunList component
+    const $item = screen.getByTestId(`course-item-${targetCourse.code}`);
+    // the course title shouldn't be a heading to prevent misdirection for screen reader users,
+    // but we want to it to visually look like a h5
+    const $courseTitle = getByText($item, targetCourse.title);
+    expect($courseTitle.tagName).toBe('STRONG');
+    expect($courseTitle.classList.contains('h5')).toBe(true);
+    screen.getByTestId(`CourseRunList-${targetCourse.course_runs.map(({ id }) => id).join('-')}`);
+
+    // - Does not Render <SaleTunnel />
+    expect(screen.queryByTestId('SaleTunnel')).toBeNull();
+  });
+});

--- a/src/frontend/js/components/CourseProductItem/CourseRunItem.tsx
+++ b/src/frontend/js/components/CourseProductItem/CourseRunItem.tsx
@@ -6,6 +6,7 @@ import {
 } from 'components/CourseProductCourseRuns';
 import { Priority } from 'types';
 import type * as Joanie from 'types/Joanie';
+import { OrderState } from 'types/Joanie';
 
 const findEnrollment = (targetCourse: Joanie.TargetCourse, order: Joanie.OrderLite) => {
   const resourceLinks = targetCourse.course_runs.map(({ resource_link }) => resource_link);
@@ -20,8 +21,8 @@ interface Props {
 }
 
 const CourseRunItem = ({ targetCourse, order }: Props) => {
-  const isOwned = order !== undefined;
-  const courseRunEnrollment = isOwned ? findEnrollment(targetCourse, order) : undefined;
+  const isEnrollable = order?.state === OrderState.VALIDATED;
+  const courseRunEnrollment = isEnrollable ? findEnrollment(targetCourse, order) : undefined;
   const isEnrolled = !!courseRunEnrollment?.is_active;
   const isOpenedCourseRun = (courseRun: Joanie.CourseRun) =>
     courseRun.state.priority <= Priority.FUTURE_NOT_YET_OPEN;
@@ -73,16 +74,16 @@ const CourseRunItem = ({ targetCourse, order }: Props) => {
       className="product-widget__item course"
     >
       <strong className="product-widget__item-title h5">{targetCourse.title}</strong>
-      {!isOwned && (
+      {!isEnrollable && (
         <CourseRunList courseRuns={targetCourse.course_runs.filter(isOpenedCourseRun)} />
       )}
-      {isOwned && !isEnrolled && (
+      {isEnrollable && !isEnrolled && (
         <EnrollableCourseRunList
           courseRuns={targetCourse.course_runs.filter(isOpenedCourseRun)}
           order={order}
         />
       )}
-      {isOwned && isEnrolled && <EnrolledCourseRun enrollment={courseRunEnrollment} />}
+      {isEnrollable && isEnrolled && <EnrolledCourseRun enrollment={courseRunEnrollment} />}
     </li>
   );
 };

--- a/src/frontend/js/components/CourseProductItem/CourseRunItem.tsx
+++ b/src/frontend/js/components/CourseProductItem/CourseRunItem.tsx
@@ -7,10 +7,7 @@ import {
 import { Priority } from 'types';
 import type * as Joanie from 'types/Joanie';
 
-const findEnrollment = (
-  targetCourse: Joanie.CourseProductTargetCourse,
-  order: Joanie.OrderLite,
-) => {
+const findEnrollment = (targetCourse: Joanie.TargetCourse, order: Joanie.OrderLite) => {
   const resourceLinks = targetCourse.course_runs.map(({ resource_link }) => resource_link);
   return order.enrollments.find(({ is_active, course_run }) => {
     return is_active && resourceLinks.includes(course_run.resource_link);
@@ -18,7 +15,7 @@ const findEnrollment = (
 };
 
 interface Props {
-  targetCourse: Joanie.CourseProductTargetCourse;
+  targetCourse: Joanie.TargetCourse;
   order?: Joanie.Order;
 }
 

--- a/src/frontend/js/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/components/CourseProductItem/_styles.scss
@@ -96,8 +96,11 @@
     padding: 0 0.875rem 1rem 0.875rem;
 
     .product-item__no-course-run {
+      color: r-theme-val(product-item, feedback-color);
+      font-size: 0.8125rem;
+      line-height: 1.2em;
+      padding: 0.5rem 0.5rem 0 0.5rem;
       text-align: center;
-      color: r-theme-val(product-item, button-background);
     }
     .product-item__cta {
       @include button-base(

--- a/src/frontend/js/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/components/CourseProductItem/_styles.scss
@@ -5,10 +5,24 @@
   background-color: white;
   border: 6px solid r-theme-val(product-item, base-border);
   border-radius: 6px;
+  min-height: 100px;
   overflow: hidden;
 
   &:not(:last-child) {
     margin-bottom: 1.5rem;
+  }
+
+  & &__overlay {
+    background-color: r-theme-val(modal, overlay-background);
+    border-radius: 6px;
+    display: grid;
+    height: 100%;
+    left: 0;
+    place-items: center;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 2;
   }
 
   & &__header {

--- a/src/frontend/js/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.tsx
@@ -89,7 +89,13 @@ const CourseProductItem = ({ productId, courseCode }: Props) => {
         </ol>
         {!isOwned && (
           <footer className="product-widget__footer">
-            <SaleTunnel product={product} courseCode={courseCode} />
+            <SaleTunnel
+              product={product}
+              onSuccess={() => {
+                productQuery.methods.refetch();
+                orderQuery.methods.refetch();
+              }}
+            />
           </footer>
         )}
       </section>

--- a/src/frontend/js/components/DashboardItem/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/components/DashboardItem/DashboardItemOrder.spec.tsx
@@ -7,22 +7,23 @@ import {
   OrderFactory,
 } from 'utils/test/factories';
 import { DashboardItemOrder } from 'components/DashboardItem/DashboardItemOrder';
-import { Order } from 'types/Joanie';
+import { Course, Order } from 'types/Joanie';
 import { DEFAULT_DATE_FORMAT } from 'utils/useDateFormat';
 
 describe('<DashboardItemOrder/>', () => {
   it('renders component without enrollments', () => {
     const order: Order = OrderFactory.generate();
+    const course = order.course as Course;
 
     render(
       <IntlProvider locale="en">
         <DashboardItemOrder order={order} />
       </IntlProvider>,
     );
-    screen.getByRole('heading', { level: 5, name: order.course!.title });
+    screen.getByRole('heading', { level: 5, name: course.title });
     const button = screen.getByRole('link', { name: 'ACCESS COURSE' });
     expect(button).toBeEnabled();
-    expect(button).toHaveAttribute('href', '/dashboard/courses/' + order.course!.code);
+    expect(button).toHaveAttribute('href', '/dashboard/courses/' + course.code);
   });
 
   it('renders component with enrollments', () => {
@@ -51,16 +52,17 @@ describe('<DashboardItemOrder/>', () => {
         },
       ],
     };
+    const course = order.course as Course;
 
     render(
       <IntlProvider locale="en">
         <DashboardItemOrder order={order} />
       </IntlProvider>,
     );
-    screen.getByRole('heading', { level: 5, name: order.course!.title });
+    screen.getByRole('heading', { level: 5, name: course.title });
     const button = screen.getAllByRole('link', { name: 'ACCESS COURSE' })[0];
     expect(button).toBeEnabled();
-    expect(button).toHaveAttribute('href', '/dashboard/courses/' + order.course!.code);
+    expect(button).toHaveAttribute('href', '/dashboard/courses/' + course.code);
 
     // First enrollment.
     {

--- a/src/frontend/js/components/DashboardItem/DashboardItemOrder.tsx
+++ b/src/frontend/js/components/DashboardItem/DashboardItemOrder.tsx
@@ -39,8 +39,8 @@ interface DashboardItemOrderProps {
 
 export const DashboardItemOrder = ({ order }: DashboardItemOrderProps) => {
   const { course } = order;
-  if (!course) {
-    throw new Error('Order must provide course attribute');
+  if (!course || typeof course === 'string') {
+    throw new Error('Order must provide course object attribute.');
   }
   const intl = useIntl();
 

--- a/src/frontend/js/hooks/useOrders.ts
+++ b/src/frontend/js/hooks/useOrders.ts
@@ -1,4 +1,4 @@
-import { API, Order, Product, Course } from 'types/Joanie';
+import { API, Order, Product, Course, OrderState } from 'types/Joanie';
 import { useJoanieApi } from 'data/JoanieApiProvider';
 import { useSessionMutation } from 'utils/react-query/useSessionMutation';
 import {
@@ -12,12 +12,32 @@ import {
 type OrderResourcesQuery = ResourcesQuery & {
   course?: Course['code'];
   product?: Product['id'];
+  state?: OrderState[];
 };
+
+function omniscientFiltering(data: Order[], filter: OrderResourcesQuery): Order[] {
+  if (!filter) return data;
+
+  return data.filter(
+    (order) =>
+      // If filter.id is defined filter by order.id
+      (!filter.id || order.id === filter.id) &&
+      // If filter.course is defined filter by order.course
+      (!filter.course ||
+        (typeof order.course === 'string' && order.course === filter.course) ||
+        (typeof order.course === 'object' && order.course?.code === filter.course)) &&
+      // If filter.product is defined filter by order.product
+      (!filter.product || order.product === filter.product) &&
+      // If filter.state is defined filter by order.state
+      (!filter.state || filter.state.includes(order.state)),
+  );
+}
 
 const props: UseResourcesProps<Order, OrderResourcesQuery, API['user']['orders']> = {
   queryKey: ['orders'],
   apiInterface: () => useJoanieApi().user.orders,
   omniscient: true,
+  omniscientFiltering,
   session: true,
 };
 

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -127,7 +127,7 @@ export enum OrderState {
 
 export interface Order {
   id: string;
-  course?: Course;
+  course?: Course['code'] | Course;
   created_on: string;
   enrollments: Enrollment[];
   main_proforma_invoice: string;

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -63,16 +63,18 @@ export interface Product {
   price_currency: string;
   call_to_action: string;
   certificate: CertificateDefinition;
-  target_courses: Omit<Course, 'products'>[];
+  target_courses: TargetCourse[];
   orders: Order['id'][];
 }
 
 // - Course
-export interface CourseProductTargetCourse {
+export interface TargetCourse {
   code: string;
-  organization: Organization;
+  organizations: Organization[];
   title: string;
-  course_runs: Array<CourseRun>;
+  course_runs: CourseRun[];
+  is_graded: boolean;
+  position: number;
 }
 
 export type OrderLite = Pick<
@@ -89,7 +91,7 @@ export type OrderLite = Pick<
 
 export interface CourseProduct extends Product {
   order: Nullable<OrderLite>;
-  target_courses: CourseProductTargetCourse[];
+  target_courses: TargetCourse[];
 }
 
 export interface Course {
@@ -134,8 +136,8 @@ export interface Order {
   total: number;
   total_currency: string;
   state: OrderState;
-  product: string;
-  target_courses: Omit<Course, 'products'>[];
+  product: Product['id'];
+  target_courses: TargetCourse[];
 }
 
 export enum CreditCardBrand {

--- a/src/frontend/js/utils/test/factories.ts
+++ b/src/frontend/js/utils/test/factories.ts
@@ -175,7 +175,7 @@ export const JoanieEnrollmentFactory = createSpec({
 
 export const TargetCourseFactory = createSpec({
   code: faker.unique(faker.random.alphaNumeric(5)),
-  organization: OrganizationFactory,
+  organizations: [],
   title: faker.random.words(1, 3),
   course_runs: derived(() => JoanieCourseRunFactory().generate(1, 3)),
 });


### PR DESCRIPTION
## Purpose

OrderQuery invalidates itself on mutation success. By default all hooks
linked to this query triggered a rerender on this invalidation. About
the CourseProductItem that's problematic as this mutation is called
within the SaleTunnel, so the orderQuery fetching state switch to true then
the Spinner is show and SaleTunnel is unmounted. In order to prevent this
weird behavior, we rework the logic to display product information and
spinner.


## Proposal

- [x] Prevent CourseProductItem rerender on all orderQuery updates
- [x] Update some resource types
- [x] Add a `onSuccess` prop to the `SaleTunnel` component
