### PR TITLE
🐛(frontend) fix enrollment not started test for CourseProductCourseRuns

### DIFF
--- a/src/frontend/js/components/CourseProductCourseRuns/index.spec.tsx
+++ b/src/frontend/js/components/CourseProductCourseRuns/index.spec.tsx
@@ -547,10 +547,11 @@ describe('CourseProductCourseRuns', () => {
       const today = new Date();
       const startDate = new Date(enrollment.course_run.start);
       const endDate = new Date(enrollment.course_run.end);
-      startDate.setMonth(today.getMonth() + 2);
+
+      startDate.setDate(today.getDate());
+      // keep this before setMonth If the month of today is >= November
       startDate.setFullYear(today.getFullYear());
-      endDate.setMonth(today.getMonth() + 4);
-      endDate.setFullYear(today.getFullYear());
+      startDate.setMonth(today.getMonth() + 2);
 
       const newEnrollment = {
         ...enrollment,


### PR DESCRIPTION
## Purpose
The test passes randomly because of the random generation of the course_run

## Proposal
- [x] set the start date day to the today day

