### PR TITLE
✨(frontend) add ContractHelper to compute state

### DIFF
--- a/src/frontend/js/components/ContractStatus/index.tsx
+++ b/src/frontend/js/components/ContractStatus/index.tsx
@@ -1,6 +1,7 @@
 import { FormattedMessage, defineMessages } from 'react-intl';
 import useDateFormat from 'hooks/useDateFormat';
-import { Contract } from 'types/Joanie';
+import { Contract, ContractState } from 'types/Joanie';
+import { ContractHelper } from 'utils/ContractHelper';
 
 const messages = defineMessages({
   signedOn: {
@@ -19,13 +20,18 @@ export interface ContractStatusProps {
   contract?: Contract;
 }
 const ContractStatus = ({ contract }: ContractStatusProps) => {
-  const { student_signed_on: signedOn } = contract || {};
+  const state = ContractHelper.getState(contract);
   const formatDate = useDateFormat();
 
-  return signedOn ? (
-    <FormattedMessage {...messages.signedOn} values={{ date: formatDate(signedOn) }} />
-  ) : (
-    <FormattedMessage {...messages.waitingSignature} />
+  if (!state || state === ContractState.UNSIGNED) {
+    return <FormattedMessage {...messages.waitingSignature} />;
+  }
+
+  return (
+    <FormattedMessage
+      {...messages.signedOn}
+      values={{ date: formatDate(contract!.student_signed_on!) }}
+    />
   );
 };
 

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -416,6 +416,12 @@ export interface CourseProductRelationQueryFilters extends PaginatedResourceQuer
   id?: CourseProductRelation['id'];
   organization_id?: Organization['id'];
 }
+
+export enum ContractState {
+  UNSIGNED = 'unsigned',
+  LEARNER_SIGNED = 'half_signed',
+  SIGNED = 'signed',
+}
 export interface ContractFilters extends PaginatedResourceQuery {
   organization_id?: Organization['id'];
   course_id?: CourseListItem['id'];

--- a/src/frontend/js/utils/ContractHelper/index.spec.ts
+++ b/src/frontend/js/utils/ContractHelper/index.spec.ts
@@ -1,0 +1,72 @@
+import { createIntl } from 'react-intl';
+import { ContractFactory } from 'utils/test/factories/joanie';
+import { ContractState } from 'types/Joanie';
+import { ContractHelper, ContractStatePoV } from '.';
+
+const unsignedContractFactory = ContractFactory({
+  student_signed_on: undefined,
+  organization_signed_on: undefined,
+});
+const halfSignedContractFactory = ContractFactory({
+  student_signed_on: Date.toString(),
+  organization_signed_on: undefined,
+});
+const signedContractFactory = ContractFactory({
+  student_signed_on: Date.toString(),
+  organization_signed_on: Date.toString(),
+});
+
+describe('ContractHelper', () => {
+  describe('getState', () => {
+    it.each([
+      [undefined, null],
+      [unsignedContractFactory.one(), ContractState.UNSIGNED],
+      [halfSignedContractFactory.one(), ContractState.LEARNER_SIGNED],
+      [signedContractFactory.one(), ContractState.SIGNED],
+    ])('should return the correct state', (contract, state) => {
+      expect(ContractHelper.getState(contract)).toEqual(state);
+    });
+  });
+
+  describe('getStateLabel', () => {
+    const intl = createIntl({ locale: 'en' });
+
+    it.each([
+      [ContractStatePoV.LEARNER, ContractState.UNSIGNED, 'Pending for signature'],
+      [
+        ContractStatePoV.LEARNER,
+        ContractState.LEARNER_SIGNED,
+        'Pending for organization signature',
+      ],
+      [ContractStatePoV.LEARNER, ContractState.SIGNED, 'Signed'],
+      [ContractStatePoV.ORGANIZATION, ContractState.UNSIGNED, 'Pending for learner signature'],
+      [ContractStatePoV.ORGANIZATION, ContractState.LEARNER_SIGNED, 'Pending for signature'],
+      [ContractStatePoV.ORGANIZATION, ContractState.SIGNED, 'Signed'],
+    ])('should return the correct state', (pov, state, label) => {
+      expect(ContractHelper.getStateLabel(state, pov, intl)).toEqual(label);
+    });
+  });
+
+  describe('getHumanReadableState', () => {
+    const intl = createIntl({ locale: 'en' });
+
+    it.each([
+      [ContractStatePoV.LEARNER, unsignedContractFactory.one(), 'Pending for signature'],
+      [
+        ContractStatePoV.LEARNER,
+        halfSignedContractFactory.one(),
+        'Pending for organization signature',
+      ],
+      [ContractStatePoV.LEARNER, signedContractFactory.one(), 'Signed'],
+      [
+        ContractStatePoV.ORGANIZATION,
+        unsignedContractFactory.one(),
+        'Pending for learner signature',
+      ],
+      [ContractStatePoV.ORGANIZATION, halfSignedContractFactory.one(), 'Pending for signature'],
+      [ContractStatePoV.ORGANIZATION, signedContractFactory.one(), 'Signed'],
+    ])('should return the correct state', (pov, contract, label) => {
+      expect(ContractHelper.getHumanReadableState(contract, pov, intl)).toEqual(label);
+    });
+  });
+});

--- a/src/frontend/js/utils/ContractHelper/index.ts
+++ b/src/frontend/js/utils/ContractHelper/index.ts
@@ -1,0 +1,77 @@
+import { defineMessages, IntlShape } from 'react-intl';
+import { Contract, ContractState } from 'types/Joanie';
+import { StringHelper } from 'utils/StringHelper';
+import { Maybe, Nullable } from 'types/utils';
+
+const messages = defineMessages({
+  organizationUnsigned: {
+    id: 'utils.ContractHelper.organizationUnsigned',
+    description: 'Label for unsigned contract status in organization point of view',
+    defaultMessage: 'Pending for learner signature',
+  },
+  organizationHalfSigned: {
+    id: 'utils.ContractHelper.organizationHalfSigned',
+    description: 'Label for half signed contract status in organization point of view',
+    defaultMessage: 'Pending for signature',
+  },
+  organizationSigned: {
+    id: 'utils.ContractHelper.organizationSigned',
+    description: 'Label for signed contract status in organization point of view',
+    defaultMessage: 'Signed',
+  },
+  learnerUnsigned: {
+    id: 'utils.ContractHelper.learnerUnsigned',
+    description: 'Label for unsigned contract status in learner point of view',
+    defaultMessage: 'Pending for signature',
+  },
+  learnerHalfSigned: {
+    id: 'utils.ContractHelper.learnerHalfSigned',
+    description: 'Label for unsigned contract status in learner point of view',
+    defaultMessage: 'Pending for organization signature',
+  },
+  learnerSigned: {
+    id: 'utils.ContractHelper.learnerSigned',
+    description: 'Label for signed contract status in learner point of view',
+    defaultMessage: 'Signed',
+  },
+});
+
+export enum ContractStatePoV {
+  LEARNER = 'learner',
+  ORGANIZATION = 'organization',
+}
+
+export class ContractHelper {
+  static getState(contract: null | undefined): null;
+  static getState(contract: Contract): ContractState;
+  static getState(contract: Maybe<Contract>): Nullable<ContractState>;
+  static getState(contract: Maybe<Nullable<Contract>>): Nullable<ContractState> {
+    if (!contract) return null;
+
+    if (contract.student_signed_on && contract.organization_signed_on) {
+      return ContractState.SIGNED;
+    }
+
+    if (contract?.student_signed_on) {
+      return ContractState.LEARNER_SIGNED;
+    }
+
+    return ContractState.UNSIGNED;
+  }
+
+  static getStateLabel(state: ContractState, pov: ContractStatePoV, intl: IntlShape) {
+    const camelCasedState = state
+      .toLowerCase()
+      .split('_')
+      .map(StringHelper.capitalizeFirst)
+      .join('');
+    const messageKey = `${pov}${camelCasedState}` as keyof typeof messages;
+    const message = messages[messageKey];
+
+    return intl.formatMessage(message);
+  }
+  static getHumanReadableState(contract: Contract, pov: ContractStatePoV, intl: IntlShape) {
+    const state = this.getState(contract);
+    return this.getStateLabel(state, pov, intl);
+  }
+}


### PR DESCRIPTION
## Purpose

A contract expects to be signed by both learner and organization, in some of our
 views we need to get the signature state. That's the purpose of this
 ContractHelper util. It is able to return the raw state or a human readable
 label. Furthermore, according to point of view of the user (learner or
 organization), label should be adapted.


## Proposal

- [x] Create a ContractHelper to easily get signature state.
- [x] Update ContractStatus to get state from the new ContractHelper
