### PR TITLE
🐛(frontend) multiple calls of pushBreadcrumbsPlaceholders

### DIFF
--- a/src/frontend/js/hooks/useBreadcrumbsPlaceholders.tsx
+++ b/src/frontend/js/hooks/useBreadcrumbsPlaceholders.tsx
@@ -9,5 +9,5 @@ export const useBreadcrumbsPlaceholders = (data: DashboardBreadcrumbsPlaceholder
   const context = useContext(DashboardBreadcrumbsContext);
   useEffect(() => {
     context.pushBreadcrumbsPlaceholders(data);
-  }, [data]);
+  }, [JSON.stringify(data)]);
 };


### PR DESCRIPTION
## Purpose

We had multiple trigger of a useEffect that was enoying to test pages that use breadcrumb's placeholders.