### PR TITLE
💄(form) add * on select, checkbox and radio inputs when required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix form styles to suffix input label with "*" when a select,
+  radio or checkbox input is required
 - Button can be use with a className prop
 
 ## [2.20.1] - 2023-02-22

--- a/src/frontend/js/components/AddressesManagement/AddressForm.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm.tsx
@@ -59,7 +59,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
       </p>
       <TextField
         aria-invalid={!!formState.errors.title}
-        aria-required={true}
+        required
         id="title"
         label={intl.formatMessage(messages.titleInputLabel)}
         error={!!formState.errors.title}
@@ -69,7 +69,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
       <div className="form-group">
         <TextField
           aria-invalid={!!formState.errors.first_name}
-          aria-required={true}
+          required
           id="first_name"
           label={intl.formatMessage(messages.first_nameInputLabel)}
           error={!!formState.errors.first_name}
@@ -78,7 +78,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
         />
         <TextField
           aria-invalid={!!formState.errors.last_name}
-          aria-required={true}
+          required
           id="last_name"
           label={intl.formatMessage(messages.last_nameInputLabel)}
           error={!!formState.errors.last_name}
@@ -88,7 +88,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
       </div>
       <TextField
         aria-invalid={!!formState.errors.address}
-        aria-required={true}
+        required
         id="address"
         label={intl.formatMessage(messages.addressInputLabel)}
         error={!!formState.errors.address}
@@ -98,7 +98,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
       <div className="form-group">
         <TextField
           aria-invalid={!!formState.errors.postcode}
-          aria-required={true}
+          required
           id="postcode"
           label={intl.formatMessage(messages.postcodeInputLabel)}
           error={!!formState.errors.postcode}
@@ -107,7 +107,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
         />
         <TextField
           aria-invalid={!!formState.errors.city}
-          aria-required={true}
+          required
           id="city"
           label={intl.formatMessage(messages.cityInputLabel)}
           error={!!formState.errors.city}
@@ -117,7 +117,7 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
       </div>
       <CountrySelectField
         aria-invalid={!!formState.errors.country}
-        aria-required={false}
+        required
         id="country"
         label={intl.formatMessage(messages.countryInputLabel)}
         error={!!formState.errors.country}
