### PR TITLE
🐛(frontend) prevent LTIConsumer context to be refreshed on user update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Prevent LTIConsumer component to rerender on user session update
 - Fix Order interface against changed field 'target_enrollments' and 
   'enrollment'
 - Fix dashboard mobile layout.

--- a/src/frontend/js/widgets/LtiConsumer/index.tsx
+++ b/src/frontend/js/widgets/LtiConsumer/index.tsx
@@ -2,10 +2,10 @@ import { useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { iframeResize } from 'iframe-resizer';
 import queryString from 'query-string';
+import { useQuery } from '@tanstack/react-query';
 import { useSession } from 'contexts/SessionContext';
-import { REACT_QUERY_SETTINGS, RICHIE_LTI_ANONYMOUS_USER_ID_CACHE_KEY } from 'settings';
+import { RICHIE_LTI_ANONYMOUS_USER_ID_CACHE_KEY } from 'settings';
 import { handle } from 'utils/errors/handle';
-import { useSessionQuery } from 'utils/react-query/useSessionQuery';
 import { LtiConsumerContext, LtiConsumerProps } from './types/LtiConsumer';
 
 const LtiConsumer = ({ id }: LtiConsumerProps) => {
@@ -18,7 +18,7 @@ const LtiConsumer = ({ id }: LtiConsumerProps) => {
     return response.json();
   };
 
-  const [{ data: context }] = useSessionQuery<LtiConsumerContext>(
+  const { data: context } = useQuery<LtiConsumerContext>(
     [`lti-consumer-plugin-${id}`],
     () => {
       // We have to provide a unique user_id to generate the lti context. When user is authenticated, we use its
@@ -48,8 +48,7 @@ const LtiConsumer = ({ id }: LtiConsumerProps) => {
     {
       // Do not fetch LTI context until session state has been retrieved.
       enabled: user !== undefined,
-      // LTI Context lifetime is 5 minutes except in editor mode
-      staleTime: window.CMS?.config.auth ? 0 : REACT_QUERY_SETTINGS.staleTimes.session,
+      staleTime: 0,
       onError: handle,
     },
   );


### PR DESCRIPTION
## Purpose

Currently, the query in charge to retrieve the LTIConsumer context relies on the
 session state. So each time, the user is updated (e.g: when access token is
 refreshed), the LTI context is refetched so the LTI Iframe is rerendered. This
 is weird as it can reset the iframe state when user is interacting with. In
 order to prevent this drawback, we decide to not reprocess the LTI Context each
  time the user changes.

### Preview of the issue

When user session is stale, it is refetched automatically in the background. Once the new state has been retrieved, the LTIConsumer component is rerendered. In the following case study, if the session state is updated while user is watching a teaser, the video player is reset ...

https://github.com/openfun/richie/assets/9265241/cc860c85-1a41-4da8-8876-4f01991a1c21


## Proposal

- [x] Prevent LTIConsumer component to rerender on user session update
