### PR TITLE
Fix/sale tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Display 'pending' label on CourseProductItem when user owns pending order
+
 ### Changed
 
 - Improve accessibility by using darker color for info course detail label

--- a/src/frontend/js/components/CourseProductItem/PurchaseButton.spec.tsx
+++ b/src/frontend/js/components/CourseProductItem/PurchaseButton.spec.tsx
@@ -1,0 +1,154 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ContextFactory as mockContextFactory, ProductFactory } from 'utils/test/factories';
+import { SessionProvider } from 'data/SessionProvider';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import PurchaseButton from './PurchaseButton';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.endpoint.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).generate(),
+}));
+
+describe('PurchaseButton', () => {
+  beforeAll(() => {
+    // As dialog is rendered through a Portal, we have to add the DOM element in which the dialog will be rendered.
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  const Wrapper = ({ client, children }: React.PropsWithChildren<{ client: QueryClient }>) => (
+    <IntlProvider locale="en">
+      <QueryClientProvider client={client}>
+        <SessionProvider>{children}</SessionProvider>
+      </QueryClientProvider>
+    </IntlProvider>
+  );
+
+  it('shows a login button if user is not authenticated', async () => {
+    const product = ProductFactory.generate();
+
+    await act(async () => {
+      render(
+        <Wrapper client={createTestQueryClient({ user: null })}>
+          <PurchaseButton product={product} disabled={false} />
+        </Wrapper>,
+      );
+    });
+
+    await screen.findByRole('button', { name: `Login to purchase "${product.title}"` });
+  });
+
+  it('shows cta to open sale tunnel when user is authenticated', async () => {
+    const product = ProductFactory.generate();
+    fetchMock
+      .get('https://joanie.test/api/v1.0/addresses/', [])
+      .get('https://joanie.test/api/v1.0/credit-cards/', [])
+      .get('https://joanie.test/api/v1.0/orders/', []);
+
+    await act(async () => {
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PurchaseButton product={product} disabled={false} />
+        </Wrapper>,
+      );
+    });
+
+    fetchMock.resetHistory();
+
+    // Only CTA is displayed
+    const button = screen.getByRole('button', { name: product.call_to_action });
+
+    // - SaleTunnel should not be opened
+    expect(screen.queryByTestId('SaleTunnel__modal')).toBeNull();
+
+    // Then user can enter into the sale tunnel and follow its 3 steps
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // - SaleTunnel should have been opened
+    screen.getByTestId('SaleTunnel__modal');
+  });
+
+  it('renders a disabled CTA if one target course has no course runs', async () => {
+    const product = ProductFactory.generate();
+    product.target_courses[0].course_runs = [];
+    fetchMock
+      .get('https://joanie.test/api/v1.0/addresses/', [])
+      .get('https://joanie.test/api/v1.0/credit-cards/', [])
+      .get('https://joanie.test/api/v1.0/orders/', []);
+
+    await act(async () => {
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PurchaseButton product={product} disabled={false} />
+        </Wrapper>,
+      );
+    });
+
+    // CTA is displayed but disabled
+    const button: HTMLButtonElement = screen.getByRole('button', { name: product.call_to_action });
+    expect(button.disabled).toBe(true);
+
+    // Further, a message is displayed to explain why the CTA is disabled
+    screen.findByText(
+      'At least one course has no course runs, this product is not currently available for sale',
+    );
+  });
+
+  it('renders a disabled CTA if product has no target courses', async () => {
+    const product = ProductFactory.generate();
+    product.target_courses = [];
+    fetchMock
+      .get('https://joanie.test/api/v1.0/addresses/', [])
+      .get('https://joanie.test/api/v1.0/credit-cards/', [])
+      .get('https://joanie.test/api/v1.0/orders/', []);
+
+    await act(async () => {
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PurchaseButton product={product} disabled={false} />
+        </Wrapper>,
+      );
+    });
+
+    // CTA is displayed but disabled
+    const button: HTMLButtonElement = screen.getByRole('button', { name: product.call_to_action });
+    expect(button.disabled).toBe(true);
+
+    // Further, a message is displayed to explain why the CTA is disabled
+    screen.findByText(
+      'At least one course has no course runs, this product is not currently available for sale',
+    );
+  });
+
+  it('does not render CTA if disabled property is false', async () => {
+    const product = ProductFactory.generate();
+    fetchMock
+      .get('https://joanie.test/api/v1.0/addresses/', [])
+      .get('https://joanie.test/api/v1.0/credit-cards/', [])
+      .get('https://joanie.test/api/v1.0/orders/', []);
+
+    await act(async () => {
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PurchaseButton product={product} disabled={true} />
+        </Wrapper>,
+      );
+    });
+
+    // CTA is not displayed
+    expect(screen.queryByRole('button', { name: product.call_to_action })).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/js/components/CourseProductItem/PurchaseButton.tsx
+++ b/src/frontend/js/components/CourseProductItem/PurchaseButton.tsx
@@ -1,0 +1,93 @@
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { useMemo, useState } from 'react';
+import { useSession } from 'data/SessionProvider';
+import * as Joanie from 'types/Joanie';
+import { Priority } from 'types';
+import SaleTunnel from 'components/SaleTunnel';
+
+const messages = defineMessages({
+  loginToPurchase: {
+    defaultMessage: 'Login to purchase {product}',
+    description: "Label displayed inside the product's CTA when user is not logged in",
+    id: 'components.SaleTunnel.loginToPurchase',
+  },
+  noCourseRunToPurchase: {
+    defaultMessage:
+      'At least one course has no course runs, this product is not currently available for sale',
+    description: "Label displayed inside the product's when there is no courseRun",
+    id: 'components.SaleTunnel.noCourseRunToPurchase',
+  },
+  callToActionDescription: {
+    defaultMessage: 'Purchase {product}',
+    description:
+      'Additional description announced by screen readers when focusing the call to action buying button',
+    id: 'components.SaleTunnel.callToActionDescription',
+  },
+});
+
+interface PurchaseButtonProps {
+  product: Joanie.Product;
+  disabled: boolean;
+}
+
+const PurchaseButton = ({ product, disabled }: PurchaseButtonProps) => {
+  const intl = useIntl();
+  const { user, login } = useSession();
+  const [isSaleTunnelOpen, setIsSaleTunnelOpen] = useState(false);
+
+  const isOpenedCourseRun = (courseRun: Joanie.CourseRun) =>
+    courseRun.state.priority <= Priority.FUTURE_NOT_YET_OPEN;
+
+  const hasAtLeastOneCourseRun = useMemo(() => {
+    return (
+      product.target_courses.length > 0 &&
+      !product.target_courses.some(({ course_runs }) => !course_runs.some(isOpenedCourseRun))
+    );
+  }, [product]);
+
+  if (!user) {
+    return (
+      <button className="product-item__cta" onClick={login}>
+        <FormattedMessage
+          {...messages.loginToPurchase}
+          values={{ product: <span className="offscreen">&quot;{product.title}&quot;</span> }}
+        />
+      </button>
+    );
+  }
+
+  return (
+    <>
+      {!disabled && (
+        <>
+          <button
+            data-testid="PurchaseButton__cta"
+            className="product-item__cta"
+            onClick={() => hasAtLeastOneCourseRun && setIsSaleTunnelOpen(true)}
+            // so that the button is explicit on its own, we add a description that doesn't
+            // rely on the text coming from the CMS
+            // eslint-disable-next-line jsx-a11y/aria-props
+            aria-description={intl.formatMessage(messages.callToActionDescription, {
+              product: product.title,
+            })}
+            disabled={!hasAtLeastOneCourseRun}
+          >
+            {product.call_to_action}
+          </button>
+          {!hasAtLeastOneCourseRun && (
+            <p className="product-item__no-course-run">
+              <FormattedMessage {...messages.noCourseRunToPurchase} />
+            </p>
+          )}
+        </>
+      )}
+      <SaleTunnel
+        isOpen={isSaleTunnelOpen}
+        product={product}
+        onClose={() => setIsSaleTunnelOpen(false)}
+      />
+    </>
+  );
+};
+
+export default PurchaseButton;

--- a/src/frontend/js/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.spec.tsx
@@ -290,8 +290,8 @@ describe('CourseProductItem', () => {
     await waitForElementToBeRemoved(loadingMessage);
     await screen.findByRole('heading', { level: 3, name: product.title });
 
-    // - In place of product price, a label "Enrolled" should be displayed
-    const $enrolledInfo = await screen.findByText('Enrolled');
+    // - In place of product price, a label "Pending" should be displayed
+    const $enrolledInfo = await screen.findByText('Pending');
     expect($enrolledInfo.tagName).toBe('STRONG');
     expect($enrolledInfo.classList.contains('h6')).toBe(true);
 

--- a/src/frontend/js/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.spec.tsx
@@ -31,11 +31,6 @@ jest.mock('utils/context', () => ({
   }).generate(),
 }));
 
-jest.mock('components/SaleTunnel', () => ({
-  __esModule: true,
-  default: () => <div data-testid="SaleTunnel" />,
-}));
-
 jest.mock('components/CourseProductCertificateItem', () => ({
   __esModule: true,
   default: () => <div data-testid="CertificateItem" />,
@@ -63,6 +58,13 @@ describe('CourseProductItem', () => {
       currency,
       style: 'currency',
     }).format(price);
+
+  beforeAll(() => {
+    // As dialog is rendered through a Portal, we have to add the DOM element in which the dialog will be rendered.
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
 
   beforeEach(() => {
     fetchMock.get('https://joanie.test/api/v1.0/addresses/', []);
@@ -129,8 +131,10 @@ describe('CourseProductItem', () => {
     // - Render <CertificateItem />
     screen.getByTestId('CertificateItem');
 
-    // - Render <SaleTunnel />
-    screen.getByTestId('SaleTunnel');
+    // - Render a login button
+    screen.getByRole('button', { name: `Login to purchase "${product.title}"` });
+    // - Does not render PurchaseButton cta
+    expect(screen.queryByTestId('PurchaseButton__cta')).toBeNull();
   });
 
   it('does not render <CertificateItem /> if product do not have a certificate', async () => {
@@ -199,8 +203,8 @@ describe('CourseProductItem', () => {
     // - Render <CertificateItem />
     screen.getByTestId('CertificateItem');
 
-    // - Does not Render <SaleTunnel />
-    expect(screen.queryByTestId('SaleTunnel')).toBeNull();
+    // - Does not Render PurchaseButton cta
+    expect(screen.queryByTestId('PurchaseButton__cta')).toBeNull();
   });
 
   it('renders enrollment information when user is enrolled to a course run', async () => {
@@ -307,8 +311,8 @@ describe('CourseProductItem', () => {
     // - Render <CertificateItem />
     screen.getByTestId('CertificateItem');
 
-    // - Does not Render <SaleTunnel />
-    expect(screen.queryByTestId('SaleTunnel')).toBeNull();
+    // - Does not Render PurchaseButton cta
+    expect(screen.queryByTestId('PurchaseButton__cta')).toBeNull();
   });
 
   it('renders error message when product fetching has failed', async () => {

--- a/src/frontend/js/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.tsx
@@ -2,7 +2,6 @@ import { Children, useMemo } from 'react';
 import { defineMessages, FormattedMessage, FormattedNumber } from 'react-intl';
 import { CourseProductProvider } from 'data/CourseProductProvider';
 import CertificateItem from 'components/CourseProductCertificateItem';
-import SaleTunnel from 'components/SaleTunnel';
 import type * as Joanie from 'types/Joanie';
 import { useProduct } from 'hooks/useProduct';
 import { Spinner } from 'components/Spinner';
@@ -10,6 +9,7 @@ import { useOrders } from 'hooks/useOrders';
 import { OrderState } from 'types/Joanie';
 import { Icon } from 'components/Icon';
 import CourseRunItem from './CourseRunItem';
+import PurchaseButton from './PurchaseButton';
 
 const messages = defineMessages({
   enrolled: {
@@ -43,7 +43,8 @@ const CourseProductItem = ({ productId, courseCode }: Props) => {
     () => ordersQuery.items.find(({ state }) => state === OrderState.VALIDATED),
     [ordersQuery.items],
   );
-  const isOwned = useMemo(() => ordersQuery.items?.length > 0, [ordersQuery.items]);
+
+  const hasPurchased = useMemo(() => ordersQuery.items?.length > 0, [ordersQuery.items]);
 
   const targetCourses = useMemo(() => {
     if (order) {
@@ -83,9 +84,8 @@ const CourseProductItem = ({ productId, courseCode }: Props) => {
             <header className="product-widget__header">
               <h3 className="product-widget__title">{product.title}</h3>
               <strong className="product-widget__price h6">
-                {isOwned ? (
-                  <FormattedMessage {...messages.enrolled} />
-                ) : (
+                {order && <FormattedMessage {...messages.enrolled} />}
+                {!hasPurchased && (
                   <FormattedNumber
                     currency={product.price_currency}
                     value={product.price}
@@ -104,17 +104,9 @@ const CourseProductItem = ({ productId, courseCode }: Props) => {
                 <CertificateItem certificate={product.certificate} order={order} />
               )}
             </ol>
-            {!isOwned && (
-              <footer className="product-widget__footer">
-                <SaleTunnel
-                  product={product}
-                  onSuccess={() => {
-                    productQuery.methods.refetch();
-                    ordersQuery.methods.refetch();
-                  }}
-                />
-              </footer>
-            )}
+            <footer className="product-widget__footer">
+              <PurchaseButton product={product} disabled={hasPurchased} />
+            </footer>
           </>
         )}
       </section>

--- a/src/frontend/js/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/components/CourseProductItem/index.tsx
@@ -17,6 +17,12 @@ const messages = defineMessages({
     description: 'Message displayed when authenticated user owned the product',
     id: 'components.CourseProductItem.enrolled',
   },
+  pending: {
+    defaultMessage: 'Pending',
+    description:
+      'Message displayed when authenticated user has purchased the product but order is still pending',
+    id: 'components.CourseProductItem.pending',
+  },
   loading: {
     defaultMessage: 'Loading product information...',
     description:
@@ -85,6 +91,7 @@ const CourseProductItem = ({ productId, courseCode }: Props) => {
               <h3 className="product-widget__title">{product.title}</h3>
               <strong className="product-widget__price h6">
                 {order && <FormattedMessage {...messages.enrolled} />}
+                {hasPurchased && !order && <FormattedMessage {...messages.pending} />}
                 {!hasPurchased && (
                   <FormattedNumber
                     currency={product.price_currency}


### PR DESCRIPTION
## Purpose

Currently, SaleTunnel component manages at same time the button to open the
payment modal and the modal itself that is too much complicated. So we decide to
extract <PurchaseButton /> from <SaleTunnel />

Then in some case, user can have an order in a pending state for a product. In order
to prevent user to open sale tunnel in this case we do not show the purchase
button. But the label currently display show "Enrolled" that is unclear. In
order to improve user understanding, we decide to display "Pending" label in
place of the current "Enrolled" label in this case.


## Proposal

- [x] Extract PurchaseButton from SaleTunnel
- [x] Display "Pending" label when user has purchased a product but its order is pending
