### PR TITLE
✨(front) rework order layout and add new pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Add cunningham and design system.
+- Specific sidebar for order related routes
 
 ### Changed
 

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -10,7 +10,7 @@ import { EnrollmentFactory, OrderFactory, ProductFactory } from 'utils/test/fact
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { SessionProvider } from 'contexts/SessionContext';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
-import { Enrollment, Order, Product } from 'types/Joanie';
+import { CourseLight, Enrollment, Order, Product } from 'types/Joanie';
 import { expectNoSpinner, expectSpinner } from 'utils/test/expectSpinner';
 import { expectBannerError } from 'utils/test/expectBanner';
 import { Deferred } from 'utils/test/deferred';
@@ -52,6 +52,7 @@ describe('<DashboardCourses/>', () => {
   beforeEach(() => {
     fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/orders/', []);
   });
 
   afterEach(() => {
@@ -79,7 +80,10 @@ describe('<DashboardCourses/>', () => {
       const product: Product = ProductFactory().one();
       product.id = order.product;
       fetchMock.get(
-        'https://joanie.endpoint/api/v1.0/products/' + product.id + '/?course=' + order.course,
+        'https://joanie.endpoint/api/v1.0/products/' +
+          product.id +
+          '/?course=' +
+          (order.course as CourseLight).code,
         product,
       );
 
@@ -375,7 +379,7 @@ describe('<DashboardCourses/>', () => {
     await act(async () => userEvent.click(loadMoreButton));
     await waitFor(() => expectList(entities.slice(0, 250), products), { timeout: 30000 });
     expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
-  }, 30000);
+  }, 300000);
 
   it('shows an error', async () => {
     jest.spyOn(console, 'error').mockImplementation(noop);

--- a/src/frontend/js/pages/DashboardOrderLayout/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardOrderLayout/index.spec.tsx
@@ -1,0 +1,75 @@
+import { findByRole, render, screen, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from 'react-intl';
+import fetchMock from 'fetch-mock';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { Order } from 'types/Joanie';
+import { OrderFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
+import { mockProductWithOrder } from 'utils/test/mockProductWithOrder';
+import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { SessionProvider } from 'contexts/SessionContext';
+import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
+import { expectUrlMatchLocationDisplayed } from 'utils/test/expectUrlMatchLocationDisplayed';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://demo.endpoint' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint' },
+  }).one(),
+}));
+
+describe('<DashboardOrderLayout />', () => {
+  const WrapperWithDashboard = (route: string) => {
+    return (
+      <QueryClientProvider client={createTestQueryClient({ user: true })}>
+        <IntlProvider locale="en">
+          <SessionProvider>
+            <DashboardTest initialRoute={route} />
+          </SessionProvider>
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  beforeEach(() => {
+    fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/enrollments/', []);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it('renders sidebar', async () => {
+    const order: Order = {
+      ...OrderFactory().one(),
+      target_courses: [TargetCourseFactory().one()],
+      enrollments: [],
+    };
+    const product = mockProductWithOrder(order);
+    fetchMock.get(
+      'https://joanie.endpoint/api/v1.0/orders/',
+      { results: [order], next: null, previous: null, count: null },
+      { overwriteRoutes: true },
+    );
+
+    render(WrapperWithDashboard(LearnerDashboardPaths.ORDER.replace(':orderId', order.id)));
+
+    await waitFor(() =>
+      expectUrlMatchLocationDisplayed(LearnerDashboardPaths.ORDER.replace(':orderId', order.id)),
+    );
+
+    const sidebar = screen.getByTestId('dashboard__sidebar');
+    await findByRole(sidebar, 'heading', { name: product.title });
+
+    screen.getByRole('link', {
+      name: 'General informations',
+    });
+  });
+});

--- a/src/frontend/js/pages/DashboardOrderLayout/index.tsx
+++ b/src/frontend/js/pages/DashboardOrderLayout/index.tsx
@@ -1,0 +1,50 @@
+import { Outlet, useParams } from 'react-router-dom';
+import { useIntl } from 'react-intl';
+import { useMemo } from 'react';
+import {
+  getDashboardRouteLabel,
+  getDashboardRoutePath,
+} from 'widgets/Dashboard/utils/dashboardRoutes';
+import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
+import { DashboardLayout } from 'widgets/Dashboard/components/DashboardLayout';
+import { useOrder } from 'hooks/useOrders';
+import { useProduct } from 'hooks/useProduct';
+import { useBreadcrumbsPlaceholders } from 'hooks/useBreadcrumbsPlaceholders';
+import { CourseLight, Product } from 'types/Joanie';
+import { LearnerDashboardSidebar } from 'widgets/Dashboard/components/LearnerDashboardSidebar';
+
+export const DashboardOrderLayout = () => {
+  const params = useParams<{ orderId: string }>();
+  const order = useOrder(params.orderId);
+  const course = order.item?.course as CourseLight;
+  const product = useProduct(order.item?.product, { course: course?.code });
+  const intl = useIntl();
+  const getRoutePath = getDashboardRoutePath(intl);
+  const getRouteLabel = getDashboardRouteLabel(intl);
+
+  const links = useMemo(
+    () => [
+      {
+        to: getRoutePath(LearnerDashboardPaths.ORDER, { orderId: params.orderId }),
+        label: getRouteLabel(LearnerDashboardPaths.ORDER_RUNS),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <DashboardLayout
+      sidebar={<LearnerDashboardSidebar menuLinks={links} title={product.item?.title} />}
+    >
+      <DashboardOrderLayoutContent product={product.item} />
+    </DashboardLayout>
+  );
+};
+
+const DashboardOrderLayoutContent = ({ product }: { product?: Product }) => {
+  useBreadcrumbsPlaceholders({
+    orderTitle: product?.title ?? '',
+  });
+
+  return <Outlet />;
+};

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -91,6 +91,16 @@ export interface AbstractCourse {
   organizations: OrganizationLight[];
   title: string;
   course_runs: CourseRun[];
+  cover?: JoanieFile;
+}
+
+export interface JoanieFile {
+  filename: string;
+  height: number;
+  size: number;
+  src: string;
+  srcset: string;
+  width: number;
 }
 
 export interface TargetCourse extends AbstractCourse {

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -26,7 +26,7 @@ import {
 } from 'types/Joanie';
 import { CourseStateFactory } from 'utils/test/factories/richie';
 import { CourseListItemMock } from 'api/mocks/joanie/courses';
-import { FactoryConfig, factory } from './factories';
+import { factory, FactoryConfig } from './factories';
 
 export const EnrollmentFactory = factory<Enrollment>(() => {
   return {
@@ -228,7 +228,7 @@ export const OrderFactory = factory<Order>(() => {
     state: OrderState.VALIDATED,
     product: faker.datatype.uuid(),
     target_courses: TargetCourseFactory().many(5),
-    course: faker.random.alphaNumeric(5),
+    course: CourseLightFactory().one(),
     enrollments: [],
   };
 });

--- a/src/frontend/js/utils/test/mockProductWithOrder.ts
+++ b/src/frontend/js/utils/test/mockProductWithOrder.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'fetch-mock';
-import { Order, Product } from 'types/Joanie';
+import { CourseLight, Order, Product } from 'types/Joanie';
 import { ProductFactory } from 'utils/test/factories/joanie';
 
 export const mockProductWithOrder = (order: Order) => {
@@ -7,7 +7,10 @@ export const mockProductWithOrder = (order: Order) => {
     id: order.product,
   }).one();
   fetchMock.get(
-    'https://joanie.endpoint/api/v1.0/products/' + product.id + '/?course=' + order.course,
+    'https://joanie.endpoint/api/v1.0/products/' +
+      product.id +
+      '/?course=' +
+      (order.course as CourseLight).code,
     product,
   );
   return product;

--- a/src/frontend/js/utils/test/mockProductWithOrder.ts
+++ b/src/frontend/js/utils/test/mockProductWithOrder.ts
@@ -1,0 +1,14 @@
+import fetchMock from 'fetch-mock';
+import { Order, Product } from 'types/Joanie';
+import { ProductFactory } from 'utils/test/factories/joanie';
+
+export const mockProductWithOrder = (order: Order) => {
+  const product: Product = ProductFactory({
+    id: order.product,
+  }).one();
+  fetchMock.get(
+    'https://joanie.endpoint/api/v1.0/products/' + product.id + '/?course=' + order.course,
+    product,
+  );
+  return product;
+};

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -25,7 +25,7 @@ import {
   OrderFactory,
   TargetCourseFactory,
 } from 'utils/test/factories/joanie';
-import { Certificate, CourseRun, Order, OrderState } from 'types/Joanie';
+import { Certificate, CourseLight, CourseRun, Order, OrderState } from 'types/Joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { SessionProvider } from 'contexts/SessionContext';
 import { resolveAll } from 'utils/resolveAll';
@@ -113,7 +113,7 @@ describe('<DashboardItemOrder/>', () => {
     render(<DashboardItemOrder order={order} />, { wrapper });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('Pending');
     await screen.findByRole('link', { name: 'View details' });
   });
@@ -139,7 +139,7 @@ describe('<DashboardItemOrder/>', () => {
     render(<DashboardItemOrder order={order} showCertificate={true} />, { wrapper });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('Completed');
     await screen.findByRole('link', { name: 'View details' });
     await expectSpinner('Loading certificate...');
@@ -156,7 +156,7 @@ describe('<DashboardItemOrder/>', () => {
     render(<DashboardItemOrder order={order} />, { wrapper });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('Completed');
     await screen.findByRole('link', { name: 'View details' });
     await expectNoSpinner('Loading certificate ...');
@@ -174,7 +174,7 @@ describe('<DashboardItemOrder/>', () => {
     render(<DashboardItemOrder order={order} />, { wrapper });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('On going');
     await screen.findByRole('link', { name: 'View details' });
   });
@@ -186,7 +186,7 @@ describe('<DashboardItemOrder/>', () => {
     render(<DashboardItemOrder order={order} />, { wrapper });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('On going');
     await resolveAll(order.target_courses, async (course) => {
       await screen.findByRole('heading', { level: 6, name: course.title });
@@ -210,7 +210,7 @@ describe('<DashboardItemOrder/>', () => {
     render(<DashboardItemOrder order={order} />, { wrapper });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('On going');
     await resolveAll(order.target_courses, async (course) => {
       await screen.findByRole('heading', { level: 6, name: course.title });
@@ -238,7 +238,7 @@ describe('<DashboardItemOrder/>', () => {
     render(<DashboardItemOrder order={order} />, { wrapper });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('On going');
     await resolveAll(order.target_courses, async (course) => {
       await screen.findByRole('heading', { level: 6, name: course.title });
@@ -261,7 +261,7 @@ describe('<DashboardItemOrder/>', () => {
     });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('On going');
     expect(screen.queryByRole('link', { name: 'View details' })).toBeNull();
   });
@@ -283,7 +283,7 @@ describe('<DashboardItemOrder/>', () => {
     });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('On going');
     await resolveAll(order.target_courses, async (course) => {
       await screen.findByRole('heading', { level: 6, name: course.title });
@@ -749,7 +749,7 @@ describe('<DashboardItemOrder/>', () => {
     });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('On going');
 
     // The course run should be shown as enrolled even if is it past.
@@ -779,7 +779,7 @@ describe('<DashboardItemOrder/>', () => {
     });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + order.course!);
+    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
     await screen.findByText('On going');
 
     // The course run should not be shown.

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Icon } from 'components/Icon';
-import { Order, OrderState, Product } from 'types/Joanie';
+import { CourseLight, Order, OrderState, Product } from 'types/Joanie';
 import { StringHelper } from 'utils/StringHelper';
 import { CoursesHelper } from 'utils/CoursesHelper';
 import { useProduct } from 'hooks/useProduct';
@@ -13,7 +13,7 @@ import { getDashboardRoutePath } from 'widgets/Dashboard/utils/dashboardRoutes';
 import { RouterButton } from '../../RouterButton';
 import { DashboardSubItemsList } from '../DashboardSubItemsList';
 import { DashboardItemCourseEnrolling } from '../DashboardItemCourseEnrolling';
-import { DashboardItem, DEMO_IMAGE_URL } from '../index';
+import { DashboardItem } from '../index';
 
 const messages = {
   accessCourse: {
@@ -77,20 +77,20 @@ export const DashboardItemOrder = ({
   showCertificate,
   writable,
 }: DashboardItemOrderProps) => {
-  const { course } = order;
+  const course = order.course as CourseLight;
   if (!course) {
     throw new Error('Order must provide course object attribute.');
   }
   const intl = useIntl();
-  const product = useProduct(order.product, { course });
+  const product = useProduct(order.product, { course: course.code });
   const getRoutePath = getDashboardRoutePath(useIntl());
 
   return (
     <DashboardItem
       data-testid={`dashboard-item-order-${order.id}`}
       title={product.item?.title ?? ''}
-      code={'Ref. ' + course}
-      imageUrl={DEMO_IMAGE_URL}
+      code={'Ref. ' + course.code}
+      imageUrl={course.cover?.src}
       footer={
         <div className="dashboard-item-order__footer">
           <div className="dashboard-item__block__status">

--- a/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
@@ -4,6 +4,7 @@ import { useOrder } from 'hooks/useOrders';
 import { useProduct } from 'hooks/useProduct';
 import { Spinner } from 'components/Spinner';
 import Banner, { BannerType } from 'components/Banner';
+import { CourseLight } from 'types/Joanie';
 import { DashboardItemOrder } from '../DashboardItem/Order/DashboardItemOrder';
 
 const messages = defineMessages({
@@ -17,7 +18,8 @@ const messages = defineMessages({
 export const DashboardOrderLoader = () => {
   const params = useParams<{ orderId: string }>();
   const order = useOrder(params.orderId);
-  const product = useProduct(order.item?.product, { course: order.item?.course });
+  const course = order.item?.course as CourseLight;
+  const product = useProduct(order.item?.product, { course: course?.code });
   const fetching = order.states.fetching || product.states.fetching;
 
   return (

--- a/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { useBreadcrumbsPlaceholders } from 'hooks/useBreadcrumbsPlaceholders';
 import { useOrder } from 'hooks/useOrders';
 import { useProduct } from 'hooks/useProduct';
 import { Spinner } from 'components/Spinner';
@@ -18,13 +17,9 @@ const messages = defineMessages({
 export const DashboardOrderLoader = () => {
   const params = useParams<{ orderId: string }>();
   const order = useOrder(params.orderId);
-
   const product = useProduct(order.item?.product, { course: order.item?.course });
-  useBreadcrumbsPlaceholders({
-    orderTitle: product.item?.title ?? '',
-  });
-
   const fetching = order.states.fetching || product.states.fetching;
+
   return (
     <>
       {fetching && !order.item && (

--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/_styles.scss
@@ -36,6 +36,12 @@
       }
     }
 
+    &__title {
+      $titlePadding: rem-calc(r-theme-val(dashboard-sidebar, menu-link-left-padding) + 3px);
+      padding: 0 $titlePadding 1rem $titlePadding;
+      margin: 0;
+    }
+
     &__responsive-nav {
       display: none;
 
@@ -49,6 +55,7 @@
       list-style: none;
       padding: 0;
       margin: 0;
+      min-height: 8rem;
 
       @include media-breakpoint-down(lg) {
         display: none;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/index.tsx
@@ -17,10 +17,11 @@ const messages = defineMessages({
   },
 });
 
-interface DashboardSidebarProps extends PropsWithChildren {
+export interface DashboardSidebarProps extends PropsWithChildren {
   menuLinks: Record<string, string>[];
   header: string;
   subHeader: string;
+  title?: string;
 }
 
 export const DashboardSidebar = ({
@@ -28,6 +29,7 @@ export const DashboardSidebar = ({
   menuLinks,
   header,
   subHeader,
+  title,
 }: DashboardSidebarProps) => {
   const { user } = useSession();
   const location = useLocation();
@@ -55,6 +57,7 @@ export const DashboardSidebar = ({
           <h3>{header}</h3>
           <p>{subHeader}</p>
         </header>
+        {title && <h4 className="dashboard-sidebar__container__title">{title}</h4>}
         <div className="dashboard-sidebar__container__responsive-nav">
           <label htmlFor="dashboard-responsive-nav" className="offscreen">
             <FormattedMessage {...messages.responsiveNavLabel} />

--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/index.tsx
@@ -38,7 +38,7 @@ export const DashboardSidebar = ({
   const classes = ['dashboard-sidebar'];
 
   const selectedLink = useMemo(
-    () => menuLinks.find((link) => matchPath({ path: link.to, end: false }, location.pathname))?.to,
+    () => menuLinks.find((link) => matchPath({ path: link.to, end: true }, location.pathname))?.to,
     [location],
   );
 
@@ -83,7 +83,9 @@ export const DashboardSidebar = ({
               key={link.to}
               className={selectedLink && selectedLink === link.to ? 'active' : undefined}
             >
-              <NavLink to={link.to}>{link.label}</NavLink>
+              <NavLink to={link.to} end>
+                {link.label}
+              </NavLink>
             </li>
           ))}
         </ul>

--- a/src/frontend/js/widgets/Dashboard/components/LearnerDashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/LearnerDashboardSidebar/index.tsx
@@ -5,7 +5,10 @@ import {
   getDashboardRouteLabel,
   getDashboardRoutePath,
 } from 'widgets/Dashboard/utils/dashboardRoutes';
-import { DashboardSidebar } from 'widgets/Dashboard/components/DashboardSidebar';
+import {
+  DashboardSidebar,
+  DashboardSidebarProps,
+} from 'widgets/Dashboard/components/DashboardSidebar';
 import { useSession } from 'contexts/SessionContext';
 
 const messages = defineMessages({
@@ -21,7 +24,7 @@ const messages = defineMessages({
   },
 });
 
-export const LearnerDashboardSidebar = () => {
+export const LearnerDashboardSidebar = (props: Partial<DashboardSidebarProps>) => {
   const intl = useIntl();
   const { user } = useSession();
 
@@ -45,6 +48,7 @@ export const LearnerDashboardSidebar = () => {
       menuLinks={links}
       header={intl.formatMessage(messages.header, { name: user?.username })}
       subHeader={intl.formatMessage(messages.subHeader)}
+      {...props}
     />
   );
 };

--- a/src/frontend/js/widgets/Dashboard/utils/learnerRouteMessages.tsx
+++ b/src/frontend/js/widgets/Dashboard/utils/learnerRouteMessages.tsx
@@ -6,6 +6,7 @@ import { defineMessages } from 'react-intl';
 export enum LearnerDashboardPaths {
   COURSES = '/courses',
   ORDER = '/courses/orders/:orderId',
+  ORDER_RUNS = '/courses/orders/:orderId/runs',
   COURSE = '/courses/:code',
   PREFERENCES = '/preferences',
   CERTIFICATES = '/certificates',
@@ -25,6 +26,11 @@ export const LEARNER_DASHBOARD_ROUTE_PATHS = defineMessages<LearnerDashboardPath
     id: 'components.Dashboard.DashboardRoutes.order.path',
     description: 'The path to display an order detail view.',
     defaultMessage: '/courses/orders/{orderId}',
+  },
+  [LearnerDashboardPaths.ORDER_RUNS]: {
+    id: 'components.Dashboard.DashboardRoutes.order.runs.path',
+    description: 'The path to display an order runs view.',
+    defaultMessage: '/courses/orders/{orderId}/runs',
   },
   [LearnerDashboardPaths.COURSE]: {
     id: 'components.Dashboard.DashboardRoutes.course.path',
@@ -69,6 +75,11 @@ export const LEARNER_DASHBOARD_ROUTE_LABELS = defineMessages<LearnerDashboardPat
     id: 'components.Dashboard.DashboardRoutes.order.label',
     description: 'Label of the order view used in navigation components.',
     defaultMessage: '{orderTitle}',
+  },
+  [LearnerDashboardPaths.ORDER_RUNS]: {
+    id: 'components.Dashboard.DashboardRoutes.order.runs.label',
+    description: 'Label of the order runs view used in navigation components.',
+    defaultMessage: 'General informations',
   },
   [LearnerDashboardPaths.COURSE]: {
     id: 'components.Dashboard.DashboardRoutes.course.session.label',

--- a/src/frontend/js/widgets/Dashboard/utils/learnerRoutes.tsx
+++ b/src/frontend/js/widgets/Dashboard/utils/learnerRoutes.tsx
@@ -16,6 +16,7 @@ import {
   LearnerDashboardPaths,
 } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import { DashboardCertificates } from 'pages/DashboardCertificates';
+import { DashboardOrderLayout } from 'pages/DashboardOrderLayout';
 
 export interface DashboardRouteHandle {
   crumbLabel?: MessageDescriptor;
@@ -29,7 +30,9 @@ export function getLearnerDashboardRoutes() {
   const routes: RouteObject[] = [
     {
       path: getRoutePath(LearnerDashboardPaths.COURSES),
-      handle: { crumbLabel: LEARNER_DASHBOARD_ROUTE_LABELS[LearnerDashboardPaths.COURSES] },
+      handle: {
+        crumbLabel: LEARNER_DASHBOARD_ROUTE_LABELS[LearnerDashboardPaths.COURSES],
+      },
       element: <Outlet />,
       children: [
         {
@@ -40,8 +43,17 @@ export function getLearnerDashboardRoutes() {
           path: getRoutePath(LearnerDashboardPaths.ORDER, {
             orderId: ':orderId',
           }),
-          element: <DashboardOrderLoader />,
-          handle: { crumbLabel: LEARNER_DASHBOARD_ROUTE_LABELS[LearnerDashboardPaths.ORDER] },
+          element: <DashboardOrderLayout />,
+          handle: {
+            renderLayout: true,
+            crumbLabel: LEARNER_DASHBOARD_ROUTE_LABELS[LearnerDashboardPaths.ORDER],
+          },
+          children: [
+            {
+              index: true,
+              element: <DashboardOrderLoader />,
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
~~- [ ] Update to DashboardLayoutRoute to render only Outlet~~
- [x] Adapt renderLayout in routes
- [x] Use DashboardLayout inside Leaners dashboard
- [x] Create order routes
- [x] Make nested order routes for breadcrumbs
- [x] Exact matching to set active route on the sidebar
- [x] Breadcrumbs in new routes
- [x] Tests