### PR TITLE
Frontend - Use full_name if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Display user full_name instead of username if it exists
 - Add a footer on enrollment's item in the learner dashboard. It give the
   possibility to purchase linked product or download linked certificate.
 - Add download contracts pages on the teacher dashboard.

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.spec.tsx
@@ -103,7 +103,7 @@ describe('SaleTunnelStepPayment', () => {
 
   it('should display authenticated user information', async () => {
     const product = ProductFactory().one();
-    const user: User = UserFactory({ fullname: undefined }).one();
+    const user: User = UserFactory({ full_name: undefined }).one();
     await act(async () => {
       render(
         <Wrapper user={user} product={product}>

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.tsx
@@ -189,7 +189,7 @@ export const SaleTunnelStepPayment = ({ next }: SaleTunnelStepPaymentProps) => {
         </header>
         <div className="SaleTunnelStepPayment__block--buyer">
           <strong className="h6 SaleTunnelStepPayment__block--buyer__name">
-            {user.fullname || user.username}
+            {user.full_name || user.username}
           </strong>
           {user.email ? (
             <p className="SaleTunnelStepPayment__block--buyer__email">{user.email}</p>

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.tsx
@@ -10,6 +10,7 @@ import type * as Joanie from 'types/Joanie';
 import type { Maybe, Nullable } from 'types/utils';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { useSaleTunnelContext } from 'components/SaleTunnel/context';
+import { UserHelper } from 'utils/UserHelper';
 import { RegisteredCreditCard } from '../RegisteredCreditCard';
 
 const messages = defineMessages({
@@ -189,7 +190,7 @@ export const SaleTunnelStepPayment = ({ next }: SaleTunnelStepPaymentProps) => {
         </header>
         <div className="SaleTunnelStepPayment__block--buyer">
           <strong className="h6 SaleTunnelStepPayment__block--buyer__name">
-            {user.full_name || user.username}
+            {UserHelper.getName(user)}
           </strong>
           {user.email ? (
             <p className="SaleTunnelStepPayment__block--buyer__email">{user.email}</p>

--- a/src/frontend/js/types/User.ts
+++ b/src/frontend/js/types/User.ts
@@ -1,6 +1,6 @@
 export interface User {
   access_token?: string;
-  fullname?: string;
+  full_name?: string;
   email?: string;
   username: string;
 }

--- a/src/frontend/js/utils/UserHelper/index.spec.ts
+++ b/src/frontend/js/utils/UserHelper/index.spec.ts
@@ -1,0 +1,18 @@
+import { UserFactory } from 'utils/test/factories/richie';
+import { UserHelper } from 'utils/UserHelper/index';
+
+describe('UserHelper', () => {
+  describe('getName', () => {
+    it("should return the user's full name if it exists", () => {
+      const user = UserFactory({ full_name: 'Richie Cunningham' }).one();
+
+      expect(UserHelper.getName(user)).toEqual('Richie Cunningham');
+    });
+
+    it("should return the user's username if full name is not defined", () => {
+      const user = UserFactory({ full_name: undefined, username: 'richie_cunningham' }).one();
+
+      expect(UserHelper.getName(user)).toEqual('richie_cunningham');
+    });
+  });
+});

--- a/src/frontend/js/utils/UserHelper/index.ts
+++ b/src/frontend/js/utils/UserHelper/index.ts
@@ -1,0 +1,8 @@
+import { User } from 'types/User';
+
+export class UserHelper {
+  /* Return the user's full name if it exists, otherwise return the user's username */
+  static getName(user: User) {
+    return user?.full_name || user.username;
+  }
+}

--- a/src/frontend/js/utils/test/factories/richie.ts
+++ b/src/frontend/js/utils/test/factories/richie.ts
@@ -154,7 +154,7 @@ export const EnrollmentFactory = factory<Enrollment>(() => {
 
 export const UserFactory = factory<User>(() => ({
   access_token: faker.lorem.word(12),
-  fullname: faker.person.fullName(),
+  full_name: faker.person.fullName(),
   email: faker.internet.email(),
   username: faker.internet.userName(),
 }));

--- a/src/frontend/js/widgets/Dashboard/components/LearnerDashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/LearnerDashboardSidebar/index.tsx
@@ -10,6 +10,7 @@ import {
   DashboardSidebarProps,
 } from 'widgets/Dashboard/components/DashboardSidebar';
 import { useSession } from 'contexts/SessionContext';
+import { UserHelper } from 'utils/UserHelper';
 
 const messages = defineMessages({
   header: {
@@ -46,7 +47,7 @@ export const LearnerDashboardSidebar = (props: Partial<DashboardSidebarProps>) =
   return (
     <DashboardSidebar
       menuLinks={links}
-      header={intl.formatMessage(messages.header, { name: user?.username })}
+      header={intl.formatMessage(messages.header, { name: user ? UserHelper.getName(user) : '' })}
       subHeader={intl.formatMessage(messages.subHeader)}
       {...props}
     />

--- a/src/frontend/js/widgets/Dashboard/components/TeacherDashboardProfileSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherDashboardProfileSidebar/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'widgets/Dashboard/utils/dashboardRoutes';
 import { useSession } from 'contexts/SessionContext';
 import { useOrganizations } from 'hooks/useOrganizations';
+import { UserHelper } from 'utils/UserHelper';
 import OrganizationLinks from './components/OrganizationLinks';
 
 const messages = defineMessages({
@@ -37,7 +38,7 @@ export const TeacherDashboardProfileSidebar = () => {
   return (
     <DashboardSidebar
       menuLinks={links}
-      header={user?.username || ''}
+      header={user ? UserHelper.getName(user) : ''}
       subHeader={intl.formatMessage(messages.subHeader)}
     >
       {organizations.length > 0 && <OrganizationLinks organizations={organizations} />}

--- a/src/frontend/js/widgets/Dashboard/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/index.spec.tsx
@@ -160,10 +160,17 @@ describe('<Dashboard />', () => {
     expect(location.replace).toHaveBeenCalledWith('https://localhost');
   });
 
-  it('should render username in sidebar', () => {
-    const user: User = UserFactory().one();
+  it('should render username in sidebar if full_name is not defined', () => {
+    const user: User = UserFactory({ full_name: undefined }).one();
     render(<DashboardWithUser user={user} />);
     const sidebar = screen.getByTestId('dashboard__sidebar');
     getByText(sidebar, user.username, { exact: false });
+  });
+
+  it('should render full_name in sidebar', () => {
+    const user: User = UserFactory().one();
+    render(<DashboardWithUser user={user} />);
+    const sidebar = screen.getByTestId('dashboard__sidebar');
+    getByText(sidebar, user.full_name!, { exact: false });
   });
 });

--- a/src/frontend/js/widgets/UserLogin/components/UserMenu/DesktopUserMenu.tsx
+++ b/src/frontend/js/widgets/UserLogin/components/UserMenu/DesktopUserMenu.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useSelect } from 'downshift';
 import { location } from 'utils/indirection/window';
+import { UserHelper } from 'utils/UserHelper';
 import { UserMenuProps } from '.';
 
 const messages = defineMessages({
@@ -41,7 +42,7 @@ export const DesktopUserMenu: FC<UserMenuProps> = ({ user }) => {
         <FormattedMessage {...messages.menuPurpose} />
       </label>
       <button {...getToggleButtonProps()} className="selector__button">
-        {user.username}
+        {UserHelper.getName(user)}
         <svg role="img" className="selector__button__icon" aria-hidden="true">
           <use xlinkHref="#icon-chevron-down" />
         </svg>

--- a/src/frontend/js/widgets/UserLogin/components/UserMenu/MobileUserMenu.tsx
+++ b/src/frontend/js/widgets/UserLogin/components/UserMenu/MobileUserMenu.tsx
@@ -1,12 +1,13 @@
 import { FC } from 'react';
 import { Icon, IconTypeEnum } from 'components/Icon';
+import { UserHelper } from 'utils/UserHelper';
 import { UserMenuProps } from '.';
 
 export const MobileUserMenu: FC<UserMenuProps> = ({ user }) => (
   <div className="user-menu user-menu--mobile">
     <h6 className="user-menu__username">
       <Icon name={IconTypeEnum.LOGIN} />
-      {user.username}
+      {UserHelper.getName(user)}
     </h6>
     <ul className="user-menu__list">
       {user.urls.map(({ key, label, action }) => (

--- a/src/frontend/js/widgets/UserLogin/index.not.isJoanieEnabled.spec.tsx
+++ b/src/frontend/js/widgets/UserLogin/index.not.isJoanieEnabled.spec.tsx
@@ -53,7 +53,7 @@ describe('<UserLogin />', () => {
   );
 
   it('gets and renders the user name and a dropdown containing a logout link', async () => {
-    const user: User = UserFactory().one();
+    const user: User = UserFactory({ full_name: undefined }).one();
 
     render(
       <Wrapper user={user}>
@@ -111,7 +111,7 @@ describe('<UserLogin />', () => {
 
     await userEvent.click(button);
 
-    screen.getByText(user.username);
+    screen.getByText(user.full_name!);
     const settingsLink = screen.getByRole('link', { name: 'Settings' });
     const accountLink = screen.getByRole('link', { name: 'Account' });
     expect(settingsLink.getAttribute('href')).toEqual('https://auth.local.test/settings');

--- a/src/frontend/js/widgets/UserLogin/index.spec.tsx
+++ b/src/frontend/js/widgets/UserLogin/index.spec.tsx
@@ -81,7 +81,7 @@ describe('<UserLogin />', () => {
 
     await userEvent.click(button);
 
-    screen.getByText(user.username);
+    screen.getByText(user.full_name!);
     screen.getByText('Log out');
     expect(screen.queryByText('Loading login status...')).toBeNull();
   });
@@ -136,7 +136,7 @@ describe('<UserLogin />', () => {
 
     await userEvent.click(button);
 
-    screen.getByText(user.username);
+    screen.getByText(user.full_name!);
     const settingsLink = screen.getByRole('link', { name: 'Settings' });
     const accountLink = screen.getByRole('link', { name: 'Account' });
     expect(settingsLink.getAttribute('href')).toEqual('https://auth.local.test/settings');
@@ -172,7 +172,7 @@ describe('<UserLogin />', () => {
 
     await userEvent.click(button);
 
-    screen.getByText(user.username);
+    screen.getByText(user.full_name!);
     const settingsLink = screen.getByRole('link', { name: 'Settings' });
     const accountLink = screen.getByRole('link', { name: 'Account' });
     expect(settingsLink.getAttribute('href')).toEqual('https://auth.local.test/settings');

--- a/src/frontend/js/widgets/UserLogin/index.tsx
+++ b/src/frontend/js/widgets/UserLogin/index.tsx
@@ -122,7 +122,6 @@ const UserLogin = ({ profileUrls = {} }: UserLoginProps) => {
         </Fragment>
       ) : (
         <UserMenu
-          // If user's fullname is empty, we use its username as a fallback
           user={{
             ...user,
             urls: userMenuItems,


### PR DESCRIPTION
## Purpose

Since fonzie 0.5.0, authentication server can now return user full name. So in this case, this property is defined, we should display it instead of username.

With PR openfun/joanie#489, Joanie create dev demo script now generate several users which stick to realistic use cases. Learner, teacher, organization owner are created so on Richie, in order to improve DX, we should be able to switch easily between those profiles. That's why we update the dummy api interface. We hardcode all existing users created by dev demo joanie script then we implement a method `getUserInfo` to return the right payload just by providing a username.


## Proposal

- [x] Display fullname instead of username if it exists
- [x] Improve DX of dummy authentication backend
