### PR TITLE
🔧(cookiecutter) fix frontend package name

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cookiecutter-site",
+  "name": "{{cookiecutter.site}}",
   "version": "0.1.0",
   "description": "Richie {{cookiecutter.site}} site on {{cookiecutter.domain}}",
   "scripts": {


### PR DESCRIPTION
## Purpose

Cookiecutter package name has been renamed by mistake. We fix it...
