### PR TITLE
⬆️(cookiecutter) fix cookiecutter circleci gitlint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Course details characteristics overflow issue
 - Map all richie course properties into `getCourseGlimpseProps` util
+- Fix cookiecutter circleci gitlint configuration
 
 ### Removed
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@project.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@project.yml
@@ -20,7 +20,7 @@ lint-git:
     - run:
         name: Install gitlint
         command: |
-          pip install --user gitlint
+          pip install --user requests gitlint
     - run:
         name: lint commit messages added to main
         command: |


### PR DESCRIPTION
Missing `requests` pip package when running `gitlint`, like the same have been done on: https://github.com/openfun/richie/blob/2e3d0f4078071243a026c51ffa57b27c975ac707/.circleci/config.yml#L65