### PR TITLE
🧪(frontend) test that user token is refresh

### DIFF
--- a/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.refetch.spec.tsx
+++ b/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.refetch.spec.tsx
@@ -1,0 +1,105 @@
+import fetchMock from 'fetch-mock';
+import { IntlProvider } from 'react-intl';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act, render, waitFor } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { faker } from '@faker-js/faker';
+import {
+  RichieContextFactory as mockRichieContextFactory,
+  FonzieUserFactory,
+} from 'utils/test/factories/richie';
+import { RICHIE_USER_TOKEN } from 'settings';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import JoanieSessionProvider from './JoanieSessionProvider';
+
+jest.mock('utils/errors/handle');
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.endpoint.test' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint.test' },
+  }).one(),
+}));
+jest.mock('utils/test/isTestEnv', () => ({
+  __esModule: true,
+  default: false,
+}));
+
+// - Joanie Session Provider test suite
+describe('JoanieSessionProvider', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <IntlProvider locale="en">
+      <QueryClientProvider client={createTestQueryClient({ persister: true })}>
+        <JoanieSessionProvider>{children}</JoanieSessionProvider>
+      </QueryClientProvider>
+    </IntlProvider>
+  );
+
+  beforeEach(() => {
+    fetchMock.restore();
+    jest.useFakeTimers();
+    sessionStorage.clear();
+
+    fetchMock
+      .get('https://joanie.endpoint.test/api/v1.0/addresses/', [])
+      .get('https://joanie.endpoint.test/api/v1.0/credit-cards/', [])
+      .get('https://joanie.endpoint.test/api/v1.0/orders/', []);
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('does refetch address, credit-cards, and order when user token change', async () => {
+    const initialAccessToken = btoa(faker.string.uuid());
+    const user = FonzieUserFactory({ access_token: initialAccessToken }).one();
+    fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', user);
+    render(<Wrapper />);
+
+    await waitFor(async () => {
+      const apiCallUrls = fetchMock.calls().map((call) => call[0]);
+      expect(apiCallUrls).toContain('https://joanie.endpoint.test/api/v1.0/addresses/');
+    });
+    expect(fetchMock.lastUrl()).not.toEqual('https://auth.endpoint.test/api/v1.0/user/me');
+
+    const addressCall = fetchMock
+      .calls()
+      .find((call) => call[0] === 'https://joanie.endpoint.test/api/v1.0/addresses/');
+
+    const { headers } = addressCall![1]!;
+
+    // @ts-ignore
+    expect(headers!.Authorization).toBe(`Bearer ${initialAccessToken}`);
+
+    // Api token refresh
+    const newAccessToken = btoa(faker.string.uuid());
+    user.access_token = newAccessToken;
+
+    fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', user, { overwriteRoutes: true });
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+    await waitFor(() => {
+      expect(fetchMock.lastUrl()).toEqual('https://auth.endpoint.test/api/v1.0/user/me');
+    });
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    await waitFor(async () => {
+      expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toEqual(newAccessToken);
+    });
+
+    const allAddressCalls = fetchMock
+      .calls()
+      .filter((call) => call[0] === 'https://joanie.endpoint.test/api/v1.0/addresses/');
+    expect(allAddressCalls).toHaveLength(2);
+
+    const newAddressCall = allAddressCalls.reverse()[0];
+    const { headers: newHeaders } = newAddressCall![1]!!;
+
+    // @ts-ignore
+    expect(newHeaders!.Authorization).toBe(`Bearer ${newAccessToken}`);
+  });
+});

