### PR TITLE
Fix/course product item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Improve accessibility by using darker color for empty course label
 - Update Joanie connection documentation
 
+### Fixed
+
+- Fix an issue about CourseProductItem when session state is updated
+
 ## [2.18.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix an issue about CourseProductItem when session state is updated
+- Prevent `.icon` to shrink in flexbox content
 
 ## [2.18.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Improve accessibility by using darker color for empty course label
 - Update Joanie connection documentation
+- Display error message when CourseProductItem has error
 
 ### Fixed
 

--- a/src/frontend/js/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/components/CourseProductItem/_styles.scss
@@ -8,6 +8,20 @@
   min-height: 100px;
   overflow: hidden;
 
+  &--has-error {
+    align-items: center;
+    border-color: r-theme-val(product-item, feedback-color);
+    display: flex;
+
+    & > .product-widget__content {
+      color: r-theme-val(product-item, feedback-color);
+      display: flex;
+      flex-direction: row;
+      gap: 1rem;
+      margin-bottom: 0;
+    }
+  }
+
   &:not(:last-child) {
     margin-bottom: 1.5rem;
   }

--- a/src/frontend/js/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.spec.tsx
@@ -310,4 +310,23 @@ describe('CourseProductItem', () => {
     // - Does not Render <SaleTunnel />
     expect(screen.queryByTestId('SaleTunnel')).toBeNull();
   });
+
+  it('renders error message when product fetching has failed', async () => {
+    const product: Product = ProductFactory.generate();
+
+    fetchMock.get(`https://joanie.test/api/v1.0/products/${product.id}/?course=00000`, 404, {});
+
+    render(
+      <Wrapper>
+        <CourseProductItem productId={product.id} courseCode="00000" />
+      </Wrapper>,
+    );
+
+    // Wait for product information to be fetched
+    const loadingMessage = screen.getByRole('status', { name: 'Loading product information...' });
+    await waitForElementToBeRemoved(loadingMessage);
+
+    // - As product fetching has failed, an error message should be displayed
+    await screen.findByText('An error occurred while fetching product. Please retry later.');
+  });
 });

--- a/src/frontend/js/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.tsx
@@ -8,6 +8,7 @@ import { useProduct } from 'hooks/useProduct';
 import { Spinner } from 'components/Spinner';
 import { useOrders } from 'hooks/useOrders';
 import { OrderState } from 'types/Joanie';
