### PR TITLE
🩹(frontend) minor fixes

### DIFF
--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 import { useMemo } from 'react';
 import { Button } from '@openfun/cunningham-react';
 import { CoursesHelper } from 'utils/CoursesHelper';
@@ -19,7 +19,7 @@ import { orderNeedsSignature } from 'widgets/Dashboard/components/DashboardItem/
 import { RouterButton } from '../RouterButton';
 import { useEnroll } from '../../hooks/useEnroll';
 
-const messages = {
+const messages = defineMessages({
   notEnrolled: {
     id: 'components.DashboardItemEnrollment.notEnrolled',
     description: 'Text shown on a read-only not-enrolled target course',
@@ -81,7 +81,7 @@ const messages = {
     description: 'Message displayed as disabled button title when a contract needs to be signed.',
     defaultMessage: 'You have to sign the training contract before enrolling to your course.',
   },
-};
+});
 
 interface DashboardItemCourseEnrollingProps {
   // how does it work ?!!

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, defineMessages } from 'react-intl';
 import PurchaseButton from 'components/PurchaseButton';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { CertificateProduct, Enrollment, ProductType } from 'types/Joanie';
@@ -8,7 +8,7 @@ import { isOpenedCourseRunCertificate } from 'utils/CourseRuns';
 import CertificateStatus from '../../CertificateStatus';
 import { getActiveEnrollmentOrder } from '../../utils/order';
 
-const messages = {
+const messages = defineMessages({
   buyProductCertificateLabel: {
     id: 'components.ProductCertificateFooter.buyProductCertificateLabel',
     description: 'Label on the enrollement row that propose to buy a product of type certificate',
@@ -24,7 +24,7 @@ const messages = {
     description: 'Label on the enrollement when a product of type certificate have been bought',
     defaultMessage: 'Finish this course to obtain your certificate.',
   },
-};
+});
 
 export interface ProductCertificateFooterProps {
   product: CertificateProduct;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage, useIntl, defineMessages } from 'react-intl';
 import { CourseLight, CredentialOrder, Product } from 'types/Joanie';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { CoursesHelper } from 'utils/CoursesHelper';
@@ -18,7 +18,7 @@ import { DashboardItem } from '../index';
 import { DashboardItemContract } from '../Contract';
 import OrderStateMessage from './OrderStateMessage';
 
-const messages = {
+const messages = defineMessages({
   accessCourse: {
     id: 'components.DashboardItemOrder.gotoCourse',
     description: 'Button that redirects to the order details',
@@ -29,7 +29,7 @@ const messages = {
     description: 'Accessible label displayed while certificate is being fetched on the dashboard.',
     defaultMessage: 'Loading certificate...',
   },
-};
+});
 
 interface DashboardItemOrderProps {
   order: CredentialOrder;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
@@ -1,11 +1,11 @@
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, defineMessages } from 'react-intl';
 import { useEffect } from 'react';
 import { CertificateOrder, CredentialOrder, OrderState, Product } from 'types/Joanie';
 import { StringHelper } from 'utils/StringHelper';
 import { handle } from 'utils/errors/handle';
 import { orderNeedsSignature } from 'widgets/Dashboard/components/DashboardItem/utils/order';
 
-export const messages = {
+export const messages = defineMessages({
   statusDraft: {
     id: 'components.DashboardItem.Order.OrderStateMessage.statusDraft',
     description: 'Status shown on the dashboard order item when order is draft.',
@@ -49,7 +49,7 @@ export const messages = {
     description: 'Status shown on the dashboard order item when order status is unknown',
     defaultMessage: '{state}',
   },
-};
+});
 
 interface OrderStateMessageProps {
   order: CredentialOrder | CertificateOrder;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/_styles.scss
@@ -25,6 +25,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      text-align: center;
 
       &__avatar {
         position: absolute;
@@ -33,7 +34,6 @@
 
       h3 {
         font-weight: bold;
-        text-align: center;
         margin-bottom: rem-calc(12px);
       }
 

--- a/src/frontend/js/widgets/Dashboard/hooks/useEnroll/index.ts
+++ b/src/frontend/js/widgets/Dashboard/hooks/useEnroll/index.ts
@@ -1,4 +1,4 @@
-import { useIntl } from 'react-intl';
+import { useIntl, defineMessages } from 'react-intl';
 import { useState } from 'react';
 import { Priority } from 'types';
 import { confirm } from 'utils/indirection/window';
@@ -6,7 +6,7 @@ import { resolveAll } from 'utils/resolveAll';
 import { CourseRun, Enrollment, CredentialOrder } from 'types/Joanie';
 import { useEnrollments } from 'hooks/useEnrollments';
 
-const messages = {
+const messages = defineMessages({
   firstEnrollCourseConfirmation: {
     id: 'components.DashboardItemEnrollment.firstEnrollCourseConfirmation',
     description:
@@ -20,7 +20,7 @@ const messages = {
     defaultMessage:
       'Are you sure you want to change your session? You will be unrolled from the other session!',
   },
-};
+});
 
 export const useEnroll = (enrollments: Enrollment[], order?: CredentialOrder) => {
   const enrollmentResources = useEnrollments();


### PR DESCRIPTION
## Purpose

Currently, the content of the dashboard sidebar header was not align to center so with long content, this one was left aligned that was weird.

| Before | After |
|--------|-------|
|<img width="325" alt="Capture d’écran 2024-01-04 à 13 36 05" src="https://github.com/openfun/richie/assets/9265241/22516e1b-a382-4c7c-9a70-7ea39a453560">|<img width="325" alt="image" src="https://github.com/openfun/richie/assets/9265241/878930fa-8fe3-43b9-8a07-fe875474126a">|

Furthermore, some messages have been declared without using the react-intl defineMessages
method so those messages have not been uploaded to crowdin.


## Proposal

- [x] Align dashboard sidebar header text content to center
- [x] Use `defineMessages` where it is missing 
