### PR TITLE
🧑‍💻(frontend) use enum for http status code

### DIFF
--- a/src/frontend/js/api/joanie.spec.ts
+++ b/src/frontend/js/api/joanie.spec.ts
@@ -1,10 +1,11 @@
 import fetchMock from 'fetch-mock';
 import { ResourcesQuery } from 'hooks/useResources';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { buildApiUrl, getResponseBody } from './joanie';
 
 describe('api/joanie', () => {
   it('getResponse should handle empty response body', async () => {
-    fetchMock.mock('http://example.com', 400);
+    fetchMock.mock('http://example.com', HttpStatusCode.BAD_REQUEST);
     const res = await fetch('http://example.com');
     expect(res.ok).toBe(false);
     const responseBody = await getResponseBody(res);

--- a/src/frontend/js/components/Icon/index.stories.tsx
+++ b/src/frontend/js/components/Icon/index.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { PropsWithChildren, useState, useRef, CSSProperties } from 'react';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { Icon, IconTypeEnum } from './index';
 
 export default {
@@ -74,7 +75,7 @@ const IconContainer = ({ name, enumKey }: IconContainerProps) => {
 
     timeoutRef.current = setTimeout(() => {
       setShowTooltip(false);
-    }, 500);
+    }, HttpStatusCode.INTERNAL_SERVER_ERROR);
   };
 
   return (

--- a/src/frontend/js/components/PaymentButton/index.spec.tsx
+++ b/src/frontend/js/components/PaymentButton/index.spec.tsx
@@ -17,6 +17,7 @@ import { OrderState } from 'types/Joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { CourseProductProvider } from 'contexts/CourseProductContext';
 import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import PaymentButton from '.';
 
 jest.mock('utils/context', () => ({
@@ -508,7 +509,7 @@ describe('PaymentButton', () => {
         payment_info: paymentInfo,
       })
       .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, orderSubmitted)
-      .post(`https://joanie.test/api/v1.0/orders/${order.id}/abort/`, 200);
+      .post(`https://joanie.test/api/v1.0/orders/${order.id}/abort/`, HttpStatusCode.OK);
 
     render(
       <Wrapper client={createTestQueryClient({ user: true })}>

--- a/src/frontend/js/contexts/SessionContext/index.spec.tsx
+++ b/src/frontend/js/contexts/SessionContext/index.spec.tsx
@@ -11,6 +11,7 @@ import { Deferred } from 'utils/test/deferred';
 import { REACT_QUERY_SETTINGS } from 'settings';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { User } from 'types/User';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import BaseSessionProvider from './BaseSessionProvider';
 import { useSession } from '.';
 
@@ -103,7 +104,7 @@ describe('SessionProvider', () => {
       });
 
       await act(async () => {
-        userDeferred.resolve(401);
+        userDeferred.resolve(HttpStatusCode.UNAUTHORIZED);
       });
 
       await waitFor(() => {
@@ -148,7 +149,7 @@ describe('SessionProvider', () => {
       const userDeferred = new Deferred();
 
       fetchMock.get('https://endpoint.test/api/user/v1/me', userDeferred.promise);
-      fetchMock.get('https://endpoint.test/logout', 200);
+      fetchMock.get('https://endpoint.test/logout', HttpStatusCode.OK);
       const { result } = renderHook(useSession, { wrapper: wrapper() });
 
       await act(async () => {
@@ -176,7 +177,7 @@ describe('SessionProvider', () => {
 
     it('does not make request if there is a valid session in cache', async () => {
       const user: User = UserFactory().one();
-      fetchMock.get('https://endpoint.test/api/user/v1/me', 200);
+      fetchMock.get('https://endpoint.test/api/user/v1/me', HttpStatusCode.OK);
 
       const { result } = renderHook(useSession, {
         wrapper: wrapper(createTestQueryClient({ user })),

--- a/src/frontend/js/hooks/useDownloadCertificate/index.spec.tsx
+++ b/src/frontend/js/hooks/useDownloadCertificate/index.spec.tsx
@@ -11,6 +11,7 @@ import { Certificate } from 'types/Joanie';
 import { SessionProvider } from 'contexts/SessionContext';
 import { Deferred } from 'utils/test/deferred';
 import { CertificateFactory } from 'utils/test/factories/joanie';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/errors/handle');
 jest.mock('utils/context', () => ({
@@ -73,7 +74,7 @@ describe('useDownloadCertificate', () => {
 
     result.current.download(certificate.id);
     await waitFor(() => expect(result.current.loading).toBe(true));
-    deferred.resolve(200);
+    deferred.resolve(HttpStatusCode.OK);
 
     await waitFor(() => {
       expect(fetchMock.called(DOWNLOAD_URL)).toBe(true);
@@ -94,7 +95,7 @@ describe('useDownloadCertificate', () => {
   it('handles an error if certificate download request fails', async () => {
     const certificate: Certificate = CertificateFactory().one();
     const DOWNLOAD_URL = `https://joanie.test/api/v1.0/certificates/${certificate.id}/download/`;
-    fetchMock.get(DOWNLOAD_URL, 401);
+    fetchMock.get(DOWNLOAD_URL, HttpStatusCode.UNAUTHORIZED);
 
     const { result } = renderHook(() => useDownloadCertificate(), {
       wrapper: Wrapper,

--- a/src/frontend/js/hooks/useResources/index.spec.tsx
+++ b/src/frontend/js/hooks/useResources/index.spec.tsx
@@ -11,6 +11,7 @@ import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { Deferred } from 'utils/test/deferred';
 import { SessionProvider, useSession } from 'contexts/SessionContext';
 import { Maybe } from 'types/utils';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { ResourcesQuery, useResource, useResources, UseResourcesProps } from './index';
 
 jest.mock('utils/context', () => ({
@@ -306,7 +307,7 @@ describe('useResource (omniscient) with session', () => {
     fetchMock.get('https://joanie.endpoint/api/v1.0/orders/', []);
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', []);
     fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
-    fetchMock.get('https://demo.endpoint/logout', 200);
+    fetchMock.get('https://demo.endpoint/logout', HttpStatusCode.OK);
   });
 
   afterEach(() => {
@@ -417,7 +418,7 @@ describe('useResource (non-omniscient)', () => {
     expect(result.current.items).toEqual([]);
 
     responseDeferred.reject({
-      status: 500,
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
       body: 'Bad request',
     });
 

--- a/src/frontend/js/hooks/useUnionResource/index.spec.tsx
+++ b/src/frontend/js/hooks/useUnionResource/index.spec.tsx
@@ -12,7 +12,7 @@ import { Deferred } from 'utils/test/deferred';
 import { noop } from 'utils';
 import { mockPaginatedResponse } from 'utils/test/mockPaginatedResponse';
 import { PER_PAGE } from 'settings';
-import { HttpError } from 'utils/errors/HttpError';
+import { HttpError, HttpStatusCode } from 'utils/errors/HttpError';
 import { FetchEntityData } from './utils/fetchEntities';
 import { QueryConfig, FetchDataFunction } from './utils/fetchEntity';
 import useUnionResource from '.';
@@ -305,7 +305,9 @@ describe('useUnionResource', () => {
     expect(result.current.isLoading).toBe(true);
 
     await act(() => {
-      dataADeferred.reject(new HttpError(500, 'Bad request'));
+      dataADeferred.reject(
+        new HttpError(HttpStatusCode.INTERNAL_SERVER_ERROR, 'Internal Server Error'),
+      );
     });
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBe('An error occurred while fetching data. Please retry later.');

--- a/src/frontend/js/hooks/useUnionResource/utils/fetchEntity.ts
+++ b/src/frontend/js/hooks/useUnionResource/utils/fetchEntity.ts
@@ -2,7 +2,7 @@ import { QueryClient } from '@tanstack/query-core';
 import { PaginatedResourceQuery, PaginatedResponse } from 'types/Joanie';
 import { Maybe } from 'types/utils';
 import { REACT_QUERY_SETTINGS } from 'settings';
-import { isHttpError } from 'utils/errors/HttpError';
+import { HttpStatusCode, isHttpError } from 'utils/errors/HttpError';
 
 export type FetchDataFunction<Data, FetchDataFilter> = (
   filters: FetchDataFilter,
@@ -75,7 +75,7 @@ export const fetchEntity = async <
     return res;
   } catch (err) {
     if (isHttpError(err)) {
-      if (err.code === 401) {
+      if (err.code === HttpStatusCode.UNAUTHORIZED) {
         queryClient.invalidateQueries(['user'], { exact: true });
       }
       throw err;

--- a/src/frontend/js/pages/DashboardAddressesManagement/DashboardCreateAddress.spec.tsx
+++ b/src/frontend/js/pages/DashboardAddressesManagement/DashboardCreateAddress.spec.tsx
@@ -16,6 +16,7 @@ import { expectBreadcrumbsToEqualParts } from 'utils/test/expectBreadcrumbsToEqu
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { expectBannerError } from 'utils/test/expectBanner';
 import { changeSelect } from 'components/Form/test-utils';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -169,7 +170,7 @@ describe('<DashboardCreateAddress/>', () => {
 
     // Mock the create API route to return a 500 status.
     fetchMock.post('https://joanie.endpoint/api/v1.0/addresses/', {
-      status: 500,
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
       body: 'Bad request',
     });
 

--- a/src/frontend/js/pages/DashboardAddressesManagement/DashboardEditAddress.spec.tsx
+++ b/src/frontend/js/pages/DashboardAddressesManagement/DashboardEditAddress.spec.tsx
@@ -19,6 +19,7 @@ import { expectFetchCall } from 'utils/test/expectFetchCall';
 import { expectBreadcrumbsToEqualParts } from 'utils/test/expectBreadcrumbsToEqualParts';
 import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -46,7 +47,7 @@ describe('<DashboardEditAddress/>', () => {
     addressUpdated.id = address.id;
     fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', [address]);
     const updateUrl = 'https://joanie.endpoint/api/v1.0/addresses/' + address.id + '/';
-    fetchMock.put(updateUrl, 200);
+    fetchMock.put(updateUrl, HttpStatusCode.OK);
 
     await act(async () => {
       render(
@@ -131,7 +132,7 @@ describe('<DashboardEditAddress/>', () => {
 
     // Mock the edit API route to return a 500 status.
     const updateUrl = 'https://joanie.endpoint/api/v1.0/addresses/' + address.id + '/';
-    fetchMock.put(updateUrl, { status: 500, body: 'Bad request' });
+    fetchMock.put(updateUrl, { status: HttpStatusCode.INTERNAL_SERVER_ERROR, body: 'Bad request' });
 
     let container: HTMLElement | undefined;
     await act(async () => {

--- a/src/frontend/js/pages/DashboardAddressesManagement/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardAddressesManagement/index.spec.tsx
@@ -21,6 +21,7 @@ import { expectBreadcrumbsToEqualParts } from 'utils/test/expectBreadcrumbsToEqu
 import { resolveAll } from 'utils/resolveAll';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { expectBannerError } from 'utils/test/expectBanner';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -315,8 +316,8 @@ describe('<DashAddressesManagement/>', () => {
     AddressFactory().one();
     // Mock the API route to return a 500 error.
     fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', {
-      status: 500,
-      body: 'Bad request',
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
+      body: 'Internal Server Error',
     });
 
     await act(async () => {

--- a/src/frontend/js/pages/DashboardCertificates/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCertificates/index.spec.tsx
@@ -15,6 +15,7 @@ import { SessionProvider } from 'contexts/SessionContext';
 import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import { CertificateFactory } from 'utils/test/factories/joanie';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -155,8 +156,8 @@ describe('<DashboardCertificates/>', () => {
 
   it('shows an error when request to retrieve certificates fails', async () => {
     fetchMock.get('https://joanie.endpoint/api/v1.0/certificates/?page=1&page_size=10', {
-      status: 500,
-      body: 'Internal error',
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
+      body: 'Internal Server Error',
     });
 
     render(

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -24,6 +24,7 @@ import { Deferred } from 'utils/test/deferred';
 import { isOrder } from 'pages/DashboardCourses/useOrdersEnrollments';
 import { noop } from 'utils';
 import { PER_PAGE } from 'settings';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -276,8 +277,8 @@ describe('<DashboardCourses/>', () => {
 
     render(<Wrapper />);
     ordersDeferred.resolve({
-      status: 500,
-      body: 'Bad request',
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
+      body: 'Internal Server Error',
     });
 
     await expectNoSpinner('Loading orders and enrollments...');

--- a/src/frontend/js/pages/DashboardCreditCardsManagement/DashboardEditCreditCard.spec.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/DashboardEditCreditCard.spec.tsx
@@ -19,6 +19,7 @@ import { expectFetchCall } from 'utils/test/expectFetchCall';
 import { expectBreadcrumbsToEqualParts } from 'utils/test/expectBreadcrumbsToEqualParts';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { expectBannerError } from 'utils/test/expectBanner';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -52,7 +53,7 @@ describe('<DahsboardEditCreditCard/>', () => {
 
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', creditCards);
     const updateUrl = 'https://joanie.endpoint/api/v1.0/credit-cards/' + creditCard.id + '/';
-    fetchMock.put(updateUrl, 200);
+    fetchMock.put(updateUrl, HttpStatusCode.OK);
 
     await act(async () => {
       render(
@@ -148,7 +149,7 @@ describe('<DahsboardEditCreditCard/>', () => {
 
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', creditCards);
     const updateUrl = 'https://joanie.endpoint/api/v1.0/credit-cards/' + creditCard.id + '/';
-    fetchMock.put(updateUrl, 200);
+    fetchMock.put(updateUrl, HttpStatusCode.OK);
 
     await act(async () => {
       render(
@@ -240,7 +241,7 @@ describe('<DahsboardEditCreditCard/>', () => {
 
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', creditCards);
     const updateUrl = 'https://joanie.endpoint/api/v1.0/credit-cards/' + creditCard.id + '/';
-    fetchMock.put(updateUrl, 200);
+    fetchMock.put(updateUrl, HttpStatusCode.OK);
 
     await act(async () => {
       render(
@@ -311,8 +312,8 @@ describe('<DahsboardEditCreditCard/>', () => {
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', creditCards);
     const updateUrl = 'https://joanie.endpoint/api/v1.0/credit-cards/' + creditCard.id + '/';
     fetchMock.put(updateUrl, {
-      status: 500,
-      body: 'Internal error',
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
+      body: 'Internal Server Error',
     });
 
     await act(async () => {

--- a/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
@@ -22,6 +22,7 @@ import { confirm } from 'utils/indirection/window';
 import { expectBreadcrumbsToEqualParts } from 'utils/test/expectBreadcrumbsToEqualParts';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { expectBannerError } from 'utils/test/expectBanner';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -405,8 +406,8 @@ describe('<DashboardCreditCardsManagement/>', () => {
   it('shows an error banner in case of API error', async () => {
     // Mock the API route to return a 500 error.
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', {
-      status: 500,
-      body: 'Bad request',
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
+      body: 'Internal Server Error',
     });
 
     await act(async () => {

--- a/src/frontend/js/utils/errors/HttpError.ts
+++ b/src/frontend/js/utils/errors/HttpError.ts
@@ -22,3 +22,12 @@ export class HttpError extends Error {
 export function isHttpError(error: any): error is HttpError {
   return typeof error === 'object' && error instanceof HttpError;
 }
+
+export enum HttpStatusCode {
+  OK = 200,
+  UNAUTHORIZED = 401,
+  BAD_REQUEST = 400,
+  FORBIDDEN = 403,
+  NOT_FOUND = 404,
+  INTERNAL_SERVER_ERROR = 500,
+}

--- a/src/frontend/js/utils/react-query/useSessionMutation/index.spec.tsx
+++ b/src/frontend/js/utils/react-query/useSessionMutation/index.spec.tsx
@@ -7,6 +7,7 @@ import BaseSessionProvider from 'contexts/SessionContext/BaseSessionProvider';
 import { useSession } from 'contexts/SessionContext';
 import { checkStatus } from 'api/joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { useSessionMutation } from '.';
 
 jest.mock('utils/context', () => ({
@@ -32,8 +33,8 @@ describe('useSessionMutation', () => {
   });
 
   it('should invalidate user queries if it fails with a 401 response status', async () => {
-    fetchMock.post('http://api.endpoint/orders/create', 401);
-    fetchMock.get('https://endpoint.test/api/user/v1/me', 401);
+    fetchMock.post('http://api.endpoint/orders/create', HttpStatusCode.UNAUTHORIZED);
+    fetchMock.get('https://endpoint.test/api/user/v1/me', HttpStatusCode.UNAUTHORIZED);
     const handleError = jest.fn();
 
     const useHooks = () => {

--- a/src/frontend/js/utils/react-query/useSessionMutation/index.ts
+++ b/src/frontend/js/utils/react-query/useSessionMutation/index.ts
@@ -4,7 +4,7 @@ import type {
   UseMutationResult,
 } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { HttpError } from 'utils/errors/HttpError';
+import { HttpError, HttpStatusCode } from 'utils/errors/HttpError';
 
 /**
  * Hook to use when the mutation relies on the current session. In this way, if the
@@ -24,7 +24,7 @@ export function useSessionMutation<TData = unknown, TVariables = void, TContext 
     variables: TVariables,
     context: TContext | undefined,
   ) => {
-    if (error.code === 401) {
+    if (error.code === HttpStatusCode.UNAUTHORIZED) {
       await queryClient.invalidateQueries(['user'], { exact: true });
     }
 

--- a/src/frontend/js/utils/react-query/useSessionQuery/index.spec.tsx
+++ b/src/frontend/js/utils/react-query/useSessionQuery/index.spec.tsx
@@ -7,6 +7,7 @@ import BaseSessionProvider from 'contexts/SessionContext/BaseSessionProvider';
 import { checkStatus } from 'api/joanie';
 import { useSession } from 'contexts/SessionContext';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { useSessionQuery } from '.';
 
 jest.mock('utils/context', () => ({
@@ -32,8 +33,8 @@ describe('useSessionQuery', () => {
   });
 
   it('should invalidate user queries if it fails with a 401 response status', async () => {
-    fetchMock.get('http://api.endpoint/orders/', 401);
-    fetchMock.get('https://endpoint.test/api/user/v1/me', 401);
+    fetchMock.get('http://api.endpoint/orders/', HttpStatusCode.UNAUTHORIZED);
+    fetchMock.get('https://endpoint.test/api/user/v1/me', HttpStatusCode.UNAUTHORIZED);
     const handleError = jest.fn();
 
     const useHooks = () => {

--- a/src/frontend/js/utils/react-query/useSessionQuery/index.ts
+++ b/src/frontend/js/utils/react-query/useSessionQuery/index.ts
@@ -8,7 +8,7 @@ import type {
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'contexts/SessionContext';
 import { REACT_QUERY_SETTINGS } from 'settings';
-import type { HttpError } from 'utils/errors/HttpError';
+import { HttpStatusCode, type HttpError } from 'utils/errors/HttpError';
 import type { TSessionQueryKey } from 'utils/react-query/useSessionKey';
 import useSessionQueryKey from 'utils/react-query/useSessionKey';
 
@@ -41,7 +41,7 @@ export function useSessionQuery<
   const sessionQueryKey = useSessionQueryKey(queryKey);
 
   const handleError = async (error: HttpError) => {
-    if (error.code === 401) {
+    if (error.code === HttpStatusCode.UNAUTHORIZED) {
       queryClient.invalidateQueries(['user'], { exact: true });
     }
 

--- a/src/frontend/js/utils/search/getSuggestionsSection/index.spec.ts
+++ b/src/frontend/js/utils/search/getSuggestionsSection/index.spec.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 
 import { handle } from 'utils/errors/handle';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { getSuggestionsSection } from '.';
 
 const mockHandle: jest.Mock<typeof handle> = handle as any;
@@ -47,7 +48,7 @@ describe('utils/search/getSuggestionsSection', () => {
   it('reports the error when the server returns an error code', async () => {
     fetchMock.get('/api/v1.0/courses/autocomplete/?query=some%20search', {
       body: {},
-      status: 403,
+      status: HttpStatusCode.FORBIDDEN,
     });
     await getSuggestionsSection('courses', 'Courses', 'some search');
     expect(mockHandle).toHaveBeenCalledWith(
@@ -60,7 +61,7 @@ describe('utils/search/getSuggestionsSection', () => {
       body: {
         errors: ['Missing autocomplete "query" for request to richie_courses.'],
       },
-      status: 400,
+      status: HttpStatusCode.BAD_REQUEST,
     });
     await getSuggestionsSection('courses', 'Courses', 'error');
     expect(mockHandle).toHaveBeenCalledWith(

--- a/src/frontend/js/utils/search/getSuggestionsSection/index.ts
+++ b/src/frontend/js/utils/search/getSuggestionsSection/index.ts
@@ -2,6 +2,7 @@ import take from 'lodash-es/take';
 import queryString from 'query-string';
 
 import { Suggestion } from 'types/Suggestion';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { handle } from 'utils/errors/handle';
 
 /**
@@ -29,7 +30,9 @@ export const getSuggestionsSection = async (kind: string, title: string, query: 
   // The ok flag is the way to discriminate
   if (!response.ok) {
     const error = new Error(`Failed to get list from ${kind} autocomplete : ${response.status}`);
-    return response.status === 400 ? handle(error, await response.json()) : handle(error);
+    return response.status === HttpStatusCode.BAD_REQUEST
+      ? handle(error, await response.json())
+      : handle(error);
   }
 
   let responseData: Suggestion<string>[];

--- a/src/frontend/js/utils/search/index.tsx
+++ b/src/frontend/js/utils/search/index.tsx
@@ -7,6 +7,7 @@ import {
   SearchSuggestionSection,
 } from 'types/Suggestion';
 import { handle } from 'utils/errors/handle';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { getSuggestionsSection } from './getSuggestionsSection';
 
 /**
@@ -62,9 +63,13 @@ const onSuggestionsFetchRequested = async (
   );
 };
 
-export const onSuggestionsFetchRequestedDebounced = debounce(onSuggestionsFetchRequested, 200, {
-  maxWait: 1000,
-});
+export const onSuggestionsFetchRequestedDebounced = debounce(
+  onSuggestionsFetchRequested,
+  HttpStatusCode.OK,
+  {
+    maxWait: 1000,
+  },
+);
 
 /**
  * Helper to pick out the relevant filter for a suggestion from the general filters object.

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Certificate/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Certificate/index.spec.tsx
@@ -11,6 +11,7 @@ import { SessionProvider } from 'contexts/SessionContext';
 import { DashboardItemCertificate } from 'widgets/Dashboard/components/DashboardItem/Certificate/index';
 import { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
 import { CertificateFactory } from 'utils/test/factories/joanie';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -65,7 +66,10 @@ describe('<DashboardCertificate/>', () => {
   it('downloads the certificate', async () => {
     const certificate: Certificate = CertificateFactory().one();
 
-    fetchMock.get(`https://joanie.test/api/v1.0/certificates/${certificate.id}/download/`, 200);
+    fetchMock.get(
+      `https://joanie.test/api/v1.0/certificates/${certificate.id}/download/`,
+      HttpStatusCode.OK,
+    );
 
     render(
       <DashboardItemCertificate certificate={certificate} productType={ProductType.CREDENTIAL} />,

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -38,6 +38,7 @@ import { expectNoSpinner, expectSpinner } from 'utils/test/expectSpinner';
 import { Deferred } from 'utils/test/deferred';
 import { expectBreadcrumbsToEqualParts } from 'utils/test/expectBreadcrumbsToEqualParts';
 import { mockCourseProductWithOrder } from 'utils/test/mockCourseProductWithOrder';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { LearnerDashboardPaths } from '../../../utils/learnerRouteMessages';
 import { DashboardTest } from '../../DashboardTest';
 import { DashboardItemOrder } from './DashboardItemOrder';
@@ -405,8 +406,8 @@ describe('<DashboardItemOrder/>', () => {
     );
 
     fetchMock.post('https://joanie.endpoint/api/v1.0/enrollments/', {
-      status: 500,
-      body: 'Bad request',
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
+      body: 'Internal Server Error',
     });
 
     render(WrapperWithDashboard(LearnerDashboardPaths.ORDER.replace(':orderId', order.id)));

--- a/src/frontend/js/widgets/Search/index.spec.tsx
+++ b/src/frontend/js/widgets/Search/index.spec.tsx
@@ -9,6 +9,7 @@ import * as mockWindow from 'utils/indirection/window';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import context from 'utils/context';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import Search from '.';
 
 let mockMatches = false;
@@ -49,7 +50,7 @@ describe('<Search />', () => {
   it('shows a spinner while the results are loading', async () => {
     fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', {
       meta: {
-        total_count: 200,
+        total_count: HttpStatusCode.OK,
       },
       objects: [],
     });
@@ -131,7 +132,7 @@ describe('<Search />', () => {
   });
 
   it('shows an error message when it fails to get the results', async () => {
-    fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', 500);
+    fetchMock.get('/api/v1.0/courses/?limit=20&offset=0', HttpStatusCode.INTERNAL_SERVER_ERROR);
 
     render(
       <QueryClientProvider client={createTestQueryClient()}>

--- a/src/frontend/js/widgets/Search/utils/getResourceList/index.spec.ts
+++ b/src/frontend/js/widgets/Search/utils/getResourceList/index.spec.ts
@@ -1,4 +1,5 @@
 import fetchMock from 'fetch-mock';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 import { RequestStatus } from '../../types/api';
 import { fetchList } from '.';
@@ -68,7 +69,7 @@ describe('widgets/Search/utils/getResourceList', () => {
     });
 
     it('rejects with a FetchListResponse containing an error when the API returns an error code', async () => {
-      fetchMock.mock('/api/v1.0/courses/?limit=2&offset=43', 404);
+      fetchMock.mock('/api/v1.0/courses/?limit=2&offset=43', HttpStatusCode.NOT_FOUND);
 
       const response = (await fetchList('courses', {
         limit: '2',

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseProductCertificateItem/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseProductCertificateItem/index.spec.tsx
@@ -7,6 +7,7 @@ import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/fac
 import { CertificationDefinitionFactory, OrderLiteFactory } from 'utils/test/factories/joanie';
 import JoanieApiProvider from 'contexts/JoanieApiContext';
 import { CertificateDefinition, OrderLite } from 'types/Joanie';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import CertificateItem from '.';
 
 jest.mock('utils/errors/handle');
@@ -88,7 +89,10 @@ describe('CourseProductCertificateItem', () => {
     expect($button.disabled).toBe(false);
 
     // When user clicks on "Download" button, the certificate should be downloaded
-    fetchMock.get(`https://joanie.test/api/v1.0/certificates/${order.certificate}/download/`, 200);
+    fetchMock.get(
+      `https://joanie.test/api/v1.0/certificates/${order.certificate}/download/`,
+      HttpStatusCode.OK,
+    );
 
     fireEvent.click($button);
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseProductCourseRuns/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseProductCourseRuns/index.spec.tsx
@@ -18,6 +18,7 @@ import { CourseStateTextEnum, Priority } from 'types';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { IntlHelper } from 'utils/IntlHelper';
 import { CourseProductProvider } from 'contexts/CourseProductContext';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { CourseRunList, EnrollableCourseRunList, EnrolledCourseRun } from '.';
 
 jest.mock('utils/context', () => ({
@@ -240,7 +241,7 @@ describe('CourseProductCourseRuns', () => {
       screen.getByRole('status', { name: 'Enrolling...' });
 
       await act(async () => {
-        enrollmentDeferred.resolve(200);
+        enrollmentDeferred.resolve(HttpStatusCode.OK);
       });
 
       const calls = fetchMock.calls();
@@ -258,7 +259,7 @@ describe('CourseProductCourseRuns', () => {
       const course: CourseLight = CourseLightFactory().one();
       const courseRuns: CourseRun[] = CourseRunFactory().many(2);
       const order: OrderLite = OrderFactory().one();
-      fetchMock.get(`https://joanie.test/api/v1.0/courses/${course.code}/`, 200);
+      fetchMock.get(`https://joanie.test/api/v1.0/courses/${course.code}/`, HttpStatusCode.OK);
 
       render(
         <Wrapper productId={order.product} code={course.code}>
@@ -343,7 +344,7 @@ describe('CourseProductCourseRuns', () => {
       screen.getByRole('status', { name: 'Enrolling...' });
 
       await act(async () => {
-        enrollmentDeferred.resolve(500);
+        enrollmentDeferred.resolve(HttpStatusCode.INTERNAL_SERVER_ERROR);
       });
 
       await screen.findByText(

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
@@ -22,6 +22,7 @@ import { CourseRun, Enrollment, Order, OrderState } from 'types/Joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { Deferred } from 'utils/test/deferred';
 import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import CourseProductItem from '.';
 
 jest.mock('utils/context', () => ({
@@ -627,7 +628,11 @@ describe('CourseProductItem', () => {
   it('renders error message when product fetching has failed', async () => {
     const { product } = CourseProductRelationFactory().one();
 
-    fetchMock.get(`https://joanie.test/api/v1.0/courses/00000/products/${product.id}/`, 404, {});
+    fetchMock.get(
+      `https://joanie.test/api/v1.0/courses/00000/products/${product.id}/`,
+      HttpStatusCode.NOT_FOUND,
+      {},
+    );
 
     render(
       <Wrapper>

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/index.joanie.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/index.joanie.spec.tsx
@@ -11,6 +11,7 @@ import {
 } from 'utils/test/factories/richie';
 import { SessionProvider } from 'contexts/SessionContext';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import CourseRunEnrollment from './index';
 
 jest.mock('utils/errors/handle');
@@ -97,7 +98,10 @@ describe('<CourseRunEnrollment /> with joanie backend ', () => {
     const courseRun = CourseRunFactory().one();
     courseRun.resource_link = `https://joanie.endpoint/api/v1.0/course-runs/${courseRun.id}`;
 
-    fetchMock.get(`${endpoint}/api/v1.0/enrollments/?course_run=${courseRun.id}`, 500);
+    fetchMock.get(
+      `${endpoint}/api/v1.0/enrollments/?course_run=${courseRun.id}`,
+      HttpStatusCode.INTERNAL_SERVER_ERROR,
+    );
 
     await act(async () => {
       render(
@@ -201,7 +205,7 @@ describe('<CourseRunEnrollment /> with joanie backend ', () => {
     });
 
     const button = await screen.findByRole('button', { name: 'Enroll now' });
-    fetchMock.post(`${endpoint}/api/v1.0/enrollments/`, 500);
+    fetchMock.post(`${endpoint}/api/v1.0/enrollments/`, HttpStatusCode.INTERNAL_SERVER_ERROR);
     await act(async () => {
       fireEvent.click(button);
     });
@@ -248,7 +252,10 @@ describe('<CourseRunEnrollment /> with joanie backend ', () => {
       });
     });
 
-    fetchMock.put(`${endpoint}/api/v1.0/enrollments/57b35536-5c92-4606-bca3-13aa53d04d07/`, 500);
+    fetchMock.put(
+      `${endpoint}/api/v1.0/enrollments/57b35536-5c92-4606-bca3-13aa53d04d07/`,
+      HttpStatusCode.INTERNAL_SERVER_ERROR,
+    );
 
     const unenroll = await screen.findByText('Unenroll from this course');
     await act(async () => {

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/index.openedx.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/index.openedx.spec.tsx
@@ -14,6 +14,7 @@ import { handle } from 'utils/errors/handle';
 import { SessionProvider } from 'contexts/SessionContext';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { User } from 'types/User';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import CourseRunEnrollment from './index';
 
 jest.mock('utils/errors/handle');
@@ -131,7 +132,10 @@ describe('<CourseRunEnrollment />', () => {
     const button = await screen.findByRole('button', { name: 'Enroll now' });
 
     // const enrollmentAction = new Deferred();
-    fetchMock.post(`${endpoint}/api/enrollment/v1/enrollment`, 500);
+    fetchMock.post(
+      `${endpoint}/api/enrollment/v1/enrollment`,
+      HttpStatusCode.INTERNAL_SERVER_ERROR,
+    );
 
     await act(async () => {
       expect(() => fireEvent.click(button)).not.toThrow();
@@ -179,7 +183,7 @@ describe('<CourseRunEnrollment />', () => {
 
     // const enrollmentAction = new Deferred();
     fetchMock.post(`${endpoint}/api/enrollment/v1/enrollment`, {
-      status: 400,
+      status: HttpStatusCode.BAD_REQUEST,
       body: { localizedMessage: 'You are not authorized to enroll' },
     });
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/hooks/useCourseWish/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/hooks/useCourseWish/index.spec.tsx
@@ -11,6 +11,7 @@ import {
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import JoanieApiProvider from 'contexts/JoanieApiContext';
 import BaseSessionProvider from 'contexts/SessionContext/BaseSessionProvider';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import { useCourseWish } from '.';
 
 jest.mock('utils/context', () => ({
@@ -57,7 +58,7 @@ describe('useCourseWish', () => {
     await waitFor(() => expect(result.current.states.fetching).toBe(true));
     await act(async () => {
       responseDeferred.resolve({
-        status: 200,
+        status: HttpStatusCode.OK,
         body: {
           status: false,
         },
@@ -73,7 +74,7 @@ describe('useCourseWish', () => {
   it('adds a course wish', async () => {
     const urlWishlist = `https://joanie.test/api/v1.0/courses/${course.code}/wish/`;
     fetchMock.get(urlWishlist, {
-      status: 200,
+      status: HttpStatusCode.OK,
       body: {
         status: false,
       },
@@ -85,9 +86,9 @@ describe('useCourseWish', () => {
 
     // We dont care about POST request return values,
     // react-query will refetch data using the GET url.
-    fetchMock.post(urlWishlist, 200);
+    fetchMock.post(urlWishlist, HttpStatusCode.OK);
     fetchMock.get(urlWishlist, {
-      status: 200,
+      status: HttpStatusCode.OK,
       body: {
         status: true,
       },
@@ -106,7 +107,7 @@ describe('useCourseWish', () => {
   it('removes a course to user wishlist', async () => {
     const url = `https://joanie.test/api/v1.0/courses/${course.code}/wish/`;
     fetchMock.get(url, {
-      status: 200,
+      status: HttpStatusCode.OK,
       body: {
         status: true,
       },
@@ -116,9 +117,9 @@ describe('useCourseWish', () => {
     });
     fetchMock.restore();
 
-    fetchMock.delete(url, 200);
+    fetchMock.delete(url, HttpStatusCode.OK);
     fetchMock.get(url, {
-      status: 200,
+      status: HttpStatusCode.OK,
       body: {
         status: false,
       },

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/index.login.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/index.login.spec.tsx
@@ -15,6 +15,7 @@ import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import JoanieApiProvider from 'contexts/JoanieApiContext';
 import { SessionProvider } from 'contexts/SessionContext';
 import { Course } from 'types/Course';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import CourseWishButton from '.';
 
 jest.mock('utils/context', () => ({
@@ -60,7 +61,7 @@ describe('CourseWishButton', () => {
 
   it('renders a notify me button', async () => {
     fetchMock.get(`https://joanie.test/api/v1.0/courses/${course.code}/wish/`, {
-      status: 200,
+      status: HttpStatusCode.OK,
       body: {
         status: false,
       },
@@ -79,11 +80,11 @@ describe('CourseWishButton', () => {
     nbApiCalls += 1; // useUserWishlistCourses inital fetch
     expect(fetchMock.calls().length).toBe(nbApiCalls);
 
-    fetchMock.post(`https://joanie.test/api/v1.0/courses/${course.code}/wish/`, 200);
+    fetchMock.post(`https://joanie.test/api/v1.0/courses/${course.code}/wish/`, HttpStatusCode.OK);
     fetchMock.get(
       `https://joanie.test/api/v1.0/courses/${course.code}/wish/`,
       {
-        status: 200,
+        status: HttpStatusCode.OK,
         body: {
           status: true,
         },
@@ -103,7 +104,7 @@ describe('CourseWishButton', () => {
 
   it('renders a "do not notify me" button', async () => {
     fetchMock.get(`https://joanie.test/api/v1.0/courses/${course.code}/wish/`, {
-      status: 200,
+      status: HttpStatusCode.OK,
       body: {
         status: true,
       },
@@ -127,11 +128,14 @@ describe('CourseWishButton', () => {
     // We dont care about POST request return values,
     // react-query will refetch data using the GET url.
 
-    fetchMock.delete(`https://joanie.test/api/v1.0/courses/${course.code}/wish/`, 200);
+    fetchMock.delete(
+      `https://joanie.test/api/v1.0/courses/${course.code}/wish/`,
+      HttpStatusCode.OK,
+    );
     fetchMock.get(
       `https://joanie.test/api/v1.0/courses/${course.code}/wish/`,
       {
-        status: 200,
+        status: HttpStatusCode.OK,
         body: {
           status: false,
         },

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/hooks/useCourseEnrollment/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/hooks/useCourseEnrollment/index.spec.tsx
@@ -14,6 +14,7 @@ import BaseSessionProvider from 'contexts/SessionContext/BaseSessionProvider';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { User } from 'types/User';
 import useCourseEnrollment from 'widgets/SyllabusCourseRunsList/hooks/useCourseEnrollment/index';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -52,7 +53,7 @@ describe('useCourseEnrollment', () => {
 
     fetchMock.get(
       `${endpoint}/api/enrollment/v1/enrollment/${user.username},${courseRun.resource_link}`,
-      401,
+      HttpStatusCode.UNAUTHORIZED,
     );
 
     const { result } = renderHook(() => useCourseEnrollment(courseRun.resource_link), {

--- a/src/frontend/js/widgets/UserLogin/index.spec.tsx
+++ b/src/frontend/js/widgets/UserLogin/index.spec.tsx
@@ -13,6 +13,7 @@ import context from 'utils/context';
 import { SessionProvider } from 'contexts/SessionContext';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { User } from 'types/User';
+import { HttpStatusCode } from 'utils/errors/HttpError';
 import UserLogin from '.';
 
 jest.mock('utils/errors/handle', () => ({
@@ -78,7 +79,7 @@ describe('<UserLogin />', () => {
     );
 
     await act(async () => {
-      loginDeferred.resolve(401);
+      loginDeferred.resolve(HttpStatusCode.UNAUTHORIZED);
     });
 
     await findByText('Log in');


### PR DESCRIPTION
## Purpose

Improve readability by using text instead of code for http status error 


## Proposal

add an enum `HttpStatusCode` and use it instead of raw code.
