### PR TITLE
♿(frontend) use darker color for empty course detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Improve accessibility by using darker color for empty course label
 - Update Joanie connection documentation
 
 ## [2.18.0]

--- a/src/frontend/scss/colors/_theme.scss
+++ b/src/frontend/scss/colors/_theme.scss
@@ -85,7 +85,7 @@ $r-theme: (
     background-image: url('../../richie/images/components/wave-white.svg'),
   ),
   block-schemes: (
-    empty-color: r-color('slate-grey'),
+    empty-color: r-color('dark-grey'),
     divider: r-color('azure2'),
     variants: (
       clear: $light-grey-scheme,


### PR DESCRIPTION
## Purpose
When no opened course runs are available, a label is displayed to explain that to the user but currently the shade difference between the color label and its background does not comply with RGAA. A good takeoff seems to use the "dark-grey" color which is not the best contrast but good enough for RGAA and light enough to understand that something is "disabled".

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/9265241/214362223-32d1a7cb-1a81-4149-87f7-2127a9979ca5.png">


<img width="1127" alt="Before" src="https://user-images.githubusercontent.com/9265241/214361718-5524b5d2-039f-4812-90d5-2f8a24b965c0.png">

<img width="1130" alt="After" src="https://user-images.githubusercontent.com/9265241/214361799-3ade47fa-51fa-4796-8a21-90ff727d5bab.png">


## Proposal

- [x] Update `scheme-block.empty-color` to use a darker color
