### PR TITLE
✅(frontend) act clean in PurchaseButton test

### DIFF
--- a/src/frontend/js/components/PurchaseButton/index.spec.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { IntlProvider } from 'react-intl';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -50,17 +50,15 @@ describe('PurchaseButton', () => {
   it('shows a login button if user is not authenticated', async () => {
     const product = ProductFactory().one();
 
-    act(() => {
-      render(
-        <Wrapper client={createTestQueryClient({ user: null })}>
-          <PurchaseButton
-            product={product}
-            disabled={false}
-            course={CourseLightFactory({ code: '00000' }).one()}
-          />
-        </Wrapper>,
-      );
-    });
+    render(
+      <Wrapper client={createTestQueryClient({ user: null })}>
+        <PurchaseButton
+          product={product}
+          disabled={false}
+          course={CourseLightFactory({ code: '00000' }).one()}
+        />
+      </Wrapper>,
+    );
 
     expect(
       await screen.findByRole('button', { name: `Login to purchase "${product.title}"` }),
@@ -74,29 +72,25 @@ describe('PurchaseButton', () => {
       .get('https://joanie.test/api/v1.0/credit-cards/', [])
       .get('https://joanie.test/api/v1.0/orders/', []);
 
-    act(() => {
-      render(
-        <Wrapper client={createTestQueryClient({ user: true })}>
-          <PurchaseButton
-            product={product}
-            disabled={false}
-            course={CourseLightFactory({ code: '00000' }).one()}
-          />
-        </Wrapper>,
-      );
-    });
+    render(
+      <Wrapper client={createTestQueryClient({ user: true })}>
+        <PurchaseButton
+          product={product}
+          disabled={false}
+          course={CourseLightFactory({ code: '00000' }).one()}
+        />
+      </Wrapper>,
+    );
 
     fetchMock.resetHistory();
 
     // Only CTA is displayed
-    const button = screen.getByRole('button', { name: product.call_to_action });
+    const button = await screen.findByRole('button', { name: product.call_to_action });
 
     // - SaleTunnel should not be opened
     expect(screen.queryByTestId('SaleTunnel__modal')).toBeNull();
 
-    // act is needed here because we've no way, in SaleTunnel, to check useOrder !fetching state from the DOM
-    // Then user can enter into the sale tunnel and follow its 3 steps
-    await act(async () => userEvent.click(button));
+    await userEvent.click(button);
 
     // - SaleTunnel should have been opened
     expect(screen.getByTestId('SaleTunnel__modal')).toBeInTheDocument();
@@ -109,17 +103,15 @@ describe('PurchaseButton', () => {
       .get('https://joanie.test/api/v1.0/credit-cards/', [])
       .get('https://joanie.test/api/v1.0/orders/', []);
 
-    act(() => {
-      render(
-        <Wrapper client={createTestQueryClient({ user: true })}>
-          <PurchaseButton
-            product={product}
-            disabled={false}
-            course={CourseLightFactory({ code: '00000' }).one()}
-          />
-        </Wrapper>,
-      );
-    });
+    render(
+      <Wrapper client={createTestQueryClient({ user: true })}>
+        <PurchaseButton
+          product={product}
+          disabled={false}
+          course={CourseLightFactory({ code: '00000' }).one()}
+        />
+      </Wrapper>,
+    );
 
     fetchMock.resetHistory();
 
@@ -131,9 +123,7 @@ describe('PurchaseButton', () => {
     // - SaleTunnel should not be opened
     expect(screen.queryByTestId('SaleTunnel__modal')).not.toBeInTheDocument();
 
-    // act is needed here because we've no way, in SaleTunnel, to check useOrder !fetching state from the DOM
-    // Then user can enter into the sale tunnel and follow its 3 steps
-    await act(async () => userEvent.click(button));
+    await userEvent.click(button);
 
     // - SaleTunnel should have been opened
     expect(await screen.findByTestId('SaleTunnel__modal')).toBeInTheDocument();
@@ -148,17 +138,15 @@ describe('PurchaseButton', () => {
       .get('https://joanie.test/api/v1.0/credit-cards/', [])
       .get('https://joanie.test/api/v1.0/orders/', []);
 
-    act(() => {
-      render(
-        <Wrapper client={createTestQueryClient({ user: true })}>
-          <PurchaseButton
-            product={product}
-            disabled={false}
-            course={CourseLightFactory({ code: '00000' }).one()}
-          />
-        </Wrapper>,
-      );
-    });
+    render(
+      <Wrapper client={createTestQueryClient({ user: true })}>
+        <PurchaseButton
+          product={product}
+          disabled={false}
+          course={CourseLightFactory({ code: '00000' }).one()}
+        />
+      </Wrapper>,
+    );
 
     fetchMock.resetHistory();
 
@@ -170,9 +158,7 @@ describe('PurchaseButton', () => {
     // - SaleTunnel should not be opened
     expect(screen.queryByTestId('SaleTunnel__modal')).not.toBeInTheDocument();
 
-    // act is needed here because we've no way, in SaleTunnel, to check useOrder !fetching state from the DOM
-    // Then user can enter into the sale tunnel and follow its 3 steps
-    await act(async () => userEvent.click(button));
+    await userEvent.click(button);
 
     // - SaleTunnel should have been opened
     expect(await screen.findByTestId('SaleTunnel__modal')).toBeInTheDocument();
@@ -185,20 +171,20 @@ describe('PurchaseButton', () => {
       .get('https://joanie.test/api/v1.0/credit-cards/', [])
       .get('https://joanie.test/api/v1.0/orders/', []);
 
-    act(() => {
-      render(
-        <Wrapper client={createTestQueryClient({ user: true })}>
-          <PurchaseButton
-            product={product}
-            disabled={false}
-            course={CourseLightFactory({ code: '00000' }).one()}
-          />
-        </Wrapper>,
-      );
-    });
+    render(
+      <Wrapper client={createTestQueryClient({ user: true })}>
+        <PurchaseButton
+          product={product}
+          disabled={false}
+          course={CourseLightFactory({ code: '00000' }).one()}
+        />
+      </Wrapper>,
+    );
 
     // CTA is displayed but disabled
-    const button: HTMLButtonElement = screen.getByRole('button', { name: product.call_to_action });
+    const button: HTMLButtonElement = await screen.findByRole('button', {
+      name: product.call_to_action,
+    });
     expect(button).toBeDisabled();
 
     // Further, a message is displayed to explain why the CTA is disabled
@@ -221,20 +207,18 @@ describe('PurchaseButton', () => {
         .get('https://joanie.test/api/v1.0/credit-cards/', [])
         .get('https://joanie.test/api/v1.0/orders/', []);
 
-      act(() => {
-        render(
-          <Wrapper client={createTestQueryClient({ user: true })}>
-            <PurchaseButton
-              product={product}
-              disabled={false}
-              course={CourseLightFactory({ code: '00000' }).one()}
-            />
-          </Wrapper>,
-        );
-      });
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PurchaseButton
+            product={product}
+            disabled={false}
+            course={CourseLightFactory({ code: '00000' }).one()}
+          />
+        </Wrapper>,
+      );
 
       // CTA is displayed but disabled
-      const button: HTMLButtonElement = screen.getByRole('button', {
+      const button: HTMLButtonElement = await screen.findByRole('button', {
         name: product.call_to_action,
       });
       expect(button).toBeDisabled();
@@ -272,13 +256,11 @@ describe('PurchaseButton', () => {
         .get('https://joanie.test/api/v1.0/credit-cards/', [])
         .get('https://joanie.test/api/v1.0/orders/', []);
 
-      act(() => {
-        render(
-          <Wrapper client={createTestQueryClient({ user: true })}>
-            <PurchaseButton product={product} disabled={false} enrollment={enrollment} />
-          </Wrapper>,
-        );
-      });
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PurchaseButton product={product} disabled={false} enrollment={enrollment} />
+        </Wrapper>,
+      );
 
       // CTA is displayed but disabled
       const button: HTMLButtonElement = await screen.findByRole('button', {
@@ -328,13 +310,11 @@ describe('PurchaseButton', () => {
         .get('https://joanie.test/api/v1.0/credit-cards/', [])
         .get('https://joanie.test/api/v1.0/orders/', []);
 
-      act(() => {
-        render(
-          <Wrapper client={createTestQueryClient({ user: true })}>
-            <PurchaseButton product={product} disabled={false} enrollment={enrollment} />
-          </Wrapper>,
-        );
-      });
+      render(
+        <Wrapper client={createTestQueryClient({ user: true })}>
+          <PurchaseButton product={product} disabled={false} enrollment={enrollment} />
+        </Wrapper>,
+      );
 
       // CTA should not be disabled
       const button: HTMLButtonElement = await screen.findByRole('button', {
@@ -359,20 +339,20 @@ describe('PurchaseButton', () => {
       .get('https://joanie.test/api/v1.0/credit-cards/', [])
       .get('https://joanie.test/api/v1.0/orders/', []);
 
-    act(() => {
-      render(
-        <Wrapper client={createTestQueryClient({ user: true })}>
-          <PurchaseButton
-            product={product}
-            disabled={false}
-            course={CourseLightFactory({ code: '00000' }).one()}
-          />
-        </Wrapper>,
-      );
-    });
+    render(
+      <Wrapper client={createTestQueryClient({ user: true })}>
+        <PurchaseButton
+          product={product}
+          disabled={false}
+          course={CourseLightFactory({ code: '00000' }).one()}
+        />
+      </Wrapper>,
+    );
 
     // CTA is displayed but disabled
-    const button: HTMLButtonElement = screen.getByRole('button', { name: product.call_to_action });
+    const button: HTMLButtonElement = await screen.findByRole('button', {
+      name: product.call_to_action,
+    });
     expect(button).toBeDisabled();
 
     // Further, a message is displayed to explain why the CTA is disabled
@@ -388,17 +368,15 @@ describe('PurchaseButton', () => {
       .get('https://joanie.test/api/v1.0/credit-cards/', [])
       .get('https://joanie.test/api/v1.0/orders/', []);
 
-    act(() => {
-      render(
-        <Wrapper client={createTestQueryClient({ user: true })}>
-          <PurchaseButton
-            product={product}
-            disabled={true}
-            course={CourseLightFactory({ code: '00000' }).one()}
-          />
-        </Wrapper>,
-      );
-    });
+    render(
+      <Wrapper client={createTestQueryClient({ user: true })}>
+        <PurchaseButton
+          product={product}
+          disabled={true}
+          course={CourseLightFactory({ code: '00000' }).one()}
+        />
+      </Wrapper>,
+    );
 
     // CTA is not displayed
     expect(screen.queryByRole('button', { name: product.call_to_action })).not.toBeInTheDocument();


### PR DESCRIPTION
Wrong usage of act can hide real bug. Most of the time RTL handle needed act and we just have to await a element on the page.

```
$ yarn test js/components/PurchaseButton/index.spec.tsx
yarn run v1.22.19
$ jest js/components/PurchaseButton/index.spec.tsx
 PASS  js/components/PurchaseButton/index.spec.tsx (5.387 s)
  PurchaseButton
    ✓ shows a login button if user is not authenticated (107 ms)
    ✓ shows cta to open sale tunnel when user is authenticated (112 ms)
    ✓ shows cta to open sale tunnel when remaining orders is null (76 ms)
    ✓ shows cta to open sale tunnel when remaining orders is undefined (61 ms)
    ✓ renders a disabled CTA if the product have no remaining orders (24 ms)
    ✓ renders a disabled CTA if one target course has no course runs. Case "Product credential" (27 ms)
    ✓ renders a disabled CTA if one target course has no course runs. Case "Product credential without remaining orders" (29 ms)
    ✓ renders a disabled CTA for product certificate if the linked course run is not open (30 ms)
    ✓ renders a disabled CTA for product certificate if the linked course run is not open (33 ms)
    ✓ renders a disabled CTA for product certificate if the linked course run is not open (30 ms)
    ✓ do not renders a disabled CTA for product certificate if the linked course run is open (31 ms)
    ✓ do not renders a disabled CTA for product certificate if the linked course run is open (30 ms)
    ✓ do not renders a disabled CTA for product certificate if the linked course run is open (30 ms)
    ✓ do not renders a disabled CTA for product certificate if the linked course run is open (28 ms)
    ✓ do not renders a disabled CTA for product certificate if the linked course run is open (31 ms)
    ✓ renders a disabled CTA if product has no target courses (21 ms)
    ✓ does not render CTA if disabled property is false (13 ms)

Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total
```

Still some cleaning to do :)
```
$ git grep 'act(' | wc -l
312
```