@@ -127,7 +127,6 @@ const AddressForm = ({ handleReset, onSubmit, address }: Props) => {
       {!address ? (
         <CheckboxField
           aria-invalid={!!formState.errors?.save}
-          aria-required={false}
           id="save"
           label={intl.formatMessage(messages.saveInputLabel)}
           error={!!formState.errors?.save}

--- a/src/frontend/js/components/DashboardCreditCardsManagement/DashboardEditCreditCard.tsx
+++ b/src/frontend/js/components/DashboardCreditCardsManagement/DashboardEditCreditCard.tsx
@@ -144,7 +144,6 @@ export const DashboardEditCreditCard = ({ creditCard, onSettled = noop }: Props)
         {!creditCard.is_main && (
           <CheckboxField
             aria-invalid={!!formState.errors?.is_main}
-            aria-required={false}
             id="is_main"
             label={intl.formatMessage(messages.isMainInputLabel)}
             error={!!formState.errors?.is_main}

--- a/src/frontend/js/components/Form/Field.stories.tsx
+++ b/src/frontend/js/components/Form/Field.stories.tsx
@@ -6,13 +6,16 @@ export const defaultConfig = {
     id: 'id',
   },
   argTypes: {
+    disabled: {
+      control: 'boolean',
+    },
     error: {
       control: 'boolean',
     },
     message: {
       control: 'text',
     },
-    disabled: {
+    required: {
       control: 'boolean',
     },
   },

--- a/src/frontend/js/components/Form/Inputs.tsx
+++ b/src/frontend/js/components/Form/Inputs.tsx
@@ -14,6 +14,7 @@ interface FieldProps {
   error?: Boolean;
   message?: ReactNode | string;
   fieldClasses?: string[];
+  required?: boolean;
 }
 
 // - Field
@@ -22,6 +23,7 @@ const Field = ({
   inputId,
   error,
   message,
+  required = false,
   children,
 }: React.PropsWithChildren<FieldProps>) => {
   const classList = useMemo(() => {
@@ -29,8 +31,11 @@ const Field = ({
     if (error) {
       classes.push('form-field--error');
     }
+    if (required) {
+      classes.push('form-field--required');
+    }
     return classes.join(' ');
-  }, [fieldClasses, error]);
+  }, [fieldClasses, required, error]);
 
   const iconHref = error ? '#icon-warning' : '#icon-info-rounded';
 
@@ -78,14 +83,21 @@ interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputElement>, Fi
  */
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
-  ({ fieldClasses = [], label, id, type = 'text', error, message, ...props }, ref) => (
-    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
+  ({ fieldClasses = [], label, id, type = 'text', error, message, required, ...props }, ref) => (
+    <Field
+      inputId={id}
+      error={error}
+      message={message}
+      fieldClasses={fieldClasses}
+      required={required}
+    >
       <input
         className="form-field__input"
         id={id}
         placeholder={label}
         ref={ref}
         type={type}
+        required={required}
         {...props}
         {...(!!message && {
           'aria-describedby': `${id}-message`,
@@ -116,13 +128,20 @@ interface TextareaFieldProps extends React.TextareaHTMLAttributes<HTMLTextAreaEl
  * @return {HTMLTextAreaElement} HTMLTextAreaElement
  */
 export const TextareaField = forwardRef<HTMLTextAreaElement, TextareaFieldProps>(
-  ({ fieldClasses = [], error, message, label, id, ...props }, ref) => (
-    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
+  ({ fieldClasses = [], error, message, label, id, required, ...props }, ref) => (
+    <Field
+      inputId={id}
+      error={error}
+      message={message}
+      required={required}
+      fieldClasses={fieldClasses}
+    >
       <textarea
         className="form-field__textarea"
         id={id}
         placeholder={label}
         ref={ref}
+        required={required}
         {...props}
         {...(!!message && {
           'aria-describedby': `${id}-message`,
@@ -156,8 +175,14 @@ export interface SelectFieldProps
  * @return {HTMLSelectElement} HTMLSelectElement
  */
 export const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
-  ({ fieldClasses = [], error, message, label, id, children, ...props }, ref) => (
-    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
+  ({ fieldClasses = [], error, message, label, id, required, children, ...props }, ref) => (
+    <Field
+      inputId={id}
+      error={error}
+      message={message}
+      required={required}
+      fieldClasses={fieldClasses}
+    >
       {label && (
         <label className="form-field__label" htmlFor={id}>
           {label}
@@ -168,6 +193,7 @@ export const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
           className="form-field__select-input"
           id={id}
           ref={ref}
+          required={required}
           {...props}
           {...(!!message && {
             'aria-describedby': `${id}-message`,
@@ -197,13 +223,20 @@ interface CheckboxFieldProps extends Omit<TextFieldProps, 'type'> {
  * @return {HTMLSelectElement} HTMLSelectElement
  */
 export const CheckboxField = forwardRef<HTMLInputElement, CheckboxFieldProps>(
-  ({ fieldClasses = [], error, message, label, id, ...props }, ref) => (
-    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
+  ({ fieldClasses = [], error, message, label, id, required, ...props }, ref) => (
+    <Field
+      inputId={id}
+      error={error}
+      message={message}
+      required={required}
+      fieldClasses={fieldClasses}
+    >
       <input
         className="form-field__checkbox-input"
         id={id}
         ref={ref}
         type="checkbox"
+        required={required}
         {...props}
         {...(!!message && {
           'aria-describedby': `${id}-message`,
@@ -234,13 +267,20 @@ interface RadioFieldProps extends CheckboxFieldProps {}
  * @return {HTMLSelectElement} HTMLInputElement
  */
 export const RadioField = forwardRef<HTMLInputElement, RadioFieldProps>(
-  ({ fieldClasses = [], error, label, message, id, onClick, ...props }, ref) => (
-    <Field inputId={id} error={error} message={message} fieldClasses={fieldClasses}>
+  ({ fieldClasses = [], error, label, message, id, required, onClick, ...props }, ref) => (
+    <Field
+      inputId={id}
+      error={error}
+      message={message}
+      required={required}
+      fieldClasses={fieldClasses}
+    >
       <input
         className="form-field__radio-input"
         id={id}
         ref={ref}
         type="radio"
+        required={required}
         {...props}
         {...(!!message && {
           'aria-describedby': `${id}-message`,

--- a/src/frontend/js/hooks/useDashboardAddressForm.tsx
+++ b/src/frontend/js/hooks/useDashboardAddressForm.tsx
@@ -54,7 +54,7 @@ export const useDashboardAddressForm = (address?: Address) => {
     <form>
       <TextField
         aria-invalid={!!formState.errors.title}
-        aria-required={true}
+        required
         id="title"
         label={intl.formatMessage(managementMessages.titleInputLabel)}
         error={!!formState.errors.title}
@@ -63,7 +63,7 @@ export const useDashboardAddressForm = (address?: Address) => {
       />
       <TextField
         aria-invalid={!!formState.errors.first_name}
-        aria-required={true}
+        required
         id="first_name"
         label={intl.formatMessage(managementMessages.first_nameInputLabel)}
         error={!!formState.errors.first_name}
@@ -72,7 +72,7 @@ export const useDashboardAddressForm = (address?: Address) => {
       />
       <TextField
         aria-invalid={!!formState.errors.last_name}
-        aria-required={true}
+        required
         id="last_name"
         label={intl.formatMessage(managementMessages.last_nameInputLabel)}
         error={!!formState.errors.last_name}
@@ -81,7 +81,7 @@ export const useDashboardAddressForm = (address?: Address) => {
       />
       <TextField
         aria-invalid={!!formState.errors.address}
-        aria-required={true}
+        required
         id="address"
         label={intl.formatMessage(managementMessages.addressInputLabel)}
         error={!!formState.errors.address}
@@ -90,7 +90,7 @@ export const useDashboardAddressForm = (address?: Address) => {
       />
       <TextField
         aria-invalid={!!formState.errors.postcode}
-        aria-required={true}
+        required
         id="postcode"
         label={intl.formatMessage(managementMessages.postcodeInputLabel)}
         error={!!formState.errors.postcode}
@@ -99,7 +99,7 @@ export const useDashboardAddressForm = (address?: Address) => {
       />
       <TextField
         aria-invalid={!!formState.errors.city}
-        aria-required={true}
+        required
         id="city"
         label={intl.formatMessage(managementMessages.cityInputLabel)}
         error={!!formState.errors.city}
@@ -108,7 +108,7 @@ export const useDashboardAddressForm = (address?: Address) => {
       />
       <CountrySelectField
         aria-invalid={!!formState.errors.country}
-        aria-required={false}
+        required
         id="country"
         label={intl.formatMessage(managementMessages.countryInputLabel)}
         error={!!formState.errors.country}
@@ -118,7 +118,6 @@ export const useDashboardAddressForm = (address?: Address) => {
       {!(address && address.is_main) && (
         <CheckboxField
           aria-invalid={!!formState.errors?.is_main}
-          aria-required={false}
           id="save"
           label={intl.formatMessage(messages.isMainInputLabel)}
           error={!!formState.errors?.is_main}

--- a/src/frontend/scss/objects/_form.scss
+++ b/src/frontend/scss/objects/_form.scss
@@ -112,6 +112,7 @@
       color: r-theme-val(form, input-placeholder);
       cursor: pointer;
       margin: 0;
+      position: relative;
     }
 
     // Text inputs & Textarea
@@ -158,15 +159,6 @@
     &__textarea:focus + &__label,
     &__textarea:not(:placeholder-shown) + &__label {
       transform: scale(0.66) translateY(-0.25rem);
-    }
-
-    &__input[aria-required='true'] + &__label:after,
-    &__textarea[aria-required='true'] + &__label:after,
-    &__input:required + &__label:after,
-    &__textarea:required + &__label:after {
-      color: r-color('indianred3');
-      content: '*';
-      vertical-align: super;
     }
 
     // Checkbox & Radio
@@ -339,6 +331,14 @@
         right: 0;
         transform-origin: top right;
       }
+    }
+
+    // Required
+    &--required &__label:after {
+      color: r-theme-val(form, required-note-color);
+      content: '*';
+      position: absolute;
+      vertical-align: super;
     }
 
     // Error


### PR DESCRIPTION
## Purpose

Currently, checkbox and select labels are not suffixed by an asterisk when they are required.


## Proposal

- [x] Fix Select, Checkbox and Radio fields
- [x] Add a param `Required` into input stories
