### PR TITLE
🐛(frontend) fix omniscient stale query that stay empty

### DIFF
--- a/src/frontend/js/hooks/useResources/useResourcesOmniscient.ts
+++ b/src/frontend/js/hooks/useResources/useResourcesOmniscient.ts
@@ -73,7 +73,7 @@ export const useResourcesOmniscient = <
       return;
     }
     filter();
-  }, [useResources.items, JSON.stringify(filters)]);
+  }, [useResources.states.fetching, useResources.items, JSON.stringify(filters)]);
 
   return { ...useResources, items: data };
 };


### PR DESCRIPTION
When leaving a tab opened for at least 20min ( which is the stale time delay ), the first refresh was giving empty react-query results even if the HTTP request was appearing in the network. It was only affecting omniscient resources, it was due to that the fact that stale queries are the only one that, in the first render, will have at the same time fetching===true and datas fullfilled. This fix allows the useEffect that applies the filter to be called when fetching turns false.
