### PR TITLE
♻️(frontend) refactor joanie api endpoints

### DIFF
--- a/src/frontend/js/api/joanie.spec.ts
+++ b/src/frontend/js/api/joanie.spec.ts
@@ -12,21 +12,47 @@ describe('api/joanie', () => {
     expect(responseBody).toBe('');
     fetchMock.restore();
   });
+
   it('buildApiUrl should build api url', () => {
     interface TestApiFilters extends ResourcesQuery {
+      addresses: string[];
+      age?: number;
       firstname: string;
+      gender: string;
+      is_active: boolean;
       lastname: string;
-      gender: string[];
+      links: string[];
+      profile: string | null;
     }
     const apiFilters: TestApiFilters = {
       id: 'DUMMY_TEST_API_ID',
+      addresses: ['1', '2'],
+      age: undefined,
       firstname: 'John',
+      gender: '',
+      is_active: false,
       lastname: 'Do',
-      gender: ['male', 'robot'],
+      links: [],
+      profile: null,
     };
-    const url = buildApiUrl('test/:id/', apiFilters);
+    const url = buildApiUrl('http://example.com/test/:id/', apiFilters);
     expect(url).toEqual(
-      'test/DUMMY_TEST_API_ID/?firstname=John&gender=male&gender=robot&lastname=Do',
+      'http://example.com/test/DUMMY_TEST_API_ID/?addresses=1&addresses=2&firstname=John&is_active=false&lastname=Do',
     );
+  });
+
+  it('buildApiUrl should build api url with nested resource', () => {
+    // If an url string parameter is not provided, it should be cleaned up
+    let url = buildApiUrl('http://example.com/resource/:id/nested/:nested_id/', {
+      id: '1',
+    });
+    expect(url).toEqual('http://example.com/resource/1/nested/');
+
+    // Now if we provide the nested_id, it should be added to the url
+    url = buildApiUrl('http://example.com/resource_1/:id/resource_2/:nested_id/', {
+      id: '1',
+      nested_id: '2',
+    });
+    expect(url).toEqual('http://example.com/resource_1/1/resource_2/2/');
   });
 });

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -167,10 +167,10 @@ export const getRoutes = () => {
     courses: {
       get: `${baseUrl}/courses/:id/`,
       courseRuns: {
-        get: `${baseUrl}/courses/:id/course-runs/`,
+        get: `${baseUrl}/courses/:course_id/course-runs/`,
       },
       products: {
-        get: `${baseUrl}/courses/:id/products/:product_id/`,
+        get: `${baseUrl}/courses/:course_id/products/:id/`,
       },
     },
     courseRuns: {
@@ -389,18 +389,13 @@ const API = (): Joanie.API => {
             throw new Error(
               'A course code and a product id are required to fetch a course product',
             );
-          } else if (!filters.id) {
+          } else if (!filters.course_id) {
             throw new Error('A course code is required to fetch a course product');
-          } else if (!filters.productId) {
+          } else if (!filters.id) {
             throw new Error('A product id is required to fetch a course product');
           }
 
-          const { id: courseId, productId, ...queryFilters } = filters;
-          const url = ROUTES.courses.products.get
-            .replace(':id', courseId)
-            .replace(':product_id', productId);
-
-          return fetchWithJWT(buildApiUrl(url, queryFilters)).then(checkStatus);
+          return fetchWithJWT(buildApiUrl(ROUTES.courses.products.get, filters)).then(checkStatus);
         },
       },
     },

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -150,18 +150,18 @@ export const getRoutes = () => {
         create: `${baseUrl}/courses/:course_code/wish/`,
         delete: `${baseUrl}/courses/:course_code/wish/`,
       },
