### PR TITLE
💄(frontend) fix style bug on course glimpse when used in a section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix a style bug on the course glimpse when used in a section
+  with variant overriding svg color
+
 ## [2.20.0] - 2023-02-17
 
 ### Added

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -228,6 +228,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     }
 
     .icon {
+      fill: currentColor;
       margin-bottom: 0.15rem;
       margin-right: 0.5rem;
     }


### PR DESCRIPTION
## Purpose

In some cases, section variant can enforce the svg fill color of its children. That leads to a conflict with the course glimpses when they are used within this kind of section as organization and reference icons fill color are overriden.

<p>
<img height="384" alt="before" src="https://user-images.githubusercontent.com/9265241/220581089-26fbdb82-af71-4bd3-bc54-829ada4d8210.png">
<img height="384" alt="after" src="https://user-images.githubusercontent.com/9265241/220581108-24863904-b43e-4b75-9708-65ee01d9641a.png">
</p>

## Proposal

- [x] Enforce fill color of metadata icons within course glimpse
