### PR TITLE
✨(frontend) buy certificate from enrollement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Add a footer on enrollment's item in the learner dashboard. It give the
+  possibility to purchase linked product or download linked certificate.
+
 ### Changed
 
 - When a course have multiple seller organizations, CourseGlimpse now display

--- a/src/frontend/js/components/DownloadCertificateButton/index.tsx
+++ b/src/frontend/js/components/DownloadCertificateButton/index.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@openfun/cunningham-react';
+import { FormattedMessage, defineMessages } from 'react-intl';
+import { Spinner } from 'components/Spinner';
+import { useDownloadCertificate } from 'hooks/useDownloadCertificate';
+import { Certificate } from 'types/Joanie';
+
+const messages = defineMessages({
+  download: {
+    defaultMessage: 'Download',
+    description: 'Label for the download button of a certificate',
+    id: 'components.DownloadCertificateButton.download',
+  },
+  generatingCertificate: {
+    defaultMessage: 'Certificate is being generated...',
+    description: 'Accessible label displayed while certificate is being generated.',
+    id: 'components.DownloadCertificateButton.generatingCertificate',
+  },
+});
+
+interface DownloadCertificateButtonProps {
+  certificateId: Certificate['id'];
+  className?: string;
+}
+
+const DownloadCertificateButton = ({
+  certificateId,
+  className,
+}: DownloadCertificateButtonProps) => {
+  const { download, loading } = useDownloadCertificate();
+  const onDownloadClick = async () => {
+    if (!certificateId) {
+      return;
+    }
+    await download(certificateId);
+  };
+
+  return (
+    <Button className={className} color="secondary" disabled={loading} onClick={onDownloadClick}>
+      {loading ? (
+        <Spinner theme="primary" aria-labelledby="generating-certificate">
+          <span id="generating-certificate">
+            <FormattedMessage {...messages.generatingCertificate} />
+          </span>
+        </Spinner>
+      ) : (
+        <FormattedMessage {...messages.download} />
+      )}
+    </Button>
+  );
+};
+
+export default DownloadCertificateButton;

--- a/src/frontend/js/components/PaymentButton/index.tsx
+++ b/src/frontend/js/components/PaymentButton/index.tsx
@@ -3,7 +3,7 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { Button } from '@openfun/cunningham-react';
 import { Spinner } from 'components/Spinner';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
-import { useOrders } from 'hooks/useOrders';
+import { useOmniscientOrders } from 'hooks/useOrders';
 import { PAYMENT_SETTINGS } from 'settings';
 import type * as Joanie from 'types/Joanie';
 import { OrderState } from 'types/Joanie';
