### PR TITLE
✨(backend) add a route to redirect to course page through a course code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a shortcut route to redirect to the course page through a course code.
 - Add cunningham and design system.
 - Specific sidebar for order related routes
 - List teacher's course's course runs in the teacher course dashboard page.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,15 @@ $ make migrate
 
 ## Unreleased
 
+- `courses` app export new routes named `redirects_urlpatterns`. You have to add those new routes to
+  the urls module of your app.
+  ```python
+  from richie.apps.courses.urls import redirects_urlpatterns as courses_redirects_urlpatterns
+  
+  urlpatterns += [
+    re_path(r"^redirects/", include([*courses_redirects_urlpatterns])),
+  ]
+  ```
 - Legacy colors are now defined in cunningham.cjs instead of palette.scss.
   `yarn build-theme` command generates tokens files scss/cunningham-tokens.scss and /utils/cunningham-tokens.ts.
   $palette variable is now deprecated and will be removed in the next major release.

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/setup.cfg
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/setup.cfg
@@ -16,6 +16,7 @@ exclude =
     */migrations/*
 
 [isort]
+profile=black
 known_django=django
 include_trailing_comma=True
 line_length=88

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/urls.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/urls.py
@@ -1,5 +1,5 @@
 """
-FUN-MOOC urls
+{{cookiecutter.site}} urls
 """
 from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
@@ -11,8 +11,10 @@ from django.views.generic import TemplateView
 from django.views.static import serve
 
 from cms.sitemaps import CMSSitemap
-
-from richie.apps.courses.urls import urlpatterns as courses_urlpatterns
+from richie.apps.courses.urls import (
+    redirects_urlpatterns as courses_redirects_urlpatterns,
+    urlpatterns as courses_urlpatterns,
+)
 from richie.apps.search.urls import urlpatterns as search_urlpatterns
 from richie.plugins.urls import urlpatterns as plugins_urlpatterns
 

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -14,6 +14,9 @@ from cms.sitemaps import CMSSitemap
 
 from richie.apps.core.templatetags.feature_flags import is_feature_enabled
 from richie.apps.core.templatetags.joanie import is_joanie_enabled
+from richie.apps.courses.urls import (
+    redirects_urlpatterns as courses_redirects_urlpatterns,
+)
 from richie.apps.courses.urls import urlpatterns as courses_urlpatterns
 from richie.apps.search.urls import urlpatterns as search_urlpatterns
 from richie.plugins.urls import urlpatterns as plugins_urlpatterns
@@ -41,6 +44,7 @@ urlpatterns = [
         rf"api/{API_PREFIX:s}/",
         include([*courses_urlpatterns, *search_urlpatterns, *plugins_urlpatterns]),
     ),
+    re_path(r"^redirects/", include([*courses_redirects_urlpatterns])),
     path(r"", include("filer.server.urls")),
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,6 +106,7 @@ exclude =
     */migrations/*
 
 [isort]
+profile=black
 known_django=django
 known_richie=richie
 include_trailing_comma=True

--- a/src/richie/apps/courses/urls.py
+++ b/src/richie/apps/courses/urls.py
@@ -6,7 +6,7 @@ from django.urls import path, re_path
 from rest_framework import routers
 
 from .api import CourseRunsViewSet, sync_course_runs_from_request
-from .views import PageAdminAutocomplete
+from .views import CourseCodeRedirectView, PageAdminAutocomplete
 
 ROUTER = routers.SimpleRouter()
 
@@ -21,5 +21,13 @@ urlpatterns = ROUTER.urls + [
         "page-admin-autocomplete/<slug:model_name>>/",
         PageAdminAutocomplete.as_view(),
         name="page-admin-autocomplete",
+    ),
+]
+
+redirects_urlpatterns = [
+    re_path(
+        r"^courses/(?P<course_code>[\w]+)/?$",
+        CourseCodeRedirectView.as_view(),
+        name="redirect-course-code-to-course-url",
     ),
 ]

--- a/tests/apps/courses/test_views_course_code_redirect.py
+++ b/tests/apps/courses/test_views_course_code_redirect.py
@@ -1,0 +1,117 @@
+"""
+Test suite for the CourseCodeRedirectView.
+"""
+from django.conf import settings
+from django.http import Http404
+from django.urls import reverse
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.courses import factories
+from richie.apps.courses.views import CourseCodeRedirectView
+
+
+class CourseCodeRedirectViewTestCase(CMSTestCase):
+    """
+    The CourseCodeRedirectView should redirect to the CMS course page
+    from the course code, if the course page exists and is published.
+    """
+
+    def test_views_course_code_redirect_ok(self):
+        """
+        The CourseCodeRedirectView should redirect to the CMS course page.
+        """
+        course = factories.CourseFactory(should_publish=True)
+        url = reverse(
+            "redirect-course-code-to-course-url", kwargs={"course_code": course.code}
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(
+            response["Location"], course.extended_object.get_absolute_url()
+        )
+
+    def test_views_course_code_redirect_not_found(self):
+        """
+        The CourseCodeRedirectView should return a 404 if the course does not exist.
+        """
+        url = reverse(
+            "redirect-course-code-to-course-url", kwargs={"course_code": "00000"}
+        )
+
+        request = self.client.get(url, follow=True)
+        self.assertEqual(request.status_code, 404)
+
+        # Under the hood, a Http404 exception is raised
+        with self.assertRaises(Http404) as context:
+            CourseCodeRedirectView().get(request, course_code="00000")
+
+        self.assertEqual(str(context.exception), "No page found for course 00000.")
+
+    def test_views_course_code_redirect_with_draft_only(self):
+        """
+        The CourseCodeRedirectView should return a 404 if the course is not published.
+        """
+        factories.CourseFactory(should_publish=False)
+        url = reverse(
+            "redirect-course-code-to-course-url", kwargs={"course_code": "00000"}
+        )
+
+        request = self.client.get(url, follow=True)
+        self.assertEqual(request.status_code, 404)
+
+        # Under the hood, a Http404 exception is raised
+        with self.assertRaises(Http404) as context:
+            CourseCodeRedirectView().get(request, course_code="00000")
+
+        self.assertEqual(str(context.exception), "No page found for course 00000.")
+
+    def test_views_course_code_redirect_with_multilingual_page(self):
+        """
+        If a Course page exists in multiple languages, the CourseCodeRedirectView should
+        redirect to the page in the current language.
+        """
+        course = factories.CourseFactory(
+            page_languages=["en", "fr"], should_publish=True
+        )
+        url = reverse(
+            "redirect-course-code-to-course-url", kwargs={"course_code": course.code}
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(
+            response["Location"], course.extended_object.get_absolute_url(language="en")
+        )
+
+        # If the current language is French, the redirect should be on the French page
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: "fr"})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(
+            response["Location"], course.extended_object.get_absolute_url(language="fr")
+        )
+
+    def test_views_course_code_redirect_with_snapshot(self):
+        """
+        The CourseCodeRedirectView should redirect to the CMS course page property even
+        if the page has snapshots.
+        """
+        course = factories.CourseFactory(should_publish=True)
+        # Create a snapshot for the course page
+        factories.CourseFactory(page_parent=course.extended_object, should_publish=True)
+
+        url = reverse(
+            "redirect-course-code-to-course-url", kwargs={"course_code": course.code}
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(
+            response["Location"], course.extended_object.get_absolute_url()
+        )


### PR DESCRIPTION
## Purpose

Within react component, we want to be able to create a link to course's syllabus . We get data from Joanie API so we cannot pass this link through component data-props. As a workaround, we decide to add a redirect route `/redirects/courses/<course_code>` which redirects the user to the course page through its course code.


## Proposal


- [x] Add a redirect view `/redirects/courses/<course_code>`
- [x] Write tests
