### PR TITLE
🏷️(frontend) Fix order types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Frontend Order type have been split into two: CredentialOrder and 
+  CertificateOrder.
 - Update PurchaseButton messages to aid with translation.
 - Update courses and organizations default permissions
 - Update cunningham to 2.0.0

--- a/src/frontend/js/components/PaymentButton/index.spec.tsx
+++ b/src/frontend/js/components/PaymentButton/index.spec.tsx
@@ -7,8 +7,8 @@ import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/fac
 import {
   AddressFactory,
   CreditCardFactory,
-  OrderWithOneClickPaymentFactory,
-  OrderWithPaymentFactory,
+  CredentialOrderWithOneClickPaymentFactory,
+  CredentialOrderWithPaymentFactory,
   ProductFactory,
 } from 'utils/test/factories/joanie';
 import { PAYMENT_SETTINGS } from 'settings';
@@ -178,8 +178,8 @@ describe('PaymentButton', () => {
     const product: Joanie.Product = ProductFactory().one();
     const billingAddress: Joanie.Address = AddressFactory().one();
     const handleSuccess = jest.fn();
-    const { payment_info: paymentInfo, ...order }: Joanie.OrderWithPaymentInfo =
-      OrderWithPaymentFactory().one();
+    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
+      CredentialOrderWithPaymentFactory().one();
     fetchMock
       .get(
         `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
@@ -277,8 +277,8 @@ describe('PaymentButton', () => {
     const product: Joanie.Product = ProductFactory().one();
     const billingAddress: Joanie.Address = AddressFactory().one();
     const creditCard: Joanie.CreditCard = CreditCardFactory().one();
-    const { payment_info: paymentInfo, ...order }: Joanie.OrderWithPaymentInfo =
-      OrderWithOneClickPaymentFactory().one();
+    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
+      CredentialOrderWithOneClickPaymentFactory().one();
     const handleSuccess = jest.fn();
 
     fetchMock
@@ -378,8 +378,8 @@ describe('PaymentButton', () => {
     const product: Joanie.Product = ProductFactory().one();
     const billingAddress: Joanie.Address = AddressFactory().one();
     const creditCard: Joanie.CreditCard = CreditCardFactory().one();
-    const { payment_info: paymentInfo, ...order }: Joanie.OrderWithPaymentInfo =
-      OrderWithOneClickPaymentFactory().one();
+    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
+      CredentialOrderWithOneClickPaymentFactory().one();
     const handleSuccess = jest.fn();
     const initialOrder = {
       ...order,
@@ -491,8 +491,8 @@ describe('PaymentButton', () => {
     const product: Joanie.Product = ProductFactory().one();
     const billingAddress: Joanie.Address = AddressFactory().one();
     const creditCard: Joanie.CreditCard = CreditCardFactory().one();
-    const { payment_info: paymentInfo, ...order }: Joanie.OrderWithPaymentInfo =
-      OrderWithOneClickPaymentFactory().one();
+    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
+      CredentialOrderWithOneClickPaymentFactory().one();
     const orderSubmitted = {
       ...order,
       state: OrderState.SUBMITTED,
@@ -595,8 +595,8 @@ describe('PaymentButton', () => {
   it('should render an error message when payment failed', async () => {
     const product: Joanie.Product = ProductFactory().one();
     const billingAddress: Joanie.Address = AddressFactory().one();
-    const { payment_info: paymentInfo, ...order }: Joanie.OrderWithPaymentInfo =
-      OrderWithPaymentFactory().one();
+    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
+      CredentialOrderWithPaymentFactory().one();
     const handleSuccess = jest.fn();
 
     fetchMock

--- a/src/frontend/js/components/PaymentButton/index.spec.tsx
+++ b/src/frontend/js/components/PaymentButton/index.spec.tsx
@@ -9,11 +9,14 @@ import {
   CreditCardFactory,
   CredentialOrderWithOneClickPaymentFactory,
   CredentialOrderWithPaymentFactory,
-  ProductFactory,
+  CertificateOrderWithOneClickPaymentFactory,
+  CertificateOrderWithPaymentFactory,
+  CertificateProductFactory,
+  CredentialProductFactory,
 } from 'utils/test/factories/joanie';
 import { PAYMENT_SETTINGS } from 'settings';
 import type * as Joanie from 'types/Joanie';
-import { OrderState } from 'types/Joanie';
+import { OrderState, ProductType } from 'types/Joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { CourseProductProvider } from 'contexts/CourseProductContext';
 import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
@@ -35,641 +38,656 @@ jest.mock('utils/context', () => ({
 
 jest.mock('./components/PaymentInterfaces');
 
-describe('PaymentButton', () => {
-  let nbApiCalls: number;
-  const formatPrice = (price: number, currency: string) =>
-    new Intl.NumberFormat('en', {
-      currency,
-      style: 'currency',
-    }).format(price);
+describe.each([
+  {
+    productType: ProductType.CREDENTIAL,
+    ProductFactory: CredentialProductFactory,
+    OrderWithOneClickPaymentFactory: CredentialOrderWithOneClickPaymentFactory,
+    OrderWithPaymentFactory: CredentialOrderWithPaymentFactory,
+  },
+  {
+    productType: ProductType.CERTIFICATE,
+    ProductFactory: CertificateProductFactory,
+    OrderWithOneClickPaymentFactory: CertificateOrderWithOneClickPaymentFactory,
+    OrderWithPaymentFactory: CertificateOrderWithPaymentFactory,
+  },
+])(
+  'PaymentButton for $productType product',
+  ({ ProductFactory, OrderWithOneClickPaymentFactory, OrderWithPaymentFactory }) => {
+    let nbApiCalls: number;
+    const formatPrice = (price: number, currency: string) =>
+      new Intl.NumberFormat('en', {
+        currency,
+        style: 'currency',
+      }).format(price);
 
-  const Wrapper = ({
-    client = createTestQueryClient({ user: true }),
-    children,
-  }: PropsWithChildren<{ client?: QueryClient }>) => {
-    return (
-      <IntlProvider locale="en">
-        <QueryClientProvider client={client}>
-          <JoanieSessionProvider>
-            <CourseProductProvider productId="" courseCode="00000">
-              {children}
-            </CourseProductProvider>
-          </JoanieSessionProvider>
-        </QueryClientProvider>
-      </IntlProvider>
-    );
-  };
+    const Wrapper = ({
+      client = createTestQueryClient({ user: true }),
+      children,
+    }: PropsWithChildren<{ client?: QueryClient }>) => {
+      return (
+        <IntlProvider locale="en">
+          <QueryClientProvider client={client}>
+            <JoanieSessionProvider>
+              <CourseProductProvider productId="" courseCode="00000">
+                {children}
+              </CourseProductProvider>
+            </JoanieSessionProvider>
+          </QueryClientProvider>
+        </IntlProvider>
+      );
+    };
 
-  beforeEach(() => {
-    jest.useFakeTimers();
-    jest.clearAllTimers();
-    jest.resetAllMocks();
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.clearAllTimers();
+      jest.resetAllMocks();
 
-    fetchMock.restore();
-    sessionStorage.clear();
+      fetchMock.restore();
+      sessionStorage.clear();
 
-    // Joanie providers calls
-    fetchMock.get('https://joanie.test/api/v1.0/orders/', []);
-    fetchMock.get('https://joanie.test/api/v1.0/credit-cards/', []);
-    fetchMock.get('https://joanie.test/api/v1.0/addresses/', []);
-    nbApiCalls = 3;
-  });
-
-  afterEach(() => {
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
-    cleanup();
-  });
-
-  it('should render a payment button', async () => {
-    const product: Joanie.Product = ProductFactory().one();
-    fetchMock.get(
-      `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
-      [],
-    );
-    render(
-      <Wrapper>
-        <PaymentButton product={product} onSuccess={jest.fn()} />
-      </Wrapper>,
-    );
-
-    const $button = screen.getByRole('button', {
-      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
-    }) as HTMLButtonElement;
-
-    // a billing address is missing, but the button stays enabled
-    // this allows the user to get feedback on what's missing to make the payment by clicking on the button
-    expect($button.disabled).toBe(false);
-
-    // clicking the button should show an error and focus it so that screen reader users know what's happening
-    await act(async () => {
-      fireEvent.click($button);
+      // Joanie providers calls
+      fetchMock.get('https://joanie.test/api/v1.0/orders/', []);
+      fetchMock.get('https://joanie.test/api/v1.0/credit-cards/', []);
+      fetchMock.get('https://joanie.test/api/v1.0/addresses/', []);
+      nbApiCalls = 3;
     });
-    const $error = screen.getByText('You must have a billing address.');
-    expect(document.activeElement).toBe($error);
-  });
 
