### PR TITLE
⬆️(cookiecutter) migrate to node 18

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@frontend.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@frontend.yml
@@ -5,7 +5,7 @@ build-front-production:
     site:
       type: string
   docker:
-    - image: cimg/node:16.15
+    - image: cimg/node:18.19
   working_directory: ~/fun/sites/<< parameters.site >>/src/frontend/
   steps:
     - checkout:
@@ -33,7 +33,7 @@ lint-front:
     site:
       type: string
   docker:
-    - image: cimg/node:16.15
+    - image: cimg/node:18.19
   working_directory: ~/fun/sites/<< parameters.site >>/src/frontend/
   steps:
     - checkout:

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Dockerfile
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Dockerfile
@@ -10,7 +10,7 @@ ARG DOCKER_USER=10000
 FROM python:3.10-buster as base
 
 # ---- front-end builder image ----
-FROM node:16.15 as front-builder
+FROM node:18.19 as front-builder
 
 ARG SITE
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -98,7 +98,7 @@ services:
     image: jwilder/dockerize
 
   node:
-    image: node:18
+    image: node:18.19
     working_dir: /app/src/frontend
     user: ${DOCKER_USER:-1000}
     volumes:

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/frontend/package.json
@@ -33,5 +33,8 @@
     "source-map-loader": "4.0.1",
     "webpack": "5.88.2",
     "webpack-cli": "5.1.4"
+  },
+  "volta": {
+    "node": "18.19.0"
   }
 }


### PR DESCRIPTION
## Purpose

Some frontend dependencies now requires node >= 18, we recently update node images of the repository but forgot cookiecutter ones.


## Proposal

- [x] Upgrade cookiecutter node images to the most recent version of node 18
