### PR TITLE
🐛(frontend) fix various cache order issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix cookiecutter circleci gitlint configuration
 - Opened Course Run show empty date as '...'
 - Fix dashboard enrollment listing when they're linked to a product certificate.
+- Fix order cache issues
 
 ### Removed
 

--- a/src/frontend/js/hooks/useUnionResource/utils/fetchEntity.ts
+++ b/src/frontend/js/hooks/useUnionResource/utils/fetchEntity.ts
@@ -53,7 +53,8 @@ export const fetchEntity = async <
   // Here we need to mimic the behavior of staleTime, which does not seems to be implemented when using `getQueryData`.
   if (
     state &&
-    state.dataUpdatedAt >= new Date().getTime() - REACT_QUERY_SETTINGS.staleTimes.sessionItems
+    state.dataUpdatedAt >= new Date().getTime() - REACT_QUERY_SETTINGS.staleTimes.sessionItems &&
+    !state.isInvalidated
   ) {
     data = state.data;
   }

--- a/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
+++ b/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
@@ -55,7 +55,7 @@ export const useOrdersEnrollments = ({
     { was_created_by_order: boolean } & PaginatedResourceQuery
   >({
     queryAConfig: {
-      queryKey: ['user', 'order'],
+      queryKey: ['user', 'orders'],
       fn: api.user.orders.get,
       filters: orderFilters,
     },


### PR DESCRIPTION
We had a bug where the cache invalidation triggered when a contract is signed was not impacting useOrdersEnrollments. This was causing the "Sign" button to be still displayed. A related bug where after buying a product from the syllabus page, the newly created order was not shown was also fixed by theses changes.
