### PR TITLE
Ci/fix/cookiecutter bootstrap

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/env.d/development.dist
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/env.d/development.dist
@@ -22,10 +22,11 @@ DB_PORT=5432
 
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
-EDX_JS_BACKEND=base
-EDX_JS_COURSE_REGEX='^.*/courses/(.*)/info$'
 EDX_BASE_URL=http://localhost:8073
+EDX_COURSE_REGEX='^.*/courses/(?P<course_id>.*)/info/?$'
+EDX_JS_COURSE_REGEX='^.*/courses/(.*)/info/?$'
+EDX_JS_BACKEND=openedx-hawthorn
 
 # Authentication Backend
 AUTHENTICATION_BASE_URL=http://localhost:8073
-AUTHENTICATION_BACKEND=base
+AUTHENTICATION_BACKEND=openedx-hawthorn

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/cookiecutter.json
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/cookiecutter.json
@@ -1,6 +1,5 @@
 {
     "_organization": null,
     "site": null,
-    "domain": null,
-    "_extensions": ["jinja2_time.TimeExtension"]
+    "domain": null
 }

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/base.txt
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/base.txt
@@ -1,9 +1,9 @@
-boto3==1.21.4
-django-check-seo==0.4.3
-django-configurations==2.3.2
-django-storages==1.11.1
-dockerflow==2022.1.0
+boto3==1.28.9
+django-check-seo==0.6.2
+django-configurations==2.4.1
+django-storages==1.13.2
+dockerflow==2022.8.0
 gunicorn==20.1.0
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.6
 richie==2.22.0
-sentry-sdk==1.14.0
+sentry-sdk==1.28.1

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/base.txt
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/base.txt
@@ -6,4 +6,5 @@ dockerflow==2022.8.0
 gunicorn==20.1.0
 psycopg2-binary==2.9.6
 richie==2.22.0
+unidecode==1.3.6 # required by django-check-seo
 sentry-sdk==1.28.1

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/dev.txt
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/requirements/dev.txt
@@ -1,16 +1,16 @@
-bandit==1.7.2
-black==22.3.0
+bandit==1.7.5
+black==23.7.0
 Faker==13.2.0
 factory-boy==3.2.1
-flake8==4.0.1
-isort==5.10.1
-pylint==2.12.2
-pylint-django==2.5.2
-pytest==7.0.1
-pytest-cov==3.0.0
+flake8==6.0.0
+isort==5.12.0
+pylint==2.17.4
+pylint-django==2.5.3
+pytest==7.4.0
+pytest-cov==4.1.0
 pytest-django==4.5.2
 raincoat==1.0.1
 
 # Testing html
-lxml==4.9.1
-cssselect==1.1.0
+lxml==4.9.3
+cssselect==1.2.0

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/urls.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/urls.py
@@ -11,10 +11,7 @@ from django.views.generic import TemplateView
 from django.views.static import serve
 
 from cms.sitemaps import CMSSitemap
-from richie.apps.courses.urls import (
-    redirects_urlpatterns as courses_redirects_urlpatterns,
-    urlpatterns as courses_urlpatterns,
-)
+from richie.apps.courses.urls import urlpatterns as courses_urlpatterns
 from richie.apps.search.urls import urlpatterns as search_urlpatterns
 from richie.plugins.urls import urlpatterns as plugins_urlpatterns
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
@@ -23,15 +23,15 @@
     "richie-education": "2.22.0"
   },
   "devDependencies": {
-    "babel-loader": "9.1.2",
-    "@formatjs/cli": "6.1.0",
-    "eslint": "8.38.0",
+    "@formatjs/cli": "6.1.3",
+    "babel-loader": "9.1.3",
+    "eslint": "8.44.0",
     "eslint-import-resolver-webpack": "0.13.2",
-    "nodemon": "2.0.22",
-    "prettier": "2.8.7",
-    "sass": "1.62.0",
+    "nodemon": "3.0.1",
+    "prettier": "3.0.0",
+    "sass": "1.63.6",
     "source-map-loader": "4.0.1",
-    "webpack": "5.80.0",
-    "webpack-cli": "5.0.1"
+    "webpack": "5.88.1",
+    "webpack-cli": "5.1.4"
   }
 }


### PR DESCRIPTION
## Purpose

The `cookiecutter-bootstrap` job warns us something went wrong with the cookiecutter template. This PR aims to fix the template to work without extra configuration with the latest Richie release.

We also take opportunity to upgrade all dependencies.

### Related Pull request
#2032 

## Proposal

- [x] Upgrade all deps
- [x] Install unidecode (thanks @Riezebos)
- [x] Fix cookiecutter configuration to be able to use latest version
- [x] Revert urls change that has been added too soon.