-  it('should render a payment button with a specific label when a credit card is provided', () => {
-    /*
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+      cleanup();
+    });
+
+    it('should render a payment button', async () => {
+      const product: Joanie.Product = ProductFactory().one();
+      fetchMock.get(
+        `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
+        [],
+      );
+      render(
+        <Wrapper>
+          <PaymentButton product={product} onSuccess={jest.fn()} />
+        </Wrapper>,
+      );
+
+      const $button = screen.getByRole('button', {
+        name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+      }) as HTMLButtonElement;
+
+      // a billing address is missing, but the button stays enabled
+      // this allows the user to get feedback on what's missing to make the payment by clicking on the button
+      expect($button.disabled).toBe(false);
+
+      // clicking the button should show an error and focus it so that screen reader users know what's happening
+      await act(async () => {
+        fireEvent.click($button);
+      });
+      const $error = screen.getByText('You must have a billing address.');
+      expect(document.activeElement).toBe($error);
+    });
+
+    it('should render a payment button with a specific label when a credit card is provided', () => {
+      /*
       If a credit card is provided, it seems that the payment should be a one click,
       so the payment button label should mention this information.
     */
-    const product: Joanie.Product = ProductFactory().one();
-    const creditCard: Joanie.CreditCard = CreditCardFactory().one();
+      const product: Joanie.Product = ProductFactory().one();
+      const creditCard: Joanie.CreditCard = CreditCardFactory().one();
 
-    fetchMock.get(
-      `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
-      [],
-    );
-    const { rerender } = render(
-      <Wrapper>
-        <PaymentButton product={product} creditCard={creditCard.id} onSuccess={jest.fn()} />
-      </Wrapper>,
-    );
-
-    const $button = screen.getByRole('button', {
-      name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
-    }) as HTMLButtonElement;
-
-    // a billing address is missing, but the button stays enabled
-    // this allows the user to get feedback on what's missing to make the payment by clicking on the button
-    expect($button.disabled).toBe(false);
-
-    const billingAddress: Joanie.Address = AddressFactory().one();
-
-    rerender(
-      <Wrapper>
-        <PaymentButton
-          billingAddress={billingAddress}
-          product={product}
-          creditCard={creditCard.id}
-          onSuccess={jest.fn()}
-        />
-      </Wrapper>,
-    );
-
-    // the button should be active
-    expect($button.disabled).toBe(false);
-  });
-
-  it('should render an enabled payment button if a billing address is provided', () => {
-    const product: Joanie.Product = ProductFactory().one();
-    const billingAddress: Joanie.Address = AddressFactory().one();
-
-    fetchMock.get(
-      `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
-      [],
-    );
-    render(
-      <Wrapper>
-        <PaymentButton billingAddress={billingAddress} product={product} onSuccess={jest.fn()} />
-      </Wrapper>,
-    );
-
-    const $button = screen.getByRole('button', {
-      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
-    }) as HTMLButtonElement;
-
-    // the button should be active
-    expect($button.disabled).toBe(false);
-  });
-
-  it('should create an order then display the payment interface when user clicks on payment button', async () => {
-    const product: Joanie.Product = ProductFactory().one();
-    const billingAddress: Joanie.Address = AddressFactory().one();
-    const handleSuccess = jest.fn();
-    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
-      CredentialOrderWithPaymentFactory().one();
-    fetchMock
-      .get(
+      fetchMock.get(
         `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
         [],
-      )
-      .post('https://joanie.test/api/v1.0/orders/', order)
-      .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
-        paymentInfo,
-      })
-      .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, {
-        ...order,
+      );
+      const { rerender } = render(
+        <Wrapper>
+          <PaymentButton product={product} creditCard={creditCard.id} onSuccess={jest.fn()} />
+        </Wrapper>,
+      );
+
+      const $button = screen.getByRole('button', {
+        name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
+      }) as HTMLButtonElement;
+
+      // a billing address is missing, but the button stays enabled
+      // this allows the user to get feedback on what's missing to make the payment by clicking on the button
+      expect($button.disabled).toBe(false);
+
+      const billingAddress: Joanie.Address = AddressFactory().one();
+
+      rerender(
+        <Wrapper>
+          <PaymentButton
+            billingAddress={billingAddress}
+            product={product}
+            creditCard={creditCard.id}
+            onSuccess={jest.fn()}
+          />
+        </Wrapper>,
+      );
+
+      // the button should be active
+      expect($button.disabled).toBe(false);
+    });
+
+    it('should render an enabled payment button if a billing address is provided', () => {
+      const product: Joanie.Product = ProductFactory().one();
+      const billingAddress: Joanie.Address = AddressFactory().one();
+
+      fetchMock.get(
+        `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
+        [],
+      );
+      render(
+        <Wrapper>
+          <PaymentButton billingAddress={billingAddress} product={product} onSuccess={jest.fn()} />
+        </Wrapper>,
+      );
+
+      const $button = screen.getByRole('button', {
+        name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+      }) as HTMLButtonElement;
+
+      // the button should be active
+      expect($button.disabled).toBe(false);
+    });
+
+    it('should create an order then display the payment interface when user clicks on payment button', async () => {
+      const product: Joanie.Product = ProductFactory().one();
+      const billingAddress: Joanie.Address = AddressFactory().one();
+      const handleSuccess = jest.fn();
+      const { payment_info: paymentInfo, ...order } = OrderWithPaymentFactory().one();
+      fetchMock
+        .get(
+          `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
+          [],
+        )
+        .post('https://joanie.test/api/v1.0/orders/', order)
+        .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
+          paymentInfo,
+        })
+        .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, {
+          ...order,
+        });
+
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PaymentButton
+            billingAddress={billingAddress}
+            product={product}
+            onSuccess={handleSuccess}
+          />
+        </Wrapper>,
+      );
+      nbApiCalls += 1; // fetch order for useProductOrder
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+
+      const $button = screen.getByRole('button', {
+        name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+      }) as HTMLButtonElement;
+
+      // - Payment button should not be disabled.
+      expect($button.disabled).toBe(false);
+
+      // - User clicks on pay button
+      await act(async () => {
+        fireEvent.click($button);
       });
 
-    render(
-      <Wrapper client={createTestQueryClient({ user: true })}>
-        <PaymentButton
-          billingAddress={billingAddress}
-          product={product}
-          onSuccess={handleSuccess}
-        />
-      </Wrapper>,
-    );
-    nbApiCalls += 1; // fetch order for useProductOrder
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+      // - Route to create order should have been called
+      nbApiCalls += 1; // order post create (invalidate queries)
+      nbApiCalls += 1; // refetch omniscient orders
+      nbApiCalls += 1; // refetch useProductOrder
+      nbApiCalls += 1; // order submit
 
-    const $button = screen.getByRole('button', {
-      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
-    }) as HTMLButtonElement;
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+      expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
 
-    // - Payment button should not be disabled.
-    expect($button.disabled).toBe(false);
+      // - Spinner should be displayed
+      screen.getByText('Payment in progress');
 
-    // - User clicks on pay button
-    await act(async () => {
-      fireEvent.click($button);
+      // - Payment interface should be displayed
+      screen.getByText('Payment interface component');
+
+      // - Simulate the payment has succeeded
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('payment-success'));
+      });
+
+      // - Once payment succeeded, order should be refetch
+      nbApiCalls += 1; // fetch validated order
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+      expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
+
+      // - Order should be polled until its state is validated
+      fetchMock.get(
+        `https://joanie.test/api/v1.0/orders/${order.id}/`,
+        {
+          ...order,
+          state: OrderState.VALIDATED,
+        },
+        {
+          overwriteRoutes: true,
+        },
+      );
+
+      // - Advance timer to one tick
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+
+      // - Order should have been refetched
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+      expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
+
+      // - As order state is validated, the onSuccess callback should be triggered.
+      expect(handleSuccess).toHaveBeenCalledTimes(1);
+
+      // - And poller should be stopped
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
     });
 
-    // - Route to create order should have been called
-    nbApiCalls += 1; // order post create (invalidate queries)
-    nbApiCalls += 1; // refetch omniscient orders
-    nbApiCalls += 1; // refetch useProductOrder
-    nbApiCalls += 1; // order submit
+    it('should render only a spinner if payment is a one click when user clicks on payment button', async () => {
+      const product: Joanie.Product = ProductFactory().one();
+      const billingAddress: Joanie.Address = AddressFactory().one();
+      const creditCard: Joanie.CreditCard = CreditCardFactory().one();
+      const { payment_info: paymentInfo, ...order } = OrderWithOneClickPaymentFactory().one();
+      const handleSuccess = jest.fn();
 
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
+      fetchMock
+        .get(
+          `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
+          [],
+        )
+        .post('https://joanie.test/api/v1.0/orders/', order)
+        .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
+          payment_info: paymentInfo,
+        })
+        .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, {
+          ...order,
+          state: OrderState.SUBMITTED,
+        });
 
-    // - Spinner should be displayed
-    screen.getByText('Payment in progress');
+      render(
+        <Wrapper client={createTestQueryClient({ user: null })}>
+          <PaymentButton
+            billingAddress={billingAddress}
+            creditCard={creditCard.id}
+            product={product}
+            onSuccess={handleSuccess}
+          />
+        </Wrapper>,
+      );
 
-    // - Payment interface should be displayed
-    screen.getByText('Payment interface component');
+      const $button = screen.getByRole('button', {
+        name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
+      }) as HTMLButtonElement;
 
-    // - Simulate the payment has succeeded
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('payment-success'));
+      // - Payment button should not be disabled.
+      expect($button.disabled).toBe(false);
+
+      // - User clicks on pay button
+      await act(async () => {
+        fireEvent.click($button);
+      });
+
+      // - Route to create order should have been called + submit
+      // - Furthermore, as payment succeeded immediately, order should have been refetched
+      expect(fetchMock.calls()).toHaveLength(3);
+      expect(fetchMock.calls()[0][0]).toBe('https://joanie.test/api/v1.0/orders/');
+
+      expect(JSON.parse(fetchMock.calls()[0][1]!.body as string)).toEqual({
+        course: '00000',
+        product: product.id,
+      });
+
+      expect(fetchMock.calls()[1][0]).toBe(
+        `https://joanie.test/api/v1.0/orders/${order.id}/submit/`,
+      );
+
+      expect(JSON.parse(fetchMock.calls()[1][1]!.body as string)).toEqual({
+        billing_address: billingAddress,
+        credit_card_id: creditCard.id,
+      });
+
+      expect(fetchMock.calls()[2][0]).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
+
+      // - Spinner should be displayed
+      screen.getByText('Payment in progress');
+
+      // - Payment interface should not be displayed
+      expect(screen.queryByText('Payment interface component')).toBeNull();
+
+      // - Order should be polled until its state is validated
+      fetchMock.get(
+        `https://joanie.test/api/v1.0/orders/${order.id}/`,
+        {
+          ...order,
+          state: OrderState.VALIDATED,
+        },
+        {
+          overwriteRoutes: true,
+        },
+      );
+
+      // - Advance timer to one tick
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+
+      // - Order should have been refetched
+      expect(fetchMock.calls()).toHaveLength(4);
+      expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
+
+      // - As order state is validated, the onSuccess callback should be triggered.
+      expect(handleSuccess).toHaveBeenCalledTimes(1);
+      //
+      // - And poller should be stopped
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      expect(fetchMock.calls()).toHaveLength(4);
     });
 
-    // - Once payment succeeded, order should be refetch
-    nbApiCalls += 1; // fetch validated order
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
-
-    // - Order should be polled until its state is validated
-    fetchMock.get(
-      `https://joanie.test/api/v1.0/orders/${order.id}/`,
-      {
+    it('should render a payment button and not call the order creation route', async () => {
+      const product: Joanie.Product = ProductFactory().one();
+      const billingAddress: Joanie.Address = AddressFactory().one();
+      const creditCard: Joanie.CreditCard = CreditCardFactory().one();
+      const { payment_info: paymentInfo, ...order } = OrderWithOneClickPaymentFactory().one();
+      const handleSuccess = jest.fn();
+      const initialOrder = {
         ...order,
-        state: OrderState.VALIDATED,
-      },
-      {
-        overwriteRoutes: true,
-      },
-    );
-
-    // - Advance timer to one tick
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-
-    // - Order should have been refetched
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
-
-    // - As order state is validated, the onSuccess callback should be triggered.
-    expect(handleSuccess).toHaveBeenCalledTimes(1);
-
-    // - And poller should be stopped
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-  });
-
-  it('should render only a spinner if payment is a one click when user clicks on payment button', async () => {
-    const product: Joanie.Product = ProductFactory().one();
-    const billingAddress: Joanie.Address = AddressFactory().one();
-    const creditCard: Joanie.CreditCard = CreditCardFactory().one();
-    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
-      CredentialOrderWithOneClickPaymentFactory().one();
-    const handleSuccess = jest.fn();
-
-    fetchMock
-      .get(
-        `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
-        [],
-      )
-      .post('https://joanie.test/api/v1.0/orders/', order)
-      .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
-        payment_info: paymentInfo,
-      })
-      .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, {
+        state: OrderState.PENDING,
+      };
+      const orderSubmitted = {
         ...order,
         state: OrderState.SUBMITTED,
+      };
+
+      fetchMock
+        .get(
+          `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
+          [initialOrder],
+        )
+        .post('https://joanie.test/api/v1.0/orders/', order)
+        .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
+          payment_info: paymentInfo,
+        })
+        .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, orderSubmitted);
+
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PaymentButton
+            billingAddress={billingAddress}
+            creditCard={creditCard.id}
+            product={product}
+            onSuccess={handleSuccess}
+          />
+        </Wrapper>,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('payment-button-order-loaded')).toBeInTheDocument();
       });
 
-    render(
-      <Wrapper client={createTestQueryClient({ user: null })}>
-        <PaymentButton
-          billingAddress={billingAddress}
-          creditCard={creditCard.id}
-          product={product}
-          onSuccess={handleSuccess}
-        />
-      </Wrapper>,
-    );
+      nbApiCalls += 1; // useProductOrder get order with filters
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+      const $button = screen.getByRole('button', {
+        name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
+      }) as HTMLButtonElement;
 
-    const $button = screen.getByRole('button', {
-      name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
-    }) as HTMLButtonElement;
+      // - Payment button should not be disabled.
+      expect($button.disabled).toBe(false);
 
