### PR TITLE
🚑️(api) fix sync error using MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix error `MultipleObjectsReturned` during synchronization due to missing
+  `distinct`.
+
 ## [2.21.1] - 2023-04-04
 
 ### Fixed

--- a/src/richie/apps/courses/api.py
+++ b/src/richie/apps/courses/api.py
@@ -160,7 +160,7 @@ def sync_course_run(data):
     # Look for the course targeted by the resource link
     course_code = normalize_code(lms.extract_course_code(data))
     try:
-        course = Course.objects.get(
+        course = Course.objects.distinct().get(
             code=course_code,
             extended_object__publisher_is_draft=True,
             # Exclude snapshots


### PR DESCRIPTION
Fix error `MultipleObjectsReturned` when synchronize course runs, when using MySQL as Richie database.
fixes #1956