@@ -90,7 +90,7 @@ const PaymentButton = ({ product, billingAddress, creditCard, onSuccess }: Payme
   const API = useJoanieApi();
   const timeoutRef = useRef<NodeJS.Timeout>();
   const { courseCode } = useCourseProduct();
-  const orderManager = useOrders();
+  const orderManager = useOmniscientOrders();
 
   const isReadyToPay = useMemo(() => {
     return courseCode && product.id && billingAddress;

--- a/src/frontend/js/components/PurchaseButton/index.spec.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.spec.tsx
@@ -3,10 +3,15 @@ import fetchMock from 'fetch-mock';
 import { IntlProvider } from 'react-intl';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
-import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import {
+  CourseStateFactory,
+  RichieContextFactory as mockRichieContextFactory,
+} from 'utils/test/factories/richie';
 import { ProductFactory } from 'utils/test/factories/joanie';
 import { SessionProvider } from 'contexts/SessionContext';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { ProductType } from 'types/Joanie';
+import { Priority } from 'types';
 import PurchaseButton from '.';
 
 jest.mock('utils/context', () => ({
@@ -176,8 +181,11 @@ describe('PurchaseButton', () => {
   });
 
   it.each([
-    { label: 'base product', productData: {} },
-    { label: 'No remaining orders', productData: { remaining_order_count: 0 } },
+    { label: 'Product credential', productData: { type: ProductType.CREDENTIAL } },
+    {
+      label: 'Product credential without remaining orders',
+      productData: { remaining_order_count: 0, type: ProductType.CREDENTIAL },
+    },
   ])(
     'renders a disabled CTA if one target course has no course runs. Case "$label"',
     async ({ productData }) => {
@@ -203,9 +211,111 @@ describe('PurchaseButton', () => {
       expect(button).toBeDisabled();
 
       // Further, a message is displayed to explain why the CTA is disabled
-      screen.findByText(
-        'At least one course has no course runs, this product is not currently available for sale',
-      );
+      expect(
+        await screen.findByText(
+          'At least one course has no course runs, this product is not currently available for sale',
+        ),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    {
+      label: 'state: ARCHIVED_CLOSED',
+      courseRunStateData: { priority: Priority.ARCHIVED_CLOSED },
+    },
+    {
+      label: 'state: ARCHIVED_OPEN',
+      courseRunStateData: { priority: Priority.ARCHIVED_OPEN },
+    },
+    {
+      label: 'state: TO_BE_SCHEDULED',
+      courseRunStateData: { priority: Priority.TO_BE_SCHEDULED },
+    },
+  ])(
+    'renders a disabled CTA for product certificate if the linked course run is not open',
+    async ({ courseRunStateData }) => {
+      const product = ProductFactory({ type: ProductType.CERTIFICATE }).one();
+      const courseRunState = CourseStateFactory(courseRunStateData).one();
+      fetchMock
+        .get('https://joanie.test/api/v1.0/addresses/', [])
+        .get('https://joanie.test/api/v1.0/credit-cards/', [])
+        .get('https://joanie.test/api/v1.0/orders/', []);
+
+      act(() => {
+        render(
+          <Wrapper client={createTestQueryClient({ user: true })}>
+            <PurchaseButton product={product} disabled={false} courseRunState={courseRunState} />
+          </Wrapper>,
+        );
+      });
+
+      // CTA is displayed but disabled
+      const button: HTMLButtonElement = await screen.findByRole('button', {
+        name: product.call_to_action,
+      });
+      expect(button).toBeDisabled();
+
+      // Further, a message is displayed to explain why the CTA is disabled
+      expect(
+        screen.getByText(
+          'The course run is not active, this product is not currently available for sale',
+        ),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    {
+      label: 'state: ONGOING_OPEN',
+      courseRunStateData: { priority: Priority.ONGOING_OPEN },
+    },
+    {
+      label: 'state: FUTURE_OPEN',
+      courseRunStateData: { priority: Priority.FUTURE_OPEN },
+    },
+    {
+      label: 'state: FUTURE_NOT_YET_OPEN',
+      courseRunStateData: { priority: Priority.FUTURE_NOT_YET_OPEN },
+    },
+    {
+      label: 'state: FUTURE_CLOSED',
+      courseRunStateData: { priority: Priority.FUTURE_CLOSED },
+    },
+    {
+      label: 'state: ONGOING_CLOSED',
+      courseRunStateData: { priority: Priority.ONGOING_CLOSED },
+    },
+  ])(
+    'do not renders a disabled CTA for product certificate if the linked course run is open',
+    async ({ courseRunStateData }) => {
+      const product = ProductFactory({ type: ProductType.CERTIFICATE }).one();
+      const courseRunState = CourseStateFactory(courseRunStateData).one();
+      fetchMock
+        .get('https://joanie.test/api/v1.0/addresses/', [])
+        .get('https://joanie.test/api/v1.0/credit-cards/', [])
+        .get('https://joanie.test/api/v1.0/orders/', []);
+
+      act(() => {
+        render(
+          <Wrapper client={createTestQueryClient({ user: true })}>
+            <PurchaseButton product={product} disabled={false} courseRunState={courseRunState} />
+          </Wrapper>,
+        );
+      });
+
+      // CTA should not be disabled
+      const button: HTMLButtonElement = await screen.findByRole('button', {
+        name: product.call_to_action,
+      });
+      expect(button).not.toBeDisabled();
+
+      // No alert message
+      expect(
+        screen.queryByText(
+          'The course run is not active, this product is not currently available for sale',
+        ),
+      ).not.toBeInTheDocument();
     },
   );
 

--- a/src/frontend/js/components/PurchaseButton/styles.scss
+++ b/src/frontend/js/components/PurchaseButton/styles.scss
@@ -13,5 +13,4 @@
     $font-weight: $font-weight-bold
   );
   background-color: r-theme-val(product-item, button-background);
-  width: 100%;
 }

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Modal } from 'components/Modal';
-import type * as Joanie from 'types/Joanie';
-import { useOmniscientOrders } from 'hooks/useOrders';
+import { Product } from 'types/Joanie';
+import { useOmniscientOrders, useOrders } from 'hooks/useOrders';
 import { IconTypeEnum } from 'components/Icon';
 import { Manifest, useStepManager } from 'hooks/useStepManager';
 import { SaleTunnelStepValidation } from './components/SaleTunnelStepValidation';
@@ -38,14 +38,19 @@ const focusCurrentStep = (container: HTMLElement) => {
 };
 
 type Props = {
-  product: Joanie.Product;
+  product: Product;
   isOpen: boolean;
   onClose: () => void;
 };
 
 const SaleTunnel = ({ product, isOpen = false, onClose }: Props) => {
   const intl = useIntl();
-  const { methods: ordersMethods } = useOmniscientOrders();
+  const {
+    methods: { refetch: refetchOmniscientOrders },
+  } = useOmniscientOrders();
+  const {
+    methods: { invalidate: invalidateOrders },
+  } = useOrders(undefined, { enabled: false });
 
   const manifest: Manifest<TunnelSteps, 'resume'> = {
     start: 'validation',
@@ -67,7 +72,9 @@ const SaleTunnel = ({ product, isOpen = false, onClose }: Props) => {
         onExit: () => {
           // Once the user has completed the purchase, we need to refetch the orders
           // to update the ordersQuery cache
-          ordersMethods.refetch();
+          invalidateOrders();
+          refetchOmniscientOrders();
+
           handleModalClose();
         },
       },

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Modal } from 'components/Modal';
 import type * as Joanie from 'types/Joanie';
-import { useOrders } from 'hooks/useOrders';
+import { useOmniscientOrders } from 'hooks/useOrders';
 import { IconTypeEnum } from 'components/Icon';
 import { Manifest, useStepManager } from 'hooks/useStepManager';
 import { SaleTunnelStepValidation } from './components/SaleTunnelStepValidation';
@@ -45,7 +45,7 @@ type Props = {
 
 const SaleTunnel = ({ product, isOpen = false, onClose }: Props) => {
   const intl = useIntl();
-  const { methods: ordersMethods } = useOrders();
+  const { methods: ordersMethods } = useOmniscientOrders();
 
   const manifest: Manifest<TunnelSteps, 'resume'> = {
     start: 'validation',

--- a/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.tsx
+++ b/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import JoanieApiProvider from 'contexts/JoanieApiContext';
 import { useAddresses } from 'hooks/useAddresses';
-import { useOrders } from 'hooks/useOrders';
+import { useOmniscientOrders } from 'hooks/useOrders';
 import { REACT_QUERY_SETTINGS, RICHIE_USER_TOKEN } from 'settings';
 import type { User } from 'types/User';
 import type { Nullable } from 'types/utils';
@@ -57,7 +57,7 @@ const JoanieSessionProvider = ({ children }: React.PropsWithChildren<any>) => {
   const queryClient = useQueryClient();
   const addresses = useAddresses();
   const creditCards = useCreditCards();
-  const orders = useOrders();
+  const orders = useOmniscientOrders();
 
   const login = useCallback(() => {
     queryClient.clear();

--- a/src/frontend/js/hooks/useOrders.ts
+++ b/src/frontend/js/hooks/useOrders.ts
@@ -1,5 +1,13 @@
 import { defineMessages } from 'react-intl';
-import { API, CourseLight, Order, OrderState, PaginatedResourceQuery, Product } from 'types/Joanie';
+import {
+  API,
+  CourseLight,
+  Order,
+  OrderState,
+  PaginatedResourceQuery,
+  Product,
+  ProductType,
+} from 'types/Joanie';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
 import { useSessionMutation } from 'utils/react-query/useSessionMutation';
 import { QueryOptions, useResource, useResourcesCustom, UseResourcesProps } from './useResources';
@@ -8,6 +16,7 @@ export type OrderResourcesQuery = PaginatedResourceQuery & {
   course?: CourseLight['code'];
   product?: Product['id'];
   state?: OrderState[];
+  product__type?: ProductType[];
 };
 
 const messages = defineMessages({

--- a/src/frontend/js/hooks/useOrders.ts
+++ b/src/frontend/js/hooks/useOrders.ts
@@ -41,25 +41,29 @@ function omniscientFiltering(data: Order[], filter: OrderResourcesQuery): Order[
   );
 }
 
+const useOrdersBase =
+  (props: UseResourcesProps<Order, OrderResourcesQuery, API['user']['orders']>) =>
+  (filters?: OrderResourcesQuery, queryOptions?: QueryOptions<Order>) => {
+    const custom = useResourcesCustom({ ...props, filters, queryOptions });
+    const abortHandler = useSessionMutation(useJoanieApi().user.orders.abort);
+    return {
+      ...custom,
+      methods: {
+        ...custom.methods,
+        abort: abortHandler.mutateAsync,
+      },
+    };
+  };
+
 const props: UseResourcesProps<Order, OrderResourcesQuery, API['user']['orders']> = {
   queryKey: ['orders'],
   apiInterface: () => useJoanieApi().user.orders,
   messages,
-  omniscient: true,
-  omniscientFiltering,
   session: true,
 };
+const propsOmniscient = { ...props, omniscient: true, omniscientFiltering };
+export const useOmniscientOrders = useOrdersBase(propsOmniscient);
+export const useOmniscientOrder = useResource(propsOmniscient);
 
-export const useOrders = (filters?: OrderResourcesQuery, queryOptions?: QueryOptions<Order>) => {
-  const custom = useResourcesCustom({ ...props, filters, queryOptions });
-  const abortHandler = useSessionMutation(useJoanieApi().user.orders.abort);
-  return {
-    ...custom,
-    methods: {
-      ...custom.methods,
-      abort: abortHandler.mutateAsync,
-    },
-  };
-};
-
+export const useOrders = useOrdersBase(props);
 export const useOrder = useResource(props);

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -140,7 +140,7 @@ describe('<DashboardCourses/>', () => {
   it('renders an empty placeholder', async () => {
     const ordersDeferred = new Deferred();
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}`,
+      `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}&product__type=credential`,
       ordersDeferred.promise,
     );
     const enrollmentsDeferred = new Deferred();
@@ -175,24 +175,33 @@ describe('<DashboardCourses/>', () => {
   it('should render the list of entities', async () => {
     const client = createTestQueryClient({ user: true });
     const { orders, relations } = mockOrders(OrderFactory().many(perPage * 2 + 1), client);
-    fetchMock.get(`https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}`, {
-      results: orders.slice(0, perPage),
-      next: `https://joanie.endpoint/api/v1.0/orders/?page=2&page_size=${perPage}`,
-      prev: null,
-      count: orders.length,
-    });
-    fetchMock.get(`https://joanie.endpoint/api/v1.0/orders/?page=2&page_size=${perPage}`, {
-      results: orders.slice(perPage, perPage * 2),
-      next: `https://joanie.endpoint/api/v1.0/orders/?page=3&page_size=${perPage}`,
-      prev: null,
-      count: orders.length,
-    });
-    fetchMock.get(`https://joanie.endpoint/api/v1.0/orders/?page=3&page_size=${perPage}`, {
-      results: orders.slice(perPage * 2, perPage * 3),
-      next: null,
-      prev: null,
-      count: orders.length,
-    });
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}&product__type=credential`,
+      {
+        results: orders.slice(0, perPage),
+        next: `https://joanie.endpoint/api/v1.0/orders/?page=2&page_size=${perPage}&product__type=credential`,
+        prev: null,
+        count: orders.length,
+      },
+    );
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/orders/?page=2&page_size=${perPage}&product__type=credential`,
+      {
+        results: orders.slice(perPage, perPage * 2),
+        next: `https://joanie.endpoint/api/v1.0/orders/?page=3&page_size=${perPage}&product__type=credential`,
+        prev: null,
+        count: orders.length,
+      },
+    );
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/orders/?page=3&page_size=${perPage}&product__type=credential`,
+      {
+        results: orders.slice(perPage * 2, perPage * 3),
+        next: null,
+        prev: null,
+        count: orders.length,
+      },
+    );
     const enrollments: Enrollment[] = EnrollmentFactory().many(perPage * 2 + 2);
     enrollments.sort((a, b) => {
       const aDate = new Date(a.created_on);
@@ -257,7 +266,7 @@ describe('<DashboardCourses/>', () => {
     jest.spyOn(console, 'error').mockImplementation(noop);
     const ordersDeferred = new Deferred();
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}`,
+      `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}&product__type=credential`,
       ordersDeferred.promise,
     );
     fetchMock.get(

--- a/src/frontend/js/pages/DashboardCourses/index.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.tsx
@@ -11,6 +11,7 @@ import { DashboardItemEnrollment } from 'widgets/Dashboard/components/DashboardI
 import { DashboardItemOrder } from 'widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder';
 import Banner, { BannerType } from 'components/Banner';
 import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
+import { ProductType } from 'types/Joanie';
 
 const messages = defineMessages({
   loading: {
@@ -31,7 +32,9 @@ const messages = defineMessages({
 });
 
 export const DashboardCourses = () => {
-  const { next, data, hasMore, error, isLoading, count } = useOrdersEnrollments();
+  const { next, data, hasMore, error, isLoading, count } = useOrdersEnrollments({
+    orderFilters: { product__type: [ProductType.CREDENTIAL] },
+  });
 
   const loadMoreButtonRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
   useIntersectionObserver({

--- a/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
+++ b/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
@@ -3,6 +3,7 @@ import { useJoanieApi } from 'contexts/JoanieApiContext';
 import { Enrollment, Order, PaginatedResourceQuery } from 'types/Joanie';
 import useUnionResource, { ResourceUnionPaginationProps } from 'hooks/useUnionResource';
 import { PER_PAGE } from 'settings';
+import { OrderResourcesQuery } from 'hooks/useOrders';
 
 export const isOrder = (obj: Order | Enrollment): obj is Order => {
   return 'total' in obj && 'enrollments' in obj;
@@ -19,9 +20,14 @@ const messages = defineMessages({
   },
 });
 
+interface UseOrdersEnrollmentsProps extends ResourceUnionPaginationProps {
+  orderFilters?: OrderResourcesQuery;
+}
+
 export const useOrdersEnrollments = ({
   perPage = PER_PAGE.useOrdersEnrollments,
-}: ResourceUnionPaginationProps = {}) => {
+  orderFilters = {},
+}: UseOrdersEnrollmentsProps = {}) => {
   const api = useJoanieApi();
   return useUnionResource<
     Order,
@@ -32,7 +38,7 @@ export const useOrdersEnrollments = ({
     queryAConfig: {
       queryKey: ['user', 'order'],
       fn: api.user.orders.get,
-      filters: {},
+      filters: orderFilters,
     },
     queryBConfig: {
       queryKey: ['user', 'enrollments'],

--- a/src/frontend/js/pages/DashboardOrderLayout/index.tsx
+++ b/src/frontend/js/pages/DashboardOrderLayout/index.tsx
@@ -7,7 +7,7 @@ import {
 } from 'widgets/Dashboard/utils/dashboardRoutes';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import { DashboardLayout } from 'widgets/Dashboard/components/DashboardLayout';
-import { useOrder } from 'hooks/useOrders';
+import { useOmniscientOrder } from 'hooks/useOrders';
 import { useBreadcrumbsPlaceholders } from 'hooks/useBreadcrumbsPlaceholders';
 import { CourseLight, Product } from 'types/Joanie';
 import { LearnerDashboardSidebar } from 'widgets/Dashboard/components/LearnerDashboardSidebar';
@@ -15,7 +15,7 @@ import { useCourseProduct } from 'hooks/useCourseProducts';
 
 export const DashboardOrderLayout = () => {
   const params = useParams<{ orderId: string }>();
-  const order = useOrder(params.orderId);
+  const order = useOmniscientOrder(params.orderId);
   const course = order.item?.course as CourseLight;
   const courseProduct = useCourseProduct(course?.code, { productId: order.item?.product });
   const product = courseProduct?.item?.product;

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -47,7 +47,7 @@ export interface CourseRun {
   start: string;
   state: CourseState;
   title: string;
-  course?: CourseLight;
+  course: CourseLight;
 }
 
 // - Certificate
@@ -166,6 +166,7 @@ export interface Enrollment {
   course_run: CourseRun;
   was_created_by_order: boolean;
   created_on: string;
+  products: Product[];
 }
 
 // Order

--- a/src/frontend/js/utils/CourseRuns/index.ts
+++ b/src/frontend/js/utils/CourseRuns/index.ts
@@ -77,3 +77,15 @@ export const computeState = (courseRun: CourseRun): CourseState => {
     text: CourseStateTextEnum.ENROLLMENT_CLOSED,
   };
 };
+
+export const isOpenedCourseRunCredential = (courseRunState: CourseState) =>
+  courseRunState.priority <= Priority.FUTURE_NOT_YET_OPEN;
+
+export const isOpenedCourseRunCertificate = (courseRunState: CourseState) =>
+  [
+    Priority.ONGOING_OPEN,
+    Priority.FUTURE_OPEN,
+    Priority.FUTURE_NOT_YET_OPEN,
+    Priority.FUTURE_CLOSED,
+    Priority.ONGOING_CLOSED,
+  ].includes(courseRunState.priority);

--- a/src/frontend/js/utils/test/factories/joanie.spec.ts
+++ b/src/frontend/js/utils/test/factories/joanie.spec.ts
@@ -1,0 +1,7 @@
+import * as joanieFactories from './joanie';
+
+describe('Factories joanie', () => {
+  it.each(Object.entries(joanieFactories))('can instanciate %s', (name, Factory) => {
+    expect(() => Factory().one()).not.toThrow(Error);
+  });
+});

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -101,12 +101,12 @@ export const CertificateFactory = factory((): Certificate => {
   };
 });
 
-export const CertificateProductFactory = factory((): Product => {
+export const CredentialProductFactory = factory((): Product => {
   return {
     id: faker.string.uuid(),
     created_on: faker.date.past().toISOString(),
     title: FactoryHelper.sequence((counter) => `Certificate Product ${counter}`),
-    type: ProductType.CERTIFICATE,
+    type: ProductType.CREDENTIAL,
     price: faker.number.int(),
     price_currency: faker.finance.currencyCode(),
     call_to_action: faker.lorem.words(3),
@@ -119,16 +119,16 @@ export const CertificateProductFactory = factory((): Product => {
 
 export const CertificateCourseProductFactory = factory((): CourseProduct => {
   return {
-    ...CertificateProductFactory().one(),
+    ...CredentialProductFactory().one(),
     order: OrderLiteFactory().one(),
     target_courses: TargetCourseFactory().many(3),
   };
 });
 
-// ProductFactory is an alias for CertificateProductFactory
+// ProductFactory is an alias for CredentialProductFactory
 // in the future we'll have differents types of products,
 // factories.js need a feature that return a random factory from a list.
-export const ProductFactory = CertificateProductFactory;
+export const ProductFactory = CredentialProductFactory;
 
 export const CourseRunFactory = factory((): CourseRun => {
   return {
@@ -210,7 +210,8 @@ export const CourseLightFactory = factory((): CourseLight => {
     code: faker.string.alphanumeric(5),
     organizations: OrganizationLightFactory().many(1),
     title: FactoryHelper.sequence((counter) => `Course light ${counter}`),
-    products: CertificateCourseProductFactory().many(3),
+    // products: CertificateCourseProductFactory().many(3),
+    products: [],
     course_runs: [],
     orders: [],
   };

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -47,6 +47,7 @@ export const EnrollmentFactory = factory((): Enrollment => {
     id: faker.string.uuid(),
     course_run: CourseRunWithCourseFactory().one(),
     is_active: true,
+    products: ProductFactory().many(1),
     state: EnrollmentState.SET,
     was_created_by_order: false,
     created_on: faker.date.past({ years: 1 }).toISOString(),
@@ -132,6 +133,7 @@ export const ProductFactory = CredentialProductFactory;
 
 export const CourseRunFactory = factory((): CourseRun => {
   return {
+    course: CourseLightFactory().one(),
     end: faker.date.future({ years: 0.75 }).toISOString(),
     enrollment_end: faker.date.future({ years: 0.5 }).toISOString(),
     enrollment_start: faker.date.past({ years: 0.5 }).toISOString(),
@@ -210,7 +212,10 @@ export const CourseLightFactory = factory((): CourseLight => {
     code: faker.string.alphanumeric(5),
     organizations: OrganizationLightFactory().many(1),
     title: FactoryHelper.sequence((counter) => `Course light ${counter}`),
-    // products: CertificateCourseProductFactory().many(3),
+    // do not use a ProductFactory here.
+    // ProductFactory will call CourseLightFactory and create a infinit loop.
+    // if we need a factory of course with a product, it should be a
+    // different one than CourseLightFactory.
     products: [],
     course_runs: [],
     orders: [],

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Certificate/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Certificate/index.spec.tsx
@@ -5,7 +5,7 @@ import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
-import { Certificate, CourseLight } from 'types/Joanie';
+import { Certificate, CourseLight, ProductType } from 'types/Joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { SessionProvider } from 'contexts/SessionContext';
 import { DashboardItemCertificate } from 'widgets/Dashboard/components/DashboardItem/Certificate/index';
@@ -49,7 +49,10 @@ describe('<DashboardCertificate/>', () => {
 
   it('displays a certificate', async () => {
     const certificate: Certificate = CertificateFactory().one();
-    render(<DashboardItemCertificate certificate={certificate} />, { wrapper: Wrapper });
+    render(
+      <DashboardItemCertificate certificate={certificate} productType={ProductType.CREDENTIAL} />,
+      { wrapper: Wrapper },
+    );
 
     await waitFor(() => screen.getByText(certificate.certificate_definition.title));
     screen.getByText((certificate.order.course as CourseLight).title);
@@ -64,7 +67,10 @@ describe('<DashboardCertificate/>', () => {
 
     fetchMock.get(`https://joanie.test/api/v1.0/certificates/${certificate.id}/download/`, 200);
 
-    render(<DashboardItemCertificate certificate={certificate} />, { wrapper: Wrapper });
+    render(
+      <DashboardItemCertificate certificate={certificate} productType={ProductType.CREDENTIAL} />,
+      { wrapper: Wrapper },
+    );
 
     await waitFor(() => screen.getByText(certificate.certificate_definition.title));
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Certificate/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Certificate/index.tsx
@@ -1,50 +1,20 @@
-import { defineMessages, FormattedMessage } from 'react-intl';
-import { Button } from '@openfun/cunningham-react';
 import { Icon, IconTypeEnum } from 'components/Icon';
-import { Certificate, CertificateDefinition, CourseLight } from 'types/Joanie';
-import { useDownloadCertificate } from 'hooks/useDownloadCertificate';
-import { Spinner } from 'components/Spinner';
-import useDateFormat from 'hooks/useDateFormat';
+import { Certificate, CertificateDefinition, CourseLight, ProductType } from 'types/Joanie';
 import { DashboardItem } from 'widgets/Dashboard/components/DashboardItem/index';
 import { Maybe } from 'types/utils';
+import DownloadCertificateButton from 'components/DownloadCertificateButton';
+import CertificateStatus from '../CertificateStatus';
 
-const messages = defineMessages({
-  download: {
-    defaultMessage: 'Download',
-    description: 'Label for the download button of a certificate',
-    id: 'components.DashboardCertificate.download',
-  },
-  details: {
-    defaultMessage: 'Details',
-    description: 'Label for the details button of a certificate',
-    id: 'components.DashboardCertificate.details',
-  },
-  issuedOn: {
-    defaultMessage: 'Issued on {date}',
-    description: 'Label for the date of issue of a certificate',
-    id: 'components.DashboardCertificate.issuedOn',
-  },
-  noCertificate: {
-    defaultMessage:
-      'When all your courses will be passed, you will be able to download your certificate here.',
-    description: 'Label displayed when no certificate is available',
-    id: 'components.DashboardCertificate.noCertificate',
-  },
-  generatingCertificate: {
-    defaultMessage: 'Certificate is being generated...',
-    description:
-      'Accessible label displayed while certificate is being generated on the dashboard.',
-    id: 'components.DashboardCertificate.generatingCertificate',
-  },
-});
-
+interface DashboardItemCertificateProps {
+  certificate?: Certificate;
+  certificateDefinition?: CertificateDefinition;
+  productType?: ProductType;
+}
 export const DashboardItemCertificate = ({
   certificate,
   certificateDefinition,
-}: {
-  certificate?: Certificate;
-  certificateDefinition?: CertificateDefinition;
-}) => {
+  productType,
+}: DashboardItemCertificateProps) => {
   if (certificate) {
     if (certificateDefinition) {
       throw new Error('certificate and certificateDefinition are mutually exclusive');
@@ -59,16 +29,6 @@ export const DashboardItemCertificate = ({
   }
 
   const course = certificate?.order.course as Maybe<CourseLight>;
-  const { download, loading } = useDownloadCertificate();
-  const formatDate = useDateFormat();
-
-  const onDownloadClick = async () => {
-    if (!certificate) {
-      return;
-    }
-    await download(certificate.id);
-  };
-
   return (
     <DashboardItem
       title={course?.title ?? ''}
@@ -82,30 +42,9 @@ export const DashboardItemCertificate = ({
           </div>
           <div className="dashboard-certificate__footer">
             <span>
-              {certificate ? (
-                <FormattedMessage
-                  {...messages.issuedOn}
-                  values={{ date: formatDate(certificate!.issued_on) }}
-                />
-              ) : (
-                <FormattedMessage {...messages.noCertificate} />
-              )}
+              <CertificateStatus certificate={certificate} productType={productType} />
             </span>
-            <div>
-              {certificate && (
-                <Button color="secondary" disabled={loading} onClick={onDownloadClick}>
-                  {loading ? (
-                    <Spinner theme="primary" aria-labelledby="generating-certificate">
-                      <span id="generating-certificate">
-                        <FormattedMessage {...messages.generatingCertificate} />
-                      </span>
-                    </Spinner>
-                  ) : (
-                    <FormattedMessage {...messages.download} />
-                  )}
-                </Button>
-              )}
-            </div>
+            <div>{certificate && <DownloadCertificateButton certificateId={certificate.id} />}</div>
           </div>
         </>
       }

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Certificate/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Certificate/index.tsx
@@ -29,11 +29,13 @@ export const DashboardItemCertificate = ({
   }
 
   const course = certificate?.order.course as Maybe<CourseLight>;
+
   return (
     <DashboardItem
       title={course?.title ?? ''}
       code={'Ref. ' + (course?.code ?? '')}
       imageUrl="https://d29emq8to944i.cloudfront.net/cba69447-b9f7-b4d7-c0d5-4d98b5280a4e/thumbnails/1659356729_1080.jpg"
+      imageFile={course?.cover}
       footer={
         <>
           <div className="dashboard-certificate__body">

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/CertificateStatus/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/CertificateStatus/index.spec.tsx
@@ -1,0 +1,65 @@
+import { IntlProvider } from 'react-intl';
+import { render, screen } from '@testing-library/react';
+import { ProductType } from 'types/Joanie';
+import { CertificateFactory } from 'utils/test/factories/joanie';
+import CertificateStatus, { CertificateStatusProps } from '.';
+
+describe('<CertificateStatus/>', () => {
+  const Wrapper = ({ certificate, productType }: CertificateStatusProps) => (
+    <IntlProvider locale="en">
+      <CertificateStatus certificate={certificate} productType={productType} />
+    </IntlProvider>
+  );
+
+  it('should display message for issued certificate.', () => {
+    const certificate = CertificateFactory({
+      issued_on: new Date('01/01/2021').toISOString(),
+    }).one();
+    render(<Wrapper certificate={certificate} productType={ProductType.CERTIFICATE} />);
+    expect(screen.getByText('Issued on Jan 01, 2021')).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(
+        'When you pass your exam, you will be able to download your certificate here.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'When all your courses have been passed, you will be able to download your certificate here.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display message for no certificate of product type certificate.', () => {
+    render(<Wrapper productType={ProductType.CERTIFICATE} />);
+
+    expect(
+      screen.getByText(
+        'When you pass your exam, you will be able to download your certificate here.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText('Issued on', { exact: false })).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'When all your courses have been passed, you will be able to download your certificate here.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display message for no certificate of product type credential.', () => {
+    render(<Wrapper productType={ProductType.CREDENTIAL} />);
+    expect(
+      screen.getByText(
+        'When all your courses have been passed, you will be able to download your certificate here.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText('Issued on', { exact: false })).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'When you pass your exam, you will be able to download your certificate here.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/CertificateStatus/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/CertificateStatus/index.tsx
@@ -1,0 +1,61 @@
+import { FormattedMessage, MessageDescriptor, defineMessages } from 'react-intl';
+import useDateFormat from 'hooks/useDateFormat';
+import { Certificate, ProductType } from 'types/Joanie';
+
+const messages = defineMessages({
+  issuedOn: {
+    defaultMessage: 'Issued on {date}',
+    description: 'Label for the date of issue of a certificate',
+    id: 'components.DashboardCertificate.issuedOn',
+  },
+  noCertificateCredential: {
+    defaultMessage:
+      'When all your courses have been passed, you will be able to download your certificate here.',
+    description: 'Label displayed when no certificate credential is available',
+    id: 'components.DashboardCertificate.noCertificateCredential',
+  },
+  noCertificateCertificate: {
+    defaultMessage: 'When you pass your exam, you will be able to download your certificate here.',
+    description: 'Label displayed when no certificate certificate is available',
+    id: 'components.DashboardCertificate.noCertificateCertificate',
+  },
+  noCertificateUnknown: {
+    defaultMessage:
+      'When all requirements are met, you will be able to download your certificate here.',
+    description:
+      'Label displayed when we dont have the product type and no certificate is available',
+    id: 'components.DashboardCertificate.noCertificateUnknown',
+  },
+});
+
+export interface CertificateStatusProps {
+  certificate?: Certificate;
+  productType?: ProductType;
+}
+const CertificateStatus = ({ certificate, productType }: CertificateStatusProps) => {
+  const getMessage = () => {
+    const messagesByProductType: Record<ProductType, MessageDescriptor> = {
+      [ProductType.CREDENTIAL]: messages.noCertificateCredential,
+      [ProductType.CERTIFICATE]: messages.noCertificateCertificate,
+      // ProductType.ENROLLMENT doesn't exist yet
+      [ProductType.ENROLLMENT]: messages.noCertificateUnknown,
+    };
+
+    if (!productType) {
+      return messages.noCertificateUnknown;
+    }
+
+    return messagesByProductType[productType!];
+  };
+  const formatDate = useDateFormat();
+  return certificate ? (
+    <FormattedMessage
+      {...messages.issuedOn}
+      values={{ date: formatDate(certificate!.issued_on) }}
+    />
+  ) : (
+    <FormattedMessage {...getMessage()} />
+  );
+};
+
+export default CertificateStatus;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
@@ -266,6 +266,7 @@ export const Enrolled = ({
       {SHOW_ACCESS_COURSE_PRIORITIES.includes(enrollment.course_run.state.priority) && (
         // FIXME: cunningham button should allow usage of href.
         <RichieButton
+          className="dashboard-item__button"
           color="outline-primary"
           href={enrollment.course_run.resource_link}
           data-testid="dashboard-item-enrollment__button"

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.spec.tsx
@@ -1,14 +1,38 @@
 import { IntlProvider } from 'react-intl';
 import { render, screen } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Enrollment } from 'types/Joanie';
-import { CourseStateFactory } from 'utils/test/factories/richie';
+import {
+  CourseStateFactory,
+  RichieContextFactory as mockRichieContextFactory,
+} from 'utils/test/factories/richie';
 import { CourseRunWithCourseFactory, EnrollmentFactory } from 'utils/test/factories/joanie';
 import { DATETIME_FORMAT } from 'hooks/useDateFormat';
 import { Priority } from 'types';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
 import { DashboardItemEnrollment } from './DashboardItemEnrollment';
 
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.endpoint.test' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint.test' },
+  }).one(),
+}));
+
 describe('<DashboardItemEnrollment/>', () => {
+  const Wrapper = ({ enrollment }: { enrollment: Enrollment }) => (
+    <IntlProvider locale="en">
+      <QueryClientProvider client={createTestQueryClient()}>
+        <JoanieSessionProvider>
+          <DashboardItemEnrollment enrollment={enrollment} />
+        </JoanieSessionProvider>
+      </QueryClientProvider>
+    </IntlProvider>
+  );
+
   it('renders a opened enrollment', () => {
     const enrollment: Enrollment = EnrollmentFactory({
       course_run: CourseRunWithCourseFactory({
@@ -20,11 +44,7 @@ describe('<DashboardItemEnrollment/>', () => {
     }).one();
     enrollment.course_run.state.priority = Priority.ONGOING_OPEN;
 
-    render(
-      <IntlProvider locale="en">
-        <DashboardItemEnrollment enrollment={enrollment} />
-      </IntlProvider>,
-    );
+    render(<Wrapper enrollment={enrollment} />);
     screen.getByText(enrollment.course_run.course!.title);
     screen.getByText('Ref. ' + enrollment.course_run.course!.code);
     const link = screen.getByRole('link', { name: 'Access course' });
@@ -52,11 +72,7 @@ describe('<DashboardItemEnrollment/>', () => {
       }).one(),
     }).one();
 
-    render(
-      <IntlProvider locale="en">
-        <DashboardItemEnrollment enrollment={enrollment} />
-      </IntlProvider>,
-    );
+    render(<Wrapper enrollment={enrollment} />);
     screen.getByText(enrollment.course_run.course!.title);
     screen.getByText('Ref. ' + enrollment.course_run.course!.code);
     const link = screen.getByRole('link', { name: 'Access course' });
@@ -79,11 +95,7 @@ describe('<DashboardItemEnrollment/>', () => {
       course_run: CourseRunWithCourseFactory().one(),
     };
 
-    render(
-      <IntlProvider locale="en">
-        <DashboardItemEnrollment enrollment={enrollment} />
-      </IntlProvider>,
-    );
+    render(<Wrapper enrollment={enrollment} />);
     screen.getByText(enrollment.course_run.course!.title);
     screen.getByText('Ref. ' + enrollment.course_run.course!.code);
     screen.getByText('Not enrolled');

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.tsx
@@ -1,24 +1,42 @@
-import { Enrollment } from 'types/Joanie';
+import { useMemo } from 'react';
+import { Enrollment, ProductType } from 'types/Joanie';
 import { DashboardItemCourseEnrolling } from '../DashboardItemCourseEnrolling';
 import { DashboardItem } from '..';
+import ProductCertificateFooter from './ProductCertificateFooter';
 
 interface DashboardItemCourseRunProps {
   enrollment: Enrollment;
 }
 
 export const DashboardItemEnrollment = ({ enrollment }: DashboardItemCourseRunProps) => {
-  const { course } = enrollment.course_run;
+  const { course, state: courseRunState } = enrollment.course_run;
   if (!course) {
     throw new Error("Enrollment's course_run must provide course attribute");
   }
 
-  return (
-    <DashboardItem
-      title={course.title}
-      code={'Ref. ' + course.code}
-      footer={
-        <DashboardItemCourseEnrolling course={course} activeEnrollment={enrollment} icon={true} />
+  const footerList = useMemo(() => {
+    const partialFooterList = [
+      <DashboardItemCourseEnrolling
+        key={`${enrollment.id}`}
+        course={course}
+        activeEnrollment={enrollment}
+        icon={true}
+      />,
+    ];
+    enrollment.products.forEach((product) => {
+      if (product.type === ProductType.CERTIFICATE) {
+        partialFooterList.push(
+          <ProductCertificateFooter
+            key={[enrollment.id, product.id].join('_')}
+            product={product}
+            course={course}
+            courseRunState={courseRunState}
+          />,
+        );
       }
-    />
-  );
+    });
+    return partialFooterList;
+  }, [enrollment, course]);
+
+  return <DashboardItem title={course.title} code={'Ref. ' + course.code} footer={footerList} />;
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.spec.tsx
@@ -1,0 +1,163 @@
+import { IntlProvider } from 'react-intl';
+import { render, screen } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import fetchMock from 'fetch-mock';
+import { CourseLight, OrderState, Product, ProductType } from 'types/Joanie';
+import {
+  CourseStateFactory,
+  UserFactory,
+  RichieContextFactory as mockRichieContextFactory,
+} from 'utils/test/factories/richie';
+import {
+  CertificateFactory,
+  CourseLightFactory,
+  OrderFactory,
+  ProductFactory,
+} from 'utils/test/factories/joanie';
+import { Priority } from 'types';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
+import queryString from 'query-string';
+import { OrderResourcesQuery } from 'hooks/useOrders';
+import ProductCertificateFooter, { ProductCertificateFooterProps } from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.endpoint.test' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint.test' },
+  }).one(),
+}));
+
+describe('<ProductCertificateFooter/>', () => {
+  const Wrapper = ({ course, product, courseRunState }: ProductCertificateFooterProps) => (
+    <IntlProvider locale="en">
+      <QueryClientProvider client={createTestQueryClient({ user: UserFactory().one() })}>
+        <JoanieSessionProvider>
+          <ProductCertificateFooter
+            course={course}
+            product={product}
+            courseRunState={courseRunState}
+          />
+        </JoanieSessionProvider>
+      </QueryClientProvider>
+    </IntlProvider>
+  );
+  let product: Product;
+  let course: CourseLight;
+  let orderQueryParameters: OrderResourcesQuery;
+
+  beforeAll(() => {
+    // As dialog is rendered through a Portal, we have to add the DOM element in which the dialog will be rendered.
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
+
+  beforeEach(() => {
+    fetchMock.get('https://joanie.endpoint.test/api/v1.0/addresses/', []);
+    fetchMock.get('https://joanie.endpoint.test/api/v1.0/credit-cards/', []);
+    fetchMock.get('https://joanie.endpoint.test/api/v1.0/orders/', []);
+
+    product = ProductFactory({ type: ProductType.CERTIFICATE }).one();
+    course = CourseLightFactory().one();
+    orderQueryParameters = {
+      product: product.id,
+      course: course.code,
+      state: [OrderState.PENDING, OrderState.VALIDATED],
+    };
+    fetchMock.get(
+      `https://joanie.endpoint.test/api/v1.0/orders/?${queryString.stringify(
+        orderQueryParameters,
+      )}`,
+      [OrderFactory().one()],
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  it.each([
+    {
+      label: 'state: ONGOING_OPEN',
+      courseRunStateData: { priority: Priority.ONGOING_OPEN },
+    },
+    {
+      label: 'state: FUTURE_OPEN',
+      courseRunStateData: { priority: Priority.FUTURE_OPEN },
+    },
+    {
+      label: 'state: FUTURE_NOT_YET_OPEN',
+      courseRunStateData: { priority: Priority.FUTURE_NOT_YET_OPEN },
+    },
+    {
+      label: 'state: FUTURE_CLOSED',
+      courseRunStateData: { priority: Priority.FUTURE_CLOSED },
+    },
+    {
+      label: 'state: ONGOING_CLOSED',
+      courseRunStateData: { priority: Priority.ONGOING_CLOSED },
+    },
+  ])(
+    'should display purchase button for a open course run without order (state $courseRunStateData.priority).',
+    async ({ courseRunStateData }) => {
+      const courseRunState = CourseStateFactory(courseRunStateData).one();
+      render(<Wrapper course={course} product={product} courseRunState={courseRunState} />);
+      expect(screen.getByTestId('PurchaseButton__cta')).toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    {
+      label: 'state: ARCHIVED_CLOSED',
+      courseRunStateData: { priority: Priority.ARCHIVED_CLOSED },
+    },
+    {
+      label: 'state: ARCHIVED_OPEN',
+      courseRunStateData: { priority: Priority.ARCHIVED_OPEN },
+    },
+    {
+      label: 'state: TO_BE_SCHEDULED',
+      courseRunStateData: { priority: Priority.TO_BE_SCHEDULED },
+    },
+  ])(
+    "shouldn't display purchase button for a closed course run without order (state $courseRunStateData.priority).",
+    async ({ courseRunStateData }) => {
+      const courseRunState = CourseStateFactory(courseRunStateData).one();
+      render(<Wrapper course={course} product={product} courseRunState={courseRunState} />);
+      expect(screen.queryByTestId('PurchaseButton__cta')).not.toBeInTheDocument();
+    },
+  );
+
+  it('should display download button for a course run with certificate.', async () => {
+    const courseRunState = CourseStateFactory().one();
+    fetchMock.get(
+      `https://joanie.endpoint.test/api/v1.0/orders/?${queryString.stringify(
+        orderQueryParameters,
+      )}`,
+      [OrderFactory({ certificate: 'FAKE_CERTIFICATE_ID' }).one()],
+      { overwriteRoutes: true },
+    );
+
+    fetchMock.get(
+      'https://joanie.endpoint.test/api/v1.0/certificates/FAKE_CERTIFICATE_ID/',
+      CertificateFactory(),
+    );
+    render(<Wrapper course={course} product={product} courseRunState={courseRunState} />);
+    expect(await screen.findByRole('button', { name: 'Download' })).toBeInTheDocument();
+    expect(screen.queryByTestId('PurchaseButton__cta')).not.toBeInTheDocument();
+  });
+
+  it.each<ProductType>([ProductType.CERTIFICATE, ProductType.CREDENTIAL])(
+    'should not display button (download or purchase) for a course run with order but without certificate (product type: "%s").',
+    async ([productType]) => {
+      product.type = productType as ProductType;
+      const courseRunState = CourseStateFactory().one();
+      render(<Wrapper course={course} product={product} courseRunState={courseRunState} />);
+      expect(await screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('PurchaseButton__cta')).not.toBeInTheDocument();
+    },
+  );
+});

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
@@ -1,0 +1,103 @@
+import { FormattedMessage } from 'react-intl';
+import PurchaseButton from 'components/PurchaseButton';
+import { Icon, IconTypeEnum } from 'components/Icon';
+import { CourseLight, Order, OrderState, Product, ProductType } from 'types/Joanie';
+import { useOrders } from 'hooks/useOrders';
+import { CourseProductProvider } from 'contexts/CourseProductContext';
+import DownloadCertificateButton from 'components/DownloadCertificateButton';
+import { useCertificate } from 'hooks/useCertificates';
+import { CourseState } from 'types';
+import { isOpenedCourseRunCertificate } from 'utils/CourseRuns';
+import { useMemo } from 'react';
+import CertificateStatus from '../../CertificateStatus';
+
+const messages = {
+  buyProductCertificateLabel: {
+    id: 'components.ProductCertificateFooter.buyProductCertificateLabel',
+    description: 'Label on the enrollement row that propose to buy a product of type certificate',
+    defaultMessage: 'An exam which delivers a certificate can be purchased for this course.',
+  },
+  downloadProductCertificateLabel: {
+    id: 'components.ProductCertificateFooter.downloadProductCertificateLabel',
+    description: 'Label on the enrollement row that propose to download a certificate',
+    defaultMessage: 'A certificate is available for download.',
+  },
+  pendingProductCertificateLabel: {
+    id: 'components.ProductCertificateFooter.pendingProductCertificateLabel',
+    description: 'Label on the enrollement when a product of type certificate have been bought',
+    defaultMessage: 'Finish this course to obtain your certificate.',
+  },
+};
+
+export interface ProductCertificateFooterProps {
+  course: CourseLight;
+  product: Product;
+  courseRunState: CourseState;
+}
+
+const ProductCertificateFooter = ({
+  course,
+  product,
+  courseRunState,
+}: ProductCertificateFooterProps) => {
+  if (product.type !== ProductType.CERTIFICATE) {
+    return null;
+  }
+  const { items: orders } = useOrders({
+    product: product.id,
+    course: course.code,
+    state: [OrderState.PENDING, OrderState.VALIDATED],
+  });
+
+  // Only one order can existe for a product and a course.
+  if (orders.length > 1) {
+    throw Error(
+      `Multiple orders found (${orders.length}) for product: "${product.id}" and course "${course.id}"`,
+    );
+  }
+
+  const order: Order | null = useMemo(() => {
+    return orders.length ? orders[0] : null;
+  }, [orders]);
+  const { item: certificate } = useCertificate(order?.certificate);
+
+  // The course run is no longer available
+  // and no product certificate had been bought therefore there isn't any certifcate to download.
+  if (!order && !isOpenedCourseRunCertificate(courseRunState)) {
+    return null;
+  }
+
+  return (
+    <CourseProductProvider courseCode={course.code} productId={product.id}>
+      <div className="dashboard-item__course-enrolling__infos">
+        <div className="dashboard-item__block__status">
+          <Icon name={IconTypeEnum.CERTIFICATE} />
+          {order ? (
+            <>
+              {product.certificate_definition.title + '. '}
+              <CertificateStatus certificate={certificate} productType={product.type} />
+            </>
+          ) : (
+            <FormattedMessage {...messages.buyProductCertificateLabel} />
+          )}
+        </div>
+        {order ? (
+          order.certificate && (
+            <DownloadCertificateButton
+              className="dashboard-item__button"
+              certificateId={order.certificate}
+            />
+          )
+        ) : (
+          <PurchaseButton
+            className="dashboard-item__button"
+            product={product}
+            courseRunState={courseRunState}
+          />
+        )}
+      </div>
+    </CourseProductProvider>
+  );
+};
+
+export default ProductCertificateFooter;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -52,9 +52,19 @@ interface DashboardItemOrderProps {
   writable?: boolean;
 }
 
-const DashboardItemOrderCertificate = ({ order, product }: { order: Order; product: Product }) => {
+interface DashboardItemOrderCertificateProps {
+  order: Order;
+  product: Product;
+}
+
+const DashboardItemOrderCertificate = ({ order, product }: DashboardItemOrderCertificateProps) => {
   if (!order.certificate) {
-    return <DashboardItemCertificate certificateDefinition={product.certificate_definition} />;
+    return (
+      <DashboardItemCertificate
+        certificateDefinition={product.certificate_definition}
+        productType={product.type}
+      />
+    );
   }
   const certificate = useCertificate(order.certificate);
   return (
@@ -66,7 +76,9 @@ const DashboardItemOrderCertificate = ({ order, product }: { order: Order; produ
           </span>
         </Spinner>
       )}
-      {certificate.item && <DashboardItemCertificate certificate={certificate.item} />}
+      {certificate.item && (
+        <DashboardItemCertificate certificate={certificate.item} productType={product.type} />
+      )}
     </>
   );
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -125,6 +125,7 @@ export const DashboardItemOrder = ({
           </div>
           {showDetailsButton && (
             <RouterButton
+              className="dashboard-item__button"
               color="transparent-darkest"
               href={getRoutePath(LearnerDashboardPaths.ORDER, { orderId: order.id })}
               data-testid="dashboard-item-order__button"

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -121,6 +121,11 @@
     padding: 0.5rem 1rem;
     min-height: 3.75rem;
 
+    border-top: $onepixel solid r-theme-val(dashboard-item, base-border);
+    &:first-child {
+      border-top: 0;
+    }
+
     @include media-breakpoint-down(sm) {
       flex-direction: column;
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -52,6 +52,11 @@
       }
     }
   }
+
+  &__button {
+    justify-content: center;
+    min-width: rem-calc(140px);
+  }
 }
 
 .dashboard-sub-item-list {
@@ -119,12 +124,14 @@
     @include media-breakpoint-down(sm) {
       flex-direction: column;
 
-      .button {
+      .button,
+      .dashboard-item__button {
         width: 100%;
       }
     }
 
-    .button {
+    .button,
+    .dashboard-item__button {
       flex-shrink: 0;
     }
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/index.tsx
@@ -1,10 +1,12 @@
 import { PropsWithChildren, ReactNode } from 'react';
+import { JoanieFile } from 'types/Joanie';
 import { PropsWithTestId } from 'types/utils';
 
 type Props = PropsWithTestId<{
   title: string;
   code: string;
   imageUrl?: string;
+  imageFile?: JoanieFile;
   footer?: ReactNode;
 }>;
 
@@ -22,13 +24,24 @@ export const DashboardItem = (props: PropsWithChildren<Props>) => {
             props.imageUrl ? 'dashboard-item__block__head--with-image' : '',
           ].join(' ')}
         >
-          {!!props.imageUrl && (
+          {props.imageFile ? (
             <img
               data-testid="dashboard-item__block__head__thumbnail"
               className="dashboard-item__block__head__thumbnail"
-              src={props.imageUrl}
+              sizes={props.imageFile.size + ''}
+              src={props.imageFile.src}
+              srcSet={props.imageFile.srcset}
               alt=""
             />
+          ) : (
+            props.imageUrl && (
+              <img
+                data-testid="dashboard-item__block__head__thumbnail"
+                className="dashboard-item__block__head__thumbnail"
+                src={props.imageUrl}
+                alt=""
+              />
+            )
           )}
           <div className="dashboard-item__block__head__captions">
             <h5 className="dashboard-item__block__head__title">{props.title}</h5>

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/stories.mock.ts
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/stories.mock.ts
@@ -30,4 +30,5 @@ export const enrollment: Enrollment = {
       ],
     },
   },
+  products: [],
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { useOrder } from 'hooks/useOrders';
+import { useOmniscientOrder } from 'hooks/useOrders';
 import { Spinner } from 'components/Spinner';
 import Banner, { BannerType } from 'components/Banner';
 import { CourseLight } from 'types/Joanie';
@@ -17,7 +17,7 @@ const messages = defineMessages({
 
 export const DashboardOrderLoader = () => {
   const params = useParams<{ orderId: string }>();
-  const order = useOrder(params.orderId);
+  const order = useOmniscientOrder(params.orderId);
   const course = order.item?.course as CourseLight;
   const courseProduct = useCourseProduct(course?.code, { productId: order.item?.product });
   const fetching = order.states.fetching || courseProduct.states.fetching;

--- a/src/frontend/js/widgets/Dashboard/components/RouterButton/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/RouterButton/index.tsx
@@ -13,6 +13,7 @@ export const RouterButton = (props: ButtonProps) => {
   const ref = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
   return (
     <Button
+      className={props.className}
       ref={ref}
       href={hrefBase + props.href}
       onClick={(event: MouseEvent) => {

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/_styles.scss
@@ -122,5 +122,9 @@
 
   &__footer {
     padding: 0 0.875rem 1rem 0.875rem;
+
+    .purchase-button__cta {
+      width: 100%;
+    }
   }
 }

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
@@ -4,7 +4,7 @@ import { useCourseProduct } from 'hooks/useCourseProducts';
 import type * as Joanie from 'types/Joanie';
 import { OrderState } from 'types/Joanie';
 import { Spinner } from 'components/Spinner';
-import { useOrders } from 'hooks/useOrders';
+import { useOmniscientOrders } from 'hooks/useOrders';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { CourseProductProvider } from 'contexts/CourseProductContext';
 import PurchaseButton from 'components/PurchaseButton';
@@ -39,7 +39,7 @@ export interface Props {
 const CourseProductItem = ({ productId, courseCode }: Props) => {
   const productQuery = useCourseProduct(courseCode, { productId });
   const product = productQuery.item?.product;
-  const ordersQuery = useOrders({
+  const ordersQuery = useOmniscientOrders({
     product: productId,
     course: courseCode,
     state: [OrderState.VALIDATED, OrderState.PENDING],


### PR DESCRIPTION
## Purpose

[see issus](https://github.com/openfun/richie/issues/2048) 

## To live test this PR

If the reviewer want to see this new feature, it need to switch joanie to [this branche](https://github.com/openfun/joanie/pull/375)
then reset joanie development database by executing: 
```sh
make demo-dev
```

## Proposal

:warning: As we don't have `ButtonLink` in cunningham, even with the merge of [the button PR](https://github.com/openfun/richie/pull/2031), we'll have old button's design for "view details" and "access course" links.

- [x] Design for enrollement dashboard item with purchase button
- [x] Design for enrollement dashboard item with pending certificate
- [x] Design for enrollement dashboard item with download button
- [x] I can download my certificate
- [x] I can purchase the product
- [x] I can download an "enrollment certificate"
- [ ] Design for SaleTunel step "Validation"
- [ ] Design for SaleTunel step "Payement"
- [x] Test coverage


![image](https://github.com/openfun/richie/assets/139848/ebefdeb8-78b4-448a-9fa7-d9caf25ccda6)
![image](https://github.com/openfun/richie/assets/139848/31aec568-c338-4a15-a960-ad4049bd5f98)
![image](https://github.com/openfun/richie/assets/139848/b51996c9-22dc-4033-8c52-a36f12e07637)
