### PR TITLE
💄(frontend) fix organization logo link size issue

### DIFF
--- a/src/frontend/js/widgets/Dashboard/components/TeacherDashboardProfileSidebar/components/OrganizationLinks/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherDashboardProfileSidebar/components/OrganizationLinks/_styles.scss
@@ -18,13 +18,13 @@
     }
 
     &__link {
-      flex: 0 0 32%;
-      display: flex;
-      border: thin solid r-theme-val(organization-thumb, border-color);
-      border-radius: rem-calc(8px);
-      overflow: hidden;
-      justify-content: center;
       align-items: center;
+      border-radius: rem-calc(8px);
+      border: thin solid r-theme-val(organization-thumb, border-color);
+      display: flex;
+      flex: 0 0 32%;
+      justify-content: center;
+      overflow: hidden;
       padding: rem-calc(2px);
       &:hover,
       &:focus,
@@ -33,9 +33,13 @@
         box-shadow: 0 0 rem-calc(3px) r-theme-val(organization-thumb, border-color);
       }
       &__img {
-        object-fit: cover;
+        object-fit: contain;
         object-position: center center;
-        aspect-ratio: 2/1;
+        aspect-ratio: 1/1;
+      }
+
+      @include media-breakpoint-down(lg) {
+        max-width: rem-calc(64px);
       }
     }
   }

--- a/src/frontend/js/widgets/Dashboard/components/TeacherDashboardProfileSidebar/components/OrganizationLinks/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherDashboardProfileSidebar/components/OrganizationLinks/index.tsx
@@ -44,6 +44,7 @@ const OrganizationLinks = ({ organizations }: OrganizationLinksProps) => {
               className="dashboard-sidebar__organization-section__link__img"
               alt={organization.title}
               src={organization.logo.src}
+              srcSet={organization.logo.srcset}
             />
           </Link>
         ))}


### PR DESCRIPTION
## Purpose

Currently, the organization logo could be truncated if its dimensions does not match the aspect-ratio defined in style. E.g a 1/1 logo was truncated as the aspect ratio is 2/1.

Furthermore, joanie is returning a srcset property into its file detail, so we can take benefit of this attribute to properly set organization logo size in responsive context.


| Before | After |
|--------|-------|
|<img width="292" alt="Capture d’écran 2023-12-12 à 11 36 31" src="https://github.com/openfun/richie/assets/9265241/dbbca011-6a81-4f7e-8fe1-b60e5f351231">|<img width="289" alt="Capture d’écran 2023-12-12 à 11 51 51" src="https://github.com/openfun/richie/assets/9265241/5ca2f77c-07b0-44b9-a2cd-f8decf56acbe">|


## Proposal

- [x] Set `srcset` on Organization logo
- [x] Fix and improve Organization logo link layout
