### PR TITLE
🔧(cookiecutter) fix frontend build

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
@@ -23,12 +23,12 @@
     "richie-education": "2.21.0"
   },
   "devDependencies": {
-    "@formatjs/cli": "4.8.2",
-    "eslint": "8.9.0",
+    "@formatjs/cli": "6.0.4",
+    "eslint": "8.36.0",
     "eslint-import-resolver-webpack": "0.13.2",
-    "nodemon": "2.0.15",
-    "prettier": "2.5.1",
-    "sass": "1.49.8",
+    "nodemon": "2.0.22",
+    "prettier": "2.8.7",
+    "sass": "1.60.0",
     "source-map-loader": "4.0.1",
     "webpack": "5.76.3",
     "webpack-cli": "5.0.1"

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
@@ -25,8 +25,12 @@
   "devDependencies": {
     "@formatjs/cli": "4.8.2",
     "eslint": "8.9.0",
+    "eslint-import-resolver-webpack": "0.13.2",
     "nodemon": "2.0.15",
     "prettier": "2.5.1",
-    "sass": "1.49.8"
+    "sass": "1.49.8",
+    "source-map-loader": "4.0.1",
+    "webpack": "5.76.3",
+    "webpack-cli": "5.0.1"
   }
 }

--- a/src/frontend/js/widgets/CourseProductItem/components/CourseProductCourseRuns/index.spec.tsx
+++ b/src/frontend/js/widgets/CourseProductItem/components/CourseProductCourseRuns/index.spec.tsx
@@ -466,12 +466,7 @@ describe('CourseProductCourseRuns', () => {
     it('renders enrollment not started', async () => {
       const enrollment: Enrollment = JoanieEnrollmentFactory.generate();
       const today = new Date();
-      const startDate = new Date(enrollment.course_run.start);
-      const endDate = new Date(enrollment.course_run.end);
-
-      startDate.setDate(today.getDate());
-      // keep this before setMonth If the month of today is >= November
-      startDate.setFullYear(today.getFullYear());
+      const startDate = new Date();
       startDate.setMonth(today.getMonth() + 2);
 
       const newEnrollment = {
@@ -479,7 +474,6 @@ describe('CourseProductCourseRuns', () => {
         course_run: {
           ...enrollment.course_run,
           start: startDate.toISOString(),
-          end: endDate.toISOString(),
         },
       };
 

--- a/src/frontend/js/widgets/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/widgets/CourseProductItem/index.spec.tsx
@@ -110,9 +110,11 @@ describe('CourseProductItem', () => {
     await screen.findByRole('heading', { level: 3, name: product.title });
     // the price shouldn't be a heading to prevent misdirection for screen reader users,
     // but we want to it to visually look like a h6
+
     const $price = screen.getByText(
       // the price formatter generates non-breaking spaces and getByText doesn't seem to handle that well, replace it
-      priceFormatter(product.price_currency, product.price).replace(/\u00a0/g, ' '),
+      // with a regular space. We replace NNBSP (\u202F) and NBSP (\u00a0) with a regular space
+      priceFormatter(product.price_currency, product.price).replace(/(\u202F|\u00a0)/g, ' '),
     );
     expect($price.tagName).toBe('STRONG');
     expect($price.classList.contains('h6')).toBe(true);


### PR DESCRIPTION
## Purpose

Currently, the nightly round job is failing because the cookiecutter fails to install frontend deps. Indeed, previously, webpack & webpack-cli were installed implicitly by `richie-education` package all was working fine. But now, it appears we have to installed explicitly those dependencies.

https://app.circleci.com/pipelines/github/openfun/richie/6136/workflows/33dcf424-4b4b-477d-93ab-735adee1d093/jobs/171755

## Proposal

- [x] Add `webpack` & `webpack-cli` packages into the list of devDependencies into the cookiecutter frontend app.
