### PR TITLE
💚(crowdin) upgrade crowdin to version 3.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ jobs:
   # translation management tool
   upload-i18n-strings:
     docker:
-      - image: crowdin/cli:3.3.0
+      - image: crowdin/cli:3.13.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       - .:/app
 
   crowdin:
-    image: crowdin/cli:3.5.5
+    image: crowdin/cli:3.13.0
     volumes:
       - ".:/app"
     env_file:


### PR DESCRIPTION
## Purpose

Currently, the job to upload translations to crowdin fails. Actually, Crowdin API seems have breaking change that does not comply with current version of crowdin we are using. Upgrade to the latest version of crowdin fixes the issue.


## Proposal

- [x] Fix `upload-i18n-strings` job 
