### PR TITLE
💄(course-detail) fix characteristics overflow issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Course details characteristics overflow issue
+
 ## [2.23.0] - 2023-07-28
 
 ### Added

--- a/src/frontend/scss/objects/_characteristics.scss
+++ b/src/frontend/scss/objects/_characteristics.scss
@@ -5,22 +5,22 @@
 // Simple inline with optional color scheme features
 .characteristics {
   @include feature-list($margin: 0.5rem 0 0.5rem 0);
-
   color: inherit;
 
-  &__row {
-    text-align: center;
-  }
-
   &__item {
-    @include feature-item($parent_selector: '.characteristics');
+    @include feature-item($parent_selector: '.characteristics', $valign: flex-start, $expand: true);
     color: inherit;
+    margin-bottom: 0.5rem;
+
+    &--full-width {
+      width: 100%;
+    }
   }
 
   &__term {
     align-items: center;
     color: inherit;
-    padding-top: 0.2125rem; // Fine tune vertical alignment with icons
+    margin-top: rem-calc(-2px); // Fine tune vertical alignment with icons
   }
 
   // When using through a color scheme, item adopt button behaviors
@@ -43,12 +43,5 @@
       @include button-tiny($form-factor: 'pill', $display: flex);
       @include r-button-colors(r-theme-val(characteristics, tertiary-item), $apply-border: true);
     }
-  }
-
-  &__enrollment-count {
-    @include make-container();
-    padding-left: 0;
-    padding-right: 0;
-    font-size: 1rem;
   }
 }

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -115,27 +115,25 @@
                                     <span class="characteristics__term">{% trans "Pace:" %} {{ instance.get_pace_display|default:"NA" }}</span>
                                 </li>
                                 {% endif %}
-                                <div class="characteristics__row">
-                                    <li class="characteristics__item">
-                                        <svg role="img" class="characteristics__icon" aria-hidden="true">
-                                            <use href="#icon-languages" />
-                                        </svg>
-                                        <span class="characteristics__term">{% trans "Languages:" %} {{ course.languages_display|default:"NA" }}</span>
-                                    </li>
-                                </div>
+                                <li class="characteristics__item characteristics__item--full-width">
+                                    <svg role="img" class="characteristics__icon" aria-hidden="true">
+                                        <use href="#icon-languages" />
+                                    </svg>
+                                    <span class="characteristics__term">{% trans "Languages:" %} {{ course.languages_display|default:"NA" }}</span>
+                                </li>
                                 {% block enrollment_count %}
                                     {% with enrollment_count=course.course_runs_enrollment_count %}
                                         {% if enrollment_count > 0 and RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT > 0 and enrollment_count >= RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT %}
-                                            <div class="characteristics__enrollment-count">
                                                 <li class="characteristics__item">
                                                     <svg role="img" class="characteristics__icon" aria-hidden="true">
                                                         <use href="#icon-groups" />
                                                     </svg>
+                                                    <span class="characteristics__term">
                                                     {% blocktrans with count=enrollment_count|intcomma %}
                                                         {{ count }} already enrolled!
                                                     {% endblocktrans %}
+                                                    </span>
                                                 </li>
-                                            </div>
                                         {% endif %}
                                     {% endwith %}
                                 {% endblock enrollment_count %}

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -206,7 +206,6 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         )
 
         # Check that enrollment count is not present
-        self.assertContains(response, "enrollment-count")
         self.assertContains(response, "11,000 already enrolled!")
 
     def test_templates_course_detail_cms_published_content_no_code(self):
@@ -802,7 +801,6 @@ class RunsCourseCMSTestCase(CMSTestCase):
 
         response = self.client.get(course.extended_object.get_absolute_url())
 
-        self.assertNotContains(response, "enrollment-count")
         self.assertNotContains(response, "already enrolled")
 
     @override_settings(RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT=None)
@@ -820,7 +818,6 @@ class RunsCourseCMSTestCase(CMSTestCase):
 
         response = self.client.get(course.extended_object.get_absolute_url())
 
-        self.assertNotContains(response, "enrollment-count")
         self.assertNotContains(response, "already enrolled")
 
     def test_templates_course_detail_license_missing(self):


### PR DESCRIPTION
## Purpose

We recently display course languages into the course subheader. But when the list is too long, its content does not go the next line and overflows.

### Before
<img width="600" alt="image" src="https://github.com/openfun/richie/assets/9265241/23aeedff-63ed-499c-acc3-18dcb80cce51">

### After
<img width="600" alt="image" src="https://github.com/openfun/richie/assets/9265241/0a810bcb-82e1-432b-af6c-718d08eddce0">


## Proposal

- [x] Fix layout issue
