### PR TITLE
✨(backend) change course glimpse footer state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ dashboard.
 course's listing page.
 - The product purchase button is now disabled and display a contextual 
 information message when the product have no remaining order.
+- Change footer text and remove datime on glimpse course according state.
 
 ### Changed
 

--- a/src/frontend/js/pages/TeacherCourseDashboardLoader/CourseRunList/utils.tsx
+++ b/src/frontend/js/pages/TeacherCourseDashboardLoader/CourseRunList/utils.tsx
@@ -21,7 +21,7 @@ export const messages = defineMessages({
 
 export const buildCourseRunData = (intl: IntlShape, courseRuns: CourseRun[]) => {
   const CourseStateIconMap: Record<CourseStateTextEnum, IconTypeEnum> = {
-    [CourseStateTextEnum.CLOSING_ON]: IconTypeEnum.MORE,
+    [CourseStateTextEnum.ENROLLMENT_OPENED]: IconTypeEnum.MORE,
     [CourseStateTextEnum.STARTING_ON]: IconTypeEnum.CHECK_ROUNDED,
     [CourseStateTextEnum.ENROLLMENT_CLOSED]: IconTypeEnum.MORE,
     [CourseStateTextEnum.ON_GOING]: IconTypeEnum.MORE,

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -1,7 +1,7 @@
 import { Nullable } from 'types/utils';
 
 export enum CourseStateTextEnum {
-  CLOSING_ON = 'closing on',
+  ENROLLMENT_OPENED = 'open for enrollment',
   STARTING_ON = 'starting on',
   ENROLLMENT_CLOSED = 'enrollment closed',
   ON_GOING = 'on-going',

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -138,7 +138,7 @@ export const CourseRunFactory = factory((): CourseRun => {
       priority: Priority.FUTURE_OPEN,
       datetime: faker.date.past({ years: 0.25 }).toISOString(),
       call_to_action: 'enroll now',
-      text: CourseStateTextEnum.CLOSING_ON,
+      text: CourseStateTextEnum.ENROLLMENT_OPENED,
     }).one(),
   };
 });

--- a/src/frontend/js/utils/test/factories/richie.ts
+++ b/src/frontend/js/utils/test/factories/richie.ts
@@ -11,9 +11,9 @@ import { factory } from './factories';
  * mapping between priority and text
  * | Priority | Text |
  * | ----------- | ----------- |
- * |ONGOING_OPEN        | CLOSING_ON|
+ * |ONGOING_OPEN        | ENROLLMENT_OPENED|
  * |FUTURE_OPEN         | STARTING_ON|
- * |ARCHIVED_OPEN       | CLOSING_ON|
+ * |ARCHIVED_OPEN       | ENROLLMENT_OPENED|
  * |FUTURE_NOT_YET_OPEN | STARTING_ON|
  * |FUTURE_CLOSED       | ENROLLMENT_CLOSED|
  * |ONGOING_CLOSED      | ON_GOING|
@@ -25,7 +25,7 @@ export const CourseStateFactory = factory<CourseState>(() => {
     priority: Priority.ONGOING_OPEN,
     datetime: faker.date.past().toISOString(),
     call_to_action: 'enroll now',
-    text: CourseStateTextEnum.CLOSING_ON,
+    text: CourseStateTextEnum.ENROLLMENT_OPENED,
   };
 });
 

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -63,7 +63,7 @@ class CourseState(Mapping):
     }
 
     STATE_TEXTS = {
-        ONGOING_OPEN: _("closing on"),
+        ONGOING_OPEN: _("open for enrollment"),
         FUTURE_OPEN: _("starting on"),
         ARCHIVED_OPEN: _("closing on"),
         FUTURE_NOT_YET_OPEN: _("starting on"),
@@ -110,12 +110,16 @@ class CourseState(Mapping):
         ):
             text = _("forever open")
             date_time = None
+        elif priority == CourseState.ONGOING_OPEN:
+            date_time = None
+
         kwargs = {
             "priority": priority,
             "datetime": date_time,
             "call_to_action": self.STATE_CALLS_TO_ACTION[priority],
             "text": text,
         }
+
         self._d = {**kwargs}
 
     def __iter__(self):
