### PR TITLE
✨(frontend) Teacher dashboard: list organization courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ relations.
 - Add a page for training details (courseProductRelation) in the teacher
 dashboard.
 - Add a link to the LMS course run session in teacher dashbaord course run lists
+- Finalize the design of teacher dashboard organization sidebar.
+- Use union of organization courses and course product relations on organization
+course's listing page.
 
 ### Changed
 

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -102,7 +102,7 @@ export const getAPIEndpoint = () => {
   return `${endpoint}/api/${version}`;
 };
 
-const getRoutes = () => {
+export const getRoutes = () => {
   const baseUrl = getAPIEndpoint();
 
   return {
@@ -143,6 +143,12 @@ const getRoutes = () => {
       },
       organizations: {
         get: `${baseUrl}/organizations/:id/`,
+        courseProductRelations: {
+          get: `${baseUrl}/organizations/:id/course-product-relations/`,
+        },
+        courses: {
+          get: `${baseUrl}/organizations/:id/courses/`,
+        },
       },
     },
     products: {
@@ -356,11 +362,13 @@ const API = (): Joanie.API => {
       },
     },
     courses: {
-      get: (filters) => {
-        const { id, ...queryParameters } = filters || {};
+      get: (filters?: Joanie.CourseQueryFilters) => {
+        const { id, organization_id: organizationId, ...queryParameters } = filters || {};
         let url;
 
-        if (id) url = ROUTES.courses.get.replace(':id', id);
+        if (organizationId)
+          url = ROUTES.user.organizations.courses.get.replace(':id', organizationId);
+        else if (id) url = ROUTES.courses.get.replace(':id', id);
         else url = ROUTES.courses.get.replace(':id/', '');
 
         if (!ObjectHelper.isEmpty(queryParameters)) {
@@ -375,9 +383,8 @@ const API = (): Joanie.API => {
         const { id, course_id: courseId, ...queryParameters } = filters || {};
         let url;
 
-        if (courseId) {
-          url = ROUTES.courses.courseRuns.get.replace(':id', courseId);
-        } else if (id) url = ROUTES.courseRuns.get.replace(':id', id);
+        if (courseId) url = ROUTES.courses.courseRuns.get.replace(':id', courseId);
+        else if (id) url = ROUTES.courseRuns.get.replace(':id', id);
         else url = ROUTES.courseRuns.get.replace(':id/', '');
 
         if (!ObjectHelper.isEmpty(queryParameters)) {
@@ -388,11 +395,13 @@ const API = (): Joanie.API => {
       },
     },
     courseProductRelations: {
-      get: (filters) => {
-        const { id, ...queryParameters } = filters || {};
+      get: (filters?: Joanie.CourseProductRelationQueryFilters) => {
+        const { id, organization_id: organizationId, ...queryParameters } = filters || {};
         let url;
 
-        if (id) url = ROUTES.courseProductRelations.get.replace(':id', id);
+        if (organizationId)
+          url = ROUTES.user.organizations.courseProductRelations.get.replace(':id', organizationId);
+        else if (id) url = ROUTES.courseProductRelations.get.replace(':id', id);
         else url = ROUTES.courseProductRelations.get.replace(':id/', '');
 
         if (!ObjectHelper.isEmpty(queryParameters)) {

--- a/src/frontend/js/components/TeacherDashboardCourseList/index.tsx
+++ b/src/frontend/js/components/TeacherDashboardCourseList/index.tsx
@@ -30,13 +30,22 @@ const messages = defineMessages({
 
 interface TeacherDashboardCourseListProps {
   titleTranslated: string;
+  organizationId?: string;
 }
 
-const TeacherDashboardCourseList = ({ titleTranslated }: TeacherDashboardCourseListProps) => {
+const TeacherDashboardCourseList = ({
+  titleTranslated,
+  organizationId,
+}: TeacherDashboardCourseListProps) => {
   const loadMoreButtonRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
   const intl = useIntl();
   const routerLocal = intl.locale.split('-')[0];
-  const { data: courseAndProductList, isLoading, next, hasMore } = useCourseProductUnion();
+  const {
+    data: courseAndProductList,
+    isLoading,
+    next,
+    hasMore,
+  } = useCourseProductUnion({ perPage: 25, organizationId });
   useIntersectionObserver({
     target: loadMoreButtonRef,
     onIntersect: next,

--- a/src/frontend/js/hooks/useCourseProductUnion/index.spec.tsx
+++ b/src/frontend/js/hooks/useCourseProductUnion/index.spec.tsx
@@ -1,0 +1,128 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from 'react-intl';
+import fetchMock from 'fetch-mock';
+import { PropsWithChildren } from 'react';
+import { CourseListItem, CourseProductRelation } from 'types/Joanie';
+import { History, HistoryContext } from 'hooks/useHistory';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { SessionProvider } from 'contexts/SessionContext';
+import { getRoutes } from 'api/joanie';
+import { mockPaginatedResponse } from 'utils/test/mockPaginatedResponse';
+import { CourseListItemFactory, CourseProductRelationFactory } from 'utils/test/factories/joanie';
+import { useCourseProductUnion } from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://demo.endpoint' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint' },
+  }).one(),
+}));
+
+const PER_PAGE = 3;
+
+const renderUseCourseProductUnion = ({ organizationId }: { organizationId?: string } = {}) => {
+  const Wrapper = ({ client, children }: PropsWithChildren<{ client?: QueryClient }>) => {
+    const historyPushState = jest.fn();
+    const historyReplaceState = jest.fn();
+    const makeHistoryOf: (params: any) => History = () => [
+      {
+        state: { name: '', data: {} },
+        title: '',
+        url: `/`,
+      },
+      historyPushState,
+      historyReplaceState,
+    ];
+
+    return (
+      <QueryClientProvider client={client ?? createTestQueryClient({ user: true })}>
+        <IntlProvider locale="en">
+          <HistoryContext.Provider value={makeHistoryOf({})}>
+            <SessionProvider>{children}</SessionProvider>
+          </HistoryContext.Provider>
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  return renderHook(() => useCourseProductUnion({ perPage: PER_PAGE, organizationId }), {
+    wrapper: Wrapper,
+  });
+};
+
+describe('useCourseProductUnion', () => {
+  let courseList: CourseListItem[];
+  let courseProductRelationList: CourseProductRelation[];
+  let nbApiCalls: number;
+
+  beforeEach(() => {
+    courseList = CourseListItemFactory().many(6);
+    courseProductRelationList = CourseProductRelationFactory().many(6);
+
+    fetchMock.get('https://joanie.endpoint/api/v1.0/orders/', [], { overwriteRoutes: true });
+    fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', [], { overwriteRoutes: true });
+    fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', [], { overwriteRoutes: true });
+    nbApiCalls = 3;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it('should call courses and coursesProductRelation endpoints', async () => {
+    const ROUTES = getRoutes();
+    const coursesUrl = ROUTES.courses.get.replace(':id/', '');
+    const courseProductRelationsUrl = ROUTES.courseProductRelations.get.replace(':id/', '');
+    fetchMock.get(
+      `${coursesUrl}?page=1&page_size=${PER_PAGE}`,
+      mockPaginatedResponse(courseList.slice(0, PER_PAGE), 0, false),
+    );
+    fetchMock.get(
+      `${courseProductRelationsUrl}?page=1&page_size=${PER_PAGE}`,
+      mockPaginatedResponse(courseProductRelationList.slice(0, PER_PAGE), 0, false),
+    );
+    const { result } = renderUseCourseProductUnion();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data.length).toBe(PER_PAGE);
+    nbApiCalls += 1; // courses page 1
+    nbApiCalls += 1; // course product relations page 1
+    const calledUrls = fetchMock.calls().map((call) => call[0]);
+    expect(calledUrls).toHaveLength(nbApiCalls);
+    expect(calledUrls).toContain(`${coursesUrl}?page=1&page_size=${PER_PAGE}`);
+    expect(calledUrls).toContain(`${courseProductRelationsUrl}?page=1&page_size=${PER_PAGE}`);
+  });
+
+  it('should call organization courses and organization coursesProductRelation endpoints', async () => {
+    const organizationId = 'DUMMY_ORGANIZATION_ID';
+    const ROUTES = getRoutes();
+    const organizationCoursesUrl = ROUTES.user.organizations.courses.get.replace(
+      ':id',
+      organizationId,
+    );
+    const organizationCourseProductRelationsUrl =
+      ROUTES.user.organizations.courseProductRelations.get.replace(':id', organizationId);
+    fetchMock.get(
+      `${organizationCoursesUrl}?page=1&page_size=${PER_PAGE}`,
+      mockPaginatedResponse(courseList.slice(0, PER_PAGE), 0, false),
+    );
+    fetchMock.get(
+      `${organizationCourseProductRelationsUrl}?page=1&page_size=${PER_PAGE}`,
+      mockPaginatedResponse(courseProductRelationList.slice(0, PER_PAGE), 0, false),
+    );
+    const { result } = renderUseCourseProductUnion({ organizationId: 'DUMMY_ORGANIZATION_ID' });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data.length).toBe(PER_PAGE);
+    nbApiCalls += 1; // courses page 1
+    nbApiCalls += 1; // course product relations page 1
+    const calledUrls = fetchMock.calls().map((call) => call[0]);
+    expect(calledUrls).toHaveLength(nbApiCalls);
+    expect(calledUrls).toContain(`${organizationCoursesUrl}?page=1&page_size=${PER_PAGE}`);
+    expect(calledUrls).toContain(
+      `${organizationCourseProductRelationsUrl}?page=1&page_size=${PER_PAGE}`,
+    );
+  });
+});

--- a/src/frontend/js/hooks/useCourseProductUnion/index.ts
+++ b/src/frontend/js/hooks/useCourseProductUnion/index.ts
@@ -3,11 +3,11 @@ import { useJoanieApi } from 'contexts/JoanieApiContext';
 import {
   CourseListItem,
   Product,
-  PaginatedResourceQuery,
   CourseProductRelation,
+  CourseQueryFilters,
+  CourseProductRelationQueryFilters,
 } from 'types/Joanie';
 import useUnionResource, { ResourceUnionPaginationProps } from 'hooks/useUnionResource';
-import { PER_PAGE } from 'settings';
 
 export const isCourseListItem = (obj: CourseListItem | Product): obj is CourseListItem => {
   return 'course_runs' in obj;
@@ -24,25 +24,30 @@ const messages = defineMessages({
   },
 });
 
+interface UseCourseProductUnionProps extends ResourceUnionPaginationProps {
+  organizationId?: string;
+}
+
 export const useCourseProductUnion = ({
-  perPage = PER_PAGE.useCourseProductUnion,
-}: ResourceUnionPaginationProps = {}) => {
+  perPage = 50,
+  organizationId,
+}: UseCourseProductUnionProps = {}) => {
   const api = useJoanieApi();
   return useUnionResource<
     CourseListItem,
     CourseProductRelation,
-    PaginatedResourceQuery,
-    PaginatedResourceQuery
+    CourseQueryFilters,
+    CourseProductRelationQueryFilters
   >({
     queryAConfig: {
       queryKey: ['user', 'courses'],
       fn: api.courses.get,
-      filters: {},
+      filters: { organization_id: organizationId },
     },
     queryBConfig: {
       queryKey: ['user', 'course_product_relations'],
       fn: api.courseProductRelations.get,
-      filters: {},
+      filters: { organization_id: organizationId },
     },
     perPage,
     errorGetMessage: messages.errorGet,

--- a/src/frontend/js/pages/TeacherOrganizationCourseDashboardLoader/index.tsx
+++ b/src/frontend/js/pages/TeacherOrganizationCourseDashboardLoader/index.tsx
@@ -1,9 +1,17 @@
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { useParams } from 'react-router-dom';
 import { Spinner } from 'components/Spinner';
 import { DashboardLayout } from 'widgets/Dashboard/components/DashboardLayout';
 import { TeacherOrganizationDashboardSidebar } from 'widgets/Dashboard/components/TeacherOrganizationDashboardSidebar';
+import { useOrganization } from 'hooks/useOrganizations';
+import TeacherDashboardCourseList from 'components/TeacherDashboardCourseList';
 
 const messages = defineMessages({
+  title: {
+    defaultMessage: 'Courses of {organizationTitle}',
+    description: 'Message displayed as title of organization courses page',
+    id: 'components.TeacherOrganizationCourseDashboardLoader.title',
+  },
   loading: {
     defaultMessage: 'Loading organization ...',
     description: 'Message displayed while loading an organization',
@@ -12,8 +20,12 @@ const messages = defineMessages({
 });
 
 export const TeacherOrganizationCourseDashboardLoader = () => {
-  // FIXME: fetch data
-  const fetching = false;
+  const intl = useIntl();
+  const { organizationId } = useParams<{ organizationId: string }>();
+  const {
+    item: organization,
+    states: { fetching },
+  } = useOrganization(organizationId);
   return (
     <DashboardLayout sidebar={<TeacherOrganizationDashboardSidebar />}>
       {fetching && (
@@ -22,6 +34,14 @@ export const TeacherOrganizationCourseDashboardLoader = () => {
             <FormattedMessage {...messages.loading} />
           </span>
         </Spinner>
+      )}
+      {!fetching && (
+        <TeacherDashboardCourseList
+          titleTranslated={intl.formatMessage(messages.title, {
+            organizationTitle: organization.title,
+          })}
+          organizationId={organization.id}
+        />
       )}
     </DashboardLayout>
   );

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -301,6 +301,13 @@ export interface CourseRunFilters extends ResourcesQuery {
   course_id?: CourseListItem['id'];
 }
 
+export interface CourseQueryFilters extends ResourcesQuery {
+  organization_id?: Organization['id'];
+}
+export interface CourseProductRelationQueryFilters extends ResourcesQuery {
+  organization_id?: Organization['id'];
+}
+
 export interface ApiResourceInterface<
   TData extends Resource,
   TResourceQuery extends ResourcesQuery = ResourcesQuery,

--- a/src/frontend/js/widgets/Dashboard/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/_styles.scss
@@ -1,21 +1,3 @@
 .richie-react--dashboard {
   background-color: r-theme-val(dashboard, background-color);
 }
-
-$avatar-size: 100px;
-
-.dashboard {
-  &__avatar {
-    box-shadow: r-theme-val(dashboard-sidebar, base-shadow);
-    background-color: r-theme-val(dashboard-avatar, background-color);
-    border-radius: 100%;
-    width: $avatar-size;
-    height: $avatar-size;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: r-theme-val(dashboard-avatar, base-color);
-    font-size: 3rem;
-    font-weight: bold;
-  }
-}

--- a/src/frontend/js/widgets/Dashboard/components/DashboardAvatar/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardAvatar/_styles.scss
@@ -1,0 +1,28 @@
+$avatar-size: 100px;
+
+.dashboard {
+  &__avatar {
+    box-shadow: r-theme-val(dashboard-sidebar, base-shadow);
+    background-color: r-theme-val(dashboard-avatar, background-color);
+    border-radius: 100%;
+    width: $avatar-size;
+    height: $avatar-size;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: r-theme-val(dashboard-avatar, base-color);
+    font-size: 3rem;
+    font-weight: bold;
+
+    &--square {
+      border-radius: rem-calc(8px);
+      background: r-theme-val(dashboard-sidebar, background-color);
+      border: 1px solid r-theme-val(dashboard-avatar, background-color);
+      color: r-theme-val(dashboard-avatar, background-color);
+
+      img {
+        border-radius: rem-calc(6px);
+      }
+    }
+  }
+}

--- a/src/frontend/js/widgets/Dashboard/components/DashboardAvatar/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardAvatar/index.spec.tsx
@@ -1,22 +1,24 @@
-import { render } from '@testing-library/react';
-import { UserFactory } from 'utils/test/factories/richie';
-import { User } from 'types/User';
-import { DashboardAvatar } from '.';
+import { render, screen } from '@testing-library/react';
+import { DashboardAvatar, DashboardAvatarVariantEnum } from '.';
 
 describe('<DashboardAvatar/>', () => {
-  it('should work with empty username', () => {
-    const user: User = UserFactory().one();
-    user.username = '';
-    render(<DashboardAvatar user={user} />);
-    const container = document.querySelector('.dashboard__avatar')!;
-    expect(container.textContent).toEqual('');
+  it('should work with empty title', () => {
+    render(<DashboardAvatar title="" />);
+    expect(screen.getByTestId('dashboard-avatar')).toHaveTextContent('');
   });
 
-  it('should display the first letter of username', () => {
-    const user: User = UserFactory().one();
-    user.username = 'Bob';
-    render(<DashboardAvatar user={user} />);
-    const container = document.querySelector('.dashboard__avatar')!;
-    expect(container.textContent).toEqual('B');
+  it('should display the first letter of the title', () => {
+    render(<DashboardAvatar title="Bob" />);
+    expect(screen.getByTestId('dashboard-avatar')).toHaveTextContent('B');
+  });
+
+  it('should display an image if given', () => {
+    render(<DashboardAvatar title="Bob" imageUrl="http://my.awesome.image" />);
+    expect(screen.getByAltText('Bob')).toHaveAttribute('src', 'http://my.awesome.image');
+  });
+
+  it('should contain the variant class for SQUARE', () => {
+    render(<DashboardAvatar title="Bob" variant={DashboardAvatarVariantEnum.SQUARE} />);
+    expect(screen.getByTestId('dashboard-avatar')).toHaveClass('dashboard__avatar--square');
   });
 });

--- a/src/frontend/js/widgets/Dashboard/components/DashboardAvatar/index.stories.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardAvatar/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { UserFactory } from 'utils/test/factories/richie';
-import { DashboardAvatar } from '.';
+import { OrganizationFactory } from 'utils/test/factories/joanie';
+import { DashboardAvatar, DashboardAvatarVariantEnum } from '.';
 
 export default {
   component: DashboardAvatar,
@@ -10,6 +11,13 @@ type Story = StoryObj<typeof DashboardAvatar>;
 
 export const Default: Story = {
   args: {
-    user: UserFactory().one(),
+    title: UserFactory().one().username,
+  },
+};
+
+export const Organization: Story = {
+  args: {
+    title: OrganizationFactory().one().title,
+    variant: DashboardAvatarVariantEnum.SQUARE,
   },
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardAvatar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardAvatar/index.tsx
@@ -1,6 +1,30 @@
-import { User } from 'types/User';
+import c from 'classnames';
 
-export const DashboardAvatar = ({ user }: { user: User }) => {
-  const letter = user.username.charAt(0).toUpperCase();
-  return <div className="dashboard__avatar">{letter}</div>;
+export enum DashboardAvatarVariantEnum {
+  DEFAULT = 'default',
+  SQUARE = 'square',
+}
+
+interface DashboardAvatarProps {
+  title: string;
+  imageUrl?: string;
+  variant?: DashboardAvatarVariantEnum;
+}
+
+export const DashboardAvatar = ({
+  title,
+  imageUrl,
+  variant = DashboardAvatarVariantEnum.DEFAULT,
+}: DashboardAvatarProps) => {
+  const letter = title.charAt(0).toUpperCase();
+  return (
+    <div
+      data-testid="dashboard-avatar"
+      className={c('dashboard__avatar', {
+        'dashboard__avatar--square': variant === DashboardAvatarVariantEnum.SQUARE,
+      })}
+    >
+      {imageUrl ? <img src={imageUrl} alt={title} /> : letter}
+    </div>
+  );
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/_styles.scss
@@ -22,6 +22,9 @@
       &__avatar {
         position: absolute;
         top: calc($avatar-size / -2);
+        &--three_quarter {
+          top: calc($avatar-size / 3 * -2);
+        }
       }
 
       h3 {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/index.tsx
@@ -1,6 +1,7 @@
+import c from 'classnames';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { matchPath, NavLink, useLocation, useNavigate } from 'react-router-dom';
-import { ChangeEvent, PropsWithChildren, useMemo, useRef } from 'react';
+import { ChangeEvent, PropsWithChildren, ReactNode, useMemo, useRef } from 'react';
 import { useSession } from 'contexts/SessionContext';
 import { DashboardAvatar } from 'widgets/Dashboard/components/DashboardAvatar';
 
@@ -17,11 +18,18 @@ const messages = defineMessages({
   },
 });
 
+export enum DashboardAvatarPositionEnum {
+  CENTER = 'center',
+  THREE_QUARTER = 'three_quarter',
+}
+
 export interface DashboardSidebarProps extends PropsWithChildren {
   menuLinks: Record<string, string>[];
   header: string;
   subHeader: string;
   title?: string;
+  avatarPosition?: DashboardAvatarPositionEnum;
+  avatar?: ReactNode;
 }
 
 export const DashboardSidebar = ({
@@ -30,6 +38,8 @@ export const DashboardSidebar = ({
   header,
   subHeader,
   title,
+  avatar,
+  avatarPosition = DashboardAvatarPositionEnum.CENTER,
 }: DashboardSidebarProps) => {
   const { user } = useSession();
   const location = useLocation();
@@ -51,8 +61,13 @@ export const DashboardSidebar = ({
     <aside className={classes.join(' ')} data-testid="dashboard__sidebar">
       <div className="dashboard-sidebar__container">
         <header className="dashboard-sidebar__container__header">
-          <div className="dashboard-sidebar__container__header__avatar">
-            <DashboardAvatar user={user!} />
+          <div
+            className={c('dashboard-sidebar__container__header__avatar', {
+              'dashboard-sidebar__container__header__avatar--three_quarter':
+                avatarPosition === DashboardAvatarPositionEnum.THREE_QUARTER,
+            })}
+          >
+            {avatar || <DashboardAvatar title={user!.username} />}
           </div>
           <h3>{header}</h3>
           <p>{subHeader}</p>

--- a/src/frontend/js/widgets/Dashboard/components/TeacherOrganizationDashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherOrganizationDashboardSidebar/index.tsx
@@ -1,12 +1,18 @@
-import { defineMessages, useIntl } from 'react-intl';
+import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 import { generatePath, useParams } from 'react-router-dom';
 import { useMemo } from 'react';
 import { TeacherDashboardPaths } from 'widgets/Dashboard/utils/teacherRouteMessages';
-import { DashboardSidebar } from 'widgets/Dashboard/components/DashboardSidebar';
+import {
+  DashboardAvatarPositionEnum,
+  DashboardSidebar,
+} from 'widgets/Dashboard/components/DashboardSidebar';
 import {
   getDashboardRouteLabel,
   getDashboardRoutePath,
 } from 'widgets/Dashboard/utils/dashboardRoutes';
+import { useOrganization } from 'hooks/useOrganizations';
+import { Spinner } from 'components/Spinner';
+import { DashboardAvatar, DashboardAvatarVariantEnum } from '../DashboardAvatar';
 
 const messages = defineMessages({
   subHeader: {
@@ -14,13 +20,22 @@ const messages = defineMessages({
     description: 'Sub title of the organization dashboard sidebar',
     defaultMessage: 'You are on the organization dashboard',
   },
+  loading: {
+    defaultMessage: 'Loading organization...',
+    description: 'Message displayed while loading an organization',
+    id: 'components.TeacherOrganizationDashboardSidebar.loading',
+  },
 });
 
 export const TeacherOrganizationDashboardSidebar = () => {
   const intl = useIntl();
   const getRoutePath = getDashboardRoutePath(intl);
   const getRouteLabel = getDashboardRouteLabel(intl);
-  const params = useParams();
+  const { organizationId } = useParams<{ organizationId: string }>();
+  const {
+    item: organization,
+    states: { fetching },
+  } = useOrganization(organizationId);
 
   const links = useMemo(
     () =>
@@ -33,18 +48,36 @@ export const TeacherOrganizationDashboardSidebar = () => {
           getRoutePath(path, {
             organizationId: ':organizationId',
           }),
-          params,
+          { organizationId },
         ),
         label: getRouteLabel(path),
       })),
     [],
   );
 
+  if (fetching) {
+    return (
+      <Spinner aria-labelledby="loading-courses-data">
+        <span id="loading-courses-data">
+          <FormattedMessage {...messages.loading} />
+        </span>
+      </Spinner>
+    );
+  }
+
   return (
     <DashboardSidebar
       menuLinks={links}
-      header="Dummy Organization"
+      header={organization.title}
       subHeader={intl.formatMessage(messages.subHeader)}
+      avatarPosition={DashboardAvatarPositionEnum.THREE_QUARTER}
+      avatar={
+        <DashboardAvatar
+          title={organization.title}
+          variant={DashboardAvatarVariantEnum.SQUARE}
+          imageUrl={organization.logo.src}
+        />
+      }
     />
   );
 };

--- a/src/frontend/scss/components/_index.scss
+++ b/src/frontend/scss/components/_index.scss
@@ -25,6 +25,7 @@
 @import '../../js/widgets/CourseRunEnrollment/components/CourseRunUnenrollmentButton/styles';
 @import '../../js/widgets/CourseRunEnrollment/styles';
 @import '../../js/widgets/Dashboard/styles';
+@import '../../js/widgets/Dashboard/components/DashboardAvatar/styles';
 @import '../../js/widgets/Dashboard/components/DashboardBox/styles';
 @import '../../js/widgets/Dashboard/components/DashboardCard/styles';
 @import '../../js/widgets/Dashboard/components/DashboardItem/Certificate/styles';


### PR DESCRIPTION
note: rebased on #1997 and #1990
## Purpose

On the teacher dashboard, teacher needs to access the list for they organizations courses.
Everything is configured and tested as if our backend returned the right `Courses` and `CourseProductRelations` listing for :
* `organizations/{organizationId}/courses`
* `organizations/{organizationId}/course-product-relations`


![image](https://github.com/openfun/richie/assets/139848/e04be1cd-a3d5-48d3-8043-a37e15554501)

