### PR TITLE
🐛(frontend) fix organization breadcrumb

### DIFF
--- a/src/frontend/js/pages/TeacherOrganizationCourseDashboardLoader/index.tsx
+++ b/src/frontend/js/pages/TeacherOrganizationCourseDashboardLoader/index.tsx
@@ -28,7 +28,7 @@ export const TeacherOrganizationCourseDashboardLoader = () => {
     states: { fetching },
   } = useOrganization(organizationId);
   useBreadcrumbsPlaceholders({
-    organizationTitle: organization.title ?? '',
+    organizationTitle: organization?.title ?? '',
   });
   return (
     <DashboardLayout sidebar={<TeacherOrganizationDashboardSidebar />}>


### PR DESCRIPTION
We have an error when organization is not in ReactQuery cache.

