### PR TITLE
🐛(frontend) delete courseRun.starts_in_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Add download and sign contracts page on the learner dashboard.
-- Display user full_name instead of username if it exists
-- Add a footer on enrollment's item in the learner dashboard. It gives the
+- Add a footer on enrollment's item in the learner dashboard. It give the
   possibility to purchase linked product or download linked certificate.
 - Add download contracts pages on the teacher dashboard.
 - Add a contract information and actions in learner dashboard order's 
@@ -44,6 +42,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Use cunningham Button component.
 - Use cunningham form components (input, select, radio, checkbox).
 - Delete richie Button component now that we use cunningham Button component.
+- Delete courseRun.starts_in_message, we compute it on frontend side.
 
 ### Fixed
 

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -25,7 +25,6 @@ export interface CourseRun {
   enrollment_end: string;
   languages: string[];
   state: CourseState;
-  starts_in_message: Nullable<string>;
   dashboard_link: Nullable<string>;
   title?: string;
   snapshot?: string;

--- a/src/frontend/js/utils/test/factories/richie.ts
+++ b/src/frontend/js/utils/test/factories/richie.ts
@@ -55,7 +55,6 @@ export const CourseRunFactory = factory<CourseRun>(() => {
     enrollment_end: faker.date.past().toISOString(),
     languages: [faker.location.countryCode('alpha-2')],
     state: CourseStateFactory().one(),
-    starts_in_message: null,
     dashboard_link: null,
     title: faker.lorem.sentence(3),
     display_mode: CourseRunDisplayMode.DETAILED,

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/_styles.scss
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/_styles.scss
@@ -1,13 +1,5 @@
 .subheader__aside {
   .course-run-enrollment {
-    &__cta {
-      @include r-button-colors(
-        r-theme-val(course-detail, subheader-run-cta),
-        $apply-border: true,
-        $include-hover: true
-      );
-    }
-
     &__helptext,
     &__errortext {
       color: r-theme-val('course-detail', 'subheader-run-feedback-color');
@@ -18,23 +10,6 @@
 .course-run-unenrollment,
 .course-run-enrollment {
   &__cta {
-    width: 100%;
-    @include button-small($font-weight: bold);
-    @include r-button-colors(
-      r-theme-val(course-detail, run-cta),
-      $apply-border: true,
-      $include-hover: true
-    );
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: 1rem;
-
-    &.disabled {
-      opacity: 0.65;
-      cursor: not-allowed;
-    }
-
     &--loading {
       cursor: progress !important;
       opacity: 0.7;

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/index.openedx.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/index.openedx.spec.tsx
@@ -2,7 +2,6 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import fetchMock from 'fetch-mock';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { IntlProvider } from 'react-intl';
-
 import { CourseRun } from 'types';
 import { Deferred } from 'utils/test/deferred';
 import {
@@ -234,7 +233,9 @@ describe('<CourseRunEnrollment />', () => {
     const courseRun: CourseRun = CourseRunFactory().one();
     courseRun.state.priority = 0;
     courseRun.resource_link = 'https://openedx.endpoint' + courseRun.resource_link;
-    courseRun.starts_in_message = 'The course will start in 3 days';
+    const start = new Date();
+    start.setDate(new Date().getDate() + 3);
+    courseRun.start = start.toISOString();
     courseRun.dashboard_link = 'https://edx.local.dev:8073/dashboard';
 
     const enrollmentsDeferred = new Deferred();
@@ -268,7 +269,7 @@ describe('<CourseRunEnrollment />', () => {
         'https://edx.local.dev:8073/dashboard',
       ),
     );
-    screen.getByText('The course will start in 3 days');
+    screen.getByText('The course starts in 3 days');
   });
 
   it('shows a helpful message if the course run is closed', async () => {

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { createPortal } from 'react-dom';
+import { Button } from '@openfun/cunningham-react';
 import { CourseRun, Priority } from 'types';
 import { computeStates } from 'utils/CourseRuns';
 import { SyllabusAsideList } from 'widgets/SyllabusCourseRunsList/components/SyllabusAsideList';
@@ -93,13 +94,9 @@ const SyllabusCourseRunsList = ({
               values={{ count: openedRuns.length }}
             />
           </p>
-          <a
-            className="button button--primary"
-            href={'#' + OPENED_COURSES_ELEMENT_ID}
-            onClick={choose}
-          >
+          <Button href={'#' + OPENED_COURSES_ELEMENT_ID} onClick={choose} fullWidth={true}>
             <FormattedMessage {...messages.multipleOpenedCourseRunsButton} />
-          </a>
+          </Button>
         </div>
       )}
       {createPortal(


### PR DESCRIPTION
# Purpose

This attribute is no longer given by django since the migration
of the enrollment to full react. Now we need to compute it on the
front-end side to avoid any caching lags.

<img width="433" alt="Capture d’écran 2023-12-13 à 15 34 25" src="https://github.com/openfun/richie/assets/9628870/efd6fe67-7814-4375-9e26-ebf22dd9b55b">

---

Some buttons were still using the legacy style, which was rendering
different style of buttons next to each other, it was a bit odd.

<img width="467" alt="Capture d’écran 2023-12-13 à 15 34 53" src="https://github.com/openfun/richie/assets/9628870/9afab7fb-cc0b-4672-be8d-c2576f75a3e7">
<img width="412" alt="Capture d’écran 2023-12-13 à 15 34 50" src="https://github.com/openfun/richie/assets/9628870/98994e29-626e-4fe2-b3bf-6f10fc3d6a58">
