### PR TITLE
Fix ModuleNotFoundError

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/base.txt
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/base.txt
@@ -1,5 +1,6 @@
 boto3==1.21.4
 django-check-seo==0.4.3
+unidecode==1.3.6 # required by django-check-seo
 django-configurations==2.3.2
 django-storages==1.11.1
 dockerflow==2022.1.0


### PR DESCRIPTION
## Purpose

A ModuleNotFoundError occurs when bootstrapping a project according to the instructions here: https://richie.education/docs/cookiecutter#bootstrap-your-project

## Proposal

After adding the missing package the bootstrapping works