### PR TITLE
🐛(frontend) Fix useUnionResource hasLoadMore

### DIFF
--- a/src/frontend/js/hooks/useUnionResource/index.spec.tsx
+++ b/src/frontend/js/hooks/useUnionResource/index.spec.tsx
@@ -151,6 +151,7 @@ describe('useUnionResource', () => {
       PaginatedResourceQuery
     >(queryAConfig, queryBConfig);
     expect(result.current.isLoading).toBe(true);
+    expect(result.current.hasMore).toBe(false);
 
     await act(() => {
       dataADeferred.resolve(mockPaginatedResponse([], 0, false));

--- a/src/frontend/js/hooks/useUnionResource/index.ts
+++ b/src/frontend/js/hooks/useUnionResource/index.ts
@@ -147,7 +147,7 @@ const useUnionResource = <
     next,
     count: totalCount,
     data: stack.slice(0, cursorToUse),
-    hasMore: typeof totalCount === 'undefined' || cursorToUse < totalCount,
+    hasMore: totalCount ? cursorToUse < totalCount : false,
     error,
     isLoading: isSyncing,
   };

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -153,8 +153,7 @@ describe('<DashboardCourses/>', () => {
     render(<Wrapper />);
 
     await expectSpinner('Loading orders and enrollments...');
-    const loadMoreButton = await screen.findByRole('button', { name: 'Load more' });
-    expect(loadMoreButton).toBeDisabled();
+    expect(await screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
     expect(screen.queryByText('You have no enrollments nor orders yet.')).not.toBeInTheDocument();
 
     ordersDeferred.resolve({ results: [], next: null, previous: null, count: 0 });


### PR DESCRIPTION
issue: [#2168](https://github.com/openfun/richie/issues/2168)

In the orders and enrollments listing page where we use this useUnionResources, we had a "Load more" button on the first render, when data where loading.
hasLoadMore must be false until we retrieve data for the first time.
