### PR TITLE
🐛(frontend) OrderStateMessage handle error on "validated" state

### DIFF
--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
@@ -65,8 +65,8 @@ const OrderStateMessage = ({ order }: OrderStateMessageProps) => {
   };
 
   useEffect(() => {
-    if (!(order.state in orderStatusMessages)) {
-      handle(new Error(`Unknow order state ${order.state}`));
+    if (!Object.values(OrderState).includes(order.state)) {
+      handle(new Error(`Unknown order state ${order.state}`));
     }
   }, [order.state]);
 


### PR DESCRIPTION
## Purpose

The OrderStateMessage does not handle validated state properly. Indeed this component does not have message to display for this state and it handles an error like this state was unknown. Of course, we only want to handle error in case an unknown state is provided but not when the provided state does not have message to display.


## Proposal

- [x] Call `handle` method only when unknown state is provided