-      organizations: {
-        get: `${baseUrl}/organizations/:id/`,
-        courseProductRelations: {
-          get: `${baseUrl}/organizations/:id/course-product-relations/`,
-        },
-        courses: {
-          get: `${baseUrl}/organizations/:id/courses/`,
-        },
-      },
       contracts: {
         get: `${baseUrl}/contracts/:id/`,
         download: `${baseUrl}/contracts/:id/download/`,
+      },
+    },
+    organizations: {
+      get: `${baseUrl}/organizations/:id/`,
+      courseProductRelations: {
+        get: `${baseUrl}/organizations/:id/course-product-relations/:course_product_relation_id/`,
+      },
+      courses: {
+        get: `${baseUrl}/organizations/:id/courses/:course_id/`,
       },
     },
     courses: {
@@ -329,13 +329,6 @@ const API = (): Joanie.API => {
           }).then(checkStatus);
         },
       },
-      organizations: {
-        get: async (filters) => {
-          return fetchWithJWT(buildApiUrl(ROUTES.user.organizations.get, filters), {
-            method: 'GET',
-          }).then(checkStatus);
-        },
-      },
       contracts: {
         get: async (filters) => {
           let url;
@@ -357,12 +350,19 @@ const API = (): Joanie.API => {
         },
       },
     },
