### PR TITLE
Fix/course glimpse regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Course details characteristics overflow issue
+- Map all richie course properties into `getCourseGlimpseProps` util
 
 ### Removed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -43,8 +43,8 @@ $ make migrate
   // Import Cunningham tokens and icons
   @import '@openfun/cunningham-react/dist/icons';
   @import '@openfun/cunningham-react/dist/style';
-  @import 'richie-education/vendors/cunningham-tokens';
-  @import 'richie-education/vendors/css/cunningham-tokens';
+  @import 'richie-education/scss/vendors/cunningham-tokens';
+  @import 'richie-education/scss/vendors/css/cunningham-tokens';
   
   // Override default Richie settings variables
   @import 'richie-education/scss/colors/palette';

--- a/src/frontend/js/components/CourseGlimpse/CourseGlimpseFooter.tsx
+++ b/src/frontend/js/components/CourseGlimpse/CourseGlimpseFooter.tsx
@@ -2,7 +2,7 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { CommonDataProps } from 'types/commonDataProps';
-import { CourseState } from 'types';
+import { CourseGlimpseCourse } from 'components/CourseGlimpse/index';
 
 const messages = defineMessages({
   dateIconAlt: {
@@ -16,18 +16,18 @@ const messages = defineMessages({
  * <CourseGlimpseFooter />.
  * This is spun off from <CourseGlimpse /> to allow easier override through webpack.
  */
-export const CourseGlimpseFooter: React.FC<{ courseState: CourseState } & CommonDataProps> = ({
-  courseState,
+export const CourseGlimpseFooter: React.FC<{ course: CourseGlimpseCourse } & CommonDataProps> = ({
+  course,
 }) => {
   const intl = useIntl();
   return (
     <div className="course-glimpse-footer">
       <div className="course-glimpse-footer__date">
         <Icon name={IconTypeEnum.CALENDAR} title={intl.formatMessage(messages.dateIconAlt)} />
-        {courseState.text.charAt(0).toUpperCase() +
-          courseState.text.substring(1) +
-          (courseState.datetime
-            ? ` ${intl.formatDate(new Date(courseState.datetime!), {
+        {course.state.text.charAt(0).toUpperCase() +
+          course.state.text.substring(1) +
+          (course.state.datetime
+            ? ` ${intl.formatDate(new Date(course.state.datetime!), {
                 year: 'numeric',
                 month: 'short',
                 day: 'numeric',

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -36,6 +36,10 @@ export interface CourseGlimpseCourse {
   }>;
   state: CourseState;
   nb_course_runs?: number;
+  organizations?: string[];
+  duration?: string;
+  effort?: string;
+  categories?: string[];
 }
 
 export interface CourseGlimpseProps {
@@ -150,7 +154,7 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
             </span>
           </div>
         ) : null}
-        <CourseGlimpseFooter context={context} courseState={course.state} />
+        <CourseGlimpseFooter context={context} course={course} />
       </div>
     </div>
   );

--- a/src/frontend/js/components/CourseGlimpse/utils.ts
+++ b/src/frontend/js/components/CourseGlimpse/utils.ts
@@ -47,6 +47,10 @@ const getCourseGlimpsePropsFromRichieCourse = (course: RichieCourse): CourseGlim
   },
   icon: course.icon,
   state: course.state,
+  duration: course.duration,
+  effort: course.effort,
+  categories: course.categories,
+  organizations: course.organizations,
 });
 
 const getCourseGlimpsePropsFromJoanieCourse = (


### PR DESCRIPTION
## Purpose

Now CourseGlimpse is used with two kind of resources, joanie Course and richie
Course. In order to that, we created a little util that map both resource
properties to a common interface. Unfortunately, we forgot to map some
properties of the Richie course interface.

Furthermore, we rework the CourseGlimpseFooter component props. Now it takes
only course state as props instead of a full course object. But in our factory,
we are overriding this component and we need to access the full course object.


## Proposal

- [x] Map all Richie course properties through `getCourseGlimpseProps` util
- [x] Pass a full course object to CourseGlimpseFooter in order to ease its override
