### PR TITLE
✨(core) add js block into head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Add head_js block into base html template
+
 ### Fixed
 
 - Fix error `MultipleObjectsReturned` during synchronization due to missing

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -60,6 +60,7 @@
         {% endif %}
         {% endspaceless %}
 
+        {% block head_js %}{% endblock head_js %}
         {% include "richie/web_analytics.html" with location='head' %}
 
         {% render_block "css" %}
@@ -268,7 +269,7 @@
             });
         </script>
         {% endif %}
-        {% include "richie/web_analytics.html" with location='footer' %}
         {% block body_js %}{% endblock body_js %}
+        {% include "richie/web_analytics.html" with location='footer' %}
     </body>
 </html>


### PR DESCRIPTION
## Purpose

We recently added the support of multiple analytic providers. After a first use, it appears it miss a block within the template to add common code to all providers. Indeed, the only block available to override web_analytics template is one rendered within the loop which iterates over all analytic providers available.


## Proposal

- [x] Add new block `web_analytics_setup` within `web_analytics.html` template