-    // - Payment button should not be disabled.
-    expect($button.disabled).toBe(false);
-
-    // - User clicks on pay button
-    await act(async () => {
-      fireEvent.click($button);
-    });
-
-    // - Route to create order should have been called + submit
-    // - Furthermore, as payment succeeded immediately, order should have been refetched
-    expect(fetchMock.calls()).toHaveLength(3);
-    expect(fetchMock.calls()[0][0]).toBe('https://joanie.test/api/v1.0/orders/');
-
-    expect(JSON.parse(fetchMock.calls()[0][1]!.body as string)).toEqual({
-      course: '00000',
-      product: product.id,
-    });
-
-    expect(fetchMock.calls()[1][0]).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
-
-    expect(JSON.parse(fetchMock.calls()[1][1]!.body as string)).toEqual({
-      billing_address: billingAddress,
-      credit_card_id: creditCard.id,
-    });
-
-    expect(fetchMock.calls()[2][0]).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
-
-    // - Spinner should be displayed
-    screen.getByText('Payment in progress');
-
-    // - Payment interface should not be displayed
-    expect(screen.queryByText('Payment interface component')).toBeNull();
-
-    // - Order should be polled until its state is validated
-    fetchMock.get(
-      `https://joanie.test/api/v1.0/orders/${order.id}/`,
-      {
-        ...order,
-        state: OrderState.VALIDATED,
-      },
-      {
-        overwriteRoutes: true,
-      },
-    );
-
-    // - Advance timer to one tick
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-
-    // - Order should have been refetched
-    expect(fetchMock.calls()).toHaveLength(4);
-    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
-
-    // - As order state is validated, the onSuccess callback should be triggered.
-    expect(handleSuccess).toHaveBeenCalledTimes(1);
-    //
-    // - And poller should be stopped
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-    expect(fetchMock.calls()).toHaveLength(4);
-  });
-
-  it('should render a payment button and not call the order creation route', async () => {
-    const product: Joanie.Product = ProductFactory().one();
-    const billingAddress: Joanie.Address = AddressFactory().one();
-    const creditCard: Joanie.CreditCard = CreditCardFactory().one();
-    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
-      CredentialOrderWithOneClickPaymentFactory().one();
-    const handleSuccess = jest.fn();
-    const initialOrder = {
-      ...order,
-      state: OrderState.PENDING,
-    };
-    const orderSubmitted = {
-      ...order,
-      state: OrderState.SUBMITTED,
-    };
-
-    fetchMock
-      .get(
-        `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
-        [initialOrder],
-      )
-      .post('https://joanie.test/api/v1.0/orders/', order)
-      .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
-        payment_info: paymentInfo,
-      })
-      .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, orderSubmitted);
-
-    render(
-      <Wrapper client={createTestQueryClient({ user: true })}>
-        <PaymentButton
-          billingAddress={billingAddress}
-          creditCard={creditCard.id}
-          product={product}
-          onSuccess={handleSuccess}
-        />
-      </Wrapper>,
-    );
-    await waitFor(() => {
-      expect(screen.getByTestId('payment-button-order-loaded')).toBeInTheDocument();
-    });
-
-    nbApiCalls += 1; // useProductOrder get order with filters
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-    const $button = screen.getByRole('button', {
-      name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
-    }) as HTMLButtonElement;
-
-    // - Payment button should not be disabled.
-    expect($button.disabled).toBe(false);
-
-    // - User clicks on pay button
-    fetchMock.get(
-      `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
-      [orderSubmitted],
-      { overwriteRoutes: true },
-    );
-    await act(async () => {
-      fireEvent.click($button);
-    });
-
-    // - Route to submit an existing order
-    // - Furthermore, as payment succeeded immediately, order should have been refetched
-    nbApiCalls += 1; // order submit
-    nbApiCalls += 1; // order get on id
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-
-    const submitCall = fetchMock
-      .calls()
-      .find((call) => call[0] === `https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
-    expect(submitCall).not.toBeUndefined();
-    expect(JSON.parse(submitCall![1]!.body as string)).toEqual({
-      billing_address: billingAddress,
-      credit_card_id: creditCard.id,
-    });
-    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
-
-    // - Spinner should be displayed
-    screen.getByText('Payment in progress');
-
-    // - Payment interface should not be displayed
-    expect(screen.queryByText('Payment interface component')).toBeNull();
-
-    // - Order should be polled until its state is validated
-    fetchMock.get(
-      `https://joanie.test/api/v1.0/orders/${order.id}/`,
-      {
-        ...order,
-        state: OrderState.VALIDATED,
-      },
-      {
-        overwriteRoutes: true,
-      },
-    );
-
-    // - Advance timer to one tick
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-
-    // - Order should have been refetched
-    nbApiCalls += 1; // order get on id
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
-
-    // - As order state is validated, the onSuccess callback should be triggered.
-    expect(handleSuccess).toHaveBeenCalledTimes(1);
-    // - And poller should be stopped
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-  });
-
-  it('should abort the order if payment does not succeed after a given delay', async () => {
-    const product: Joanie.Product = ProductFactory().one();
-    const billingAddress: Joanie.Address = AddressFactory().one();
-    const creditCard: Joanie.CreditCard = CreditCardFactory().one();
-    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
-      CredentialOrderWithOneClickPaymentFactory().one();
-    const orderSubmitted = {
-      ...order,
-      state: OrderState.SUBMITTED,
-    };
-    const handleSuccess = jest.fn();
-
-    fetchMock
-      .get(
+      // - User clicks on pay button
+      fetchMock.get(
         `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
         [orderSubmitted],
-      )
-      .post('https://joanie.test/api/v1.0/orders/', order)
-      .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
-        payment_info: paymentInfo,
-      })
-      .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, orderSubmitted)
-      .post(`https://joanie.test/api/v1.0/orders/${order.id}/abort/`, HttpStatusCode.OK);
-
-    render(
-      <Wrapper client={createTestQueryClient({ user: true })}>
-        <PaymentButton
-          billingAddress={billingAddress}
-          creditCard={creditCard.id}
-          product={product}
-          onSuccess={handleSuccess}
-        />
-      </Wrapper>,
-    );
-    await waitFor(() => {
-      expect(screen.getByTestId('payment-button-order-loaded')).toBeInTheDocument();
-    });
-    nbApiCalls += 1; // fetcher order for userProductOrder
-    const apiCalls = fetchMock.calls().map((call) => call[0]);
-    expect(apiCalls).toContain(
-      `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
-    );
-
-    const $button = screen.getByRole('button', {
-      name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
-    }) as HTMLButtonElement;
-
-    // - Payment button should not be disabled.
-    expect($button.disabled).toBe(false);
-
-    // - User clicks on pay button
-    await act(async () => {
-      fireEvent.click($button);
-    });
-
-    // - Route to create order should have been called
-    // - Furthermore, as payment succeeded immediately, order should have been refetched
-    const onClickApiCalls = fetchMock.calls().splice(nbApiCalls);
-    nbApiCalls += 1; // order submit
-    nbApiCalls += 1; // fetch validated order
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
-
-    expect(onClickApiCalls[0][0]).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
-    expect(JSON.parse(onClickApiCalls[0][1]!.body as string)).toEqual({
-      billing_address: billingAddress,
-      credit_card_id: creditCard.id,
-    });
-
-    expect(onClickApiCalls[1][0]).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
-
-    // - Spinner should be displayed
-    screen.getByText('Payment in progress');
-
-    // - Payment interface should not be displayed
-    expect(screen.queryByText('Payment interface component')).toBeNull();
-
-    fetchMock.resetHistory();
-    // - Wait until order has been polled 29 times.
-    await jest.advanceTimersToNextTimerAsync(PAYMENT_SETTINGS.pollLimit);
-    expect(fetchMock.calls()).toHaveLength(PAYMENT_SETTINGS.pollLimit - 1);
-
-    // - This round should be the last after which the order should be aborted
-    await act(async () => {
-      jest.runOnlyPendingTimers();
-    });
-
-    await waitFor(
-      async () => {
-        expect(fetchMock.calls()).toHaveLength(PAYMENT_SETTINGS.pollLimit);
-        expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/abort/`);
-      },
-      {
-        timeout: 1100,
-      },
-    );
-
-    expect(JSON.parse(fetchMock.lastOptions()!.body!.toString())).toEqual({
-      payment_id: paymentInfo.payment_id,
-    });
-
-    // - An error message should be displayed and focused (for screen reader users)
-    const $error = screen.getByText('An error occurred during payment. Please retry later.');
-    expect(document.activeElement).toBe($error);
-  }, 10000);
-
-  it('should render an error message when payment failed', async () => {
-    const product: Joanie.Product = ProductFactory().one();
-    const billingAddress: Joanie.Address = AddressFactory().one();
-    const { payment_info: paymentInfo, ...order }: Joanie.CredentialOrderWithPaymentInfo =
-      CredentialOrderWithPaymentFactory().one();
-    const handleSuccess = jest.fn();
-
-    fetchMock
-      .get(
-        `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
-        [],
-      )
-      .post('https://joanie.test/api/v1.0/orders/', order)
-      .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
-        payment_info: paymentInfo,
-      })
-      .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, {
-        ...order,
-        state: OrderState.SUBMITTED,
+        { overwriteRoutes: true },
+      );
+      await act(async () => {
+        fireEvent.click($button);
       });
 
-    render(
-      <Wrapper client={createTestQueryClient({ user: true })}>
-        <PaymentButton
-          billingAddress={billingAddress}
-          product={product}
-          onSuccess={handleSuccess}
-        />
-      </Wrapper>,
-    );
-    nbApiCalls += 1; // useProductOrder get order with filters
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+      // - Route to submit an existing order
+      // - Furthermore, as payment succeeded immediately, order should have been refetched
+      nbApiCalls += 1; // order submit
+      nbApiCalls += 1; // order get on id
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
 
-    const $button = screen.getByRole('button', {
-      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
-    }) as HTMLButtonElement;
+      const submitCall = fetchMock
+        .calls()
+        .find((call) => call[0] === `https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
+      expect(submitCall).not.toBeUndefined();
+      expect(JSON.parse(submitCall![1]!.body as string)).toEqual({
+        billing_address: billingAddress,
+        credit_card_id: creditCard.id,
+      });
+      expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
 
-    // - As all information are provided, payment button should not be disabled.
-    expect($button.disabled).toBe(false);
+      // - Spinner should be displayed
+      screen.getByText('Payment in progress');
 
-    // - User clicks on pay button
-    await act(async () => {
-      fireEvent.click($button);
+      // - Payment interface should not be displayed
+      expect(screen.queryByText('Payment interface component')).toBeNull();
+
+      // - Order should be polled until its state is validated
+      fetchMock.get(
+        `https://joanie.test/api/v1.0/orders/${order.id}/`,
+        {
+          ...order,
+          state: OrderState.VALIDATED,
+        },
+        {
+          overwriteRoutes: true,
+        },
+      );
+
+      // - Advance timer to one tick
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+
+      // - Order should have been refetched
+      nbApiCalls += 1; // order get on id
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+      expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
+
+      // - As order state is validated, the onSuccess callback should be triggered.
+      expect(handleSuccess).toHaveBeenCalledTimes(1);
+      // - And poller should be stopped
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
     });
 
-    // - Route to create order should have been called
-    nbApiCalls += 1; // order post create (invalidate queries)
-    nbApiCalls += 1; // refetch omniscient orders
-    nbApiCalls += 1; // refetch useProductOrder
-    nbApiCalls += 1; // order submit
-    expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+    it('should abort the order if payment does not succeed after a given delay', async () => {
+      const product: Joanie.Product = ProductFactory().one();
+      const billingAddress: Joanie.Address = AddressFactory().one();
+      const creditCard: Joanie.CreditCard = CreditCardFactory().one();
+      const { payment_info: paymentInfo, ...order } = OrderWithOneClickPaymentFactory().one();
+      const orderSubmitted = {
+        ...order,
+        state: OrderState.SUBMITTED,
+      };
+      const handleSuccess = jest.fn();
 
-    expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
-    expect(JSON.parse(fetchMock.lastOptions()!.body!.toString())).toEqual({
-      billing_address: billingAddress,
+      fetchMock
+        .get(
+          `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
+          [orderSubmitted],
+        )
+        .post('https://joanie.test/api/v1.0/orders/', order)
+        .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
+          payment_info: paymentInfo,
+        })
+        .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, orderSubmitted)
+        .post(`https://joanie.test/api/v1.0/orders/${order.id}/abort/`, HttpStatusCode.OK);
+
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PaymentButton
+            billingAddress={billingAddress}
+            creditCard={creditCard.id}
+            product={product}
+            onSuccess={handleSuccess}
+          />
+        </Wrapper>,
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('payment-button-order-loaded')).toBeInTheDocument();
+      });
+      nbApiCalls += 1; // fetcher order for userProductOrder
+      const apiCalls = fetchMock.calls().map((call) => call[0]);
+      expect(apiCalls).toContain(
+        `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
+      );
+
+      const $button = screen.getByRole('button', {
+        name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
+      }) as HTMLButtonElement;
+
+      // - Payment button should not be disabled.
+      expect($button.disabled).toBe(false);
+
+      // - User clicks on pay button
+      await act(async () => {
+        fireEvent.click($button);
+      });
+
+      // - Route to create order should have been called
+      // - Furthermore, as payment succeeded immediately, order should have been refetched
+      const onClickApiCalls = fetchMock.calls().splice(nbApiCalls);
+      nbApiCalls += 1; // order submit
+      nbApiCalls += 1; // fetch validated order
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+
+      expect(onClickApiCalls[0][0]).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
+      expect(JSON.parse(onClickApiCalls[0][1]!.body as string)).toEqual({
+        billing_address: billingAddress,
+        credit_card_id: creditCard.id,
+      });
+
+      expect(onClickApiCalls[1][0]).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
+
+      // - Spinner should be displayed
+      screen.getByText('Payment in progress');
+
+      // - Payment interface should not be displayed
+      expect(screen.queryByText('Payment interface component')).toBeNull();
+
+      fetchMock.resetHistory();
+      // - Wait until order has been polled 29 times.
+      await jest.advanceTimersToNextTimerAsync(PAYMENT_SETTINGS.pollLimit);
+      expect(fetchMock.calls()).toHaveLength(PAYMENT_SETTINGS.pollLimit - 1);
+
+      // - This round should be the last after which the order should be aborted
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+
+      await waitFor(
+        async () => {
+          expect(fetchMock.calls()).toHaveLength(PAYMENT_SETTINGS.pollLimit);
+          expect(fetchMock.lastUrl()).toBe(
+            `https://joanie.test/api/v1.0/orders/${order.id}/abort/`,
+          );
+        },
+        {
+          timeout: 1100,
+        },
+      );
+
+      expect(JSON.parse(fetchMock.lastOptions()!.body!.toString())).toEqual({
+        payment_id: paymentInfo.payment_id,
+      });
+
+      // - An error message should be displayed and focused (for screen reader users)
+      const $error = screen.getByText('An error occurred during payment. Please retry later.');
+      expect(document.activeElement).toBe($error);
+    }, 10000);
+
+    it('should render an error message when payment failed', async () => {
+      const product: Joanie.Product = ProductFactory().one();
+      const billingAddress: Joanie.Address = AddressFactory().one();
+      const { payment_info: paymentInfo, ...order } = OrderWithPaymentFactory().one();
+      const handleSuccess = jest.fn();
+
+      fetchMock
+        .get(
+          `https://joanie.test/api/v1.0/orders/?course=00000&product=${product.id}&state=pending&state=validated&state=submitted`,
+          [],
+        )
+        .post('https://joanie.test/api/v1.0/orders/', order)
+        .patch(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`, {
+          payment_info: paymentInfo,
+        })
+        .get(`https://joanie.test/api/v1.0/orders/${order.id}/`, {
+          ...order,
+          state: OrderState.SUBMITTED,
+        });
+
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PaymentButton
+            billingAddress={billingAddress}
+            product={product}
+            onSuccess={handleSuccess}
+          />
+        </Wrapper>,
+      );
+      nbApiCalls += 1; // useProductOrder get order with filters
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+
+      const $button = screen.getByRole('button', {
+        name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+      }) as HTMLButtonElement;
+
+      // - As all information are provided, payment button should not be disabled.
+      expect($button.disabled).toBe(false);
+
+      // - User clicks on pay button
+      await act(async () => {
+        fireEvent.click($button);
+      });
+
+      // - Route to create order should have been called
+      nbApiCalls += 1; // order post create (invalidate queries)
+      nbApiCalls += 1; // refetch omniscient orders
+      nbApiCalls += 1; // refetch useProductOrder
+      nbApiCalls += 1; // order submit
+      expect(fetchMock.calls()).toHaveLength(nbApiCalls);
+
+      expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
+      expect(JSON.parse(fetchMock.lastOptions()!.body!.toString())).toEqual({
+        billing_address: billingAddress,
+      });
+
+      // - Spinner should be displayed and payment button should be disabled
+      screen.getByText('Payment in progress');
+      expect($button.disabled).toBe(true);
+
+      // - Payment interface should be displayed
+      await screen.findByText('Payment interface component');
+
+      // - Simulate the payment has failed
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('payment-failure'));
+      });
+
+      // - An error message should be displayed
+      const $error = screen.getByText('An error occurred during payment. Please retry later.');
+      expect(document.activeElement).toBe($error);
+      // - Payment interface should have been closed
+      expect(screen.queryByText('Payment interface component')).toBeNull();
+      // - Payment button should have been restore to its idle state
+      expect($button.disabled).toBe(false);
+      screen.getByRole('button', {
+        name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+      });
     });
