### PR TITLE
💄(frontend) Banner on dashboard/courses

### DIFF
--- a/src/frontend/js/components/Banner/index.tsx
+++ b/src/frontend/js/components/Banner/index.tsx
@@ -1,3 +1,4 @@
+import { uniqueId } from 'lodash-es';
 import { useMemo } from 'react';
 
 export enum BannerType {
@@ -13,6 +14,10 @@ interface BannerProps {
   rounded?: boolean;
 }
 
+export const getBannerTestId = (message: string, type: BannerType) => {
+  return `banner-${type}-${uniqueId(message)}`;
+};
+
 const Banner = ({ message, rounded, type = BannerType.INFO }: BannerProps) => {
   const className = useMemo(
     (): string => ['banner', `banner--${type}`, ...(rounded ? ['banner--rounded'] : [])].join(' '),
@@ -20,7 +25,7 @@ const Banner = ({ message, rounded, type = BannerType.INFO }: BannerProps) => {
   );
 
   return (
-    <div className={className}>
+    <div className={className} data-testid={getBannerTestId(message, type)}>
       <p className="banner__message">{message}</p>
     </div>
   );

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -19,7 +19,7 @@ import { SessionProvider } from 'contexts/SessionContext';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import { CourseLight, CourseProductRelation, Enrollment, CredentialOrder } from 'types/Joanie';
 import { expectNoSpinner, expectSpinner } from 'utils/test/expectSpinner';
-import { expectBannerError, expectNoBannerInfo } from 'utils/test/expectBanner';
+import { expectBannerError, expectBannerInfo, expectNoBannerInfo } from 'utils/test/expectBanner';
 import { Deferred } from 'utils/test/deferred';
 import { isOrder } from 'pages/DashboardCourses/useOrdersEnrollments';
 import { noop } from 'utils';
@@ -160,7 +160,7 @@ describe('<DashboardCourses/>', () => {
     enrollmentsDeferred.resolve({ results: [], next: null, previous: null, count: 0 });
 
     await expectNoSpinner('Loading orders and enrollments...');
-    await screen.findByText('You have no enrollments nor orders yet.');
+    expectBannerInfo('You have no enrollments nor orders yet.');
     expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
   });
 

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -19,7 +19,7 @@ import { SessionProvider } from 'contexts/SessionContext';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import { CourseLight, CourseProductRelation, Enrollment, CredentialOrder } from 'types/Joanie';
 import { expectNoSpinner, expectSpinner } from 'utils/test/expectSpinner';
-import { expectBannerError } from 'utils/test/expectBanner';
+import { expectBannerError, expectNoBannerInfo } from 'utils/test/expectBanner';
 import { Deferred } from 'utils/test/deferred';
 import { isOrder } from 'pages/DashboardCourses/useOrdersEnrollments';
 import { noop } from 'utils';
@@ -154,7 +154,7 @@ describe('<DashboardCourses/>', () => {
 
     await expectSpinner('Loading orders and enrollments...');
     expect(await screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
-    expect(screen.queryByText('You have no enrollments nor orders yet.')).not.toBeInTheDocument();
+    await expectNoBannerInfo('You have no enrollments nor orders yet');
 
     ordersDeferred.resolve({ results: [], next: null, previous: null, count: 0 });
     enrollmentsDeferred.resolve({ results: [], next: null, previous: null, count: 0 });
@@ -246,7 +246,7 @@ describe('<DashboardCourses/>', () => {
 
     // Slice 1.
     await expectNoSpinner('Loading orders and enrollments...');
-    expect(screen.queryByText('You have no enrollments nor orders yet.')).not.toBeInTheDocument();
+    await expectNoBannerInfo('You have no enrollments nor orders yet');
     let loadMoreButton = await screen.findByRole('button', { name: 'Load more' });
     expect(loadMoreButton).toBeEnabled();
     await waitFor(() => expectList(entities.slice(0, perPage), relations), { interval: 200 });
@@ -284,7 +284,7 @@ describe('<DashboardCourses/>', () => {
     });
 
     await expectNoSpinner('Loading orders and enrollments...');
-    expect(screen.queryByText('You have no enrollments nor orders yet.')).not.toBeInTheDocument();
+    await expectNoBannerInfo('You have no enrollments nor orders yet');
     expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
     await expectBannerError(
       'An error occurred while fetching orders and enrollments. Please retry later.',

--- a/src/frontend/js/pages/DashboardCourses/index.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.tsx
@@ -1,4 +1,4 @@
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useRef } from 'react';
 import { Button } from '@openfun/cunningham-react';
 import {
@@ -32,6 +32,7 @@ const messages = defineMessages({
 });
 
 export const DashboardCourses = () => {
+  const intl = useIntl();
   const { next, data, hasMore, error, isLoading, count } = useOrdersEnrollments({
     orderFilters: { product_type: [ProductType.CREDENTIAL], state_exclude: [OrderState.CANCELED] },
   });
@@ -51,7 +52,7 @@ export const DashboardCourses = () => {
         <>
           {count === 0 && (
             <p className="dashboard__courses__empty">
-              <FormattedMessage {...messages.emptyList} />
+              <Banner message={intl.formatMessage(messages.emptyList)} />
             </p>
           )}
           <div className="dashboard__courses__list">

--- a/src/frontend/js/utils/test/expectBanner.ts
+++ b/src/frontend/js/utils/test/expectBanner.ts
@@ -1,5 +1,5 @@
-import { getByText, waitFor } from '@testing-library/react';
-import { BannerType } from 'components/Banner';
+import { getByText, screen, waitFor } from '@testing-library/react';
+import { BannerType, getBannerTestId } from 'components/Banner';
 
 export const expectBannerError = async (message: string, rootElement: ParentNode = document) => {
   return expectBanner(BannerType.ERROR, message, rootElement);
@@ -17,5 +17,18 @@ export const expectBanner = async (
     const banner = rootElement.querySelector('.banner--' + type) as HTMLElement;
     expect(banner).not.toBeNull();
     getByText(banner!, message);
+  });
+};
+
+export const expectNoBannerError = async (message: string) => {
+  return expectNoBanner(BannerType.ERROR, message);
+};
+export const expectNoBannerInfo = async (message: string) => {
+  return expectNoBanner(BannerType.INFO, message);
+};
+
+export const expectNoBanner = async (type: BannerType, message: string) => {
+  await waitFor(() => {
+    expect(screen.queryByTestId(getBannerTestId(message, type))).toBeNull();
   });
 };


### PR DESCRIPTION
issue: [#2187](https://github.com/openfun/richie/issues/2187)

Use a banner component to display the "empty list" message in the orders and enrollments listing page.

Before: 
![Capture d’écran du 2023-12-19 14-09-37](https://github.com/openfun/richie/assets/139848/7221ace5-d76e-448e-b051-af9c47d16b93)
After:
![Capture d’écran du 2023-12-19 14-10-31](https://github.com/openfun/richie/assets/139848/6f3597f5-5407-4a76-9db7-a4e3338eead4)
