### PR TITLE
Feat/bind features into context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ information message when the product have no remaining order.
 
 ### Changed
 
+- Bind `settings.FEATURES` into `FRONTEND_CONTEXT['context']`
+through `context_processor`
 - Show original language name on the menu instead of translating it on the
   current language.
 - Replace helix factories by homemade engine using typescript.

--- a/env.d/development/dev-ssl.dist
+++ b/env.d/development/dev-ssl.dist
@@ -6,4 +6,4 @@ AUTHENTICATION_BACKEND=openedx-hawthorn
 EDX_BASE_URL=https://edx.local.dev:8073
 
 # Features
-FEATURES = {'JOANIE_WISHLIST': True}
+FEATURES={'WISHLIST': True, 'REACT_DASHBOARD': True}

--- a/env.d/development/dev.dist
+++ b/env.d/development/dev.dist
@@ -5,6 +5,8 @@ AUTHENTICATION_BACKEND=dummy
 # LMS Backend
 EDX_BASE_URL=http://localhost:8073
 EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
+EDX_COURSE_REGEX='^.*/courses/(?P<course_id>.*)/info/?$'
+EDX_JS_COURSE_REGEX='^.*/courses/(.*)/info/?$'
 EDX_JS_BACKEND=dummy
 
 # Features

--- a/env.d/development/dev.dist
+++ b/env.d/development/dev.dist
@@ -8,4 +8,4 @@ EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
 EDX_JS_BACKEND=dummy
 
 # Features
-FEATURES = {'JOANIE_WISHLIST': True}
+FEATURES={'WISHLIST': True, 'REACT_DASHBOARD': True}

--- a/src/frontend/js/types/commonDataProps.ts
+++ b/src/frontend/js/types/commonDataProps.ts
@@ -16,12 +16,18 @@ export interface AuthenticationBackend {
   endpoint: string;
 }
 
+enum FEATURES {
+  REACT_DASHBOARD = 'REACT_DASHBOARD',
+  WISHLIST = 'WISHLIST',
+}
+
 export interface RichieContext {
   authentication: AuthenticationBackend;
   csrftoken: string;
   environment: string;
-  lms_backends?: LMSBackend[];
+  features: Partial<Record<FEATURES, boolean>>;
   joanie_backend?: JoanieBackend;
+  lms_backends?: LMSBackend[];
   release: string;
   sentry_dsn: Nullable<string>;
   web_analytics_providers?: Nullable<string[]>;

--- a/src/frontend/js/utils/test/factories/richie.ts
+++ b/src/frontend/js/utils/test/factories/richie.ts
@@ -75,12 +75,13 @@ export const FonzieUserFactory = factory<User>(() => ({
 }));
 
 export const RichieContextFactory = factory<CommonDataProps['context']>(() => ({
-  csrftoken: faker.string.alphanumeric(64),
-  environment: 'test',
   authentication: {
     backend: APIBackend.OPENEDX_HAWTHORN,
     endpoint: 'https://endpoint.test',
   },
+  csrftoken: faker.string.alphanumeric(64),
+  environment: 'test',
+  features: {},
   lms_backends: [
     {
       backend: APIBackend.DUMMY,

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -120,6 +120,10 @@ def site_metas(request: HttpRequest):
             for lms in getattr(settings, "RICHIE_LMS_BACKENDS", [])
         ]
 
+    context["FRONTEND_CONTEXT"]["context"]["features"] = getattr(
+        settings, "FEATURES", {}
+    )
+
     context["FRONTEND_CONTEXT"] = json.dumps(context["FRONTEND_CONTEXT"])
 
     if getattr(settings, "RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT", None):

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -180,7 +180,7 @@
                                 {% if open_visible_runs|length == 0 %}
                                     <div class="course-detail__row course-detail__runs course-detail__runs--open">
                                         <div class="course-detail__empty">{% trans "No open course runs" %}</div>
-                                        {% is_feature_enabled 'JOANIE_WISHLIST' as joanie_wishlist_enabled %}
+                                        {% is_feature_enabled 'WISHLIST' as joanie_wishlist_enabled %}
                                         {% if is_joanie_enabled and joanie_wishlist_enabled  %}
                                             <div
                                                 class="richie-react richie-react--course-add-to-wishlist"

--- a/tests/apps/core/test_pages.py
+++ b/tests/apps/core/test_pages.py
@@ -85,7 +85,8 @@ class PagesTests(CMSTestCase):
         ]
     )
     @override_settings(
-        WEB_ANALYTICS={"google_universal_analytics": {"tracking_id": "TRACKING_ID"}}
+        FEATURES={"FEATURE_FLAG": True},
+        WEB_ANALYTICS={"google_universal_analytics": {"tracking_id": "TRACKING_ID"}},
     )
     def test_page_includes_frontend_context(self):
         """
@@ -122,4 +123,9 @@ class PagesTests(CMSTestCase):
         self.assertContains(
             response,
             r"\u0022web_analytics_providers\u0022: \u0022[\u005C\u0022google_universal_analytics\u005C\u0022]\u0022,",  # noqa pylint: disable=line-too-long
+        )
+
+        self.assertContains(
+            response,
+            r"\u0022features\u0022: {\u0022FEATURE_FLAG\u0022: true}",  # noqa pylint: disable=line-too-long
         )


### PR DESCRIPTION
## Purpose

Richie backend has a settings `FEATURES` to en.dis.able some feature in
    development. We are currently porting the course run list to React and this
    content contains a development feature `WISHLIST`. In order to be able to en
    .dis.able this feature, we need to get `FEATURES` settings through frontend, so
    we decided to bind this setting to `FRONTEND_CONTEXT`



## Proposal

- [x] Bind `settings.FEATURES` into `__richie_frontend_context__.context`
