### PR TITLE
🐛(frontend) fix sale tunnel order stats

### DIFF
--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/utils/order.ts
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/utils/order.ts
@@ -1,4 +1,4 @@
-import { OrderEnrollment, ACTIVE_ORDER_STATES, Order, Product } from 'types/Joanie';
+import { OrderEnrollment, ACTIVE_ORDER_STATES, Order, Product, OrderState } from 'types/Joanie';
 
 export const getActiveEnrollmentOrder = (orders: OrderEnrollment[], productId: string) => {
   const filter = (order: OrderEnrollment) =>
@@ -7,5 +7,9 @@ export const getActiveEnrollmentOrder = (orders: OrderEnrollment[], productId: s
 };
 
 export const orderNeedsSignature = (order: Order, product?: Product) => {
-  return product?.contract_definition && !(order.contract && order.contract.student_signed_on);
+  return (
+    order?.state === OrderState.VALIDATED &&
+    product?.contract_definition &&
+    !(order.contract && order.contract.student_signed_on)
+  );
 };

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
@@ -123,7 +123,7 @@ describe('CourseProductItem', () => {
     await expectNoSpinner('Loading product information...');
   });
 
-  it('renders product information', async () => {
+  it('renders product information for anonymous user', async () => {
     const relation = CourseProductRelationFactory().one();
     const { product } = relation;
     fetchMock.get(`https://joanie.test/api/v1.0/courses/00000/products/${product.id}/`, relation);
@@ -200,7 +200,7 @@ describe('CourseProductItem', () => {
     expect(screen.queryByTestId('CertificateItem')).toBeNull();
   });
 
-  it('adapts its layout if compact is set', async () => {
+  it('renders product informations in compact mode', async () => {
     const relation = CourseProductRelationFactory().one();
     fetchMock.get(
       `https://joanie.test/api/v1.0/courses/00000/products/${relation.product.id}/`,
@@ -256,7 +256,7 @@ describe('CourseProductItem', () => {
     expect(screen.queryByTestId('PurchaseButton__cta')).not.toBeInTheDocument();
   });
 
-  it('adapts information when user purchased the product', async () => {
+  it('renders product informations for a purchased product', async () => {
     const relation = CourseProductRelationFactory().one();
     const { product } = relation;
     const order = CredentialOrderFactory({
@@ -315,7 +315,7 @@ describe('CourseProductItem', () => {
     expect(screen.queryByTestId('PurchaseButton__cta')).toBeNull();
   });
 
-  it('adapts information when user purchased the product even if compact is set', async () => {
+  it('renders product informations for a purchased product in compact mode', async () => {
     const relation = CourseProductRelationFactory().one();
     const order: CredentialOrder = CredentialOrderFactory({
       product_id: relation.product.id,


### PR DESCRIPTION
## Purpose

Learner must sign there contract after they purchase a product with a
contract_definition attach.
There for it we should not show him any sign button before he complete
his purchase. It must be limited to VALIDATED orders.