+import { Icon } from 'components/Icon';
 import CourseRunItem from './CourseRunItem';
 
 const messages = defineMessages({
@@ -55,12 +56,13 @@ const CourseProductItem = ({ productId, courseCode }: Props) => {
 
     return [];
   }, [productQuery.item, order]);
-  
+
+  const hasError = Boolean(productQuery.states.error);
   const isFetching = productQuery.states.fetching || ordersQuery.states.fetching;
 
   return (
     <CourseProductProvider courseCode={courseCode} productId={productId}>
-      <section className="product-widget">
+      <section className={['product-widget', hasError && 'product-widget--has-error'].join(' ')}>
         {isFetching && (
           <div className="product-widget__overlay">
             <Spinner aria-labelledby="loading-course" theme="light" size="large">
@@ -70,7 +72,13 @@ const CourseProductItem = ({ productId, courseCode }: Props) => {
             </Spinner>
           </div>
         )}
-        {product && (
+        {hasError && (
+          <p className="product-widget__content">
+            <Icon name="icon-warning" size="small" />
+            {productQuery.states.error}
+          </p>
+        )}
+        {!hasError && product && (
           <>
             <header className="product-widget__header">
               <h3 className="product-widget__title">{product.title}</h3>

--- a/src/frontend/js/hooks/useOrders.ts
+++ b/src/frontend/js/hooks/useOrders.ts
@@ -1,3 +1,4 @@
+import { defineMessages } from 'react-intl';
 import { API, Order, Product, Course, OrderState } from 'types/Joanie';
 import { useJoanieApi } from 'data/JoanieApiProvider';
 import { useSessionMutation } from 'utils/react-query/useSessionMutation';
@@ -14,6 +15,19 @@ type OrderResourcesQuery = ResourcesQuery & {
   product?: Product['id'];
   state?: OrderState[];
 };
+
+const messages = defineMessages({
+  errorGet: {
+    id: 'hooks.useOrders.errorGet',
+    description: 'Error message shown to the user when orders fetch request fails.',
+    defaultMessage: 'An error occurred while fetching orders. Please retry later.',
+  },
+  errorNotFound: {
+    id: 'hooks.useOrders.errorNotFound',
+    description: 'Error message shown to the user when no orders matches.',
+    defaultMessage: 'Cannot find the orders.',
+  },
+});
 
 function omniscientFiltering(data: Order[], filter: OrderResourcesQuery): Order[] {
   if (!filter) return data;
@@ -36,6 +50,7 @@ function omniscientFiltering(data: Order[], filter: OrderResourcesQuery): Order[
 const props: UseResourcesProps<Order, OrderResourcesQuery, API['user']['orders']> = {
   queryKey: ['orders'],
   apiInterface: () => useJoanieApi().user.orders,
+  messages,
   omniscient: true,
   omniscientFiltering,
   session: true,

--- a/src/frontend/js/hooks/useProduct.ts
+++ b/src/frontend/js/hooks/useProduct.ts
@@ -5,14 +5,14 @@ import { useJoanieApi } from 'data/JoanieApiProvider';
 
 const messages = defineMessages({
   errorGet: {
-    id: 'hooks.useProduct.errorSelect',
+    id: 'hooks.useProduct.errorGet',
     description: 'Error message shown to the user when product fetch request fails.',
     defaultMessage: 'An error occurred while fetching product. Please retry later.',
   },
   errorNotFound: {
     id: 'hooks.useProduct.errorNotFound',
     description: 'Error message shown to the user when no product matches.',
-    defaultMessage: 'Cannot find the product',
+    defaultMessage: 'Cannot find the product.',
   },
 });
 

--- a/src/frontend/js/utils/api/joanie.ts
+++ b/src/frontend/js/utils/api/joanie.ts
@@ -279,9 +279,7 @@ const API = (): Joanie.API => {
           url += '?' + queryString.stringify(queryParameters);
         }
 
-        return fetchWithJWT(url).then((response) =>
-          checkStatus(response, { fallbackValue: null, ignoredErrorStatus: [404] }),
-        );
+        return fetchWithJWT(url).then(checkStatus);
       },
     },
   };

--- a/src/frontend/js/utils/test/factories.ts
+++ b/src/frontend/js/utils/test/factories.ts
@@ -189,6 +189,7 @@ export const CertificationDefinitionFactory = createSpec({
 export const CertificateProductFactory = createSpec({
   id: faker.datatype.uuid(),
   title: faker.unique(faker.random.words(1, 3)),
+  course: faker.unique(faker.random.alphaNumeric(5)),
   type: ProductType.CERTIFICATE,
   price: faker.datatype.number(),
   price_currency: faker.finance.currencyCode(),

--- a/src/frontend/scss/generic/_icons.scss
+++ b/src/frontend/scss/generic/_icons.scss
@@ -5,6 +5,7 @@ $iconLargeSize: 2.1875rem;
 .icon {
   display: block;
   fill: currentColor;
+  flex-shrink: 0;
 
   &--small {
     width: $iconSmallSize;


### PR DESCRIPTION
## Purpose

About CourseProductItem, previously, we guessed if current user has purchased the related product from the product response itself. Indeed, if the user has purchased the product, the product's property `orders` contains all pending and validated orders related to the product and the current user. But there was a bug as useProduct hook is not aware about session state. So in the case where the page was displayed without session state initialized, the product query was executed immediately then when the session state was updated, as the product query was not stale, it was not executed again.

In order to fix that, to guess if the authenticated user has purchased the related product, we use the `useOrders` hook which is aware of session state update.

Furthermore, if a course run targeted a Joanie product has been misconfigured, the product request can return error. Currently, nothing is display in this case that is weird. So we update the CourseProductItem to display an error message in this case with an error look'n feel.

<img width="472" alt="image" src="https://user-images.githubusercontent.com/9265241/216057311-40ff750b-f056-4461-8f82-d080bbc94157.png">

## Proposal

- [x] Fix CourseProductItem issue on session state update
- [x] Display error message when `CourseProductItem` component has error