+    organizations: {
+      get: async (filters) => {
+        return fetchWithJWT(buildApiUrl(ROUTES.organizations.get, filters), {
+          method: 'GET',
+        }).then(checkStatus);
+      },
+    },
     courses: {
       get: (filters?: Joanie.CourseQueryFilters) => {
         const { organization_id: organizationId, ...parsedFilters } = filters || {};
         return fetchWithJWT(
           organizationId
-            ? buildApiUrl(ROUTES.user.organizations.courses.get, {
+            ? buildApiUrl(ROUTES.organizations.courses.get, {
                 id: organizationId,
                 ...parsedFilters,
               })
@@ -405,8 +405,9 @@ const API = (): Joanie.API => {
         const { organization_id: organizationId, ...parsedFilters } = filters || {};
         return fetchWithJWT(
           organizationId
-            ? buildApiUrl(ROUTES.user.organizations.courseProductRelations.get, {
+            ? buildApiUrl(ROUTES.organizations.courseProductRelations.get, {
                 id: organizationId,
+                course_product_relation_id: parsedFilters.id,
                 ...parsedFilters,
               })
             : buildApiUrl(ROUTES.courseProductRelations.get, parsedFilters),

--- a/src/frontend/js/hooks/useCourseProductRelation/index.ts
+++ b/src/frontend/js/hooks/useCourseProductRelation/index.ts
@@ -1,7 +1,7 @@
 import { defineMessages } from 'react-intl';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
-import { API, CourseProductRelation } from 'types/Joanie';
-import { ResourcesQuery, useResource, useResources, UseResourcesProps } from 'hooks/useResources';
+import { API, CourseProductRelation, CourseProductRelationQueryFilters } from 'types/Joanie';
+import { useResource, useResources, UseResourcesProps } from 'hooks/useResources';
 
 const messages = defineMessages({
   errorGet: {
@@ -23,7 +23,7 @@ const messages = defineMessages({
  */
 const props: UseResourcesProps<
   CourseProductRelation,
-  ResourcesQuery,
+  CourseProductRelationQueryFilters,
   API['courseProductRelations']
 > = {
   queryKey: ['courseProductRelations'],
@@ -34,8 +34,11 @@ const props: UseResourcesProps<
 
 export const useCourseProductRelations = useResources<
   CourseProductRelation,
-  ResourcesQuery,
+  CourseProductRelationQueryFilters,
   API['courseProductRelations']
 >(props);
 
-export const useCourseProductRelation = useResource<CourseProductRelation>(props);
+export const useCourseProductRelation = useResource<
+  CourseProductRelation,
+  CourseProductRelationQueryFilters
+>(props);

--- a/src/frontend/js/hooks/useCourseProductUnion/index.spec.tsx
+++ b/src/frontend/js/hooks/useCourseProductUnion/index.spec.tsx
@@ -101,12 +101,9 @@ describe('useCourseProductUnion', () => {
   it('should call organization courses and organization coursesProductRelation endpoints', async () => {
     const organizationId = 'DUMMY_ORGANIZATION_ID';
     const ROUTES = getRoutes();
-    const organizationCoursesUrl = ROUTES.user.organizations.courses.get.replace(
-      ':id',
-      organizationId,
-    );
+    const organizationCoursesUrl = ROUTES.organizations.courses.get.replace(':id', organizationId);
     const organizationCourseProductRelationsUrl =
-      ROUTES.user.organizations.courseProductRelations.get.replace(':id', organizationId);
+      ROUTES.organizations.courseProductRelations.get.replace(':id', organizationId);
     fetchMock.get(
       `${organizationCoursesUrl}?has_listed_course_runs=true&page=1&page_size=${PER_PAGE}`,
       mockPaginatedResponse(courseList.slice(0, PER_PAGE), 0, false),

--- a/src/frontend/js/hooks/useCourseProductUnion/index.spec.tsx
+++ b/src/frontend/js/hooks/useCourseProductUnion/index.spec.tsx
@@ -101,9 +101,12 @@ describe('useCourseProductUnion', () => {
   it('should call organization courses and organization coursesProductRelation endpoints', async () => {
     const organizationId = 'DUMMY_ORGANIZATION_ID';
     const ROUTES = getRoutes();
-    const organizationCoursesUrl = ROUTES.organizations.courses.get.replace(':id', organizationId);
-    const organizationCourseProductRelationsUrl =
-      ROUTES.organizations.courseProductRelations.get.replace(':id', organizationId);
+    const organizationCoursesUrl = ROUTES.organizations.courses.get
+      .replace(':organization_id', organizationId)
+      .replace(':id/', '');
+    const organizationCourseProductRelationsUrl = ROUTES.organizations.courseProductRelations.get
+      .replace(':organization_id', organizationId)
+      .replace(':id/', '');
     fetchMock.get(
       `${organizationCoursesUrl}?has_listed_course_runs=true&page=1&page_size=${PER_PAGE}`,
       mockPaginatedResponse(courseList.slice(0, PER_PAGE), 0, false),

--- a/src/frontend/js/hooks/useCourseProducts.ts
+++ b/src/frontend/js/hooks/useCourseProducts.ts
@@ -1,5 +1,5 @@
 import { defineMessages } from 'react-intl';
-import { API, CourseProductQueryFilters, CourseProductRelation } from 'types/Joanie';
+import { API, CourseProductQueryFilters, CourseProductRelation, Product } from 'types/Joanie';
 import { QueryOptions, useResourcesCustom, UseResourcesProps } from 'hooks/useResources';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
 
@@ -30,14 +30,14 @@ const props: UseResourcesProps<
 };
 
 export const useCourseProduct = (
-  id: CourseProductQueryFilters['id'],
-  filters: Omit<CourseProductQueryFilters, 'id'>,
+  filters: Omit<CourseProductQueryFilters, 'id'> & { product_id: Product['id'] },
   queryOptions?: QueryOptions<CourseProductRelation>,
 ) => {
-  const enabled = !!id && !!filters.productId;
+  const { product_id: productId, ...queryfilters } = filters;
+  const enabled = !!productId && !!queryfilters.course_id;
   const resources = useResourcesCustom<CourseProductRelation, CourseProductQueryFilters>({
     ...props,
-    filters: { id, ...filters },
+    filters: { id: productId, ...queryfilters },
     queryOptions: { ...queryOptions, enabled },
   });
   const { items, ...subRes } = resources;

--- a/src/frontend/js/hooks/useCourses/index.ts
+++ b/src/frontend/js/hooks/useCourses/index.ts
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
-import { API, CourseListItem, PaginatedResourceQuery } from 'types/Joanie';
+import { API, CourseListItem, CourseQueryFilters } from 'types/Joanie';
 import { useResource, useResources, UseResourcesProps } from 'hooks/useResources';
 
 const messages = defineMessages({
@@ -20,12 +20,12 @@ const messages = defineMessages({
  * Joanie Api hook to retrieve course
  * owned by the authenticated user.
  */
-const props: UseResourcesProps<CourseListItem, PaginatedResourceQuery, API['courses']> = {
+const props: UseResourcesProps<CourseListItem, CourseQueryFilters, API['courses']> = {
   queryKey: ['courses'],
   apiInterface: () => useJoanieApi().courses,
   session: true,
   messages,
 };
 
-export const useCourses = useResources(props);
-export const useCourse = useResource<CourseListItem>(props);
+export const useCourses = useResources<CourseListItem, CourseQueryFilters>(props);
+export const useCourse = useResource<CourseListItem, CourseQueryFilters>(props);

--- a/src/frontend/js/hooks/useOrganizations/index.ts
+++ b/src/frontend/js/hooks/useOrganizations/index.ts
@@ -23,7 +23,7 @@ const messages = defineMessages({
  */
 const props: UseResourcesProps<Organization> = {
   queryKey: ['organizations'],
-  apiInterface: () => useJoanieApi().user.organizations,
+  apiInterface: () => useJoanieApi().organizations,
   session: true,
   messages,
 };

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -141,12 +141,12 @@ describe('<DashboardCourses/>', () => {
   it('renders an empty placeholder', async () => {
     const ordersDeferred = new Deferred();
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}&product_type=credential&state_exclude=canceled`,
+      `https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=1&page_size=${perPage}`,
       ordersDeferred.promise,
     );
     const enrollmentsDeferred = new Deferred();
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/enrollments/?page=1&page_size=${perPage}&was_created_by_order=false`,
+      `https://joanie.endpoint/api/v1.0/enrollments/?was_created_by_order=false&page=1&page_size=${perPage}`,
       enrollmentsDeferred.promise,
     );
 
@@ -180,25 +180,25 @@ describe('<DashboardCourses/>', () => {
       client,
     );
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}&product_type=credential&state_exclude=canceled`,
+      `https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=1&page_size=${perPage}`,
       {
         results: orders.slice(0, perPage),
-        next: `https://joanie.endpoint/api/v1.0/orders/?page=2&page_size=${perPage}&product_type=credentia&state_exclude=canceledl`,
+        next: `https://joanie.endpoint/api/v1.0/orders/?product_type=credentia&state_exclude=canceled&page=2&page_size=${perPage}`,
         previous: null,
         count: orders.length,
       },
     );
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?page=2&page_size=${perPage}&product_type=credential&state_exclude=canceled`,
+      `https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=2&page_size=${perPage}`,
       {
         results: orders.slice(perPage, perPage * 2),
-        next: `https://joanie.endpoint/api/v1.0/orders/?page=3&page_size=${perPage}&product_type=credential&state_exclude=canceled`,
+        next: `https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=3&page_size=${perPage}`,
         previous: null,
         count: orders.length,
       },
     );
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?page=3&page_size=${perPage}&product_type=credential&state_exclude=canceled`,
+      `https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=3&page_size=${perPage}`,
       {
         results: orders.slice(perPage * 2, perPage * 3),
         next: null,
@@ -214,25 +214,25 @@ describe('<DashboardCourses/>', () => {
     });
 
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/enrollments/?page=1&page_size=${perPage}&was_created_by_order=false`,
+      `https://joanie.endpoint/api/v1.0/enrollments/?was_created_by_order=false&page=1&page_size=${perPage}`,
       {
         results: enrollments.slice(0, perPage),
-        next: `https://joanie.endpoint/api/v1.0/enrollments/?page=2&page_size=${perPage}&was_created_by_order=false`,
+        next: `https://joanie.endpoint/api/v1.0/enrollments/?was_created_by_order=false&page=2&page_size=${perPage}`,
         previous: null,
         count: enrollments.length,
       },
     );
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/enrollments/?page=2&page_size=${perPage}&was_created_by_order=false`,
+      `https://joanie.endpoint/api/v1.0/enrollments/?was_created_by_order=false&page=2&page_size=${perPage}`,
       {
         results: enrollments.slice(perPage, perPage * 2),
-        next: `https://joanie.endpoint/api/v1.0/enrollments/?page=3&page_size=${perPage}&was_created_by_order=false`,
+        next: `https://joanie.endpoint/api/v1.0/enrollments/?was_created_by_order=false&page=3&page_size=${perPage}`,
         previous: null,
         count: enrollments.length,
       },
     );
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/enrollments/?page=3&page_size=${perPage}&was_created_by_order=false`,
+      `https://joanie.endpoint/api/v1.0/enrollments/?was_created_by_order=false&page=3&page_size=${perPage}`,
       {
         results: enrollments.slice(perPage * 2, perPage * 3),
         next: null,
@@ -270,11 +270,11 @@ describe('<DashboardCourses/>', () => {
     jest.spyOn(console, 'error').mockImplementation(noop);
     const ordersDeferred = new Deferred();
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=${perPage}&product_type=credential&state_exclude=canceled`,
+      `https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=1&page_size=${perPage}`,
       ordersDeferred.promise,
     );
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/enrollments/?page=1&page_size=${perPage}&was_created_by_order=false`,
+      `https://joanie.endpoint/api/v1.0/enrollments/?was_created_by_order=false&page=1&page_size=${perPage}`,
       { results: [], next: null, previous: null, count: 0 },
     );
 

--- a/src/frontend/js/pages/DashboardOrderLayout/index.tsx
+++ b/src/frontend/js/pages/DashboardOrderLayout/index.tsx
@@ -17,7 +17,10 @@ export const DashboardOrderLayout = () => {
   const params = useParams<{ orderId: string }>();
   const order = useOmniscientOrder(params.orderId);
   const course = order.item?.course as CourseLight;
-  const courseProduct = useCourseProduct(course?.code, { productId: order.item?.product_id });
+  const courseProduct = useCourseProduct({
+    product_id: order.item?.product_id,
+    course_id: course?.code,
+  });
   const product = courseProduct?.item?.product;
   const intl = useIntl();
   const getRoutePath = getDashboardRoutePath(intl);

--- a/src/frontend/js/pages/TeacherDashboardCourseLoader/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardCourseLoader/index.tsx
@@ -33,15 +33,16 @@ const messages = defineMessages({
 
 export const TeacherDashboardCourseLoader = () => {
   const intl = useIntl();
-  const { courseId } = useParams<{
+  const { courseId, organizationId } = useParams<{
     courseId?: string;
+    organizationId?: string;
     courseCodeAndProductId?: string;
   }>();
 
   const {
     item: course,
     states: { fetching: fetchingCourse },
-  } = useCourse(courseId);
+  } = useCourse(courseId, { organization_id: organizationId });
   const {
     items: courseRuns,
     states: { fetching: fetchingCourseRuns },

--- a/src/frontend/js/pages/TeacherDashboardTraining/TeacherDashboardTrainingLoader.tsx
+++ b/src/frontend/js/pages/TeacherDashboardTraining/TeacherDashboardTrainingLoader.tsx
@@ -22,14 +22,15 @@ const messages = defineMessages({
 });
 
 export const TeacherDashboardTrainingLoader = () => {
-  const { courseProductRelationId } = useParams<{
+  const { courseProductRelationId, organizationId } = useParams<{
     courseProductRelationId: string;
+    organizationId?: string;
   }>();
 
   const {
     item: courseProductRelation,
     states: { fetching },
-  } = useCourseProductRelation(courseProductRelationId);
+  } = useCourseProductRelation(courseProductRelationId, { organization_id: organizationId });
   useBreadcrumbsPlaceholders({
     courseTitle: courseProductRelation?.product.title ?? '',
   });

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -488,11 +488,6 @@ interface APIUser {
     create(id: string): Promise<CourseWish>;
     delete(id: string): Promise<void>;
   };
-  organizations: {
-    get<Filters extends ResourcesQuery = ResourcesQuery>(
-      filters?: Filters,
-    ): Filters extends { id: string } ? Promise<Nullable<Organization>> : Promise<Organization[]>;
-  };
   contracts: {
     get(
       filters?: ContractFilters,
@@ -514,6 +509,11 @@ export interface API {
     products: {
       get(filters?: CourseProductQueryFilters): Promise<Nullable<CourseProductRelation>>;
     };
+  };
+  organizations: {
+    get<Filters extends ResourcesQuery = ResourcesQuery>(
+      filters?: Filters,
+    ): Filters extends { id: string } ? Promise<Nullable<Organization>> : Promise<Organization[]>;
   };
   courseRuns: {
     get(

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -404,6 +404,7 @@ export interface CourseRunFilters extends ResourcesQuery {
 }
 
 export interface CourseQueryFilters extends ResourcesQuery {
+  id?: CourseListItem['id'];
   organization_id?: Organization['id'];
   has_listed_course_runs?: Boolean;
 }
@@ -411,6 +412,7 @@ export interface CourseProductQueryFilters extends ResourcesQuery {
   productId?: Product['id'];
 }
 export interface CourseProductRelationQueryFilters extends ResourcesQuery {
+  id?: CourseProductRelation['id'];
   organization_id?: Organization['id'];
 }
 export interface ContractFilters extends PaginatedResourceQuery {

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -409,7 +409,8 @@ export interface CourseQueryFilters extends ResourcesQuery {
   has_listed_course_runs?: Boolean;
 }
 export interface CourseProductQueryFilters extends ResourcesQuery {
-  productId?: Product['id'];
+  id?: Product['id'];
+  course_id?: CourseListItem['id'];
 }
 export interface CourseProductRelationQueryFilters extends ResourcesQuery {
   id?: CourseProductRelation['id'];

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -412,7 +412,7 @@ export interface CourseProductQueryFilters extends ResourcesQuery {
   id?: Product['id'];
   course_id?: CourseListItem['id'];
 }
-export interface CourseProductRelationQueryFilters extends ResourcesQuery {
+export interface CourseProductRelationQueryFilters extends PaginatedResourceQuery {
   id?: CourseProductRelation['id'];
   organization_id?: Organization['id'];
 }

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -83,7 +83,7 @@ export const DashboardItemOrder = ({
   const {
     item: courseProductRelation,
     states: { isFetched: isCourseProductRelationFetched },
-  } = useCourseProduct(course.code, { productId: order.product_id });
+  } = useCourseProduct({ product_id: order.product_id, course_id: course.code });
   const { product } = courseProductRelation || {};
   const needsSignature = orderNeedsSignature(order, product);
   const getRoutePath = getDashboardRoutePath(useIntl());

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.useUnionResource.cache.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.useUnionResource.cache.spec.tsx
@@ -93,8 +93,9 @@ describe('<DashboardItemOrder/> Contract', () => {
         previous: null,
         count: null,
       });
+
       fetchMock.get(
-        'https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=50&product_type=credential&state_exclude=canceled',
+        'https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=1&page_size=50',
         { results: [order], next: null, previous: null, count: null },
       );
 
@@ -269,7 +270,7 @@ describe('<DashboardItemOrder/> Contract', () => {
 
       // Go back to the list view to make sure the sign button is not shown anymore.
       fetchMock.get(
-        'https://joanie.endpoint/api/v1.0/orders/?page=1&page_size=50&product_type=credential&state_exclude=canceled',
+        'https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=1&page_size=50',
         { results: [signedOrder], next: null, previous: null, count: null },
         { overwriteRoutes: true },
       );

--- a/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
@@ -37,7 +37,7 @@ export const DashboardOrderLoader = () => {
   const {
     item: courseProduct,
     states: { fetching: fetchingCourseProduct, error: errorCourseProduct },
-  } = useCourseProduct(order?.course?.code, { productId: order?.product_id });
+  } = useCourseProduct({ course_id: order?.course?.code, product_id: order?.product_id });
   const intl = useIntl();
 
   const credentialOrder = order && isCredentialOrder(order) ? order : undefined;

--- a/src/frontend/js/widgets/Dashboard/components/TeacherDashboardCourseSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherDashboardCourseSidebar/index.tsx
@@ -57,7 +57,7 @@ export const TeacherDashboardCourseSidebar = () => {
   const {
     item: courseProductRelation,
     states: { fetching: courseProductRelationFetching },
-  } = useCourseProductRelation(courseProductRelationId);
+  } = useCourseProductRelation(courseProductRelationId, { organization_id: organizationId });
   const fetching = useMemo(
     () => courseFetching || courseProductRelationFetching,
     [courseFetching, courseProductRelationFetching],

--- a/src/frontend/js/widgets/Dashboard/components/TeacherDashboardCourseSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherDashboardCourseSidebar/index.tsx
@@ -53,7 +53,7 @@ export const TeacherDashboardCourseSidebar = () => {
   const {
     item: singleCourse,
     states: { fetching: courseFetching },
-  } = useCourse(courseId!);
+  } = useCourse(courseId, { organization_id: organizationId });
   const {
     item: courseProductRelation,
     states: { fetching: courseProductRelationFetching },

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
@@ -160,12 +160,10 @@ const Content = ({ product, order }: { product: Product; order?: CredentialOrder
 const CourseProductItem = ({ productId, course, compact = false }: CourseProductItemProps) => {
   // FIXME(rlecellier): useCourseProduct need's a filter on product.type that only return
   // CredentialOrder
-  const { item: courseProductRelation, states: productQueryStates } = useCourseProduct(
-    course.code,
-    {
-      productId,
-    },
-  );
+  const { item: courseProductRelation, states: productQueryStates } = useCourseProduct({
+    product_id: productId,
+    course_id: course.code,
+  });
   const product = courseProductRelation?.product;
   const { item: productOrder, states: orderQueryStates } = useProductOrder({
     productId,


### PR DESCRIPTION
## Purpose

Currently an error can occured when a user can access to a course from its organization access but it does not course/training accesses on this course. Indeed, the user will be able to access to the course/training detail page but the api will return a 404... 

To work properly, in the context of an organization, course/training information should be fetched from the nested organization endpoints.

| Before | After |
|--------|-------|
|<img width="1100" alt="Capture d’écran 2023-12-14 à 16 23 19" src="https://github.com/openfun/richie/assets/9265241/1f70165a-abbd-4642-ac3b-9711c6ec2844">|<img width="1100" alt="Capture d’écran 2023-12-14 à 16 22 51" src="https://github.com/openfun/richie/assets/9265241/72152ed5-a941-4cd2-8b53-ccddd8737c7c">|
|<img width="1100" alt="Capture d’écran 2023-12-14 à 16 23 19" src="https://github.com/openfun/richie/assets/9265241/1f70165a-abbd-4642-ac3b-9711c6ec2844">|<img width="1100" alt="Capture d’écran 2023-12-14 à 16 22 33" src="https://github.com/openfun/richie/assets/9265241/d327d0c8-f525-4eee-98a8-48c46ce87852">|
## Proposal

- [x] Improve buildAPIUrl method to support several url string params
- [x] Fetch course and course product relations from nested organizations or root endpoint according to teacher dashboard context.