-
-    // - Spinner should be displayed and payment button should be disabled
-    screen.getByText('Payment in progress');
-    expect($button.disabled).toBe(true);
-
-    // - Payment interface should be displayed
-    await screen.findByText('Payment interface component');
-
-    // - Simulate the payment has failed
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('payment-failure'));
-    });
-
-    // - An error message should be displayed
-    const $error = screen.getByText('An error occurred during payment. Please retry later.');
-    expect(document.activeElement).toBe($error);
-    // - Payment interface should have been closed
-    expect(screen.queryByText('Payment interface component')).toBeNull();
-    // - Payment button should have been restore to its idle state
-    expect($button.disabled).toBe(false);
-    screen.getByRole('button', {
-      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
-    });
-  });
-});
+  },
+);

--- a/src/frontend/js/hooks/useProductOrder/index.spec.tsx
+++ b/src/frontend/js/hooks/useProductOrder/index.spec.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
-import { CourseLightFactory, OrderFactory } from 'utils/test/factories/joanie';
+import { CourseLightFactory, CredentialOrderFactory } from 'utils/test/factories/joanie';
 import { SessionProvider } from 'contexts/SessionContext';
 import { Deferred } from 'utils/test/deferred';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
@@ -49,14 +49,14 @@ describe('useProductOrder', () => {
     'should retrieves the last order when order.state is %s',
     async (currentState) => {
       // the most recent order of accepted state will be return
-      const order = OrderFactory({
+      const order = CredentialOrderFactory({
         state: currentState,
         created_on: new Date().toISOString(),
         course: CourseLightFactory({ code: '00000' }).one(),
       }).one();
       const ordersByState = ACTIVE_ORDER_STATES.filter((state) => state !== currentState).map(
         (state) =>
-          OrderFactory({
+          CredentialOrderFactory({
             state,
             created_on: faker.date.past({ years: 1 }).toISOString(),
             course: CourseLightFactory({ code: '00000' }).one(),

--- a/src/frontend/js/hooks/useProductOrder/index.spec.tsx
+++ b/src/frontend/js/hooks/useProductOrder/index.spec.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
-import { OrderFactory } from 'utils/test/factories/joanie';
+import { CourseLightFactory, OrderFactory } from 'utils/test/factories/joanie';
 import { SessionProvider } from 'contexts/SessionContext';
 import { Deferred } from 'utils/test/deferred';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
@@ -52,14 +52,14 @@ describe('useProductOrder', () => {
       const order = OrderFactory({
         state: currentState,
         created_on: new Date().toISOString(),
-        course: '00000',
+        course: CourseLightFactory({ code: '00000' }).one(),
       }).one();
       const ordersByState = ACTIVE_ORDER_STATES.filter((state) => state !== currentState).map(
         (state) =>
           OrderFactory({
             state,
             created_on: faker.date.past({ years: 1 }).toISOString(),
-            course: '00000',
+            course: CourseLightFactory({ code: '00000' }).one(),
             product: order.product,
           }).one(),
       );

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -12,12 +12,12 @@ import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
 import {
   CourseProductRelationFactory,
   EnrollmentFactory,
-  OrderFactory,
+  CredentialOrderFactory,
 } from 'utils/test/factories/joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { SessionProvider } from 'contexts/SessionContext';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
-import { CourseLight, CourseProductRelation, Enrollment, Order } from 'types/Joanie';
+import { CourseLight, CourseProductRelation, Enrollment, CredentialOrder } from 'types/Joanie';
 import { expectNoSpinner, expectSpinner } from 'utils/test/expectSpinner';
 import { expectBannerError } from 'utils/test/expectBanner';
 import { Deferred } from 'utils/test/deferred';
@@ -91,7 +91,7 @@ describe('<DashboardCourses/>', () => {
     );
   };
 
-  const mockOrders = (orders: Order[], client?: QueryClient) => {
+  const mockOrders = (orders: CredentialOrder[], client?: QueryClient) => {
     const relations: Record<string, CourseProductRelation> = {};
     orders.forEach((order) => {
       const productId = order.product;
@@ -122,7 +122,7 @@ describe('<DashboardCourses/>', () => {
   };
 
   const expectList = (
-    entities: (Order | Enrollment)[],
+    entities: (CredentialOrder | Enrollment)[],
     relations: Record<string, CourseProductRelation>,
   ) => {
     const itemElements = document.querySelectorAll<HTMLElement>('.dashboard__courses__list__item');
@@ -165,7 +165,7 @@ describe('<DashboardCourses/>', () => {
     expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
   });
 
-  const merge = (orders: Order[], enrollments: Enrollment[]) => {
+  const merge = (orders: CredentialOrder[], enrollments: Enrollment[]) => {
     return [...orders, ...enrollments].sort((a, b) => {
       const aDate = new Date(a.created_on);
       const bDate = new Date(b.created_on);
@@ -175,7 +175,10 @@ describe('<DashboardCourses/>', () => {
 
   it('should render the list of entities', async () => {
     const client = createTestQueryClient({ user: true });
-    const { orders, relations } = mockOrders(OrderFactory().many(perPage * 2 + 1), client);
+    const { orders, relations } = mockOrders(
+      CredentialOrderFactory().many(perPage * 2 + 1),
+      client,
+    );
     fetchMock.get(
       `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}&product__type=credential`,
       {

--- a/src/frontend/js/pages/DashboardCourses/index.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import { Button } from '@openfun/cunningham-react';
 import {
   useOrdersEnrollments,
-  isEnrollement,
+  isEnrollment,
   isCredentialOrder,
 } from 'pages/DashboardCourses/useOrdersEnrollments';
 import { Spinner } from 'components/Spinner';
@@ -61,7 +61,7 @@ export const DashboardCourses = () => {
                 className="dashboard__courses__list__item"
                 data-testid="order-enrollment-list-item"
               >
-                {isEnrollement(datum) && <DashboardItemEnrollment enrollment={datum} />}
+                {isEnrollment(datum) && <DashboardItemEnrollment enrollment={datum} />}
                 {isCredentialOrder(datum) && <DashboardItemOrder order={datum} />}
               </div>
             ))}

--- a/src/frontend/js/pages/DashboardCourses/index.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.tsx
@@ -4,7 +4,7 @@ import { Button } from '@openfun/cunningham-react';
 import {
   useOrdersEnrollments,
   isEnrollement,
-  isOrder,
+  isCredentialOrder,
 } from 'pages/DashboardCourses/useOrdersEnrollments';
 import { Spinner } from 'components/Spinner';
 import { DashboardItemEnrollment } from 'widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment';
@@ -62,7 +62,7 @@ export const DashboardCourses = () => {
                 data-testid="order-enrollment-list-item"
               >
                 {isEnrollement(datum) && <DashboardItemEnrollment enrollment={datum} />}
-                {isOrder(datum) && <DashboardItemOrder order={datum} />}
+                {isCredentialOrder(datum) && <DashboardItemOrder order={datum} />}
               </div>
             ))}
           </div>

--- a/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
+++ b/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
@@ -1,14 +1,33 @@
 import { defineMessages } from 'react-intl';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
-import { Enrollment, Order, PaginatedResourceQuery } from 'types/Joanie';
+import {
+  Enrollment,
+  PaginatedResourceQuery,
+  CredentialOrder,
+  CertificateOrder,
+} from 'types/Joanie';
 import useUnionResource, { ResourceUnionPaginationProps } from 'hooks/useUnionResource';
 import { PER_PAGE } from 'settings';
 import { OrderResourcesQuery } from 'hooks/useOrders';
 
-export const isOrder = (obj: Order | Enrollment): obj is Order => {
+export const isOrder = (
+  obj: CredentialOrder | CertificateOrder | Enrollment,
+): obj is CredentialOrder | CertificateOrder => {
   return 'total' in obj && 'target_enrollments' in obj;
 };
-export const isEnrollement = (obj: Order | Enrollment): obj is Enrollment => {
+export const isCertificateOrder = (
+  obj: CredentialOrder | CertificateOrder | Enrollment,
+): obj is CertificateOrder => {
+  return isOrder(obj) && !!obj.enrollment;
+};
+export const isCredentialOrder = (
+  obj: CredentialOrder | CertificateOrder | Enrollment,
+): obj is CredentialOrder => {
+  return isOrder(obj) && !!obj.course;
+};
+export const isEnrollment = (
+  obj: CredentialOrder | CertificateOrder | Enrollment,
+): obj is Enrollment => {
   return 'was_created_by_order' in obj && 'course_run' in obj;
 };
 
@@ -30,7 +49,7 @@ export const useOrdersEnrollments = ({
 }: UseOrdersEnrollmentsProps = {}) => {
   const api = useJoanieApi();
   return useUnionResource<
-    Order,
+    CredentialOrder | CertificateOrder,
     Enrollment,
     PaginatedResourceQuery,
     { was_created_by_order: boolean } & PaginatedResourceQuery

--- a/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
@@ -69,11 +69,11 @@ describe('<DashboardCreditCardsManagement/>', () => {
 
   it('renders the correct label for expired date', async () => {
     const date = faker.date.past();
-    const creditCard: CreditCard = {
-      ...CreditCardFactory().one(),
+    const creditCard: CreditCard = CreditCardFactory({
       expiration_month: date.getMonth() + 1,
       expiration_year: date.getFullYear(),
-    };
+    }).one();
+
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', [creditCard]);
     await act(async () => {
       render(
@@ -106,11 +106,11 @@ describe('<DashboardCreditCardsManagement/>', () => {
     refDate.setMonth(refDate.getMonth() + 1);
     refDate.setDate(1);
     const futureLessThan3Months = faker.date.future({ years: 2.99 / 12, refDate });
-    const creditCard: CreditCard = {
-      ...CreditCardFactory().one(),
+    const creditCard: CreditCard = CreditCardFactory({
       expiration_month: futureLessThan3Months.getMonth() + 1,
       expiration_year: futureLessThan3Months.getFullYear(),
-    };
+    }).one();
+
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', [creditCard]);
     await act(async () => {
       render(
@@ -142,11 +142,11 @@ describe('<DashboardCreditCardsManagement/>', () => {
     const refDate = new Date();
     refDate.setMonth(refDate.getMonth() + 4);
     const date = faker.date.future({ refDate });
-    const creditCard: CreditCard = {
-      ...CreditCardFactory().one(),
+    const creditCard: CreditCard = CreditCardFactory({
       expiration_month: date.getMonth() + 1,
       expiration_year: date.getFullYear(),
-    };
+    }).one();
+
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', [creditCard]);
     await act(async () => {
       render(

--- a/src/frontend/js/pages/DashboardOrderLayout/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardOrderLayout/index.spec.tsx
@@ -3,8 +3,8 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { IntlProvider } from 'react-intl';
 import fetchMock from 'fetch-mock';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
-import { Order } from 'types/Joanie';
-import { OrderFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
+import { CredentialOrder } from 'types/Joanie';
+import { CredentialOrderFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
 import { mockCourseProductWithOrder } from 'utils/test/mockCourseProductWithOrder';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
@@ -47,8 +47,8 @@ describe('<DashboardOrderLayout />', () => {
   });
 
   it('renders sidebar', async () => {
-    const order: Order = {
-      ...OrderFactory().one(),
+    const order: CredentialOrder = {
+      ...CredentialOrderFactory().one(),
       target_courses: [TargetCourseFactory().one()],
       target_enrollments: [],
     };

--- a/src/frontend/js/pages/DashboardOrderLayout/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardOrderLayout/index.spec.tsx
@@ -47,11 +47,11 @@ describe('<DashboardOrderLayout />', () => {
   });
 
   it('renders sidebar', async () => {
-    const order: CredentialOrder = {
-      ...CredentialOrderFactory().one(),
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: [TargetCourseFactory().one()],
       target_enrollments: [],
-    };
+    }).one();
+
     const { product } = mockCourseProductWithOrder(order);
     fetchMock.get(
       'https://joanie.endpoint/api/v1.0/orders/',

--- a/src/frontend/js/pages/TeacherDashboardContractsLoader/TeacherDashboardContracts/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLoader/TeacherDashboardContracts/index.spec.tsx
@@ -140,8 +140,8 @@ describe('pages/TeacherDashboardContracts', () => {
     );
     nbApiCalls += 1;
     expect(await screen.findByTestId('contracts-loaded')).toBeInTheDocument();
-    expect(screen.getByText(contract.order.owner)).toBeInTheDocument();
-    expect(screen.getByText(contract.order.product)).toBeInTheDocument();
+    expect(screen.getByText(contract.order.owner_name)).toBeInTheDocument();
+    expect(screen.getByText(contract.order.product_title)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Download/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Open/ })).toBeInTheDocument();
   });

--- a/src/frontend/js/pages/TeacherDashboardContractsLoader/TeacherDashboardContracts/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLoader/TeacherDashboardContracts/index.tsx
@@ -79,8 +79,8 @@ const TeacherDashboardContracts = ({
   const rows = useMemo(() => {
     return contracts.map(({ id, signed_on, order }) => ({
       id,
-      learnerName: order.owner,
-      productTitle: order.product,
+      learnerName: order.owner_name,
+      productTitle: order.product_title,
       signDate: intl.formatDate(signed_on),
     }));
   }, [contracts]);

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -174,6 +174,15 @@ export interface Enrollment {
   products: Product[];
 }
 
+export interface EnrollmentLight {
+  id: string;
+  is_active: boolean;
+  state: EnrollmentState;
+  course_run: CourseRun;
+  was_created_by_order: boolean;
+  created_on: string;
+}
+
 // Order
 export enum OrderState {
   DRAFT = 'draft',
@@ -190,7 +199,7 @@ export interface Order {
   course?: CourseLight['code'] | CourseLight;
   created_on: string;
   target_enrollments: Enrollment[];
-  enrollment?: string;
+  enrollment?: EnrollmentLight;
   main_proforma_invoice: string;
   certificate?: string;
   contract?: Contract;

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -196,7 +196,7 @@ export const ACTIVE_ORDER_STATES = [OrderState.PENDING, OrderState.VALIDATED, Or
 
 export interface Order {
   id: string;
-  course?: CourseLight['code'] | CourseLight;
+  course?: CourseLight;
   created_on: string;
   target_enrollments: Enrollment[];
   enrollment?: EnrollmentLight;

--- a/src/frontend/js/utils/CoursesHelper/index.spec.ts
+++ b/src/frontend/js/utils/CoursesHelper/index.spec.ts
@@ -8,79 +8,69 @@ import {
 
 describe('CourseHelper', () => {
   it('should find an active course enrollment in order', () => {
-    const order: CredentialOrder = {
-      ...CredentialOrderFactory().one(),
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(3),
-    };
+    }).one();
     order.target_enrollments = [
-      {
-        ...EnrollmentFactory().one(),
+      EnrollmentFactory({
         course_run: order.target_courses[0].course_runs[0],
         is_active: false,
-      },
-      {
-        ...EnrollmentFactory().one(),
+      }).one(),
+      EnrollmentFactory({
         course_run: order.target_courses[1].course_runs[0],
         is_active: true,
-      },
+      }).one(),
     ];
     expect(CoursesHelper.findActiveCourseEnrollmentInOrder(order.target_courses[1], order)).toEqual(
       order.target_enrollments[1],
     );
   });
   it('should not find active course enrollment in an order containing only is_active=false enrollments', () => {
-    const order: CredentialOrder = {
-      ...CredentialOrderFactory().one(),
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(3),
-    };
+    }).one();
+
     order.target_enrollments = [
-      {
-        ...EnrollmentFactory().one(),
+      EnrollmentFactory({
         course_run: order.target_courses[0].course_runs[0],
         is_active: false,
-      },
-      {
-        ...EnrollmentFactory().one(),
+      }).one(),
+      EnrollmentFactory({
         course_run: order.target_courses[1].course_runs[0],
         is_active: false,
-      },
+      }).one(),
     ];
     expect(
       CoursesHelper.findActiveCourseEnrollmentInOrder(order.target_courses[1], order),
     ).toBeUndefined();
   });
   it('should not find active course enrollment in an order without enrollment', () => {
-    const order: CredentialOrder = {
-      ...CredentialOrderFactory().one(),
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(3),
       target_enrollments: [],
-    };
+    }).one();
     expect(
       CoursesHelper.findActiveCourseEnrollmentInOrder(order.target_courses[0], order),
     ).toBeUndefined();
   });
 
   it('should find enrollments', () => {
-    const order: CredentialOrder = {
-      ...CredentialOrderFactory().one(),
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(3),
-    };
+    }).one();
     order.target_enrollments = [
-      {
-        ...EnrollmentFactory().one(),
+      EnrollmentFactory({
         course_run: order.target_courses[0].course_runs[0],
         is_active: false,
-      },
-      {
-        ...EnrollmentFactory().one(),
+      }).one(),
+      EnrollmentFactory({
         course_run: order.target_courses[1].course_runs[0],
         is_active: true,
-      },
-      {
-        ...EnrollmentFactory().one(),
+      }).one(),
+      EnrollmentFactory({
         course_run: order.target_courses[0].course_runs[1],
         is_active: true,
-      },
+      }).one(),
     ];
     expect(CoursesHelper.findCourseEnrollmentsInOrder(order.target_courses[0], order)).toEqual([
       order.target_enrollments[0],
@@ -88,26 +78,22 @@ describe('CourseHelper', () => {
     ]);
   });
   it('should not find enrollments', () => {
-    const order: CredentialOrder = {
-      ...CredentialOrderFactory().one(),
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(3),
-    };
+    }).one();
     order.target_enrollments = [
-      {
-        ...EnrollmentFactory().one(),
+      EnrollmentFactory({
         course_run: order.target_courses[0].course_runs[0],
         is_active: false,
-      },
-      {
-        ...EnrollmentFactory().one(),
+      }).one(),
+      EnrollmentFactory({
         course_run: order.target_courses[1].course_runs[0],
         is_active: true,
-      },
-      {
-        ...EnrollmentFactory().one(),
+      }).one(),
+      EnrollmentFactory({
         course_run: order.target_courses[0].course_runs[1],
         is_active: true,
-      },
+      }).one(),
     ];
     expect(CoursesHelper.findCourseEnrollmentsInOrder(order.target_courses[2], order)).toEqual([]);
   });

--- a/src/frontend/js/utils/CoursesHelper/index.spec.ts
+++ b/src/frontend/js/utils/CoursesHelper/index.spec.ts
@@ -1,11 +1,15 @@
 import { CoursesHelper } from 'utils/CoursesHelper/index';
-import { Order } from 'types/Joanie';
-import { EnrollmentFactory, OrderFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
+import { CredentialOrder } from 'types/Joanie';
+import {
+  EnrollmentFactory,
+  CredentialOrderFactory,
+  TargetCourseFactory,
+} from 'utils/test/factories/joanie';
 
 describe('CourseHelper', () => {
   it('should find an active course enrollment in order', () => {
-    const order: Order = {
-      ...OrderFactory().one(),
+    const order: CredentialOrder = {
+      ...CredentialOrderFactory().one(),
       target_courses: TargetCourseFactory().many(3),
     };
     order.target_enrollments = [
@@ -25,8 +29,8 @@ describe('CourseHelper', () => {
     );
   });
   it('should not find active course enrollment in an order containing only is_active=false enrollments', () => {
-    const order: Order = {
-      ...OrderFactory().one(),
+    const order: CredentialOrder = {
+      ...CredentialOrderFactory().one(),
       target_courses: TargetCourseFactory().many(3),
     };
     order.target_enrollments = [
@@ -46,8 +50,8 @@ describe('CourseHelper', () => {
     ).toBeUndefined();
   });
   it('should not find active course enrollment in an order without enrollment', () => {
-    const order: Order = {
-      ...OrderFactory().one(),
+    const order: CredentialOrder = {
+      ...CredentialOrderFactory().one(),
       target_courses: TargetCourseFactory().many(3),
       target_enrollments: [],
     };
@@ -57,8 +61,8 @@ describe('CourseHelper', () => {
   });
 
   it('should find enrollments', () => {
-    const order: Order = {
-      ...OrderFactory().one(),
+    const order: CredentialOrder = {
+      ...CredentialOrderFactory().one(),
       target_courses: TargetCourseFactory().many(3),
     };
     order.target_enrollments = [
@@ -84,8 +88,8 @@ describe('CourseHelper', () => {
     ]);
   });
   it('should not find enrollments', () => {
-    const order: Order = {
-      ...OrderFactory().one(),
+    const order: CredentialOrder = {
+      ...CredentialOrderFactory().one(),
       target_courses: TargetCourseFactory().many(3),
     };
     order.target_enrollments = [

--- a/src/frontend/js/utils/CoursesHelper/index.ts
+++ b/src/frontend/js/utils/CoursesHelper/index.ts
@@ -1,17 +1,16 @@
-import * as Joanie from 'types/Joanie';
-import { Enrollment } from 'types/Joanie';
+import { TargetCourse, AbstractCourse, Enrollment, CredentialOrder } from 'types/Joanie';
 
 export class CoursesHelper {
-  static findActiveCourseEnrollmentInOrder(targetCourse: Joanie.TargetCourse, order: Joanie.Order) {
+  static findActiveCourseEnrollmentInOrder(targetCourse: TargetCourse, order: CredentialOrder) {
     return CoursesHelper.findActiveEnrollment(targetCourse, order.target_enrollments);
   }
-  static findActiveEnrollment(targetCourse: Joanie.AbstractCourse, enrollments: Enrollment[]) {
+  static findActiveEnrollment(targetCourse: AbstractCourse, enrollments: Enrollment[]) {
     const courseRunIds = targetCourse.course_runs.map(({ id }) => id);
     return enrollments.find(({ is_active, course_run }) => {
       return is_active && courseRunIds.includes(course_run.id);
     });
   }
-  static findCourseEnrollmentsInOrder(targetCourse: Joanie.AbstractCourse, order: Joanie.Order) {
+  static findCourseEnrollmentsInOrder(targetCourse: AbstractCourse, order: CredentialOrder) {
     const courseRunIds = targetCourse.course_runs.map(({ id }) => id);
     return order.target_enrollments.filter(({ course_run }) => {
       return courseRunIds.includes(course_run.id);

--- a/src/frontend/js/utils/CreditCardHelper/index.spec.tsx
+++ b/src/frontend/js/utils/CreditCardHelper/index.spec.tsx
@@ -17,11 +17,12 @@ describe('CreditCardHelper', () => {
     const date = faker.date.future({ refDate });
 
     expect(
-      CreditCardHelper.getExpirationState({
-        ...CreditCardFactory().one(),
-        expiration_month: date.getMonth() + 1,
-        expiration_year: date.getFullYear(),
-      }),
+      CreditCardHelper.getExpirationState(
+        CreditCardFactory({
+          expiration_month: date.getMonth() + 1,
+          expiration_year: date.getFullYear(),
+        }).one(),
+      ),
     ).toBe(CreditCardExpirationStatus.FINE);
   });
 
@@ -35,22 +36,24 @@ describe('CreditCardHelper', () => {
     });
 
     expect(
-      CreditCardHelper.getExpirationState({
-        ...CreditCardFactory().one(),
-        expiration_month: futureLessThan3Months.getMonth() + 1,
-        expiration_year: futureLessThan3Months.getFullYear(),
-      }),
+      CreditCardHelper.getExpirationState(
+        CreditCardFactory({
+          expiration_month: futureLessThan3Months.getMonth() + 1,
+          expiration_year: futureLessThan3Months.getFullYear(),
+        }).one(),
+      ),
     ).toBe(CreditCardExpirationStatus.SOON);
   });
 
   it('is expired', () => {
     const date = faker.date.past();
     expect(
-      CreditCardHelper.getExpirationState({
-        ...CreditCardFactory().one(),
-        expiration_month: date.getMonth() + 1,
-        expiration_year: date.getFullYear(),
-      }),
+      CreditCardHelper.getExpirationState(
+        CreditCardFactory({
+          expiration_month: date.getMonth() + 1,
+          expiration_year: date.getFullYear(),
+        }).one(),
+      ),
     ).toBe(CreditCardExpirationStatus.EXPIRED);
   });
 });

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -13,10 +13,8 @@ import {
   CreditCardBrand,
   Enrollment,
   EnrollmentState,
-  Order,
   OrderLite,
   OrderState,
-  OrderWithPaymentInfo,
   Organization,
   OrganizationLight,
   Payment,
@@ -29,6 +27,14 @@ import {
   Contract,
   OrderEnrollment,
   ContractDefinition,
+  NestedCredentialOrder,
+  NestedCertificateOrder,
+  Order,
+  CertificateOrder,
+  CredentialOrder,
+  CertificateOrderWithPaymentInfo,
+  CredentialOrderWithPaymentInfo,
+  EnrollmentLight,
 } from 'types/Joanie';
 import { CourseStateFactory } from 'utils/test/factories/richie';
 import { FactoryHelper } from 'utils/test/factories/helper';
@@ -55,6 +61,17 @@ export const EnrollmentFactory = factory((): Enrollment => {
     was_created_by_order: false,
     created_on: faker.date.past({ years: 1 }).toISOString(),
     orders: [],
+  };
+});
+
+export const EnrollmentLightFactory = factory((): EnrollmentLight => {
+  return {
+    id: faker.string.uuid(),
+    course_run: CourseRunWithCourseFactory().one(),
+    is_active: true,
+    state: EnrollmentState.SET,
+    was_created_by_order: false,
+    created_on: faker.date.past({ years: 1 }).toISOString(),
   };
 });
 
@@ -87,7 +104,7 @@ export const ContractFactory = factory((): Contract => {
     signed_on: faker.date.past().toISOString(),
     created_on: faker.date.past().toISOString(),
     definition: ContractDefinitionFactory().one(),
-    order: OrderFactory().one(),
+    order: NestedCredentialOrderFactory().one(),
   };
 });
 
@@ -119,7 +136,7 @@ export const CertificateFactory = factory((): Certificate => {
   return {
     id: faker.string.uuid(),
     certificate_definition: CertificationDefinitionFactory().one(),
-    order: OrderWithFullCourseFactory().one(),
+    order: NestedCredentialOrderFactory().one(),
     issued_on: faker.date.past().toISOString(),
   };
 });
@@ -274,7 +291,29 @@ export const OrderLiteFactory = factory((): OrderLite => {
   };
 });
 
-export const OrderFactory = factory((): Order => {
+export const NestedCertificateOrderFactory = factory((): NestedCertificateOrder => {
+  return {
+    id: faker.string.uuid(),
+    course: undefined,
+    enrollment: EnrollmentLightFactory().one(),
+    organization: OrganizationFactory().one(),
+    product_title: FactoryHelper.unique(faker.lorem.words, { args: [1] }),
+    owner_name: faker.internet.userName(),
+  };
+});
+
+export const NestedCredentialOrderFactory = factory((): NestedCredentialOrder => {
+  return {
+    id: faker.string.uuid(),
+    course: CourseLightFactory().one(),
+    enrollment: undefined,
+    organization: OrganizationFactory().one(),
+    product_title: FactoryHelper.unique(faker.lorem.words, { args: [1] }),
+    owner_name: faker.internet.userName(),
+  };
+});
+
+const AbstractOrderFactory = factory((): Order => {
   return {
     id: faker.string.uuid(),
     created_on: faker.date.past({ years: 1 }).toISOString(),
@@ -285,35 +324,66 @@ export const OrderFactory = factory((): Order => {
     state: OrderState.VALIDATED,
     product: faker.string.uuid(),
     target_courses: TargetCourseFactory().many(5),
+    target_enrollments: [],
+    enrollment: undefined,
+    course: undefined,
+  };
+});
+
+export const CredentialOrderFactory = factory((): CredentialOrder => {
+  return {
+    ...AbstractOrderFactory().one(),
     course: CourseLightFactory().one(),
     enrollment: undefined,
-    target_enrollments: [],
   };
 });
 
-export const OrderWithFullCourseFactory = factory((): Order => {
+export const CredentialOrderWithPaymentFactory = factory((): CredentialOrderWithPaymentInfo => {
   return {
-    ...OrderFactory().one(),
-    course: CourseLightFactory().one(),
-  };
-});
-
-export const OrderWithPaymentFactory = factory((): OrderWithPaymentInfo => {
-  return {
-    ...OrderFactory().one(),
+    ...CredentialOrderFactory().one(),
     payment_info: PaymentFactory().one(),
   };
 });
 
-export const OrderWithOneClickPaymentFactory = factory((): OrderWithPaymentInfo => {
+export const CredentialOrderWithOneClickPaymentFactory = factory(
+  (): CredentialOrderWithPaymentInfo => {
+    return {
+      ...CredentialOrderFactory().one(),
+      payment_info: {
+        ...PaymentFactory().one(),
+        is_paid: true,
+      },
+    };
+  },
+);
+
+export const CertificateOrderFactory = factory((): CertificateOrder => {
   return {
-    ...OrderFactory().one(),
-    payment_info: {
-      ...PaymentFactory().one(),
-      is_paid: true,
-    },
+    ...AbstractOrderFactory().one(),
+    course: undefined,
+    target_courses: [],
+    enrollment: EnrollmentLightFactory().one(),
   };
 });
+
+export const CertificateOrderWithPaymentFactory = factory((): CertificateOrderWithPaymentInfo => {
+  return {
+    ...CertificateOrderFactory().one(),
+    payment_info: PaymentFactory().one(),
+  };
+});
+
+export const CertificateOrderWithOneClickPaymentFactory = factory(
+  (): CertificateOrderWithPaymentInfo => {
+    return {
+      ...CertificateOrderFactory().one(),
+      payment_info: {
+        ...PaymentFactory().one(),
+        is_paid: true,
+      },
+    };
+  },
+);
 
 export const AddressFactory = factory((): Address => {
   return {

--- a/src/frontend/js/utils/test/mockCourseProductWithOrder.ts
+++ b/src/frontend/js/utils/test/mockCourseProductWithOrder.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'fetch-mock';
-import { CourseLight, Order } from 'types/Joanie';
+import { CredentialOrder } from 'types/Joanie';
 import {
   ContractDefinitionFactory,
   CourseFactory,
@@ -7,8 +7,8 @@ import {
   ProductFactory,
 } from 'utils/test/factories/joanie';
 
-export const mockCourseProductWithOrder = (order: Order) => {
-  const courseCode = (order.course as CourseLight).code;
+export const mockCourseProductWithOrder = (order: CredentialOrder) => {
+  const courseCode = order.course.code;
   const productId = order.product;
   const relation = CourseProductRelationFactory({
     product: ProductFactory({

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
@@ -4,7 +4,13 @@ import { Button } from '@openfun/cunningham-react';
 import { Button as RichieButton } from 'components/Button';
 import { CoursesHelper } from 'utils/CoursesHelper';
 import { Priority } from 'types';
-import { AbstractCourse, CourseRun, Enrollment, Order } from 'types/Joanie';
+import {
+  CourseRun,
+  Enrollment,
+  CredentialOrder,
+  AbstractCourse,
+  CertificateOrder,
+} from 'types/Joanie';
 import { Spinner } from 'components/Spinner';
 import Banner, { BannerType } from 'components/Banner';
 import useDateFormat, { DATETIME_FORMAT } from 'hooks/useDateFormat';
@@ -76,11 +82,11 @@ const messages = {
   },
 };
 
-interface Props {
+interface DashboardItemCourseEnrollingProps {
   course: AbstractCourse;
   activeEnrollment?: Enrollment;
-  order?: Order;
-  writable?: boolean;
+  order?: CredentialOrder;
+  writable: boolean;
   hideEnrollButtons?: boolean;
   icon?: boolean;
   notEnrolledUrl?: string;
@@ -94,7 +100,7 @@ export const DashboardItemCourseEnrolling = ({
   icon = false,
   notEnrolledUrl = '#',
   hideEnrollButtons,
-}: Props) => {
+}: DashboardItemCourseEnrollingProps) => {
   if (writable && !order) {
     throw new Error('Order is required when writable is true');
   }
@@ -127,7 +133,7 @@ export const DashboardItemCourseEnrolling = ({
 interface DashboardItemCourseEnrollingRunsProps {
   course: AbstractCourse;
   enrollments: Enrollment[];
-  order?: Order;
+  order?: CredentialOrder;
 }
 
 const DashboardItemCourseEnrollingRuns = ({
@@ -189,7 +195,7 @@ interface DashboardItemCourseEnrollingRunProps {
   courseRun: CourseRun;
   selected: boolean;
   enroll: () => void;
-  order?: Order;
+  order?: CredentialOrder | CertificateOrder;
 }
 
 const DashboardItemCourseEnrollingRun = ({

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.spec.tsx
@@ -89,11 +89,10 @@ describe('<DashboardItemEnrollment/>', () => {
   });
 
   it('renders an inactive enrollment', () => {
-    const enrollment: Enrollment = {
-      ...EnrollmentFactory().one(),
+    const enrollment: Enrollment = EnrollmentFactory({
       is_active: false,
       course_run: CourseRunWithCourseFactory().one(),
-    };
+    }).one();
 
     render(<Wrapper enrollment={enrollment} />);
     screen.getByText(enrollment.course_run.course!.title);

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Enrollment, ProductType } from 'types/Joanie';
-import { DashboardItemCourseEnrolling } from '../DashboardItemCourseEnrolling';
+import { Enrolled } from '../DashboardItemCourseEnrolling';
 import { DashboardItem } from '..';
 import ProductCertificateFooter from './ProductCertificateFooter';
 
@@ -16,12 +16,11 @@ export const DashboardItemEnrollment = ({ enrollment }: DashboardItemCourseRunPr
 
   const footerList = useMemo(() => {
     const partialFooterList = [
-      <DashboardItemCourseEnrolling
-        key={`${enrollment.id}`}
-        course={course}
-        activeEnrollment={enrollment}
-        icon={true}
-      />,
+      <div data-testid={'dashboard-item__course-enrolling__' + course.code}>
+        <div className="dashboard-item__course-enrolling__infos">
+          <Enrolled icon={true} enrollment={enrollment} />
+        </div>
+      </div>,
     ];
     enrollment.products.forEach((product) => {
       if (product.type === ProductType.CERTIFICATE) {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -341,10 +341,7 @@ describe('<DashboardItemOrder/>', () => {
     }).one();
     // Make target course enrolled.
     order.target_enrollments = [
-      {
-        ...EnrollmentFactory().one(),
-        course_run: order.target_courses[0].course_runs[0],
-      },
+      EnrollmentFactory({ course_run: order.target_courses[0].course_runs[0] }).one(),
     ];
 
     const { product } = mockCourseProductWithOrder(order);
@@ -617,12 +614,7 @@ describe('<DashboardItemOrder/>', () => {
     }).one();
 
     const initialEnrolledCourseRun = order.target_courses[0].course_runs[0];
-    order.target_enrollments = [
-      {
-        ...EnrollmentFactory().one(),
-        course_run: initialEnrolledCourseRun,
-      },
-    ];
+    order.target_enrollments = [EnrollmentFactory({ course_run: initialEnrolledCourseRun }).one()];
 
     const { product } = mockCourseProductWithOrder(order);
     fetchMock.post('https://joanie.endpoint/api/v1.0/enrollments/', []);
@@ -692,11 +684,7 @@ describe('<DashboardItemOrder/>', () => {
     }).one();
 
     const courseRun = order.target_courses[0].course_runs[0];
-    const enrollment = {
-      ...EnrollmentFactory().one(),
-      course_run: courseRun,
-      is_active: false,
-    };
+    const enrollment = EnrollmentFactory({ course_run: courseRun, is_active: false }).one();
     order.target_enrollments = [enrollment];
 
     // When the existing enrollment will be set as is_active: true.

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -23,17 +23,16 @@ import {
   CourseLightFactory,
   CourseRunFactory,
   EnrollmentFactory,
-  OrderFactory,
+  CredentialOrderFactory,
   TargetCourseFactory,
 } from 'utils/test/factories/joanie';
-import { Certificate, CourseLight, CourseRun, Order, OrderState } from 'types/Joanie';
+import { Certificate, CourseLight, CourseRun, CredentialOrder, OrderState } from 'types/Joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { SessionProvider } from 'contexts/SessionContext';
 import { resolveAll } from 'utils/resolveAll';
 import { confirm } from 'utils/indirection/window';
 import { Priority } from 'types';
 import { sleep } from 'utils/sleep';
-import { noop } from 'utils';
 import { expectBannerError } from 'utils/test/expectBanner';
 import { expectNoSpinner, expectSpinner } from 'utils/test/expectSpinner';
 import { Deferred } from 'utils/test/deferred';
@@ -98,17 +97,8 @@ describe('<DashboardItemOrder/>', () => {
    * Global
    */
 
-  it('crashes if no course is provided', async () => {
-    const order: Order = { ...OrderFactory().one(), course: undefined };
-    // Hide console.error ( https://stackoverflow.com/questions/66328549/testing-an-error-thrown-by-a-react-component-using-testing-library-and-jest )
-    jest.spyOn(console, 'error').mockImplementation(noop);
-    expect(() => render(<DashboardItemOrder order={order} />)).toThrow(
-      'Order must provide course object attribute',
-    );
-  });
-
   it('renders a pending order', async () => {
-    const order: Order = OrderFactory({ state: OrderState.PENDING }).one();
+    const order: CredentialOrder = CredentialOrderFactory({ state: OrderState.PENDING }).one();
     order.target_courses = [];
     const { product } = mockCourseProductWithOrder(order);
 
@@ -121,7 +111,9 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders an order with certificate', async () => {
-    const order: Order = OrderFactory({ certificate: faker.string.uuid() }).one();
+    const order: CredentialOrder = CredentialOrderFactory({
+      certificate: faker.string.uuid(),
+    }).one();
     order.target_courses = [];
     const { product } = mockCourseProductWithOrder(order);
 
@@ -151,7 +143,9 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('does not render an order with certificate', async () => {
-    const order: Order = OrderFactory({ certificate: faker.string.uuid() }).one();
+    const order: CredentialOrder = CredentialOrderFactory({
+      certificate: faker.string.uuid(),
+    }).one();
     order.target_courses = [];
     const { product } = mockCourseProductWithOrder(order);
 
@@ -169,7 +163,7 @@ describe('<DashboardItemOrder/>', () => {
    */
 
   it('renders a non-writable order without target courses without certificate', async () => {
-    const order: Order = OrderFactory().one();
+    const order: CredentialOrder = CredentialOrderFactory().one();
     order.target_courses = [];
     const { product } = mockCourseProductWithOrder(order);
 
@@ -182,7 +176,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders a non-writable order with target courses', async () => {
-    const order: Order = OrderFactory().one();
+    const order: CredentialOrder = CredentialOrderFactory().one();
     const { product } = mockCourseProductWithOrder(order);
 
     render(<DashboardItemOrder order={order} />, { wrapper });
@@ -196,7 +190,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders a non-writable order with enrolled target course ', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
     }).one();
 
@@ -230,7 +224,7 @@ describe('<DashboardItemOrder/>', () => {
     });
   });
   it('renders a non-writable order with not enrolled target course', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
       target_enrollments: [],
     }).one();
@@ -250,7 +244,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders a non-writable order without contract attribute', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
       target_enrollments: [],
       contract: null,
@@ -274,7 +268,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders a non-writable order with a signed contract', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
       target_enrollments: [],
       contract: ContractFactory({ signed_on: faker.date.past().toISOString() }).one(),
@@ -298,7 +292,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders a non-writable order with a contract not signed yet', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
       target_enrollments: [],
       contract: ContractFactory({ signed_on: undefined }).one(),
@@ -327,7 +321,7 @@ describe('<DashboardItemOrder/>', () => {
    */
 
   it('renders a writable order with no target courses', async () => {
-    const order: Order = OrderFactory().one();
+    const order: CredentialOrder = CredentialOrderFactory().one();
     order.target_courses = [];
     const { product } = mockCourseProductWithOrder(order);
 
@@ -342,7 +336,9 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders a writable order with enrolled target course', async () => {
-    const order: Order = OrderFactory({ target_courses: TargetCourseFactory().many(1) }).one();
+    const order: CredentialOrder = CredentialOrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+    }).one();
     // Make target course enrolled.
     order.target_enrollments = [
       {
@@ -389,7 +385,7 @@ describe('<DashboardItemOrder/>', () => {
 
   it('renders a writable order with not enrolled target course and enrolls it', async () => {
     // Initial order without enrollment.
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
       target_enrollments: [],
     }).one();
@@ -467,7 +463,7 @@ describe('<DashboardItemOrder/>', () => {
 
   it('renders a writable order with not enrolled target course and try to enroll it, but the API returns an error and it is shown', async () => {
     // Initial order without enrollment.
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
       target_enrollments: [],
     }).one();
@@ -517,7 +513,9 @@ describe('<DashboardItemOrder/>', () => {
 
   it('renders a writable order with enrolled target course and changes the enrollment', async () => {
     // Initial order with first course run enrolled.
-    const order: Order = OrderFactory({ target_courses: TargetCourseFactory().many(1) }).one();
+    const order: CredentialOrder = CredentialOrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+    }).one();
     const initialEnrolledCourseRun = order.target_courses[0].course_runs[0];
     order.target_enrollments = EnrollmentFactory({ course_run: initialEnrolledCourseRun }).many(1);
 
@@ -614,7 +612,9 @@ describe('<DashboardItemOrder/>', () => {
 
   it('renders a writable order with enrolled target course and refuse the confirm message when enrolling', async () => {
     // Initial order without enrollment.
-    const order: Order = OrderFactory({ target_courses: TargetCourseFactory().many(1) }).one();
+    const order: CredentialOrder = CredentialOrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+    }).one();
 
     const initialEnrolledCourseRun = order.target_courses[0].course_runs[0];
     order.target_enrollments = [
@@ -687,7 +687,9 @@ describe('<DashboardItemOrder/>', () => {
 
   it('renders a writable order with non-enrolled (is_active=false) target course and changes the enrollment', async () => {
     // Initial order with first course run enrolled.
-    const order: Order = OrderFactory({ target_courses: TargetCourseFactory().many(1) }).one();
+    const order: CredentialOrder = CredentialOrderFactory({
+      target_courses: TargetCourseFactory().many(1),
+    }).one();
 
     const courseRun = order.target_courses[0].course_runs[0];
     const enrollment = {
@@ -770,7 +772,7 @@ describe('<DashboardItemOrder/>', () => {
     expect(queryByRole(runElement, 'button', { name: 'Enroll' })).toBeNull();
   });
   it('renders a writable order with not yet-opened course runs', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory({
         course_runs: CourseRunFactory({
           enrollment_start: faker.date.past({ years: 0.5 }).toISOString(),
@@ -810,7 +812,7 @@ describe('<DashboardItemOrder/>', () => {
         priority: Priority.FUTURE_CLOSED,
       },
     }).one();
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory({ course_runs: [courseRun] }).many(1),
     }).one();
 
@@ -842,7 +844,7 @@ describe('<DashboardItemOrder/>', () => {
       },
     }).one();
 
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory({ course_runs: [courseRun] }).many(1),
       target_enrollments: [],
     }).one();
@@ -864,7 +866,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders a writable order with a signed contract', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
       target_enrollments: [],
       contract: ContractFactory({ signed_on: faker.date.past().toISOString() }).one(),
@@ -902,7 +904,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('renders a writable order with a contract not signed yet', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),
       target_enrollments: [],
       contract: ContractFactory({ signed_on: undefined }).one(),

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Button } from '@openfun/cunningham-react';
-import { Contract, CourseLight, Order, Product } from 'types/Joanie';
+import { Contract, CourseLight, CredentialOrder, Product } from 'types/Joanie';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { CoursesHelper } from 'utils/CoursesHelper';
 import { useCertificate } from 'hooks/useCertificates';
@@ -51,19 +51,19 @@ const messages = {
 };
 
 interface DashboardItemOrderProps {
-  order: Order;
+  order: CredentialOrder;
   showDetailsButton?: boolean;
   showCertificate?: boolean;
   writable?: boolean;
 }
 
 interface DashboardItemOrderCertificateProps {
-  order: Order;
+  order: CredentialOrder;
   product: Product;
 }
 
 interface DashboardItemOrderContractProps {
-  order: Order;
+  order: CredentialOrder;
   product?: Product;
 }
 
@@ -147,9 +147,7 @@ export const DashboardItemOrder = ({
   writable = false,
 }: DashboardItemOrderProps) => {
   const course = order.course as CourseLight;
-  if (!course) {
-    throw new Error('Order must provide course object attribute.');
-  }
+
   const intl = useIntl();
   const query = useCourseProduct(course.code, { productId: order.product });
   const product = query?.item?.product;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderReadonly.stories.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderReadonly.stories.tsx
@@ -1,13 +1,17 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { Order, OrderState, Product, TargetCourse } from 'types/Joanie';
-import { OrderFactory, ProductFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
+import { CredentialOrder, OrderState, Product, TargetCourse } from 'types/Joanie';
+import {
+  CredentialOrderFactory,
+  ProductFactory,
+  TargetCourseFactory,
+} from 'utils/test/factories/joanie';
 import { QueryStateFactory } from 'utils/test/factories/reactQuery';
 import { StorybookHelper } from 'utils/StorybookHelper';
 import { enrollment } from '../stories.mock';
 import { DashboardItemOrder } from './DashboardItemOrder';
 
-const order: Order = { ...OrderFactory().one(), target_courses: [] };
+const order: CredentialOrder = CredentialOrderFactory({ target_courses: [] }).one();
 const product: Product = ProductFactory().one();
 const targetsCourses: TargetCourse[] = TargetCourseFactory().many(3);
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderWritable.stories.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderWritable.stories.tsx
@@ -58,7 +58,7 @@ export const MultipleTargetCourses: Story = {
   args: {
     order: {
       ...order,
-      target_courses: [...targetsCourses, { ...TargetCourseFactory().one(), course_runs: [] }],
+      target_courses: [...targetsCourses, TargetCourseFactory({ course_runs: [] }).one()],
       target_enrollments: [
         {
           ...enrollment,

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderWritable.stories.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderWritable.stories.tsx
@@ -1,12 +1,16 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Order, OrderState, Product, TargetCourse } from 'types/Joanie';
+import { CredentialOrder, OrderState, Product, TargetCourse } from 'types/Joanie';
 import { QueryStateFactory } from 'utils/test/factories/reactQuery';
-import { OrderFactory, ProductFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
+import {
+  CredentialOrderFactory,
+  ProductFactory,
+  TargetCourseFactory,
+} from 'utils/test/factories/joanie';
 import { StorybookHelper } from 'utils/StorybookHelper';
 import { enrollment } from '../stories.mock';
 import { DashboardItemOrder } from './DashboardItemOrder';
 
-const order: Order = { ...OrderFactory().one(), target_courses: [] };
+const order: CredentialOrder = CredentialOrderFactory({ target_courses: [] }).one();
 const product: Product = ProductFactory().one();
 const targetsCourses: TargetCourse[] = TargetCourseFactory().many(3);
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.spec.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider, createIntl } from 'react-intl';
-import { ContractFactory, OrderFactory } from 'utils/test/factories/joanie';
+import { ContractFactory, CredentialOrderFactory } from 'utils/test/factories/joanie';
 import { OrderState } from 'types/Joanie';
 import OrderStateMessage, { messages } from '.';
 
@@ -32,7 +32,7 @@ describe('<DashboardItemOrder/>', () => {
   ])(
     'should display message from order state: %s when order have no contract',
     (state, expectedMessage) => {
-      const order = OrderFactory({ state }).one();
+      const order = CredentialOrderFactory({ state }).one();
       render(
         <Wrapper>
           <OrderStateMessage order={order} />
@@ -50,7 +50,7 @@ describe('<DashboardItemOrder/>', () => {
   ])(
     'should display message from order state: %s when order have no contract',
     (state, expectedMessage) => {
-      const orderWithContract = OrderFactory({
+      const orderWithContract = CredentialOrderFactory({
         state,
         contract: ContractFactory().one(),
       }).one();
@@ -64,7 +64,7 @@ describe('<DashboardItemOrder/>', () => {
   );
 
   it('should display message for validated order that need learner signature', () => {
-    const order = OrderFactory({
+    const order = CredentialOrderFactory({
       state: OrderState.VALIDATED,
       contract: ContractFactory({ signed_on: undefined }).one(),
     }).one();
@@ -77,7 +77,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it("should display message for validated order that don't have a generated certificate", () => {
-    const order = OrderFactory({
+    const order = CredentialOrderFactory({
       state: OrderState.VALIDATED,
       contract: ContractFactory({ signed_on: new Date().toISOString() }).one(),
       certificate: undefined,
@@ -95,7 +95,7 @@ describe('<DashboardItemOrder/>', () => {
   });
 
   it('should display message for validated order that have a generated certificate', () => {
-    const order = OrderFactory({
+    const order = CredentialOrderFactory({
       state: OrderState.VALIDATED,
       contract: ContractFactory({ signed_on: new Date().toISOString() }).one(),
       certificate: 'FAKE_CERTIFICATE_ID',

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 import { useEffect } from 'react';
-import { Order, OrderState } from 'types/Joanie';
+import { CertificateOrder, CredentialOrder, OrderState } from 'types/Joanie';
 import { StringHelper } from 'utils/StringHelper';
 import { handle } from 'utils/errors/handle';
 
@@ -51,7 +51,7 @@ export const messages = {
 };
 
 interface OrderStateMessageProps {
-  order: Order;
+  order: CredentialOrder | CertificateOrder;
 }
 
 const OrderStateMessage = ({ order }: OrderStateMessageProps) => {

--- a/src/frontend/js/widgets/Dashboard/hooks/useEnroll/index.ts
+++ b/src/frontend/js/widgets/Dashboard/hooks/useEnroll/index.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Priority } from 'types';
 import { confirm } from 'utils/indirection/window';
 import { resolveAll } from 'utils/resolveAll';
-import { CourseRun, Enrollment, Order } from 'types/Joanie';
+import { CourseRun, Enrollment, CredentialOrder } from 'types/Joanie';
 import { useEnrollments } from 'hooks/useEnrollments';
 
 const messages = {
@@ -22,7 +22,7 @@ const messages = {
   },
 };
 
-export const useEnroll = (enrollments: Enrollment[], order?: Order) => {
+export const useEnroll = (enrollments: Enrollment[], order?: CredentialOrder) => {
   const enrollmentResources = useEnrollments();
   const [isLoading, setLoading] = useState(false);
   const intl = useIntl();

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseProductCourseRuns/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseProductCourseRuns/index.spec.tsx
@@ -9,7 +9,7 @@ import {
   CourseLightFactory,
   CourseRunFactory,
   EnrollmentFactory,
-  OrderFactory,
+  CredentialOrderFactory,
 } from 'utils/test/factories/joanie';
 import JoanieApiProvider from 'contexts/JoanieApiContext';
 import type { CourseLight, CourseRun, Enrollment, OrderLite } from 'types/Joanie';
@@ -133,7 +133,7 @@ describe('CourseProductCourseRuns', () => {
     );
 
     it('renders a warning message when no course runs are provided', () => {
-      const order: OrderLite = OrderFactory().one();
+      const order: OrderLite = CredentialOrderFactory().one();
 
       render(
         <Wrapper productId={order.product} code="00000">
@@ -147,7 +147,7 @@ describe('CourseProductCourseRuns', () => {
     it('renders a list of course runs with a call to action to enroll', async () => {
       const course: CourseLight = CourseLightFactory().one();
       const courseRuns: CourseRun[] = CourseRunFactory().many(2);
-      const order: OrderLite = OrderFactory().one();
+      const order: OrderLite = CredentialOrderFactory().one();
 
       render(
         <Wrapper productId={order.product} code={course.code}>
@@ -258,7 +258,7 @@ describe('CourseProductCourseRuns', () => {
     it('enroll with errors', async () => {
       const course: CourseLight = CourseLightFactory().one();
       const courseRuns: CourseRun[] = CourseRunFactory().many(2);
-      const order: OrderLite = OrderFactory().one();
+      const order: OrderLite = CredentialOrderFactory().one();
       fetchMock.get(`https://joanie.test/api/v1.0/courses/${course.code}/`, HttpStatusCode.OK);
 
       render(
@@ -371,7 +371,7 @@ describe('CourseProductCourseRuns', () => {
           text: CourseStateTextEnum.STARTING_ON,
         },
       }).one();
-      const order = OrderFactory().one();
+      const order = CredentialOrderFactory().one();
 
       render(
         <Wrapper productId={order.product} code="00000">

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseRunItem/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseRunItem/index.spec.tsx
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { screen, getByText, render } from '@testing-library/react';
-import { OrderFactory } from 'utils/test/factories/joanie';
-import type { CourseRun, Order } from 'types/Joanie';
+import { CredentialOrderFactory } from 'utils/test/factories/joanie';
+import type { CourseRun, CredentialOrder } from 'types/Joanie';
 import { OrderState } from 'types/Joanie';
 import CourseRunItem from '.';
 
@@ -13,7 +13,7 @@ jest.mock('../CourseProductCourseRuns', () => ({
 
 describe('CourseRunItem', () => {
   it('does not allow user which purchase the product to enroll to course if order state is not validated', async () => {
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       state: faker.helpers.arrayElement([OrderState.CANCELED, OrderState.PENDING]),
     }).one();
     const targetCourse = order.target_courses[0];

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseRunItem/index.stories.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseRunItem/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { OrderFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
+import { CredentialOrderFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
 import { StorybookHelper } from 'utils/StorybookHelper';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { UserFactory } from 'utils/test/factories/richie';
@@ -29,6 +29,8 @@ type Story = StoryObj<typeof CourseRunItem>;
 export const Default: Story = {
   args: {
     targetCourse: TargetCourseFactory().one(),
-    order: OrderFactory({ certificate: "Demo User's certificate for cours Demo Course" }).one(),
+    order: CredentialOrderFactory({
+      certificate: "Demo User's certificate for cours Demo Course",
+    }).one(),
   },
 };

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseRunItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseRunItem/index.tsx
@@ -25,7 +25,7 @@ other {Languages:}
 
 interface Props {
   targetCourse: Joanie.TargetCourse;
-  order?: Joanie.Order;
+  order?: Joanie.CredentialOrder;
 }
 
 const CourseRunItem = ({ targetCourse, order }: Props) => {

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
@@ -12,6 +12,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import queryString from 'query-string';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import {
+  CourseLightFactory,
   CourseProductRelationFactory,
   EnrollmentFactory,
   OrderFactory,
@@ -232,14 +233,15 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = OrderFactory({
       product: product.id,
-      course: '00000',
+      course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
     }).one();
 
     fetchMock.get(`https://joanie.test/api/v1.0/courses/00000/products/${product.id}/`, relation);
     const orderQueryParameters = {
       product: order.product,
-      course: order.course,
+      // TODO (rlecellier): remove this when order.course is mandatory
+      course: order.course?.code,
       state: ACTIVE_ORDER_STATES,
     };
     fetchMock.get(
@@ -289,7 +291,7 @@ describe('CourseProductItem', () => {
     const relation = CourseProductRelationFactory().one();
     const order: Order = OrderFactory({
       product: relation.product.id,
-      course: '00000',
+      course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: relation.product.target_courses,
     }).one();
 
@@ -299,7 +301,8 @@ describe('CourseProductItem', () => {
     );
     const orderQueryParameters = {
       product: order.product,
-      course: order.course,
+      // TODO (rlecellier): remove this when order.course is mandatory
+      course: order.course?.code,
       state: ACTIVE_ORDER_STATES,
     };
     fetchMock.get(
@@ -360,7 +363,7 @@ describe('CourseProductItem', () => {
     }).one();
     const order: Order = OrderFactory({
       product: product.id,
-      course: '00000',
+      course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       target_enrollments: [enrollment],
     }).one();
@@ -368,7 +371,8 @@ describe('CourseProductItem', () => {
     fetchMock.get(`https://joanie.test/api/v1.0/courses/00000/products/${product.id}/`, relation);
     const orderQueryParameters = {
       product: order.product,
-      course: order.course,
+      // TODO (rlecellier): remove this when order.course is mandatory
+      course: order.course?.code,
       state: ACTIVE_ORDER_STATES,
     };
     fetchMock.get(
@@ -419,14 +423,15 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = OrderFactory({
       product: product.id,
-      course: '00000',
+      course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       state: OrderState.PENDING,
     }).one();
     fetchMock.get(`https://joanie.test/api/v1.0/courses/00000/products/${product.id}/`, relation);
     const orderQueryParameters = {
       product: order.product,
-      course: order.course,
+      // TODO (rlecellier): remove this when order.course is mandatory
+      course: order.course?.code,
       state: ACTIVE_ORDER_STATES,
     };
     fetchMock.get(
@@ -517,14 +522,15 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = OrderFactory({
       product: product.id,
-      course: '00000',
+      course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       state: OrderState.SUBMITTED,
     }).one();
     fetchMock.get(`https://joanie.test/api/v1.0/courses/00000/products/${product.id}/`, relation);
     const orderQueryParameters = {
       product: order.product,
-      course: order.course,
+      // TODO (rlecellier): remove this when order.course is mandatory
+      course: order.course?.code,
       state: ACTIVE_ORDER_STATES,
     };
     fetchMock.get(
@@ -572,7 +578,7 @@ describe('CourseProductItem', () => {
     const relation = CourseProductRelationFactory().one();
     const order: Order = OrderFactory({
       product: relation.product.id,
-      course: '00000',
+      course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: relation.product.target_courses,
       state: OrderState.SUBMITTED,
     }).one();
@@ -582,7 +588,8 @@ describe('CourseProductItem', () => {
     );
     const orderQueryParameters = {
       product: order.product,
-      course: order.course,
+      // TODO (rlecellier): remove this when order.course is mandatory
+      course: order.course?.code,
       state: ACTIVE_ORDER_STATES,
     };
     fetchMock.get(

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
@@ -15,11 +15,17 @@ import {
   CourseLightFactory,
   CourseProductRelationFactory,
   EnrollmentFactory,
-  OrderFactory,
+  CredentialOrderFactory,
   ProductFactory,
 } from 'utils/test/factories/joanie';
 import JoanieApiProvider from 'contexts/JoanieApiContext';
-import { CourseRun, Enrollment, Order, OrderState, ACTIVE_ORDER_STATES } from 'types/Joanie';
+import {
+  CourseRun,
+  Enrollment,
+  CredentialOrder,
+  OrderState,
+  ACTIVE_ORDER_STATES,
+} from 'types/Joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { Deferred } from 'utils/test/deferred';
 import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
@@ -43,7 +49,13 @@ jest.mock('./components/CourseProductCourseRuns', () => ({
   CourseRunList: ({ courseRuns }: { courseRuns: CourseRun[] }) => (
     <div data-testid={`CourseRunList-${courseRuns.map(({ id }) => id).join('-')}`} />
   ),
-  EnrollableCourseRunList: ({ courseRuns, order }: { courseRuns: CourseRun[]; order: Order }) => (
+  EnrollableCourseRunList: ({
+    courseRuns,
+    order,
+  }: {
+    courseRuns: CourseRun[];
+    order: CredentialOrder;
+  }) => (
     <div
       data-testid={`EnrollableCourseRunList-${courseRuns.map(({ id }) => id).join('-')}-${
         order.id
@@ -231,7 +243,7 @@ describe('CourseProductItem', () => {
   it('adapts information when user purchased the product', async () => {
     const relation = CourseProductRelationFactory().one();
     const { product } = relation;
-    const order = OrderFactory({
+    const order = CredentialOrderFactory({
       product: product.id,
       course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
@@ -289,7 +301,7 @@ describe('CourseProductItem', () => {
 
   it('adapts information when user purchased the product even if compact is set', async () => {
     const relation = CourseProductRelationFactory().one();
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       product: relation.product.id,
       course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: relation.product.target_courses,
@@ -361,7 +373,7 @@ describe('CourseProductItem', () => {
     const enrollment: Enrollment = EnrollmentFactory({
       course_run: product.target_courses[0]!.course_runs[0]! as CourseRun,
     }).one();
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       product: product.id,
       course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
@@ -421,7 +433,7 @@ describe('CourseProductItem', () => {
   it('renders sale tunnel button if user already has a pending order', async () => {
     const relation = CourseProductRelationFactory().one();
     const { product } = relation;
-    const order = OrderFactory({
+    const order = CredentialOrderFactory({
       product: product.id,
       course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
@@ -520,7 +532,7 @@ describe('CourseProductItem', () => {
   it('does not render sale tunnel button if user already has a submitted order', async () => {
     const relation = CourseProductRelationFactory().one();
     const { product } = relation;
-    const order = OrderFactory({
+    const order = CredentialOrderFactory({
       product: product.id,
       course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
@@ -576,7 +588,7 @@ describe('CourseProductItem', () => {
 
   it('adapts layout when user has a pending order and compact prop is set', async () => {
     const relation = CourseProductRelationFactory().one();
-    const order: Order = OrderFactory({
+    const order: CredentialOrder = CredentialOrderFactory({
       product: relation.product.id,
       course: CourseLightFactory({ code: '00000' }).one(),
       target_courses: relation.product.target_courses,


### PR DESCRIPTION
/!\ Do not merge before Joanie return a `NestedEnrollment` for `Order`

- [x] order.course must be a `CourseLight`
- [x] `Order` enrollment must be a `Enrollment`, waiting for backend to return new type `NestedEnrollment`.
- [x] `Order` is splited into `CredentialOrder`  (course, no enrollment) and `CertificateOrder` (enrollment, no course)
- [x] `Certificate` order must be a `NestedOrder`, need to add this new type.
- [x] `Order` and `NestedOrder` enrollment must be a `NestedEnrollment`, need to add this new type.