### PR TITLE
🩹(frontend) fix dashboard sidebar zindex issue

### DIFF
--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/_styles.scss
@@ -6,6 +6,8 @@
   box-shadow: r-theme-val(dashboard-sidebar, base-shadow);
   color: r-theme-val(dashboard-sidebar, base-color);
   padding-bottom: r-theme-val(dashboard-sidebar, menu-link-inline-padding);
+  position: relative;
+  z-index: 2;
 
   @include media-breakpoint-down(lg) {
     width: auto;


### PR DESCRIPTION
## Purpose

On mobile, the dashboard sidebar is displayed at the top of the page. But currently its z-index is less than the content so when user open the select menu
 to navigate this one appears below the content.

## Proposal

- [x] Increase z-index of `dashboard-sidebar`
