### PR TITLE
✨(frontend) order details: add contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a footer on enrollment's item in the learner dashboard. It give the
   possibility to purchase linked product or download linked certificate.
 - Add download contracts pages on the teacher dashboard.
+- Add a contract information and actions in learner dashboard order's 
+  listing and details.
+- In the learner dashboard, enroll actions are disabled when an unsigned
+  contract is linked to the order.
 
 ### Changed
 

--- a/src/frontend/js/pages/TeacherDashboardContractsLoader/TeacherDashboardContracts/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLoader/TeacherDashboardContracts/index.spec.tsx
@@ -140,8 +140,8 @@ describe('pages/TeacherDashboardContracts', () => {
     );
     nbApiCalls += 1;
     expect(await screen.findByTestId('contracts-loaded')).toBeInTheDocument();
-    expect(screen.getByText(contract.learner_name)).toBeInTheDocument();
-    expect(screen.getByText(contract.product_title)).toBeInTheDocument();
+    expect(screen.getByText(contract.order.owner)).toBeInTheDocument();
+    expect(screen.getByText(contract.order.product)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Download/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Open/ })).toBeInTheDocument();
   });

--- a/src/frontend/js/pages/TeacherDashboardContractsLoader/TeacherDashboardContracts/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLoader/TeacherDashboardContracts/index.tsx
@@ -77,11 +77,11 @@ const TeacherDashboardContracts = ({
   useEffect(() => onPageChange(pagination.page), [pagination.page]);
 
   const rows = useMemo(() => {
-    return contracts.map(({ id, learner_name, product_title, sign_date }) => ({
+    return contracts.map(({ id, signed_on, order }) => ({
       id,
-      learnerName: learner_name,
-      productTitle: product_title,
-      signDate: intl.formatDate(sign_date),
+      learnerName: order.owner,
+      productTitle: order.product,
+      signDate: intl.formatDate(signed_on),
     }));
   }, [contracts]);
 

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -24,11 +24,19 @@ export interface Organization {
   logo: JoanieFile;
 }
 
+export interface ContractDefinition {
+  id: string;
+  description: string;
+  language: string;
+  title: string;
+}
+
 export interface Contract {
   id: string;
-  learner_name: string;
-  product_title: string;
-  sign_date: string;
+  created_on: string;
+  signed_on: string;
+  definition: ContractDefinition;
+  order: Order;
 }
 
 export interface CourseListItem extends Resource {
@@ -98,6 +106,7 @@ export interface Product {
   remaining_order_count?: number | null;
   state: CourseState;
   instructions: Nullable<string>;
+  contract_definition?: ContractDefinition;
 }
 
 export interface CourseProduct extends Product {

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -28,6 +28,7 @@ import {
   JoanieFile,
   Contract,
   OrderEnrollment,
+  ContractDefinition,
 } from 'types/Joanie';
 import { CourseStateFactory } from 'utils/test/factories/richie';
 import { FactoryHelper } from 'utils/test/factories/helper';
@@ -71,12 +72,22 @@ export const TargetCourseFactory = factory((): TargetCourse => {
   };
 });
 
+export const ContractDefinitionFactory = factory((): ContractDefinition => {
+  return {
+    id: faker.string.uuid(),
+    description: faker.lorem.paragraph(),
+    language: faker.location.countryCode(),
+    title: faker.lorem.sentence(),
+  };
+});
+
 export const ContractFactory = factory((): Contract => {
   return {
     id: faker.string.uuid(),
-    learner_name: faker.person.fullName(),
-    product_title: faker.lorem.words(10),
-    sign_date: faker.date.past().toISOString(),
+    signed_on: faker.date.past().toISOString(),
+    created_on: faker.date.past().toISOString(),
+    definition: ContractDefinitionFactory().one(),
+    order: OrderFactory().one(),
   };
 });
 
@@ -123,6 +134,7 @@ export const CredentialProductFactory = factory((): Product => {
     price_currency: faker.finance.currencyCode(),
     call_to_action: faker.lorem.words(3),
     certificate_definition: CertificationDefinitionFactory().one(),
+    contract_definition: ContractDefinitionFactory().one(),
     target_courses: TargetCourseFactory().many(5),
     remaining_order_count: faker.number.int({ min: 1, max: 100 }),
     state: CourseStateFactory().one(),

--- a/src/frontend/js/utils/test/mockCourseProductWithOrder.ts
+++ b/src/frontend/js/utils/test/mockCourseProductWithOrder.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'fetch-mock';
 import { CourseLight, Order } from 'types/Joanie';
 import {
+  ContractDefinitionFactory,
   CourseFactory,
   CourseProductRelationFactory,
   ProductFactory,
@@ -12,6 +13,7 @@ export const mockCourseProductWithOrder = (order: Order) => {
   const relation = CourseProductRelationFactory({
     product: ProductFactory({
       id: order.product,
+      contract_definition: order.contract ? ContractDefinitionFactory().one() : undefined,
     }).one(),
     course: CourseFactory({
       code: courseCode,

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -19,6 +19,7 @@ import { DATETIME_FORMAT, DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import {
   CertificateFactory,
+  ContractFactory,
   CourseLightFactory,
   CourseRunFactory,
   EnrollmentFactory,
@@ -239,13 +240,86 @@ describe('<DashboardItemOrder/>', () => {
     render(<DashboardItemOrder order={order} />, { wrapper });
 
     await screen.findByRole('heading', { level: 5, name: product.title });
-    await screen.findByText('Ref. ' + (order.course as CourseLight).code);
-    await screen.findByText('On going');
-    await resolveAll(order.target_courses, async (course) => {
-      await screen.findByRole('heading', { level: 6, name: course.title });
+    screen.getByText('Ref. ' + (order.course as CourseLight).code);
+    screen.getByText('On going');
+    order.target_courses.forEach((course) => {
+      screen.getByRole('heading', { level: 6, name: course.title });
       screen.getByText('You are not enrolled in this course');
       screen.getByRole('link', { name: 'Enroll' });
     });
+  });
+
+  it('renders a non-writable order without contract attribute', async () => {
+    const order: Order = OrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+      target_enrollments: [],
+      contract: null,
+    }).one();
+
+    const { product } = mockCourseProductWithOrder(order);
+
+    render(<DashboardItemOrder order={order} />, { wrapper });
+    await screen.findByRole('heading', { level: 5, name: product.title });
+
+    expect(
+      screen.queryByText('You have to sign this contract to access your training.'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+    expect(screen.getByText('On going')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 6, name: order.target_courses[0].title }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('You are not enrolled in this course')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Enroll' })).toBeInTheDocument();
+  });
+
+  it('renders a non-writable order with a signed contract', async () => {
+    const order: Order = OrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+      target_enrollments: [],
+      contract: ContractFactory({ signed_on: faker.date.past().toISOString() }).one(),
+    }).one();
+
+    const { product } = mockCourseProductWithOrder(order);
+
+    render(<DashboardItemOrder order={order} />, { wrapper });
+    await screen.findByRole('heading', { level: 5, name: product.title });
+
+    expect(
+      screen.queryByText('You have to sign this contract to access your training.'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+    expect(screen.getByText('On going')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 6, name: order.target_courses[0].title }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('You are not enrolled in this course')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Enroll' })).toBeInTheDocument();
+  });
+
+  it('renders a non-writable order with a contract not signed yet', async () => {
+    const order: Order = OrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+      target_enrollments: [],
+      contract: ContractFactory({ signed_on: undefined }).one(),
+    }).one();
+
+    const { product } = mockCourseProductWithOrder(order);
+
+    render(<DashboardItemOrder order={order} />, { wrapper });
+    await screen.findByRole('heading', { level: 5, name: product.title });
+
+    expect(screen.getByText('Ref. ' + (order.course as CourseLight).code)).toBeInTheDocument();
+    expect(
+      screen.getByText('You have to sign this contract to access your training.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Signature required')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 6, name: order.target_courses[0].title }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('You are not enrolled in this course')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Enroll' })).not.toBeInTheDocument();
   });
 
   /**
@@ -787,5 +861,78 @@ describe('<DashboardItemOrder/>', () => {
     expect(
       screen.queryByTestId('dashboard-item__course-enrolling__run__' + courseRun.id),
     ).toBeNull();
+  });
+
+  it('renders a writable order with a signed contract', async () => {
+    const order: Order = OrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+      target_enrollments: [],
+      contract: ContractFactory({ signed_on: faker.date.past().toISOString() }).one(),
+    }).one();
+    const { product } = mockCourseProductWithOrder(order);
+
+    fetchMock.get(
+      'https://joanie.endpoint/api/v1.0/orders/',
+      { results: [order], next: null, previous: null, count: null },
+      { overwriteRoutes: true },
+    );
+
+    render(WrapperWithDashboard(LearnerDashboardPaths.ORDER.replace(':orderId', order.id)));
+
+    expect(
+      await screen.findByRole('heading', { level: 5, name: product.title }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('On going')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('You have to sign this contract to access your training.'),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+    expect(screen.getByText("You've accepted the training contract.")).toBeInTheDocument();
+
+    const $enrollButtons = screen.getAllByRole('button', { name: 'Enroll' });
+    expect($enrollButtons).toHaveLength(order.target_courses[0].course_runs.length);
+    $enrollButtons.forEach(($button) => expect($button).toBeEnabled());
+
+    expect(
+      screen.queryByText('You need to sign your contract before enrolling to your courses'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a writable order with a contract not signed yet', async () => {
+    const order: Order = OrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+      target_enrollments: [],
+      contract: ContractFactory({ signed_on: undefined }).one(),
+    }).one();
+    const { product } = mockCourseProductWithOrder(order);
+
+    fetchMock.get(
+      'https://joanie.endpoint/api/v1.0/orders/',
+      { results: [order], next: null, previous: null, count: null },
+      { overwriteRoutes: true },
+    );
+
+    render(WrapperWithDashboard(LearnerDashboardPaths.ORDER.replace(':orderId', order.id)));
+    expect(
+      await screen.findByRole('heading', { level: 5, name: product.title }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Signature required')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign' })).toBeInTheDocument();
+    expect(
+      screen.getByText('You have to sign this contract to access your training.'),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+    expect(screen.queryByText("You've accepted the training contract.")).not.toBeInTheDocument();
+
+    const $enrollButtons = screen.getAllByRole('button', { name: 'Enroll' });
+    expect($enrollButtons).toHaveLength(order.target_courses[0].course_runs.length);
+    $enrollButtons.forEach(($button) => expect($button).toBeDisabled());
+
+    await expectBannerError('You need to sign your contract before enrolling to course runs');
   });
 });

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.spec.tsx
@@ -66,7 +66,7 @@ describe('<DashboardItemOrder/>', () => {
   it('should display message for validated order that need learner signature', () => {
     const order = OrderFactory({
       state: OrderState.VALIDATED,
-      contract: ContractFactory({ sign_date: undefined }).one(),
+      contract: ContractFactory({ signed_on: undefined }).one(),
     }).one();
     render(
       <Wrapper>
@@ -79,7 +79,7 @@ describe('<DashboardItemOrder/>', () => {
   it("should display message for validated order that don't have a generated certificate", () => {
     const order = OrderFactory({
       state: OrderState.VALIDATED,
-      contract: ContractFactory({ sign_date: new Date().toISOString() }).one(),
+      contract: ContractFactory({ signed_on: new Date().toISOString() }).one(),
       certificate: undefined,
     }).one();
     render(
@@ -97,7 +97,7 @@ describe('<DashboardItemOrder/>', () => {
   it('should display message for validated order that have a generated certificate', () => {
     const order = OrderFactory({
       state: OrderState.VALIDATED,
-      contract: ContractFactory({ sign_date: new Date().toISOString() }).one(),
+      contract: ContractFactory({ signed_on: new Date().toISOString() }).one(),
       certificate: 'FAKE_CERTIFICATE_ID',
     }).one();
     render(

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
@@ -1,6 +1,5 @@
-import { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
-
+import { useEffect } from 'react';
 import { Order, OrderState } from 'types/Joanie';
 import { StringHelper } from 'utils/StringHelper';
 import { handle } from 'utils/errors/handle';
@@ -71,7 +70,7 @@ const OrderStateMessage = ({ order }: OrderStateMessageProps) => {
   }, [order.state]);
 
   if (order.state === OrderState.VALIDATED) {
-    if (contract && !contract.sign_date) {
+    if (contract && !contract.signed_on) {
       return <FormattedMessage {...messages.statusWaitingSignature} />;
     }
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -121,7 +121,6 @@
     padding: 0.5rem 1rem;
     min-height: 3.75rem;
 
-    border-top: $onepixel solid r-theme-val(dashboard-item, base-border);
     &:first-child {
       border-top: 0;
     }
@@ -192,12 +191,22 @@
 }
 
 .dashboard-item-order {
+  > .dashboard-item {
+    padding-top: rem-calc(16px);
+    &:first-child {
+      padding-top: 0;
+    }
+  }
   &__footer {
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding: 0.5rem 1rem;
     min-height: 3.75rem;
+    border-bottom: $onepixel solid r-theme-val(dashboard-item, base-border);
+    &:last-child {
+      border-bottom: 0;
+    }
 
     @include media-breakpoint-down(sm) {
       flex-direction: column;
@@ -213,8 +222,6 @@
   }
 
   &__certificate__container {
-    padding-top: 1rem;
-
     .dashboard-item__block__head {
       display: none;
     }

--- a/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/_styles.scss
@@ -1,0 +1,5 @@
+.dashboard-order-loader__banners {
+  .banner {
+    margin-top: 0;
+  }
+}

--- a/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useOmniscientOrder } from 'hooks/useOrders';
 import { Spinner } from 'components/Spinner';
 import Banner, { BannerType } from 'components/Banner';
@@ -13,6 +13,11 @@ const messages = defineMessages({
     description: 'Message displayed while loading an order',
     id: 'components.DashboardOrderLoader.loading',
   },
+  signatureNeeded: {
+    defaultMessage: 'You need to sign your contract before enrolling to course runs',
+    description: 'Banner displayed when the contract is not signed',
+    id: 'components.DashboardOrderLoader.signatureNeeded',
+  },
 });
 
 export const DashboardOrderLoader = () => {
@@ -21,6 +26,8 @@ export const DashboardOrderLoader = () => {
   const course = order.item?.course as CourseLight;
   const courseProduct = useCourseProduct(course?.code, { productId: order.item?.product });
   const fetching = order.states.fetching || courseProduct.states.fetching;
+  const needsSignature = order.item?.contract && !order.item?.contract.signed_on;
+  const intl = useIntl();
 
   return (
     <>
@@ -31,12 +38,17 @@ export const DashboardOrderLoader = () => {
           </span>
         </Spinner>
       )}
-      {(order.states.error || courseProduct.states.error) && (
-        <Banner
-          message={(order.states.error ?? courseProduct.states.error)!}
-          type={BannerType.ERROR}
-        />
-      )}
+      <div className="dashboard-order-loader__banners">
+        {(order.states.error || courseProduct.states.error) && (
+          <Banner
+            message={(order.states.error ?? courseProduct.states.error)!}
+            type={BannerType.ERROR}
+          />
+        )}
+        {needsSignature && (
+          <Banner message={intl.formatMessage(messages.signatureNeeded)} type={BannerType.ERROR} />
+        )}
+      </div>
       {order.item && (
         <DashboardItemOrder
           writable={true}

--- a/src/frontend/scss/components/_index.scss
+++ b/src/frontend/scss/components/_index.scss
@@ -27,6 +27,7 @@
 @import '../../js/widgets/Dashboard/components/DashboardItem/Certificate/styles';
 @import '../../js/widgets/Dashboard/components/DashboardItem/styles';
 @import '../../js/widgets/Dashboard/components/DashboardLayout/styles';
+@import '../../js/widgets/Dashboard/components/DashboardOrderLoader/styles';
 @import '../../js/widgets/Dashboard/components/DashboardBreadcrumbs/styles';
 @import '../../js/widgets/Dashboard/components/DashboardSidebar/styles';
 @import '../../js/widgets/Dashboard/components/TeacherDashboardCourseSidebar/styles';


### PR DESCRIPTION
## Purpose

When a product with contract_definition is purchased,
The learner have to sign the order.contract before
enrolling to training's courses.
If the contract have been signed, the learner can
download it.

There a new section in order details page that
handle these actions.

### Listing
![image](https://github.com/openfun/richie/assets/139848/6eff3993-5f24-403d-a7f4-770ff52b9a81)

### Signature required
![image](https://github.com/openfun/richie/assets/139848/4d8a4f0b-e063-4193-891e-6d920cb5cbf1)

## Contract signed
![image](https://github.com/openfun/richie/assets/139848/bcf2aea9-2a56-4f6f-b543-456531017b7f)
