### PR TITLE
🩹(frontend) clean billing address before order submit

### DIFF
--- a/src/frontend/js/components/PaymentButton/index.spec.tsx
+++ b/src/frontend/js/components/PaymentButton/index.spec.tsx
@@ -41,6 +41,7 @@ import {
   SaleTunnelCredentialContext,
   SaleTunnelCertificateContext,
 } from 'components/SaleTunnel/context';
+import { ObjectHelper } from 'utils/ObjectHelper';
 import PaymentButton from '.';
 
 jest.mock('utils/context', () => ({
@@ -496,7 +497,7 @@ describe.each([
         .find((call) => call[0] === `https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
       expect(submitCall).not.toBeUndefined();
       expect(JSON.parse(submitCall![1]!.body as string)).toEqual({
-        billing_address: billingAddress,
+        billing_address: ObjectHelper.omit(billingAddress, 'id', 'is_main'),
         credit_card_id: creditCard.id,
       });
       expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/`);
@@ -622,7 +623,7 @@ describe.each([
 
       expect(onClickApiCalls[0][0]).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
       expect(JSON.parse(onClickApiCalls[0][1]!.body as string)).toEqual({
-        billing_address: billingAddress,
+        billing_address: ObjectHelper.omit(billingAddress, 'id', 'is_main'),
         credit_card_id: creditCard.id,
       });
 
@@ -728,7 +729,7 @@ describe.each([
 
       expect(fetchMock.lastUrl()).toBe(`https://joanie.test/api/v1.0/orders/${order.id}/submit/`);
       expect(JSON.parse(fetchMock.lastOptions()!.body!.toString())).toEqual({
-        billing_address: billingAddress,
+        billing_address: ObjectHelper.omit(billingAddress, 'id', 'is_main'),
       });
 
       // - Spinner should be displayed and payment button should be disabled

--- a/src/frontend/js/components/PaymentButton/index.tsx
+++ b/src/frontend/js/components/PaymentButton/index.tsx
@@ -14,6 +14,7 @@ import { CourseProductEvent } from 'types/web-analytics';
 import useProductOrder from 'hooks/useProductOrder';
 import { useTerms } from 'components/PaymentButton/hooks/useTerms';
 import { useSaleTunnelContext } from 'components/SaleTunnel/context';
+import { ObjectHelper } from 'utils/ObjectHelper';
 import PaymentInterface from './components/PaymentInterfaces';
 
 const messages = defineMessages({
@@ -153,10 +154,12 @@ const PaymentButton = ({ billingAddress, creditCard, onSuccess }: PaymentButtonP
       let paymentInfos = payment;
 
       if (!paymentInfos) {
+        const billingAddressPayload = ObjectHelper.omit(billingAddress!, 'id', 'is_main');
+
         orderManager.methods.submit(
           {
             id: orderId,
-            billing_address: billingAddress!,
+            billing_address: billingAddressPayload,
             ...(creditCard && { credit_card_id: creditCard }),
           },
           {

--- a/src/frontend/js/utils/ObjectHelper/index.spec.ts
+++ b/src/frontend/js/utils/ObjectHelper/index.spec.ts
@@ -1,19 +1,27 @@
 import { ObjectHelper } from 'utils/ObjectHelper/index';
 
 describe('ObjectHelper', () => {
-  it('should return true if object is empty', () => {
-    expect(ObjectHelper.isEmpty({})).toBe(true);
+  describe('isEmpty', () => {
+    it('should return true if object is empty', () => {
+      expect(ObjectHelper.isEmpty({})).toBe(true);
+    });
+
+    it('should return false if object is not empty', () => {
+      expect(ObjectHelper.isEmpty({ foo: 'bar' })).toBe(false);
+    });
+
+    it('should return true if array is empty', () => {
+      expect(ObjectHelper.isEmpty([])).toBe(true);
+    });
+
+    it('should return true if array is not empty', () => {
+      expect(ObjectHelper.isEmpty(['foo'])).toBe(false);
+    });
   });
 
-  it('should return false if object is not empty', () => {
-    expect(ObjectHelper.isEmpty({ foo: 'bar' })).toBe(false);
-  });
-
-  it('should return true if array is empty', () => {
-    expect(ObjectHelper.isEmpty([])).toBe(true);
-  });
-
-  it('should return true if array is not empty', () => {
-    expect(ObjectHelper.isEmpty(['foo'])).toBe(false);
+  describe('omit', () => {
+    it('should return an object without the given keys', () => {
+      expect(ObjectHelper.omit({ foo: 1, bar: 2, baz: 3 }, 'foo', 'baz')).toEqual({ bar: 2 });
+    });
   });
 });

--- a/src/frontend/js/utils/ObjectHelper/index.ts
+++ b/src/frontend/js/utils/ObjectHelper/index.ts
@@ -2,4 +2,13 @@ export class ObjectHelper {
   static isEmpty(obj: object): boolean {
     return !Object.entries(obj).length;
   }
+
+  static omit<Obj, Keys extends Array<keyof Obj>>(
+    obj: Obj,
+    ...keys: Keys
+  ): Omit<Obj, (typeof keys)[number]> {
+    const cleanedObject = { ...obj };
+    keys.forEach((key) => delete cleanedObject[key]);
+    return cleanedObject;
+  }
 }


### PR DESCRIPTION
## Purpose

It appears there was a typing issue that lead to pass a wrong payload. This could break payment logic when working the dummy payment backend. Indeed, the billing address should not contain id and is_main fields but currently the address was not cleaned up before putting it in the payload. We now use the new `ObjectHelper.omit` utils to remove id and is_main fields from the selected address.


## Proposal

- [x] Remove `id` and `is_main` properties from address before passing it to `order.submit`