### PR TITLE
💄(frontend) hide order sidebar, hide filters space

### DIFF
--- a/src/frontend/js/pages/DashboardOrderLayout/_styles.scss
+++ b/src/frontend/js/pages/DashboardOrderLayout/_styles.scss
@@ -1,0 +1,5 @@
+.dashboard-order-layout {
+  .dashboard__sidebar {
+    display: none;
+  }
+}

--- a/src/frontend/js/pages/DashboardOrderLayout/index.tsx
+++ b/src/frontend/js/pages/DashboardOrderLayout/index.tsx
@@ -34,7 +34,10 @@ export const DashboardOrderLayout = () => {
   );
 
   return (
-    <DashboardLayout sidebar={<LearnerDashboardSidebar menuLinks={links} title={product?.title} />}>
+    <DashboardLayout
+      className="dashboard-order-layout"
+      sidebar={<LearnerDashboardSidebar menuLinks={links} title={product?.title} />}
+    >
       <DashboardOrderLayoutContent product={product} />
     </DashboardLayout>
   );

--- a/src/frontend/js/widgets/Dashboard/components/DashboardLayout/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardLayout/_styles.scss
@@ -1,9 +1,8 @@
-$dashboard-breadcrumb-height: rem-calc(32.4px);
+$dashboard-breadcrumb-height: rem-calc(32px);
 $dashboard-breadcrumb-filters-spacing: rem-calc(30px);
 $dashboard-filters-height: rem-calc(48px);
 $dashboard-header-spacing: rem-calc(16px);
-$sidebar-spacing-top: $dashboard-breadcrumb-height + $dashboard-filters-height +
-  $dashboard-header-spacing + $dashboard-breadcrumb-filters-spacing;
+$sidebar-spacing-top: $dashboard-breadcrumb-height + $dashboard-header-spacing;
 
 .dashboard {
   @include make-container();

--- a/src/frontend/js/widgets/Dashboard/components/DashboardLayout/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardLayout/index.tsx
@@ -1,22 +1,29 @@
 import { PropsWithChildren, ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
+import c from 'classnames';
 import { LearnerDashboardSidebar } from 'widgets/Dashboard/components/LearnerDashboardSidebar';
 import { DashboardBreadcrumbs } from 'widgets/Dashboard/components/DashboardBreadcrumbs';
 
 interface DashboardLayoutProps extends PropsWithChildren<any> {
   sidebar?: ReactNode;
   filters?: ReactNode;
+  className?: string;
 }
 
-export const DashboardLayout = ({ children, sidebar, filters }: DashboardLayoutProps) => {
+export const DashboardLayout = ({
+  children,
+  sidebar,
+  filters,
+  className,
+}: DashboardLayoutProps) => {
   const location = useLocation();
   return (
-    <div className="dashboard">
+    <div className={c('dashboard', className)}>
       <div className="dashboard__sidebar">{sidebar || <LearnerDashboardSidebar />}</div>
       <main className="dashboard__main">
         <header>
           <DashboardBreadcrumbs />
-          <div className="dashboard__filters">{filters}</div>
+          {!!filters && <div className="dashboard__filters">{filters}</div>}
         </header>
         <div className="dashboard__content" data-testid={`location-display-${location.pathname}`}>
           {children}

--- a/src/frontend/scss/components/_index.scss
+++ b/src/frontend/scss/components/_index.scss
@@ -17,6 +17,7 @@
 @import '../../js/pages/DashboardCertificates/styles';
 @import '../../js/pages/DashboardCourses/styles';
 @import '../../js/pages/DashboardCreditCardsManagement/styles';
+@import '../../js/pages/DashboardOrderLayout/styles';
 @import '../../js/pages/DashboardPreferences/styles';
 @import '../../js/pages/TeacherDashboardContractsLoader/styles';
 @import '../../js/pages/TeacherDashboardCourseLoader/CourseRunList/styles';


### PR DESCRIPTION
We decided to simply hide the sidebar inside the order details because it was empty, and in the future we will just have to remove the display none clause to show it again. Also remove the empty space caused by the filters container, now we only show it if there are filters.
