### PR TITLE
🚸(language) use original language name on menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ information message when the product have no remaining order.
 
 ### Changed
 
+- Show original language name on the menu instead of translating it on the
+  current language.
 - Replace helix factories by homemade engine using typescript.
 - Use css colors from cunningham instead of palette.scss
 - Improve the design of the dashboards layouts.

--- a/src/richie/apps/core/templates/menu/language_menu.html
+++ b/src/richie/apps/core/templates/menu/language_menu.html
@@ -1,4 +1,4 @@
-{% load i18n menu_tags cms_tags %}{% spaceless %}
+{% load i18n menu_tags cms_tags language_name %}{% spaceless %}
 {% get_current_language as current_language_code %}
 {% if languages|length > 1 %}
   <script data-language-selector type="application/json">
@@ -8,7 +8,8 @@
       {% for code, name in languages %}
       "{{ code }}": {
         "code": "{{ code }}",
-        "name": "{{ name }}",
+        {% get_original_language_name code as original_language_name %}
+        "name": "{{ original_language_name }}",
         "url": "{% page_language_url code %}"
       {% if forloop.last %}
       }

--- a/src/richie/apps/core/templatetags/language_name.py
+++ b/src/richie/apps/core/templatetags/language_name.py
@@ -1,0 +1,21 @@
+"""Simple tag related with language and i18n."""
+from django import template
+from django.conf import settings
+from django.utils import translation
+
+# do not use the lazy
+from django.utils.translation import gettext as _
+
+register = template.Library()
+
+
+@register.simple_tag()
+def get_original_language_name(language_code):
+    """Get language original name on that its locale"""
+    with translation.override(language_code):
+        lang_name_override = next(
+            _(name)
+            for language, name in settings.LANGUAGES
+            if language == language_code
+        )
+        return lang_name_override

--- a/tests/apps/core/test_language_chooser.py
+++ b/tests/apps/core/test_language_chooser.py
@@ -35,7 +35,7 @@ class LanguageChooserTests(CMSTestCase):
         self.assertContains(response, '"name": "English"')
         self.assertContains(response, '"url": "/en/language-test-page/"')
         self.assertContains(response, '"code": "fr"')
-        self.assertContains(response, '"name": "French"')
+        self.assertContains(response, '"name": "Français"')
         self.assertContains(response, '"url": "/fr/language-test-page/"')
 
     @override_settings(


### PR DESCRIPTION
Show original language name on the menu instead of translating it on the current language.

Screenshots with this PR:
If user is authenticated in English:
![image](https://github.com/openfun/richie/assets/67018/88076810-32f3-4dac-b394-dea921a31506)

If user is authenticated in French:
![image](https://github.com/openfun/richie/assets/67018/64feef5f-f8b6-4e22-916f-a8ff581f6a5d)
