### PR TITLE
⚡️(frontend) improve DashboardCourses test performance

### DIFF
--- a/src/frontend/js/pages/DashboardCourses/constants.ts
+++ b/src/frontend/js/pages/DashboardCourses/constants.ts
@@ -1,0 +1,1 @@
+export const PAGE_SIZE = 50;

--- a/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
+++ b/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
@@ -13,6 +13,7 @@ import {
 import { Maybe } from 'types/utils';
 import { OrderResourcesQuery } from 'hooks/useOrders';
 import { REACT_QUERY_SETTINGS } from 'settings';
+import { PAGE_SIZE } from './constants';
 
 export enum DataType {
   ENROLLMENT = 'enrollment',
@@ -23,8 +24,6 @@ export type Data = {
   type: DataType;
   item: Enrollment | Order;
 };
-
-const PAGE_SIZE = 50;
 
 const messages = defineMessages({
   errorGet: {


### PR DESCRIPTION
## Purpose

DashboardCourses take 150s to run.

## Proposal

Test pages of 4 elements instead of 50 for a run time of 8 seconds

## Todo

- [x] `useOrdersEnrollments::PAGE_SIZE` need to be configurable.
