### PR TITLE
✨(frontend) CourseRunEnrollment - CourseRun managed by Joanie 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added DashboardItemOrder that allows to select course runs
 - Add make dbshell cmd to access database in cli
+- Added support for courses-run managed by Joanie
 
 ### Fixed
 

--- a/src/frontend/js/components/CourseRunEnrollment/_styles.scss
+++ b/src/frontend/js/components/CourseRunEnrollment/_styles.scss
@@ -15,6 +15,7 @@
   }
 }
 
+.course-run-unenrollment,
 .course-run-enrollment {
   &__cta {
     width: 100%;
@@ -56,4 +57,12 @@
     margin-top: 0.25rem;
     text-align: center;
   }
+}
+
+.course-run-unenrollment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.25rem;
+  font-size: 1rem;
 }

--- a/src/frontend/js/components/CourseRunEnrollment/index.openedx.spec.tsx
+++ b/src/frontend/js/components/CourseRunEnrollment/index.openedx.spec.tsx
@@ -1,0 +1,272 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from 'react-intl';
+
+import { CourseRun } from 'types';
+import { Deferred } from 'utils/test/deferred';
+import * as mockFactories from 'utils/test/factories';
+import { UserFactory } from 'utils/test/factories';
+import { handle } from 'utils/errors/handle';
+import context from 'utils/context';
+import { SessionProvider } from 'data/SessionProvider';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { User } from 'types/User';
+import CourseRunEnrollment from './index';
+
+jest.mock('utils/errors/handle');
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockFactories
+    .ContextFactory({
+      authentication: {
+        endpoint: 'https://demo.endpoint',
+        backend: 'openedx-hawthorn',
+      },
+      lms_backends: [
+        {
+          backend: 'openedx-hawthorn',
+          course_regexp: '(https://openedx.endpoint.*)',
+          endpoint: 'https://demo.endpoint',
+        },
+      ],
+    })
+    .generate(),
+}));
+
+const mockHandle = handle as jest.MockedFunction<typeof handle>;
+
+describe('<CourseRunEnrollment />', () => {
+  const endpoint = 'https://demo.endpoint';
+
+  const getCourseRunProp = (courseRun: CourseRun) => ({
+    id: courseRun.id,
+    resource_link: courseRun.resource_link,
+    priority: courseRun.state.priority,
+    starts_in_message: courseRun.starts_in_message,
+    dashboard_link: courseRun.dashboard_link,
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    sessionStorage.clear();
+    fetchMock
+      .get('https://joanie.endpoint/api/v1.0/addresses/', [])
+      .get('https://joanie.endpoint/api/v1.0/credit-cards/', [])
+      .get('https://joanie.endpoint/api/v1.0/orders/', []);
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('shows an "Enroll" button and allows the user to enroll', async () => {
+    const user: User = UserFactory.generate();
+    const courseRun: CourseRun = mockFactories.CourseRunFactory.generate();
+    courseRun.state.priority = 0;
+    courseRun.resource_link = 'https://openedx.endpoint' + courseRun.resource_link;
+
+    const enrollmentsDeferred = new Deferred();
+    fetchMock.get(
+      `${endpoint}/api/enrollment/v1/enrollment/${user.username},${courseRun.resource_link}`,
+      enrollmentsDeferred.promise,
+    );
+
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createTestQueryClient({ user })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={context} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+    screen.getByRole('status', { name: 'Loading enrollment information...' });
+
+    await act(async () => {
+      enrollmentsDeferred.resolve({});
+    });
+
+    const button = await screen.findByRole('button', { name: 'Enroll now' });
+
+    const enrollActionDeferred = new Deferred();
+    fetchMock.post(`${endpoint}/api/enrollment/v1/enrollment`, enrollActionDeferred.promise);
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute('aria-busy', 'true');
+
+    await act(async () => {
+      enrollActionDeferred.resolve({ is_active: true });
+    });
+
+    screen.getByRole('link', { name: 'Go to course' });
+    screen.getByText('You are enrolled in this course run');
+  });
+
+  it('shows an error message and the enrollment button when the enrollment fails', async () => {
+    const user: User = UserFactory.generate();
+    const courseRun: CourseRun = mockFactories.CourseRunFactory.generate();
+    courseRun.state.priority = 0;
+    courseRun.resource_link = 'https://openedx.endpoint' + courseRun.resource_link;
+
+    const enrollmentDeferred = new Deferred();
+    fetchMock.get(
+      `${endpoint}/api/enrollment/v1/enrollment/${user.username},${courseRun.resource_link}`,
+      enrollmentDeferred.promise,
+    );
+
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createTestQueryClient({ user })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={context} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    screen.getByRole('status', { name: 'Loading enrollment information...' });
+
+    await act(async () => {
+      enrollmentDeferred.resolve({});
+    });
+
+    const button = await screen.findByRole('button', { name: 'Enroll now' });
+
+    // const enrollmentAction = new Deferred();
+    fetchMock.post(`${endpoint}/api/enrollment/v1/enrollment`, 500);
+
+    await act(async () => {
+      expect(() => fireEvent.click(button)).not.toThrow();
+      // enrollmentAction.reject('500 - Internal Server Error');
+    });
+
+    screen.getByRole('button', { name: 'Enroll now' });
+    screen.getByText('Your enrollment request failed.');
+    expect(mockHandle).toHaveBeenCalledWith(
+      new Error('[SET - Enrollment] > 500 - Internal Server Error'),
+    );
+  });
+
+  it('shows a link to the course if the user is already enrolled', async () => {
+    const user: User = UserFactory.generate();
+    const courseRun: CourseRun = mockFactories.CourseRunFactory.generate();
+    courseRun.resource_link = 'https://openedx.endpoint' + courseRun.resource_link;
+    courseRun.state.priority = 0;
+
+    const enrollmentsDeferred = new Deferred();
+    fetchMock.get(
+      `${endpoint}/api/enrollment/v1/enrollment/${user.username},${courseRun.resource_link}`,
+      enrollmentsDeferred.promise,
+    );
+
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createTestQueryClient({ user })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={context} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    screen.getByRole('status', { name: 'Loading enrollment information...' });
+
+    await act(async () => {
+      enrollmentsDeferred.resolve({ is_active: true });
+    });
+
+    await screen.findByRole('link', { name: 'Go to course' });
+    screen.getByText('You are enrolled in this course run');
+  });
+
+  it("shows remaining course opening time and a link to the lms dashboard if the user is already enrolled and if the course hasn't started yet", async () => {
+    const user: User = UserFactory.generate();
+    const courseRun: CourseRun = mockFactories.CourseRunFactory.generate();
+    courseRun.state.priority = 0;
+    courseRun.resource_link = 'https://openedx.endpoint' + courseRun.resource_link;
+    courseRun.starts_in_message = 'The course will start in 3 days';
+    courseRun.dashboard_link = 'https://edx.local.dev:8073/dashboard';
+
+    const enrollmentsDeferred = new Deferred();
+    fetchMock.get(
+      `${endpoint}/api/enrollment/v1/enrollment/${user.username},${courseRun.resource_link}`,
+      enrollmentsDeferred.promise,
+    );
+
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createTestQueryClient({ user })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={context} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    screen.getByRole('status', { name: 'Loading enrollment information...' });
+
+    await act(async () => {
+      enrollmentsDeferred.resolve({ is_active: true });
+    });
+
+    expect(screen.queryByRole('link', { name: 'Go to course' })).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByText('You are enrolled in this course run')).toHaveAttribute(
+        'href',
+        'https://edx.local.dev:8073/dashboard',
+      ),
+    );
+    screen.getByText('The course will start in 3 days');
+  });
+
+  it('shows a helpful message if the course run is closed', async () => {
+    const courseRun: CourseRun = mockFactories.CourseRunFactory.generate();
+    courseRun.resource_link = 'https://openedx.endpoint' + courseRun.resource_link;
+    courseRun.state.priority = 4;
+
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createTestQueryClient({ user: null })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={context} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    screen.getByText('Enrollment in this course run is closed at the moment');
+    expect(screen.queryByRole('button', { name: 'Enroll now' })).toBeNull();
+  });
+
+  it('prompts anonymous users to log in', async () => {
+    const courseRun: CourseRun = mockFactories.CourseRunFactory.generate();
+    courseRun.resource_link = 'https://openedx.endpoint' + courseRun.resource_link;
+    courseRun.state.priority = 0;
+
+    await act(async () => {
+      render(
+        <QueryClientProvider client={createTestQueryClient({ user: null })}>
+          <IntlProvider locale="en">
+            <SessionProvider>
+              <CourseRunEnrollment context={context} courseRun={getCourseRunProp(courseRun)} />
+            </SessionProvider>
+          </IntlProvider>
+        </QueryClientProvider>,
+      );
+    });
+
+    screen.getByRole('button', { name: 'Log in to enroll' });
+  });
+});

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -48,7 +48,15 @@ export interface APIAuthentication {
 export interface APIEnrollment {
   get(url: string, user: Nullable<User>): Promise<Nullable<Enrollment>>;
   isEnrolled(enrollment: Maybe<Nullable<Enrollment>>): Promise<Maybe<boolean>>;
-  set(url: string, user: User): Promise<boolean>;
+  set(
+    url: string,
+    user: User,
+    enrollment?: Maybe<Nullable<Enrollment>>,
+    isActive?: boolean,
+  ): Promise<boolean>;
+  meta?: {
+    canUnenroll?: boolean;
+  };
 }
 
 export interface APILms {

--- a/src/frontend/js/utils/api/configuration.ts
+++ b/src/frontend/js/utils/api/configuration.ts
@@ -1,0 +1,9 @@
+import context from 'utils/context';
+import { Maybe } from 'types/utils';
+import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
+
+const LMS_BACKENDS = context.lms_backends || [];
+
+export const findLmsBackend = (url: string): Maybe<AuthenticationBackend | LMSBackend> => {
+  return LMS_BACKENDS.find((lms) => new RegExp(lms.course_regexp).test(url));
+};

--- a/src/frontend/js/utils/api/enrollment.ts
+++ b/src/frontend/js/utils/api/enrollment.ts
@@ -1,22 +1,17 @@
-import { User } from 'types/User';
-import { Enrollment } from 'types';
-import { Maybe, Nullable } from 'types/utils';
+import { APIBackend, APILms } from 'types/api';
 import APIHandler from './lms';
+import JoanieEnrollmentApiInterface from './lms/joanie';
+import { findLmsBackend } from './configuration';
 
-const EnrollmentApi = (resourceLink: string) => {
+const EnrollmentApi = (resourceLink: string): APILms['enrollment'] => {
+  const apiConf = findLmsBackend(resourceLink);
+
+  if (apiConf?.backend === APIBackend.JOANIE) {
+    return JoanieEnrollmentApiInterface(apiConf);
+  }
+
   const LMS = APIHandler(resourceLink);
-
-  return {
-    get: async (user: Nullable<User>) => {
-      return LMS.enrollment.get(resourceLink, user);
-    },
-    isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) => {
-      return LMS.enrollment.isEnrolled(enrollment);
-    },
-    set: async (user: User) => {
-      return LMS.enrollment.set(resourceLink, user);
-    },
-  };
+  return LMS.enrollment;
 };
 
 export default EnrollmentApi;

--- a/src/frontend/js/utils/api/joanie.ts
+++ b/src/frontend/js/utils/api/joanie.ts
@@ -43,6 +43,7 @@ export function checkStatus(
     }
     return response.text();
   }
+
   if (options.ignoredErrorStatus.includes(response.status)) {
     return Promise.resolve(options.fallbackValue);
   }

--- a/src/frontend/js/utils/api/lms/index.ts
+++ b/src/frontend/js/utils/api/lms/index.ts
@@ -1,19 +1,13 @@
 import { handle } from 'utils/errors/handle';
-import context from 'utils/context';
 import { APIBackend, APILms } from 'types/api';
+
+import { findLmsBackend } from '../configuration';
 import DummyApiInterface from './dummy';
 import OpenEdxDogwoodApiInterface from './openedx-dogwood';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
 
-const LMS_BACKENDS = context.lms_backends || [];
-
-const selectAPIWithUrl = (url: string) => {
-  const API = LMS_BACKENDS.find((lms) => new RegExp(lms.course_regexp).test(url));
-  return API;
-};
-
 const LmsAPIHandler = (url: string): APILms => {
-  const api = selectAPIWithUrl(url);
+  const api = findLmsBackend(url);
 
   switch (api?.backend) {
     case APIBackend.DUMMY:

--- a/src/frontend/js/utils/api/lms/joanie.ts
+++ b/src/frontend/js/utils/api/lms/joanie.ts
@@ -1,0 +1,88 @@
+import JoanieApi from 'utils/api/joanie';
+import { AuthenticationBackend, LMSBackend } from '../../../types/commonDataProps';
+import { APILms } from '../../../types/api';
+
+import { Maybe, Nullable } from '../../../types/utils';
+import { User } from '../../../types/User';
+import * as Joanie from '../../../types/Joanie';
+import { Enrollment } from '../../../types/Joanie';
+
+const JoanieEnrollmentApiInterface = (
+  APIConf: AuthenticationBackend | LMSBackend,
+): APILms['enrollment'] => {
+  const joanieAPI: Joanie.API = JoanieApi();
+
+  const extractCourseRunIdFromUrl = (url: string): Maybe<Nullable<string>> => {
+    const matches = url.match((APIConf as LMSBackend).course_regexp);
+    return matches && matches[2] ? matches[2] : null;
+  };
+  return {
+    get(url: string) {
+      return new Promise((resolve, reject) => {
+        const courseRunId = extractCourseRunIdFromUrl(url);
+        joanieAPI.user.enrollments
+          .get<{ id?: string; course_run: string }>({ course_run: courseRunId as string })
+          .then((res) => {
+            if (res.count > 0) {
+              resolve(res.results[0]);
+            } else {
+              resolve(null);
+            }
+          })
+          .catch((error) => {
+            reject(error);
+          });
+      });
+    },
+    async set(
+      url: string,
+      user: User,
+      enrollment: Maybe<Nullable<Enrollment>>,
+      isActive = true,
+    ): Promise<boolean> {
+      const courseRunId = extractCourseRunIdFromUrl(url);
+      if (!courseRunId) {
+        return new Promise((resolve) => resolve(false));
+      }
+
+      return new Promise((resolve, reject) => {
+        if (!enrollment) {
+          joanieAPI.user.enrollments
+            .create({
+              course_run: courseRunId,
+              is_active: true,
+              was_created_by_order: false,
+            })
+            .then(() => {
+              resolve(isActive);
+            })
+            .catch(() => {
+              reject();
+            });
+        } else {
+          joanieAPI.user.enrollments
+            .update({
+              course_run: courseRunId,
+              id: enrollment.id,
+              is_active: isActive,
+              was_created_by_order: false,
+            })
+            .then(() => {
+              resolve(isActive);
+            })
+            .catch(() => {
+              reject();
+            });
+        }
+      });
+    },
+    isEnrolled(enrollment: Maybe<Nullable<Enrollment>>): Promise<Maybe<boolean>> {
+      return new Promise((resolve) => resolve(!!enrollment?.is_active));
+    },
+    meta: {
+      canUnenroll: true,
+    },
+  };
+};
+
+export default JoanieEnrollmentApiInterface;

--- a/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
+++ b/src/frontend/js/utils/api/lms/openedx-hawthorn.ts
@@ -73,7 +73,6 @@ const API = (APIConf: AuthenticationBackend | LMSBackend, options?: APIOptions):
       get: async (url: string, user: Nullable<User>) => {
         const courseId = extractCourseIdFromUrl(url);
         const params = user ? `${user.username},${courseId}` : courseId;
-
         return fetch(`${ROUTES.enrollment.get}/${params}`, {
           credentials: 'include',
         }).then((response) => {


### PR DESCRIPTION
## Purpose

Since #1815, Richie is able to match course runs and products managed by Joanie. But in the case of a Joanie Course Run is matched, the EnrollmentAPI interface is not able to return an interface to enroll user through the Joanie API.


## Proposal

EnrollmentAPI should be able to match joanie course run resource_link then returns to the right api to manage enrollment on Joanie.
