### PR TITLE
🐛(courses) fix course runs sync api when course has a snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added DashboardItemOrder that allows to select course runs
 - Add make dbshell cmd to access database in cli
 
+### Fixed
+
+- Prevent internal server error when course runs sync webhook targets
+  a course page having a snapshot
+
 ## [2.19.0]
 
 ### Added

--- a/src/richie/apps/courses/api.py
+++ b/src/richie/apps/courses/api.py
@@ -161,7 +161,10 @@ def sync_course_run(data):
     course_code = normalize_code(lms.extract_course_code(data))
     try:
         course = Course.objects.get(
-            code=course_code, extended_object__publisher_is_draft=True
+            code=course_code,
+            extended_object__publisher_is_draft=True,
+            # Exclude snapshots
+            extended_object__node__parent__cms_pages__course__isnull=True,
         )
     except Course.DoesNotExist as exc:
         # Create the course page in draft

--- a/tests/apps/courses/test_api_course_run_sync.py
+++ b/tests/apps/courses/test_api_course_run_sync.py
@@ -1208,3 +1208,53 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         public_course_run = CourseRun.objects.get(direct_course=course.public_extension)
         public_serializer = SyncCourseRunSerializer(instance=public_course_run)
         self.assertEqual(public_serializer.data, data[1])
+
+    def test_api_course_run_sync_create_course_run_on_course_page_with_snapshot(
+        self, mock_signal
+    ):
+        """
+        When a course run is created on a course page that has a snapshot, the course
+        run should be created successfully.
+        """
+        course = CourseFactory(code="DemoX", should_publish=False)
+
+        # Create a snapshot
+        snapshot = CourseFactory(
+            code="DemoX", page_parent=course.extended_object, should_publish=False
+        )
+        self.assertEqual(snapshot.is_snapshot, True)
+
+        # Two courses with the same code should be created
+        courses = Course.objects.filter(
+            code="DEMOX", extended_object__publisher_is_draft=True
+        )
+        self.assertEqual(courses.count(), 2)
+        self.assertEqual(CourseRun.objects.count(), 0)
+
+        data = {
+            "resource_link": "http://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+            "languages": ["en", "fr"],
+            "enrollment_count": 46782,
+            "catalog_visibility": "course_and_search",
+        }
+
+        mock_signal.reset_mock()
+
+        authorization = (
+            "SIG-HMAC-SHA256 "
+            "5bdfb326b35fccaef9961e03cf617c359c86ffbb6c64e0f7e074aa011e8af9d6"
+        )
+        response = self.client.post(
+            "/api/v1.0/course-runs-sync",
+            data,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=authorization,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(CourseRun.objects.count(), 1)


### PR DESCRIPTION
## Purpose

Currently, the `sync_course_run` method raises a `MultipleReturnedObject` exception when trying to retrieve a Course which has snaphots.

## Proposal

- [x] Exclude snapshots from Course queryset.
