### PR TITLE
🐛(frontend) fix course run that should not be archived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Course details characteristics overflow issue
 - Map all richie course properties into `getCourseGlimpseProps` util
+- Fix course run computed state. A run without end date must be ONGOING_OPEN
 - Fix cookiecutter circleci gitlint configuration
 
 ### Removed

--- a/src/frontend/js/utils/CourseRuns/index.spec.tsx
+++ b/src/frontend/js/utils/CourseRuns/index.spec.tsx
@@ -1,5 +1,5 @@
 import { Priority } from 'types';
-import { computeStates } from 'utils/CourseRuns/index';
+import { computeState, computeStates } from 'utils/CourseRuns/index';
 import { CourseRunFactoryFromPriority } from 'utils/test/factories/richie';
 
 describe('computeStates', () => {
@@ -15,5 +15,24 @@ describe('computeStates', () => {
   ])('correctly computes priority = %p', (priority) => {
     const courseRun = computeStates([CourseRunFactoryFromPriority(priority)().one()])[0];
     expect(courseRun.state.priority).toEqual(priority);
+  });
+
+  it('is ongoing when there are no enrollment end date nor course end date', () => {
+    const courseRun = CourseRunFactoryFromPriority(Priority.ONGOING_OPEN)().one();
+    (courseRun as any).enrollment_end = undefined;
+    (courseRun as any).end = undefined;
+    expect(computeState(courseRun).priority).toEqual(Priority.ONGOING_OPEN);
+  });
+
+  it('is ongoing when there are no enrollment end date', () => {
+    const courseRun = CourseRunFactoryFromPriority(Priority.ONGOING_OPEN)().one();
+    (courseRun as any).enrollment_end = undefined;
+    expect(computeState(courseRun).priority).toEqual(Priority.ONGOING_OPEN);
+  });
+
+  it('is ongoing when there are no course end date', () => {
+    const courseRun = CourseRunFactoryFromPriority(Priority.ONGOING_OPEN)().one();
+    (courseRun as any).end = undefined;
+    expect(computeState(courseRun).priority).toEqual(Priority.ONGOING_OPEN);
   });
 });

--- a/src/frontend/js/utils/CourseRuns/index.ts
+++ b/src/frontend/js/utils/CourseRuns/index.ts
@@ -19,8 +19,8 @@ export const computeState = (courseRun: CourseRun): CourseState => {
     };
   }
   const now = new Date();
-  const end = new Date(courseRun.end) ?? MAX_DATE;
-  const enrollmentEnd = new Date(courseRun.enrollment_end) ?? MAX_DATE;
+  const end = courseRun.end ? new Date(courseRun.end) : MAX_DATE;
+  const enrollmentEnd = courseRun.enrollment_end ? new Date(courseRun.enrollment_end) : MAX_DATE;
 
   if (new Date(courseRun.start) < now) {
     if (end > now) {


### PR DESCRIPTION
A miss in the code caused courses runs without enrollment end date or without end date to be considered as archived, where they are in reality ongoing.

Based on #2063 