### PR TITLE
✨(backend) implement feature flags from .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add make dbshell cmd to access database in cli
 - Added support for courses-run managed by Joanie
 - Display message to user when product course it is enrolled is not yet started
+- Add feature flags system with settings and template tag.
 
 ### Fixed
 

--- a/env.d/development/dev-ssl.dist
+++ b/env.d/development/dev-ssl.dist
@@ -4,3 +4,6 @@ AUTHENTICATION_BACKEND=openedx-hawthorn
 
 # LMS Backend
 EDX_BASE_URL=https://edx.local.dev:8073
+
+# Features
+FEATURES = {'JOANIE_WISHLIST': True}

--- a/env.d/development/dev.dist
+++ b/env.d/development/dev.dist
@@ -6,3 +6,6 @@ AUTHENTICATION_BACKEND=dummy
 EDX_BASE_URL=http://localhost:8073
 EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
 EDX_JS_BACKEND=dummy
+
+# Features
+FEATURES = {'JOANIE_WISHLIST': True}

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -578,6 +578,9 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         environ_prefix=None,
     )
 
+    # Feature flags
+    FEATURES = values.DictValue(environ_name="FEATURES", environ_prefix=None)
+
     @classmethod
     def _get_environment(cls):
         """Environment in which the application is launched."""

--- a/src/richie/apps/core/templatetags/feature_flags.py
+++ b/src/richie/apps/core/templatetags/feature_flags.py
@@ -1,0 +1,15 @@
+"""Custom template tags related to FEATURES settings."""
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+
+@register.simple_tag()
+def is_feature_enabled(flag):
+    """
+    template tag to know if a feature flag is enable / disable
+    """
+    if hasattr(settings, "FEATURES"):
+        return settings.FEATURES.get(flag, False)
+    return False

--- a/tests/apps/core/test_templatetags_feature_flags.py
+++ b/tests/apps/core/test_templatetags_feature_flags.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for the template tags related to FeatureFlags.
+"""
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from richie.apps.core.templatetags.feature_flags import is_feature_enabled
+
+
+class FeatureFlagsTemplateTagsTestCase(TestCase):
+    """
+    Unit test suite to validate the behavior of the `is_feature_enabled` template tags
+    """
+
+    @override_settings(
+        FEATURES={
+            "TEST_FEATURE": True,
+        }
+    )
+    def test_templatetags_is_feature_enabled_true(self):
+        """
+        is_feature_enabled should return True if
+        an feature flags is set to True in settings.
+        """
+        self.assertTrue(is_feature_enabled("TEST_FEATURE"))
+
+    @override_settings(
+        FEATURES={
+            "TEST_FEATURE": False,
+        }
+    )
+    def test_templatetags_is_feature_enabled_false(self):
+        """
+        is_feature_enabled should return False if
+        an feature flags is set to False in settings.
+        """
+        self.assertFalse(is_feature_enabled("TEST_FEATURE"))
+
+    @override_settings(FEATURES={})
+    def test_templatetags_is_feature_enabled_missing(self):
+        """
+        is_feature_enabled should return False if
+        an feature flags is missing in settings.
+        """
+        self.assertFalse(is_feature_enabled("TEST_FEATURE"))
+
+    def test_templatetags_settings_features_unset(self):
+        """
+        is_feature_enabled should return False if FEATURES
+        is not defined in settings.
+        """
+        self.assertFalse(is_feature_enabled("TEST_FEATURE"))


### PR DESCRIPTION
## Purpose

We need to activate / disable some features during development.
This will let us push partial features (only front,only back for example).

## Proposal

* configure feature flag in .env files with the prefix: "FEATURE_".
* add this flag in settings.py
* either use `settings.get('FEATURE_{MY_FEATURE}')` in python or use `{ feature_flags.feature 'MY_FEATURE' }` in jinja templates

## Improvement

I tried like to use a dict in .env file but i didn't find how to do it.
The idea is to set `settings.FEATURES` only once instead of editing `settings.py` each time we wanna add/remove a flag.