@@ -604,7 +608,6 @@ class Course(EsIdMixin, BasePageExtension):
             if state["priority"] == CourseState.ONGOING_OPEN:
                 # We found the best state, don't waste more time
                 break
-
         return best_state
 
     def copy_relations(self, oldinstance, language=None):

--- a/tests/apps/courses/test_models_course_run.py
+++ b/tests/apps/courses/test_models_course_run.py
@@ -286,7 +286,7 @@ class CourseRunModelsTestCase(TestCase):
             },
         )
 
-    def test_models_course_run_state_archived_open_closing_on(self):
+    def test_models_course_run_state_archived_open_enrollment_opened(self):
         """
         A course run that is passed and has an enrollment end in the future should return
         a state with priority 2 and "closing on" as text.
@@ -341,9 +341,9 @@ class CourseRunModelsTestCase(TestCase):
             dict(course_run.state),
             {
                 "priority": 0,
-                "text": "closing on",
+                "text": "open for enrollment",
                 "call_to_action": "enroll now",
-                "datetime": self.now + timedelta(hours=1),
+                "datetime": None,
             },
         )
 

--- a/tests/apps/search/test_query_courses.py
+++ b/tests/apps/search/test_query_courses.py
@@ -633,10 +633,8 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         "state": {
                             "priority": 0,
                             "call_to_action": "enroll now",
-                            "datetime": data["course_runs"]["A"]["enrollment_end"]
-                            .isoformat()
-                            .replace("+00:00", "Z"),
-                            "text": "closing on",
+                            "datetime": None,
+                            "text": "open for enrollment",
                         },
                         "title": "Artificial intelligence for mushroom picking",
                     },
@@ -686,11 +684,9 @@ class CourseRunsCoursesQueryTestCase(TestCase):
                         ],
                         "state": {
                             "priority": 0,
-                            "datetime": data["course_runs"]["B"]["enrollment_end"]
-                            .isoformat()
-                            .replace("+00:00", "Z"),
+                            "datetime": None,
                             "call_to_action": "enroll now",
-                            "text": "closing on",
+                            "text": "open for enrollment",
                         },
                         "title": "Building a data lake out of mountain springs",
                     },
@@ -1043,11 +1039,9 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             [
                 {
                     "call_to_action": "enroll now",
-                    "datetime": data["course_runs"]["A"]["enrollment_end"]
-                    .isoformat()
-                    .replace("+00:00", "Z"),
+                    "datetime": None,
                     "priority": 0,
-                    "text": "closing on",
+                    "text": "open for enrollment",
                 },
                 {
                     "call_to_action": "enroll now",
@@ -1141,11 +1135,9 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             [
                 {
                     "call_to_action": "enroll now",
-                    "datetime": data["course_runs"]["A"]["enrollment_end"]
-                    .isoformat()
-                    .replace("+00:00", "Z"),
+                    "datetime": None,
                     "priority": 0,
-                    "text": "closing on",
+                    "text": "open for enrollment",
                 },
                 {
                     "call_to_action": "enroll now",
@@ -1310,11 +1302,9 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             [
                 {
                     "call_to_action": "enroll now",
-                    "datetime": data["course_runs"]["A"]["enrollment_end"]
-                    .isoformat()
-                    .replace("+00:00", "Z"),
+                    "datetime": None,
                     "priority": 0,
-                    "text": "closing on",
+                    "text": "open for enrollment",
                 },
                 {
                     "call_to_action": None,
@@ -1468,11 +1458,9 @@ class CourseRunsCoursesQueryTestCase(TestCase):
             [
                 {
                     "call_to_action": "enroll now",
-                    "datetime": data["course_runs"]["B"]["enrollment_end"]
-                    .isoformat()
-                    .replace("+00:00", "Z"),
+                    "datetime": None,
                     "priority": 0,
-                    "text": "closing on",
+                    "text": "open for enrollment",
                 },
                 {
                     "call_to_action": None,


### PR DESCRIPTION
This commit change text and remove datetime on glimpse footer.

## Purpose
Change text and remove datime on glimpse footer when state is ONGOING_OPEN 

## Proposal
This commit resolve the issue https://github.com/openfun/richie/issues/1970

- Changes was made on course models
- Existent tests was refactored.
