### PR TITLE
🐛(frontend) fix Storybook preview file import

### DIFF
--- a/src/frontend/.storybook/preview.tsx
+++ b/src/frontend/.storybook/preview.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { IntlProvider } from 'react-intl';
-import { useAsyncEffect } from '../js/utils/useAsyncEffect';
 import './__mocks__/utils/context';
+import { useAsyncEffect } from 'hooks/useAsyncEffect';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },


### PR DESCRIPTION
The frontend architecture rework missed the rewrite of the Storybook preview file useAsyncEffect import causing Storybook to crash.