--- a/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.spec.tsx
+++ b/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.spec.tsx
@@ -1,17 +1,16 @@
 import fetchMock from 'fetch-mock';
 import { IntlProvider } from 'react-intl';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { act, render, renderHook, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 import {
   RichieContextFactory as mockRichieContextFactory,
   FonzieUserFactory,
 } from 'utils/test/factories/richie';
 import { Deferred } from 'utils/test/deferred';
-import { REACT_QUERY_SETTINGS, RICHIE_USER_TOKEN } from 'settings';
+import { RICHIE_USER_TOKEN } from 'settings';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import JoanieSessionProvider from './JoanieSessionProvider';
-import { useSession } from '.';
 
 jest.mock('utils/errors/handle');
 jest.mock('utils/context', () => ({
@@ -20,11 +19,6 @@ jest.mock('utils/context', () => ({
     authentication: { backend: 'fonzie', endpoint: 'https://auth.endpoint.test' },
     joanie_backend: { endpoint: 'https://joanie.endpoint.test' },
   }).one(),
-}));
-jest.mock('utils/indirection/window', () => ({
-  location: {
-    assign: jest.fn(),
-  },
 }));
 
 // - Joanie Session Provider test suite
@@ -55,12 +49,10 @@ describe('JoanieSessionProvider', () => {
 
   it('stores user access token within session storage', async () => {
     const user = FonzieUserFactory().one();
-
     fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', user);
 
-    await act(async () => {
-      render(<Wrapper />);
-    });
+    render(<Wrapper />);
+
     await waitFor(async () => {
       expect(fetchMock.lastUrl()).toEqual('https://auth.endpoint.test/api/v1.0/user/me');
     });
@@ -75,19 +67,17 @@ describe('JoanieSessionProvider', () => {
 
     fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', deferredUser.promise);
 
-    await act(async () => {
-      render(<Wrapper />);
-    });
+    render(<Wrapper />);
 
     await act(async () => deferredUser.resolve(user));
 
     await waitFor(async () => {
-      const calls = fetchMock.calls();
-      expect(calls).toHaveLength(4);
-      expect(calls[0][0]).toEqual('https://auth.endpoint.test/api/v1.0/user/me');
-      expect(calls[1][0]).toEqual('https://joanie.endpoint.test/api/v1.0/addresses/');
-      expect(calls[2][0]).toEqual('https://joanie.endpoint.test/api/v1.0/credit-cards/');
-      expect(calls[3][0]).toEqual('https://joanie.endpoint.test/api/v1.0/orders/');
+      const apiCallUrls = fetchMock.calls().map((call) => call[0]);
+      expect(apiCallUrls).toHaveLength(4);
+      expect(apiCallUrls).toContain('https://auth.endpoint.test/api/v1.0/user/me');
+      expect(apiCallUrls).toContain('https://joanie.endpoint.test/api/v1.0/addresses/');
+      expect(apiCallUrls).toContain('https://joanie.endpoint.test/api/v1.0/credit-cards/');
+      expect(apiCallUrls).toContain('https://joanie.endpoint.test/api/v1.0/orders/');
     });
   });
 
@@ -96,9 +86,7 @@ describe('JoanieSessionProvider', () => {
 
     fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', deferredUser.promise);
 
-    await act(async () => {
-      render(<Wrapper />);
-    });
+    render(<Wrapper />);
 
     await act(async () => deferredUser.resolve(null));
 
@@ -108,69 +96,5 @@ describe('JoanieSessionProvider', () => {
 
     expect(fetchMock.calls()).toHaveLength(1);
     expect(fetchMock.lastUrl()).toEqual('https://auth.endpoint.test/api/v1.0/user/me');
-  });
-
-  it('clears session storage on login', async () => {
-    const user = FonzieUserFactory().one();
-    const userDeferred = new Deferred();
-
-    fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', userDeferred.promise);
-    const { result, rerender } = renderHook(useSession, {
-      wrapper: Wrapper,
-    });
-
-    await act(async () => {
-      userDeferred.resolve(user);
-    });
-
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-
-    expect(result.current.user).toStrictEqual(user);
-    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toContain(user.username);
-    expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toEqual(user.access_token);
-
-    await act(async () => {
-      result.current.login();
-    });
-
-    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toBeNull();
-    expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toBeNull();
-
-    rerender();
-    await waitFor(async () => expect(result.current.user).toBeUndefined());
-  });
-
-  it('clears session storage on register', async () => {
-    const user = FonzieUserFactory().one();
-    const userDeferred = new Deferred();
-
-    fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', userDeferred.promise);
-    const { result, rerender } = renderHook(useSession, {
-      wrapper: Wrapper,
-    });
-
-    await act(async () => {
-      userDeferred.resolve(user);
-    });
-
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-
-    expect(result.current.user).toStrictEqual(user);
-    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toContain(user.username);
-    expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toEqual(user.access_token);
-
-    await act(async () => {
-      result.current.register();
-    });
-
-    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toBeNull();
-    expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toBeNull();
-
-    rerender();
-    await waitFor(async () => expect(result.current.user).toBeUndefined());
   });
 });

--- a/src/frontend/js/contexts/SessionContext/useSession.spec.tsx
+++ b/src/frontend/js/contexts/SessionContext/useSession.spec.tsx
@@ -1,0 +1,117 @@
+import fetchMock from 'fetch-mock';
+import { IntlProvider } from 'react-intl';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import {
+  RichieContextFactory as mockRichieContextFactory,
+  FonzieUserFactory,
+} from 'utils/test/factories/richie';
+import { Deferred } from 'utils/test/deferred';
+import { REACT_QUERY_SETTINGS, RICHIE_USER_TOKEN } from 'settings';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import JoanieSessionProvider from './JoanieSessionProvider';
+import { useSession } from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.endpoint.test' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint.test' },
+  }).one(),
+}));
+jest.mock('utils/indirection/window', () => ({
+  location: {
+    assign: jest.fn(),
+  },
+}));
+
+describe('useSession', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <IntlProvider locale="en">
+      <QueryClientProvider client={createTestQueryClient({ persister: true })}>
+        <JoanieSessionProvider>{children}</JoanieSessionProvider>
+      </QueryClientProvider>
+    </IntlProvider>
+  );
+
+  beforeEach(() => {
+    fetchMock.restore();
+    jest.useFakeTimers();
+    sessionStorage.clear();
+
+    fetchMock
+      .get('https://joanie.endpoint.test/api/v1.0/addresses/', [])
+      .get('https://joanie.endpoint.test/api/v1.0/credit-cards/', [])
+      .get('https://joanie.endpoint.test/api/v1.0/orders/', []);
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('clears session storage on login', async () => {
+    const user = FonzieUserFactory().one();
+    const userDeferred = new Deferred();
+
+    fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', userDeferred.promise);
+    const { result, rerender } = renderHook(useSession, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      userDeferred.resolve(user);
+    });
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(result.current.user).toStrictEqual(user);
+    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toContain(user.username);
+    expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toEqual(user.access_token);
+
+    await act(async () => {
+      result.current.login();
+    });
+
+    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toBeNull();
+    expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toBeNull();
+
+    rerender();
+    await waitFor(async () => expect(result.current.user).toBeUndefined());
+  });
+
+  it('clears session storage on register', async () => {
+    const user = FonzieUserFactory().one();
+    const userDeferred = new Deferred();
+
+    fetchMock.get('https://auth.endpoint.test/api/v1.0/user/me', userDeferred.promise);
+    const { result, rerender } = renderHook(useSession, {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      userDeferred.resolve(user);
+    });
+
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(result.current.user).toStrictEqual(user);
+    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toContain(user.username);
+    expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toEqual(user.access_token);
+
+    await act(async () => {
+      result.current.register();
+    });
+
+    expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toBeNull();
+    expect(sessionStorage.getItem(RICHIE_USER_TOKEN)).toBeNull();
+
+    rerender();
+    await waitFor(async () => expect(result.current.user).toBeUndefined());
+  });
+});


### PR DESCRIPTION
We've a production issue where all api calls to joanie return 401. This test reproduce this bug.
