### PR TITLE
✨(frontend) handle OrderGroup on product purchase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add the ability to sign an order's contract.
 - Add terms checkbox and specific "sign" button in the Sale Tunnel.
 - The CourseRunProductItem disables enrollment if there is a needed signature.
+- Handle OrderGroup on product purchase
 
 ### Changed
 

--- a/src/frontend/js/components/PaymentButton/index.tsx
+++ b/src/frontend/js/components/PaymentButton/index.tsx
@@ -98,7 +98,7 @@ const PaymentButton = ({ billingAddress, creditCard, onSuccess }: PaymentButtonP
   const intl = useIntl();
   const API = useJoanieApi();
   const timeoutRef = useRef<NodeJS.Timeout>();
-  const { course, key, enrollment, product, setOrder } = useSaleTunnelContext();
+  const { course, key, enrollment, product, setOrder, orderGroup } = useSaleTunnelContext();
   const { item: order } = useProductOrder({ courseCode: course.code, productId: product.id });
   const orderManager = useOmniscientOrders();
   const [payment, setPayment] = useState<PaymentInfo | OneClickPaymentInfo>();
@@ -201,6 +201,7 @@ const PaymentButton = ({ billingAddress, creditCard, onSuccess }: PaymentButtonP
           : {
               product_id: product.id,
               course_code: course.code,
+              ...(orderGroup ? { order_group_id: orderGroup.id } : {}),
             };
 
       orderManager.methods.create(payload, {

--- a/src/frontend/js/components/PurchaseButton/index.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.tsx
@@ -42,6 +42,8 @@ const messages = defineMessages({
 interface PurchaseButtonProps {
   product: Joanie.Product;
   course: Joanie.CourseLight;
+  // If the product is a credential, the orderGroup can be required.
+  orderGroup?: Joanie.OrderGroup;
   enrollment?: Joanie.Enrollment;
   disabled?: boolean;
   className?: string;
@@ -51,6 +53,7 @@ const PurchaseButton = ({
   product,
   course,
   enrollment,
+  orderGroup,
   disabled = false,
   className,
 }: PurchaseButtonProps) => {
@@ -128,6 +131,7 @@ const PurchaseButton = ({
         isOpen={isSaleTunnelOpen}
         product={product}
         enrollment={enrollment}
+        orderGroup={orderGroup}
         course={course}
         onClose={() => setIsSaleTunnelOpen(false)}
       />

--- a/src/frontend/js/components/SaleTunnel/context.tsx
+++ b/src/frontend/js/components/SaleTunnel/context.tsx
@@ -1,8 +1,9 @@
 import { createContext, useContext } from 'react';
-import { CourseLight, Order, Product, Enrollment } from 'types/Joanie';
+import { CourseLight, Order, OrderGroup, Product, Enrollment } from 'types/Joanie';
 
 export interface SaleTunnelContextType {
   product: Product;
+  orderGroup?: OrderGroup;
   order?: Order;
   enrollment?: Enrollment;
   setOrder: (order: Order) => void;

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Modal } from 'components/Modal';
-import { CourseLight, Order, Product } from 'types/Joanie';
+import { CourseLight, Order, Product, OrderGroup } from 'types/Joanie';
 import { useOmniscientOrders, useOrders } from 'hooks/useOrders';
 import { IconTypeEnum } from 'components/Icon';
 import WebAnalyticsAPIHandler from 'api/web-analytics';
@@ -46,11 +46,19 @@ type Props = {
   product: Product;
   course: CourseLight;
   enrollment?: Joanie.Enrollment;
+  orderGroup?: OrderGroup;
   isOpen: boolean;
   onClose: () => void;
 };
 
-const SaleTunnel = ({ product, course, isOpen = false, onClose, enrollment }: Props) => {
+const SaleTunnel = ({
+  product,
+  course,
+  orderGroup,
+  isOpen = false,
+  onClose,
+  enrollment,
+}: Props) => {
   const intl = useIntl();
   const {
     methods: { refetch: refetchOmniscientOrders },
@@ -118,8 +126,9 @@ const SaleTunnel = ({ product, course, isOpen = false, onClose, enrollment }: Pr
       key,
       course,
       enrollment,
+      orderGroup,
     }),
-    [product, order, setOrder, key, course, enrollment],
+    [product, order, setOrder, key, course, enrollment, orderGroup],
   );
 
   /**

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -119,6 +119,7 @@ export interface CourseProductRelation {
   organizations: Organization[];
   product: Product;
   created_on: string;
+  order_groups: OrderGroup[];
 }
 export function isCourseProductRelation(
   entity: CourseListItem | CourseProductRelation | RichieCourse,
@@ -329,12 +330,15 @@ export interface AddressCreationPayload extends Omit<Address, 'id' | 'is_main'> 
   is_main?: boolean;
 }
 
-interface OrderProductCertificateCreationPayload {
+interface OrderProductCreationPayload {
   product_id: Product['id'];
+  order_group_id?: OrderGroup['id'];
+}
+
+interface OrderProductCertificateCreationPayload extends OrderProductCreationPayload {
   enrollment_id: Enrollment['id'];
 }
-interface OrderCredentialCreationPayload {
-  product_id: Product['id'];
+export interface OrderCredentialCreationPayload extends OrderProductCreationPayload {
   course_code: CourseLight['code'];
 }
 

--- a/src/frontend/js/utils/ProductHelper/index.ts
+++ b/src/frontend/js/utils/ProductHelper/index.ts
@@ -1,5 +1,5 @@
 import { IntlShape } from 'react-intl';
-import { Product, TargetCourse } from 'types/Joanie';
+import { CourseProductRelation, Product, TargetCourse } from 'types/Joanie';
 import { Maybe } from 'types/utils';
 import { IntlHelper } from 'utils/IntlHelper';
 
@@ -40,5 +40,9 @@ export class ProductHelper {
     if (!humanized || !intl) return uniqueLanguages;
 
     return IntlHelper.getLocalizedLanguages(uniqueLanguages, intl);
+  }
+
+  static getActiveOrderGroups(courseProductRelation: CourseProductRelation) {
+    return courseProductRelation.order_groups?.filter((orderGroup) => orderGroup.is_active);
   }
 }

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -34,6 +34,7 @@ import {
   CertificateOrderWithPaymentInfo,
   CredentialOrderWithPaymentInfo,
   EnrollmentLight,
+  OrderGroup,
 } from 'types/Joanie';
 import { CourseStateFactory } from 'utils/test/factories/richie';
 import { FactoryHelper } from 'utils/test/factories/helper';
@@ -229,6 +230,25 @@ export const CourseLightFactory = factory((): CourseLight => {
   };
 });
 
+export const OrderGroupFactory = factory((): OrderGroup => {
+  const seats = faker.number.int({ min: 5, max: 100 });
+  return {
+    id: faker.string.uuid(),
+    is_active: true,
+    nb_seats: seats,
+    nb_available_seats: faker.number.int({ min: 2, max: seats }),
+  };
+});
+
+export const OrderGroupFullFactory = factory((): OrderGroup => {
+  return {
+    id: faker.string.uuid(),
+    is_active: true,
+    nb_seats: faker.number.int({ min: 5, max: 100 }),
+    nb_available_seats: 0,
+  };
+});
+
 export const CourseProductRelationFactory = factory((): CourseProductRelation => {
   return {
     id: faker.string.uuid(),
@@ -236,6 +256,7 @@ export const CourseProductRelationFactory = factory((): CourseProductRelation =>
     course: CourseFactory().one(),
     product: ProductFactory().one(),
     organizations: OrganizationFactory().many(1),
+    order_groups: [],
   };
 });
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/_styles.scss
@@ -138,9 +138,24 @@
 
   &__footer {
     padding: 0 0.875rem 1rem 0.875rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 
     .purchase-button__cta {
       width: 100%;
+    }
+
+    &__message {
+      text-align: center;
+    }
+
+    &__order-group {
+      text-align: center;
+
+      p {
+        margin-top: 0.25rem;
+      }
     }
   }
 


### PR DESCRIPTION
We need to disable purchasing a product when all order groups are full, and also display multiple purchase button when there are multiple with seats available.

<img width="582" alt="Capture d’écran 2023-11-24 à 17 26 55" src="https://github.com/openfun/richie/assets/9628870/da3192f8-329c-48bb-a443-a763b51e07de">

<img width="525" alt="Capture d’écran 2023-11-24 à 17 28 37" src="https://github.com/openfun/richie/assets/9628870/c933e984-13de-454c-bdfa-22949f8b7be0">

