### PR TITLE
🐛(frontend) Fix sale tunnel

### DIFF
--- a/src/frontend/js/components/Modal/index.tsx
+++ b/src/frontend/js/components/Modal/index.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useMemo } from 'react';
 import ReactModal from 'react-modal';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
-import { Button } from '@openfun/cunningham-react';
+import { Button, CunninghamProvider } from '@openfun/cunningham-react';
 import { StringHelper } from 'utils/StringHelper';
 import { Icon, IconTypeEnum } from 'components/Icon';
 
@@ -69,26 +69,28 @@ export const Modal = ({
       overlayClassName={mergeClasses({ base: 'modal__overlay', classes: overlayClassName })}
       {...props}
     >
-      <header className={headerClasses.join(' ')}>
-        {StringHelper.isString(title) && <h2>{title}</h2>}
-        {!StringHelper.isString(title) && title}
-        {hasCloseButton && (
-          <Button
-            aria-label={intl.formatMessage(messages.closeDialog)}
-            className="modal__closeButton"
-            onClick={(e) => props.onRequestClose?.(e)}
-            title={intl.formatMessage(messages.closeDialog)}
-            color="tertiary"
-            size="small"
-          >
-            <Icon name={IconTypeEnum.ROUND_CLOSE} />
-            <span className="offscreen">
-              <FormattedMessage {...messages.closeDialog} />
-            </span>
-          </Button>
-        )}
-      </header>
-      {children}
+      <CunninghamProvider>
+        <header className={headerClasses.join(' ')}>
+          {StringHelper.isString(title) && <h2>{title}</h2>}
+          {!StringHelper.isString(title) && title}
+          {hasCloseButton && (
+            <Button
+              aria-label={intl.formatMessage(messages.closeDialog)}
+              className="modal__closeButton"
+              onClick={(e) => props.onRequestClose?.(e)}
+              title={intl.formatMessage(messages.closeDialog)}
+              color="tertiary"
+              size="small"
+            >
+              <Icon name={IconTypeEnum.ROUND_CLOSE} />
+              <span className="offscreen">
+                <FormattedMessage {...messages.closeDialog} />
+              </span>
+            </Button>
+          )}
+        </header>
+        {children}
+      </CunninghamProvider>
     </ReactModal>
   );
 };

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.spec.tsx
@@ -71,7 +71,7 @@ describe('SaleTunnelStepPayment', () => {
     // - It should display product information (title & price)
     screen.getByRole('heading', { level: 2, name: 'You are about to purchase' });
     screen.getByText(product.title, { exact: true });
-    screen.getByText(formatter.format(product.price).replaceAll(' ', ' '));
+    screen.getByText(formatter.format(product.price).replaceAll(/\s/g, ' '));
   });
 
   it('should display authenticated user information', async () => {

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepValidation/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepValidation/index.spec.tsx
@@ -44,7 +44,7 @@ describe('SaleTunnelStepValidation', () => {
     });
 
     screen.getByRole('heading', { level: 2, name: product.title });
-    screen.getByText(`${formatter.format(product.price).replaceAll(' ', ' ')} including VAT`);
+    screen.getByText(`${formatter.format(product.price).replaceAll(/\s/g, ' ')} including VAT`);
 
     expect(screen.getByTestId('product-certificate')).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 3, name: product.certificate_definition.title }));


### PR DESCRIPTION
:skull: The payment step of the sale tunnel is not accessible

Quickfix: 
Sale tunnel modal is render in a portal.
All our route are render inside a `<CunninghamProvider/>` but the modal's portal wasn't.

