### PR TITLE
✨(frontend) adapt contract status with organization_signed_on

### DIFF
--- a/src/frontend/js/components/ContractStatus/index.spec.tsx
+++ b/src/frontend/js/components/ContractStatus/index.spec.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+import { IntlProvider, createIntl } from 'react-intl';
+import { faker } from '@faker-js/faker';
+import { ContractFactory } from 'utils/test/factories/joanie';
+import { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
+import ContractStatus from '.';
+
+describe('<ContractStatus />', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return <IntlProvider locale="en">{children}</IntlProvider>;
+  };
+  it('should display status for unsigned contract', () => {
+    render(
+      <Wrapper>
+        <ContractStatus
+          contract={ContractFactory({
+            student_signed_on: null,
+            organization_signed_on: null,
+          }).one()}
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.queryByText('You have to sign this training contract to access your training.'),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText(/You signed this training contract/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/The organization have signed this training contract./),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'You cannot download your training contract until it had been signed by the organization.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display status for a contract signed by the studdent', () => {
+    const intl = createIntl({ locale: 'en' });
+    const studentSignedOn = faker.date.past().toISOString();
+    render(
+      <Wrapper>
+        <ContractStatus
+          contract={ContractFactory({
+            student_signed_on: studentSignedOn,
+            organization_signed_on: null,
+          }).one()}
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.queryByText(
+        `You signed this training contract. Signed on ${intl.formatDate(studentSignedOn, {
+          ...DEFAULT_DATE_FORMAT,
+        })}`,
+        { exact: false },
+      ),
+    ).toBeInTheDocument();
+    screen.debug();
+    expect(
+      screen.queryByText(
+        'You cannot download your training contract until it had been signed by the organization.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('You have to sign this training contract to access your training.'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/The organization have signed this training contract./),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display status for a contract signed by the studdent and the organization', () => {
+    const intl = createIntl({ locale: 'en' });
+    const studentSignedOn = faker.date.past().toISOString();
+    const organizationSignedOn = faker.date.past().toISOString();
+    render(
+      <Wrapper>
+        <ContractStatus
+          contract={ContractFactory({
+            student_signed_on: studentSignedOn,
+            organization_signed_on: organizationSignedOn,
+          }).one()}
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.queryByText(
+        `You signed this training contract. Signed on ${intl.formatDate(studentSignedOn, {
+          ...DEFAULT_DATE_FORMAT,
+        })}`,
+      ),
+    ).toBeInTheDocument();
+    // The organization have signed this training contract. Signed on {date}
+    expect(
+      screen.queryByText(
+        `The organization have signed this training contract. Signed on ${intl.formatDate(
+          organizationSignedOn,
+          {
+            ...DEFAULT_DATE_FORMAT,
+          },
+        )}`,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(
+        'You cannot download your training contract until it had been signed by the organization.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('You have to sign this training contract to access your training.'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/js/components/ContractStatus/index.tsx
+++ b/src/frontend/js/components/ContractStatus/index.tsx
@@ -4,15 +4,26 @@ import { Contract, ContractState } from 'types/Joanie';
 import { ContractHelper } from 'utils/ContractHelper';
 
 const messages = defineMessages({
-  signedOn: {
+  learnerSignedOn: {
     defaultMessage: 'You signed this training contract. Signed on {date}',
-    description: 'Label for the date of sign of a contract',
-    id: 'components.ContractStatus.signedOn',
+    description: 'Label for the date of sign of a training contract by the learner',
+    id: 'components.ContractStatus.learnerSignedOn',
   },
-  waitingSignature: {
+  organizationSignedOn: {
+    defaultMessage: 'The organization have signed this training contract. Signed on {date}',
+    description: 'Label for the date of sign of a training contract by the organization',
+    id: 'components.ContractStatus.organizationSignedOn',
+  },
+  waitingLearnerSignature: {
     defaultMessage: 'You have to sign this training contract to access your training.',
-    description: 'Label displayed when a contract need to be signed',
+    description: 'Label displayed when a training contract need to be signed by the learner',
     id: 'components.ContractStatus.waitingSignature',
+  },
+  waitingOrganization: {
+    defaultMessage:
+      'You cannot download your training contract until it had been signed by the organization.',
+    description: 'Label displayed when a training contract need to be signed by the organization',
+    id: 'components.ContractStatus.waitingOrganization',
   },
 });
 
@@ -20,18 +31,36 @@ export interface ContractStatusProps {
   contract?: Contract;
 }
 const ContractStatus = ({ contract }: ContractStatusProps) => {
+  const { student_signed_on: studentSignedOn, organization_signed_on: organizationSignedOn } =
+    contract || {};
   const state = ContractHelper.getState(contract);
   const formatDate = useDateFormat();
 
-  if (!state || state === ContractState.UNSIGNED) {
-    return <FormattedMessage {...messages.waitingSignature} />;
-  }
-
-  return (
-    <FormattedMessage
-      {...messages.signedOn}
-      values={{ date: formatDate(contract!.student_signed_on!) }}
-    />
+  return state === ContractState.UNSIGNED ? (
+    <FormattedMessage {...messages.waitingLearnerSignature} />
+  ) : (
+    <>
+      {[ContractState.SIGNED, ContractState.LEARNER_SIGNED].includes(state) && (
+        <div>
+          <FormattedMessage
+            {...messages.learnerSignedOn}
+            values={{ date: formatDate(studentSignedOn!) }}
+          />
+        </div>
+      )}
+      {state === ContractState.SIGNED ? (
+        <div>
+          <FormattedMessage
+            {...messages.organizationSignedOn}
+            values={{ date: formatDate(organizationSignedOn!) }}
+          />
+        </div>
+      ) : (
+        <div>
+          <FormattedMessage {...messages.waitingOrganization} />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/frontend/js/components/SignContractButton/index.omniscientOrders.spec.tsx
+++ b/src/frontend/js/components/SignContractButton/index.omniscientOrders.spec.tsx
@@ -56,7 +56,7 @@ describe('<SignContractButton/>', () => {
     fetchMock.restore();
   });
 
-  it('should switch sign button to download on contract sign', async () => {
+  it('should hide sign button on learner training contract sign', async () => {
     const ApiOrdersWrapper = () => {
       const { items: orders } = useOmniscientOrders();
       return (
@@ -135,7 +135,7 @@ describe('<SignContractButton/>', () => {
     await user.click($closeButton);
     expect(screen.queryByTestId('dashboard-contract-frame')).not.toBeInTheDocument();
 
-    expect(await screen.findByRole('button', { name: 'Download' })).toBeInTheDocument();
+    expect(await screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/js/components/SignContractButton/index.spec.tsx
+++ b/src/frontend/js/components/SignContractButton/index.spec.tsx
@@ -26,11 +26,11 @@ jest.mock('utils/context', () => ({
 
 enum TestCase {
   FROM_ORDER_WITH_CONTRACT = 'from order with a contract',
-  FROM_ORDER_WITHOUT = 'from order without a contract',
+  FROM_ORDER_WITHOUT_CONTRACT = 'from order without a contract',
   FROM_CONTRACT = 'from contract',
 }
 interface FromOrderTestData {
-  testCase: TestCase.FROM_ORDER_WITH_CONTRACT | TestCase.FROM_ORDER_WITHOUT;
+  testCase: TestCase.FROM_ORDER_WITH_CONTRACT | TestCase.FROM_ORDER_WITHOUT_CONTRACT;
   OrderFactory: typeof CredentialOrderFactory;
 }
 interface FromContractTestData {
@@ -38,108 +38,182 @@ interface FromContractTestData {
   OrderFactory: typeof NestedCredentialOrderFactory;
 }
 
-describe.each<FromOrderTestData | FromContractTestData>([
-  {
-    testCase: TestCase.FROM_ORDER_WITH_CONTRACT,
-    OrderFactory: CredentialOrderFactory,
-  },
-  {
-    testCase: TestCase.FROM_ORDER_WITHOUT,
-    OrderFactory: CredentialOrderFactory,
-  },
-  {
-    testCase: TestCase.FROM_CONTRACT,
-    OrderFactory: NestedCredentialOrderFactory,
-  },
-])('<SignContractButton/>, $testCase', ({ testCase, OrderFactory }) => {
-  let contract: undefined | Contract;
-  let order: CredentialOrder | NestedCredentialOrder;
-  const Wrapper = ({ children }: PropsWithChildren) => {
-    return (
-      <QueryClientProvider client={createTestQueryClient({ user: true })}>
-        <IntlProvider locale="en">
-          <JoanieApiProvider>
-            <MemoryRouter>{children}</MemoryRouter>
-          </JoanieApiProvider>
-        </IntlProvider>
-      </QueryClientProvider>
-    );
-  };
-
+describe('<SignContractButton/>', () => {
   beforeAll(() => {
     const modalExclude = document.createElement('div');
     modalExclude.setAttribute('id', 'modal-exclude');
     document.body.appendChild(modalExclude);
   });
 
-  describe('with training contract not signed by the learner', () => {
-    beforeEach(() => {
-      if (testCase === TestCase.FROM_CONTRACT) {
-        contract = ContractFactory({ student_signed_on: null }).one();
-        order = contract.order as NestedCredentialOrder;
-      } else {
-        const orderContract =
-          testCase === TestCase.FROM_ORDER_WITH_CONTRACT
-            ? ContractFactory({ student_signed_on: null }).one()
-            : undefined;
-        order = OrderFactory({ contract: orderContract }).one();
-        contract = order.contract;
-      }
-    });
-
-    it('should display a link to the contract when writable is set to false', () => {
-      render(
-        <Wrapper>
-          <SignContractButton order={order} contract={contract} writable={false} />
-        </Wrapper>,
+  describe.each<FromOrderTestData | FromContractTestData>([
+    {
+      testCase: TestCase.FROM_ORDER_WITH_CONTRACT,
+      OrderFactory: CredentialOrderFactory,
+    },
+    {
+      testCase: TestCase.FROM_ORDER_WITHOUT_CONTRACT,
+      OrderFactory: CredentialOrderFactory,
+    },
+    {
+      testCase: TestCase.FROM_CONTRACT,
+      OrderFactory: NestedCredentialOrderFactory,
+    },
+  ])('$testCase', ({ testCase, OrderFactory }) => {
+    let contract: undefined | Contract;
+    let order: CredentialOrder | NestedCredentialOrder;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      return (
+        <QueryClientProvider client={createTestQueryClient({ user: true })}>
+          <IntlProvider locale="en">
+            <JoanieApiProvider>
+              <MemoryRouter>{children}</MemoryRouter>
+            </JoanieApiProvider>
+          </IntlProvider>
+        </QueryClientProvider>
       );
-      expect(screen.getByRole('link', { name: 'Sign' })).toBeInTheDocument();
+    };
+
+    describe('with training contract not signed by the learner', () => {
+      beforeEach(() => {
+        if (testCase === TestCase.FROM_CONTRACT) {
+          contract = ContractFactory({ student_signed_on: null }).one();
+          order = contract.order as NestedCredentialOrder;
+        } else {
+          const orderContract =
+            testCase === TestCase.FROM_ORDER_WITH_CONTRACT
+              ? ContractFactory({ student_signed_on: null }).one()
+              : undefined;
+          order = OrderFactory({ contract: orderContract }).one();
+          contract = order.contract;
+        }
+      });
+
+      it('should display a link to the training contract when writable is set to false', () => {
+        render(
+          <Wrapper>
+            <SignContractButton order={order} contract={contract} writable={false} />
+          </Wrapper>,
+        );
+        expect(screen.getByRole('link', { name: 'Sign' })).toBeInTheDocument();
+
+        expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+        expect(document.querySelector('div.ReactModalPortal')).not.toBeInTheDocument();
+      });
+
+      it('should display a button that open ContractFrame modal', async () => {
+        render(
+          <Wrapper>
+            <SignContractButton order={order} contract={contract} writable={true} />
+          </Wrapper>,
+        );
+        const $signButton = screen.queryByRole('button', { name: 'Sign' });
+        expect($signButton).toBeInTheDocument();
+        expect(document.querySelector('div.ReactModalPortal')).toBeInTheDocument();
+
+        expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Sign' })).not.toBeInTheDocument();
+
+        const user = userEvent.setup();
+        await user.click($signButton!);
+
+        expect(screen.getByTestId('dashboard-contract-frame')).toBeInTheDocument();
+      });
     });
 
-    it("should display a button that open ContractFrame modal when given contract isn't signed", async () => {
-      render(
-        <Wrapper>
-          <SignContractButton order={order} contract={contract} writable={true} />
-        </Wrapper>,
-      );
-      const $signButton = screen.queryByRole('button', { name: 'Sign' });
-      expect($signButton).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+    describe('with training contract signed by the learner', () => {
+      beforeEach(() => {
+        if (testCase === TestCase.FROM_CONTRACT) {
+          contract = ContractFactory({ student_signed_on: faker.date.past().toISOString() }).one();
+          order = contract.order as NestedCredentialOrder;
+        } else {
+          order = OrderFactory({
+            contract: ContractFactory({ student_signed_on: faker.date.past().toISOString() }).one(),
+          }).one();
+          contract = order.contract;
+        }
+      });
 
-      const user = userEvent.setup();
-      await user.click($signButton!);
+      it('should display render the sign training contract modal portal when writable is set to false', () => {
+        render(
+          <Wrapper>
+            <SignContractButton order={order} contract={contract} writable={false} />
+          </Wrapper>,
+        );
+        expect(document.querySelector('div.ReactModalPortal')).toBeInTheDocument();
 
-      expect(screen.getByTestId('dashboard-contract-frame')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Sign' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+      });
+
+      it('should neither display sign or download buttons, but ContractFrame should render', async () => {
+        if (testCase === TestCase.FROM_ORDER_WITHOUT_CONTRACT) {
+          // order without contract cannot have a signed contract
+          return;
+        }
+
+        render(
+          <Wrapper>
+            <SignContractButton order={order} contract={contract} writable={true} />
+          </Wrapper>,
+        );
+
+        expect(document.querySelector('div.ReactModalPortal')).toBeInTheDocument();
+
+        expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Sign' })).not.toBeInTheDocument();
+      });
     });
-  });
 
-  describe('with training contract signed by the learner', () => {
-    beforeEach(() => {
-      if (testCase === TestCase.FROM_CONTRACT) {
-        contract = ContractFactory({ student_signed_on: faker.date.past().toISOString() }).one();
-        order = contract.order as NestedCredentialOrder;
-      } else {
-        order = OrderFactory({
-          contract: ContractFactory({ student_signed_on: faker.date.past().toISOString() }).one(),
+    describe('with training contract signed by the learner and by organization', () => {
+      beforeEach(() => {
+        contract = ContractFactory({
+          student_signed_on: faker.date.past().toISOString(),
+          organization_signed_on: faker.date.past().toISOString(),
         }).one();
-        contract = order.contract;
-      }
-    });
+        if (testCase === TestCase.FROM_CONTRACT) {
+          order = contract.order as NestedCredentialOrder;
+        } else {
+          order = OrderFactory({
+            contract,
+          }).one();
+          contract = order.contract;
+        }
+      });
 
-    it('should display a button to download contract when given contract is signed', async () => {
-      if (testCase === TestCase.FROM_ORDER_WITHOUT) {
-        // order without contract cannot have a signed contract
-        return;
-      }
+      it('should display a download button when writable is set to false', () => {
+        render(
+          <Wrapper>
+            <SignContractButton order={order} contract={contract} writable={false} />
+          </Wrapper>,
+        );
+        expect(screen.queryByRole('button', { name: 'Download' })).toBeInTheDocument();
+        expect(document.querySelector('div.ReactModalPortal')).toBeInTheDocument();
 
-      render(
-        <Wrapper>
-          <SignContractButton order={order} contract={contract} writable={true} />
-        </Wrapper>,
-      );
+        expect(screen.queryByRole('link', { name: 'Sign' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+      });
 
-      expect(screen.queryByRole('button', { name: 'Download' })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+      it('should display a button to download the training contract', async () => {
+        if (testCase === TestCase.FROM_ORDER_WITHOUT_CONTRACT) {
+          // order without contract cannot have a signed contract
+          return;
+        }
+
+        render(
+          <Wrapper>
+            <SignContractButton order={order} contract={contract} writable={true} />
+          </Wrapper>,
+        );
+
+        expect(screen.queryByRole('button', { name: 'Download' })).toBeInTheDocument();
+        expect(document.querySelector('div.ReactModalPortal')).toBeInTheDocument();
+
+        expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Sign' })).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/frontend/js/components/SignContractButton/index.tsx
+++ b/src/frontend/js/components/SignContractButton/index.tsx
@@ -2,12 +2,13 @@ import { Button } from '@openfun/cunningham-react';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 import { useState } from 'react';
 import { ContractFrame } from 'components/ContractFrame';
-import { Contract, CredentialOrder, NestedCredentialOrder } from 'types/Joanie';
+import { Contract, ContractState, CredentialOrder, NestedCredentialOrder } from 'types/Joanie';
 import { RouterButton } from 'widgets/Dashboard/components/RouterButton';
 import { getDashboardRoutePath } from 'widgets/Dashboard/utils/dashboardRoutes';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import DownloadContractButton from 'components/DownloadContractButton';
 import { Maybe } from 'types/utils';
+import { ContractHelper } from 'utils/ContractHelper';
 
 const messages = defineMessages({
   contractSignActionLabel: {
@@ -58,16 +59,18 @@ const SignContractButtonLink = ({ orderId, className }: SignContractButtonLinkPr
 const SignContractButton = ({ order, contract, writable, className }: SignContractButtonProps) => {
   const [contractFrameOpened, setContractFrameOpened] = useState(false);
   const [contractLoading, setContractLoading] = useState(false);
+  const contractState = ContractHelper.getState(contract);
 
-  if (!writable) {
+  if (!writable && contractState === ContractState.UNSIGNED) {
     return <SignContractButtonLink orderId={order.id} className={className} />;
   }
 
   return (
     <>
-      {contract && contract.student_signed_on ? (
-        <DownloadContractButton contract={contract} className="dashboard-item__button" />
-      ) : (
+      {contractState === ContractState.SIGNED && (
+        <DownloadContractButton contract={contract!} className="dashboard-item__button" />
+      )}
+      {contractState === ContractState.UNSIGNED && (
         <Button
           size="small"
           className={className}

--- a/src/frontend/js/pages/DashboardContracts/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardContracts/index.spec.tsx
@@ -53,6 +53,13 @@ describe('<DashboardContract/>', () => {
     </QueryClientProvider>
   );
 
+  beforeAll(() => {
+    // As dialog is rendered through a Portal, we have to add the DOM element in which the dialog will be rendered.
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
+
   beforeEach(() => {
     fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
     fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', []);

--- a/src/frontend/js/utils/ContractHelper/index.spec.ts
+++ b/src/frontend/js/utils/ContractHelper/index.spec.ts
@@ -19,7 +19,8 @@ const signedContractFactory = ContractFactory({
 describe('ContractHelper', () => {
   describe('getState', () => {
     it.each([
-      [undefined, null],
+      [null, ContractState.UNSIGNED],
+      [undefined, ContractState.UNSIGNED],
       [unsignedContractFactory.one(), ContractState.UNSIGNED],
       [halfSignedContractFactory.one(), ContractState.LEARNER_SIGNED],
       [signedContractFactory.one(), ContractState.SIGNED],

--- a/src/frontend/js/utils/ContractHelper/index.ts
+++ b/src/frontend/js/utils/ContractHelper/index.ts
@@ -42,13 +42,8 @@ export enum ContractStatePoV {
 }
 
 export class ContractHelper {
-  static getState(contract: null | undefined): null;
-  static getState(contract: Contract): ContractState;
-  static getState(contract: Maybe<Contract>): Nullable<ContractState>;
-  static getState(contract: Maybe<Nullable<Contract>>): Nullable<ContractState> {
-    if (!contract) return null;
-
-    if (contract.student_signed_on && contract.organization_signed_on) {
+  static getState(contract: Maybe<Nullable<Contract>>): ContractState {
+    if (contract?.student_signed_on && contract?.organization_signed_on) {
       return ContractState.SIGNED;
     }
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Contract/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Contract/_styles.scss
@@ -18,6 +18,10 @@
     justify-content: space-between;
     align-items: center;
 
+    &__status {
+      line-height: rem-calc(32px);
+    }
+
     span {
       font-size: 0.875rem;
     }

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Contract/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Contract/index.tsx
@@ -1,7 +1,6 @@
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { Contract, ContractDefinition, CredentialOrder, NestedCredentialOrder } from 'types/Joanie';
 import ContractStatus from 'components/ContractStatus';
-import DownloadContractButton from 'components/DownloadContractButton';
 import SignContractButton from 'components/SignContractButton';
 import { DashboardItem, DashboardItemProps } from '..';
 
@@ -35,20 +34,16 @@ export const DashboardItemContract = ({
             <span>{contract_definition.title}</span>
           </div>
           <div className="dashboard-contract__footer">
-            <span>
+            <span className="dashboard-contract__footer__status">
               <ContractStatus contract={contract} />
             </span>
             <div>
-              {contract && contract.student_signed_on ? (
-                <DownloadContractButton contract={contract} />
-              ) : (
-                <SignContractButton
-                  order={order}
-                  contract={contract}
-                  writable={writable}
-                  className="dashboard-item__button"
-                />
-              )}
+              <SignContractButton
+                order={order}
+                contract={contract}
+                writable={writable}
+                className="dashboard-item__button"
+              />
             </div>
           </div>
         </>

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.spec.tsx
@@ -239,7 +239,10 @@ describe('<DashboardItemOrder/> Contract', () => {
       const order = CredentialOrderFactory({
         target_courses: TargetCourseFactory().many(1),
         target_enrollments: [],
-        contract: ContractFactory({ student_signed_on: faker.date.past().toISOString() }).one(),
+        contract: ContractFactory({
+          student_signed_on: faker.date.past().toISOString(),
+          organization_signed_on: faker.date.past().toISOString(),
+        }).one(),
       }).one();
       const { product } = mockCourseProductWithOrder(order);
 
@@ -277,7 +280,10 @@ describe('<DashboardItemOrder/> Contract', () => {
       const order = CredentialOrderFactory({
         target_courses: TargetCourseFactory().many(1),
         target_enrollments: [],
-        contract: ContractFactory({ student_signed_on: faker.date.past().toISOString() }).one(),
+        contract: ContractFactory({
+          student_signed_on: faker.date.past().toISOString(),
+          organization_signed_on: faker.date.past().toISOString(),
+        }).one(),
       }).one();
       mockCourseProductWithOrder(order);
 


### PR DESCRIPTION
Learner's training contract can have a new status where it's signed by the
learner but waiting the organization to counter-sign it.
There a small adaptation of our ContractStatus and
DashboardItemContract components

New state "waiting for organization to sign"
![Capture d’écran du 2023-12-19 16-48-07](https://github.com/openfun/richie/assets/139848/7746a432-c5f7-4137-95b8-6f30c8c74622)

Modified state "Download your training contract"
![Capture d’écran du 2023-12-18 17-15-03](https://github.com/openfun/richie/assets/139848/16f8e6b2-4279-4595-b69f-6095e5c508e7)
