### PR TITLE
🐛(frontend) make remaining_order_count optional

### DIFF
--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -101,7 +101,7 @@ export interface Product {
   target_courses: TargetCourse[];
   created_on: string;
   orders: Order['id'][];
-  remaining_order_count: number | null;
+  remaining_order_count?: number | null;
 }
 
 export interface CourseProduct extends Product {

--- a/src/frontend/js/widgets/CourseProductItem/components/PurchaseButton/index.tsx
+++ b/src/frontend/js/widgets/CourseProductItem/components/PurchaseButton/index.tsx
@@ -63,7 +63,7 @@ const PurchaseButton = ({ product, disabled }: PurchaseButtonProps) => {
   }
 
   const hasAtLeastOneRemainingOrder =
-    product.remaining_order_count === null || product.remaining_order_count > 0;
+    typeof product?.remaining_order_count !== 'number' || product.remaining_order_count > 0;
   const isPurchasable = hasAtLeastOneRemainingOrder && hasAtLeastOneCourseRun;
 
   return (


### PR DESCRIPTION
## Purpose

Currently, Joanie product endpoint does not return the `remaining_order_count`. In order to prevent to break the CourseProductItemWidget, we make this property optional.


## Proposal

- [x] Make `Product.remaining_order_count` optional
