### PR TITLE
✨(frontend) add contract bulk download 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add contracts bulk download button in teacher dashboard contract list page.
 - Change menu link order on the learner dashboard sidebar.
 - Organization bulk contract signature
 - Add a Badge React component

--- a/src/frontend/js/hooks/useContractArchive/index.download.spec.tsx
+++ b/src/frontend/js/hooks/useContractArchive/index.download.spec.tsx
@@ -1,0 +1,119 @@
+import fetchMock from 'fetch-mock';
+import { PropsWithChildren } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from 'react-intl';
+import { fireEvent, renderHook, waitFor } from '@testing-library/react';
+import { faker } from '@faker-js/faker';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { handle } from 'utils/errors/handle';
+import { SessionProvider } from 'contexts/SessionContext';
+import { Deferred } from 'utils/test/deferred';
+import { HttpStatusCode } from 'utils/errors/HttpError';
+import useContractArchive from '.';
+
+jest.mock('utils/errors/handle');
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+const mockHandle = handle as jest.MockedFn<typeof handle>;
+
+describe('useContractArchive', () => {
+  beforeEach(() => {
+    fetchMock.get('https://joanie.test/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/addresses/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/credit-cards/', []);
+  });
+
+  beforeAll(() => {
+    // eslint-disable-next-line compat/compat
+    URL.createObjectURL = jest.fn();
+    // eslint-disable-next-line compat/compat
+    URL.revokeObjectURL = jest.fn();
+    HTMLAnchorElement.prototype.click = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <QueryClientProvider client={createTestQueryClient({ user: true })}>
+        <IntlProvider locale="en">
+          <SessionProvider>{children}</SessionProvider>
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  it('downloads the certificate', async () => {
+    const archiveId = faker.string.uuid();
+    const DOWNLOAD_URL = `https://joanie.test/api/v1.0/contracts/zip-archive/${archiveId}/`;
+    const deferred = new Deferred();
+    fetchMock.get(DOWNLOAD_URL, deferred.promise);
+
+    const { result } = renderHook(() => useContractArchive(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(fetchMock.called(DOWNLOAD_URL)).toBe(false);
+    // eslint-disable-next-line compat/compat
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+
+    result.current.methods.get(archiveId);
+    deferred.resolve(HttpStatusCode.OK);
+
+    await waitFor(() => {
+      expect(fetchMock.called(DOWNLOAD_URL)).toBe(true);
+      // eslint-disable-next-line compat/compat
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line compat/compat
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+    });
+
+    // - A event listener should have attached to window to know when window is blurred.
+    // This event is triggered in browser when the download pop up is displayed.
+    fireEvent.blur(window);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles an error if certificate download request fails', async () => {
+    const archiveId = faker.string.uuid();
+    const DOWNLOAD_URL = `https://joanie.test/api/v1.0/contracts/zip-archive/${archiveId}/`;
+    fetchMock.get(DOWNLOAD_URL, HttpStatusCode.UNAUTHORIZED);
+
+    const { result } = renderHook(() => useContractArchive(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(fetchMock.called(DOWNLOAD_URL)).toBe(false);
+    expect(mockHandle).not.toHaveBeenCalled();
+    // eslint-disable-next-line compat/compat
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+
+    await result.current.methods.get(archiveId);
+
+    await waitFor(() => {
+      expect(fetchMock.called(DOWNLOAD_URL)).toBe(true);
+      expect(mockHandle).toHaveBeenNthCalledWith(1, new Error('Unauthorized'));
+      // eslint-disable-next-line compat/compat
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+      // eslint-disable-next-line compat/compat
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/src/frontend/js/hooks/useContractArchive/index.spec.tsx
+++ b/src/frontend/js/hooks/useContractArchive/index.spec.tsx
@@ -1,0 +1,91 @@
+import { faker } from '@faker-js/faker';
+import fetchMock from 'fetch-mock';
+import { renderHook } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { PropsWithChildren } from 'react';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import JoanieApiProvider from 'contexts/JoanieApiContext';
+import { HttpStatusCode } from 'utils/errors/HttpError';
+import useContractArchive from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+describe('useContractArchive', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <IntlProvider locale="en">
+        <JoanieApiProvider>{children}</JoanieApiProvider>
+      </IntlProvider>
+    );
+  };
+  afterEach(() => {
+    fetchMock.restore();
+  });
+  it.each([
+    {
+      label: `response code: ${HttpStatusCode.NO_CONTENT}`,
+      statusCode: HttpStatusCode.NO_CONTENT,
+      expectedValue: true,
+    },
+    {
+      label: `response code: ${HttpStatusCode.NOT_FOUND}`,
+      statusCode: HttpStatusCode.NOT_FOUND,
+      expectedValue: false,
+    },
+    {
+      label: `response code: ${HttpStatusCode.FORBIDDEN}`,
+      statusCode: HttpStatusCode.FORBIDDEN,
+      expectedValue: false,
+    },
+    {
+      label: `response code: ${HttpStatusCode.INTERNAL_SERVER_ERROR}`,
+      statusCode: HttpStatusCode.INTERNAL_SERVER_ERROR,
+      expectedValue: false,
+    },
+    {
+      label: `response code: ${HttpStatusCode.UNAUTHORIZED}`,
+      statusCode: HttpStatusCode.UNAUTHORIZED,
+      expectedValue: false,
+    },
+  ])(
+    'check method should return the right value for response code: $label',
+    async ({ statusCode, expectedValue }) => {
+      const contractArchiveId = faker.string.uuid();
+      fetchMock.mock(
+        (url, options) => {
+          return (
+            options.method === 'OPTIONS' &&
+            url === `https://joanie.test/api/v1.0/contracts/zip-archive/${contractArchiveId}/`
+          );
+        },
+        new Response('', { status: statusCode }),
+      );
+
+      const { result } = renderHook(useContractArchive, {
+        wrapper: Wrapper,
+      });
+      const response = await result.current.methods.check(contractArchiveId);
+      expect(response).toBe(expectedValue);
+    },
+  );
+
+  it('create should return a contractArchiveId', async () => {
+    const contractArchiveId = faker.string.uuid();
+    fetchMock.post('https://joanie.test/api/v1.0/contracts/zip-archive/', {
+      url: `http://test.url/uri/${contractArchiveId}/uri/?toto=tata`,
+    });
+    const { result } = renderHook(useContractArchive, {
+      wrapper: Wrapper,
+    });
+
+    const organizationId = faker.string.uuid();
+    const response = await result.current.methods.create(organizationId);
+    expect(response).toBe(contractArchiveId);
+  });
+});

--- a/src/frontend/js/hooks/useContractArchive/index.ts
+++ b/src/frontend/js/hooks/useContractArchive/index.ts
@@ -1,0 +1,83 @@
+import { useJoanieApi } from 'contexts/JoanieApiContext';
+import { HttpStatusCode } from 'utils/errors/HttpError';
+import { handle } from 'utils/errors/handle';
+
+const extractArchiveId = (url: string): string => {
+  const uuidRegex = /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/;
+  const match = url.match(uuidRegex);
+
+  if (match === null) {
+    const error = new Error(
+      'Unable to extract `contractArchiveId` from `contract.zip_archive.create` response',
+    );
+    handle(error);
+    throw error;
+  }
+
+  return match[0];
+};
+
+// TODO: should be factorized with useDownloadCertificate
+// and maybe DownloadContractButton
+const buildArchiveFromBlob = (fileName: string, blob: Blob) => {
+  // eslint-disable-next-line compat/compat
+  const url = URL.createObjectURL(blob);
+  const $link = document.createElement('a');
+  $link.href = url;
+  $link.download = fileName;
+
+  const revokeObject = () => {
+    // eslint-disable-next-line compat/compat
+    URL.revokeObjectURL(url);
+    window.removeEventListener('blur', revokeObject);
+  };
+
+  window.addEventListener('blur', revokeObject);
+  $link.click();
+};
+
+const useContractArchive = () => {
+  const api = useJoanieApi();
+  return {
+    methods: {
+      check: async (archiveId: string): Promise<boolean> => {
+        const response = await api.user.contracts.zip_archive.check(archiveId);
+
+        if (response.ok) {
+          if (response.status === HttpStatusCode.NO_CONTENT) {
+            return true;
+          }
+          handle(
+            new Error(
+              `Unknown success code ${response.status} for OPTION request to contract's zip_archive endpoint.`,
+            ),
+          );
+        }
+
+        return false;
+      },
+      get: async (archiveId: string): Promise<true | void> => {
+        try {
+          const response = api.user.contracts.zip_archive.get(archiveId);
+          buildArchiveFromBlob('contracts.zip', await response);
+          return true;
+        } catch (error) {
+          handle(error);
+        }
+
+        // FIXME: two thing could happen here with HttpStatusCode.NOT_FOUND response:
+        // * nothing found because the zip is generating.
+        // * nothing found because the zip doesn't and will never exist.
+      },
+      create: async (organizationId: string): Promise<string> => {
+        const response = await api.user.contracts.zip_archive.create({
+          organization_id: organizationId,
+        });
+
+        return extractArchiveId(response.url);
+      },
+    },
+  };
+};
+
+export default useContractArchive;

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/components/BulkDownloadContractButton/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/components/BulkDownloadContractButton/index.spec.tsx
@@ -1,0 +1,136 @@
+import { faker } from '@faker-js/faker';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { PropsWithChildren } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import userEvent from '@testing-library/user-event';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import JoanieApiProvider from 'contexts/JoanieApiContext';
+
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { ContractDownloadStatus } from 'pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive';
+
+import BulkDownloadContractButton from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+let mockDownloadContractArchive = jest.fn(() => Promise<void>);
+let mockCreateContractArchive = jest.fn(() => Promise<void>);
+let mockDownloadContractArchiveStatus: ContractDownloadStatus;
+jest.mock('pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive', () => ({
+  __esModule: true,
+  ...jest.requireActual('pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive'),
+  default: () => ({
+    downloadContractArchive: mockDownloadContractArchive,
+    createContractArchive: mockCreateContractArchive,
+    status: mockDownloadContractArchiveStatus,
+  }),
+}));
+
+let mockHasContractToDownload: boolean;
+jest.mock('pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload/index.tsx', () => ({
+  __esModule: true,
+  default: () => mockHasContractToDownload,
+}));
+
+describe('TeacherDashboardContractsLayout/BulkDownloadContractButton', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <IntlProvider locale="en">
+        <QueryClientProvider client={createTestQueryClient({ user: true })}>
+          <JoanieApiProvider>{children}</JoanieApiProvider>
+        </QueryClientProvider>
+      </IntlProvider>
+    );
+  };
+
+  beforeEach(() => {
+    // useDownloadContractArchive mocked values
+    mockHasContractToDownload = false;
+    mockDownloadContractArchive = jest.fn(() => Promise<void>);
+    mockCreateContractArchive = jest.fn(() => Promise<void>);
+    mockDownloadContractArchiveStatus = ContractDownloadStatus.IDLE;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shouldn't render generate archive button for archive generation IDLE", async () => {
+    mockDownloadContractArchiveStatus = ContractDownloadStatus.IDLE;
+
+    render(
+      <Wrapper>
+        <BulkDownloadContractButton organizationId={faker.string.uuid()} />
+      </Wrapper>,
+    );
+
+    const $button = screen.queryByRole('button', { name: /Request contracts archive/ });
+    expect($button).toBeInTheDocument();
+    expect($button).toBeEnabled();
+
+    const user = userEvent.setup();
+    await user.click($button!);
+    expect(mockDownloadContractArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it("shouldn't render waiting archive button for archive generation PENDING", async () => {
+    mockDownloadContractArchiveStatus = ContractDownloadStatus.PENDING;
+
+    render(
+      <Wrapper>
+        <BulkDownloadContractButton organizationId={faker.string.uuid()} />
+      </Wrapper>,
+    );
+
+    const $button = screen.queryByRole('button', { name: /Generating contracts archive.../ });
+    expect($button).toBeInTheDocument();
+    expect($button).toBeDisabled();
+
+    const user = userEvent.setup();
+    await user.click($button!);
+    expect(mockDownloadContractArchive).not.toHaveBeenCalled();
+  });
+
+  it("shouldn't render download button for archive is READY", async () => {
+    mockDownloadContractArchiveStatus = ContractDownloadStatus.READY;
+
+    render(
+      <Wrapper>
+        <BulkDownloadContractButton organizationId={faker.string.uuid()} />
+      </Wrapper>,
+    );
+
+    const $button = screen.queryByRole('button', { name: /Download contracts archive/ });
+    expect($button).toBeInTheDocument();
+    expect($button).toBeEnabled();
+
+    const user = userEvent.setup();
+    await user.click($button!);
+    expect(mockDownloadContractArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render disabled download button when INITIALIZING', async () => {
+    mockDownloadContractArchiveStatus = ContractDownloadStatus.INITIALIZING;
+
+    render(
+      <Wrapper>
+        <BulkDownloadContractButton organizationId={faker.string.uuid()} />
+      </Wrapper>,
+    );
+
+    const $button = screen.queryByRole('button', { name: /Download contracts archive/ });
+    expect($button).toBeInTheDocument();
+    expect($button).toBeDisabled();
+
+    const user = userEvent.setup();
+    await user.click($button!);
+    expect(mockDownloadContractArchive).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/components/BulkDownloadContractButton/index.timer.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/components/BulkDownloadContractButton/index.timer.spec.tsx
@@ -1,0 +1,144 @@
+import { faker } from '@faker-js/faker';
+import { render, screen, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { PropsWithChildren } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import JoanieApiProvider from 'contexts/JoanieApiContext';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+
+import {
+  getStoredContractArchiveId,
+  storeContractArchiveId,
+  unstoreContractArchiveId,
+} from 'pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/contractArchiveLocalStorage';
+import { CONTRACT_DOWNLOAD_SETTINGS } from 'settings';
+import BulkDownloadContractButton from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+let mockHasContractToDownload: boolean;
+jest.mock('pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload/index.tsx', () => ({
+  __esModule: true,
+  default: () => mockHasContractToDownload,
+}));
+
+const mockCheckArchive = jest.fn();
+const mockCreateArchive = jest.fn();
+const mockGetArchive = jest.fn();
+jest.mock('hooks/useContractArchive', () => ({
+  __esModule: true,
+  default: () => ({
+    methods: { get: mockGetArchive, create: mockCreateArchive, check: mockCheckArchive },
+  }),
+}));
+
+describe('TeacherDashboardContractsLayout/BulkDownloadContractButton with fake timer', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <IntlProvider locale="en">
+        <QueryClientProvider client={createTestQueryClient({ user: true })}>
+          <JoanieApiProvider>{children}</JoanieApiProvider>
+        </QueryClientProvider>
+      </IntlProvider>
+    );
+  };
+
+  let contractArchiveId: string;
+  beforeEach(() => {
+    mockHasContractToDownload = true;
+
+    const now = Date.now();
+    const unvalidCreationTime =
+      now - CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalVaklidityDurationMs * 2;
+
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(unvalidCreationTime));
+    contractArchiveId = faker.string.uuid();
+    storeContractArchiveId(contractArchiveId);
+    jest.setSystemTime(new Date(now));
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    unstoreContractArchiveId();
+  });
+
+  it("should return IDLE status and clear stored id when archive doesn't exists on the server", async () => {
+    mockHasContractToDownload = true;
+    mockCheckArchive.mockResolvedValue(false);
+
+    render(
+      <Wrapper>
+        <BulkDownloadContractButton organizationId={faker.string.uuid()} />
+      </Wrapper>,
+    );
+
+    const $downloadButton = screen.queryByRole('button', {
+      name: /Download contracts archive/,
+    });
+    expect($downloadButton).toBeInTheDocument();
+
+    // BulkDownloadButton is disabled until initiliazed
+    expect($downloadButton).toBeDisabled();
+    expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+
+    // Button should initalize with idle state and propose an archive generation
+    await waitFor(() => {
+      const $createArchiveButton = screen.queryByRole('button', {
+        name: /Request contracts archive/,
+      });
+      expect($createArchiveButton).toBeInTheDocument();
+      expect($createArchiveButton).toBeEnabled();
+    });
+
+    expect(getStoredContractArchiveId()).toBe(null);
+    expect(mockGetArchive).not.toHaveBeenCalled();
+    expect(mockCreateArchive).not.toHaveBeenCalled();
+
+    // polling shouldn't start, mockCheckArchive shouldn't been called more than once
+    expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return READY status when archive exists on the server', async () => {
+    mockHasContractToDownload = true;
+    mockCheckArchive.mockResolvedValue(true);
+
+    render(
+      <Wrapper>
+        <BulkDownloadContractButton organizationId={faker.string.uuid()} />
+      </Wrapper>,
+    );
+
+    const $initButton = screen.queryByRole('button', {
+      name: /Download contracts archive/,
+    });
+    expect($initButton).toBeInTheDocument();
+    // BulkDownloadButton is disabled until initiliazed
+    expect($initButton).toBeDisabled();
+    expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      const $downloadButton = screen.queryByRole('button', {
+        name: /Download contracts archive/,
+      });
+      expect($downloadButton).toBeInTheDocument();
+      expect($downloadButton).toBeEnabled();
+    });
+
+    expect(getStoredContractArchiveId()).toBe(contractArchiveId);
+    expect(mockGetArchive).not.toHaveBeenCalled();
+    expect(mockCreateArchive).not.toHaveBeenCalled();
+
+    // polling shouldn't start, mockCheckArchive shouldn't been called more than once
+    expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/components/BulkDownloadContractButton/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/components/BulkDownloadContractButton/index.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@openfun/cunningham-react';
+import { FormattedMessage, defineMessages } from 'react-intl';
+import { useEffect } from 'react';
+import useDownloadContractArchive, {
+  ContractDownloadStatus,
+} from 'pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive';
+import { Organization } from 'types/Joanie';
+
+const messages = defineMessages({
+  bulkDownloadButtonDownloadLabel: {
+    defaultMessage: 'Download contracts archive',
+    description: 'The label of the bulk download button when the zip archive is ready for download',
+    id: 'pages.TeacherDashboardContractsLayout.BulkDownloadContractButton.bulkDownloadButtonDownloadLabel',
+  },
+  bulkDownloadButtonPendingLabel: {
+    defaultMessage: 'Generating contracts archive...',
+    description: 'The label of the bulk download button when archive generation is pending',
+    id: 'pages.TeacherDashboardContractsLayout.BulkDownloadContractButton.bulkDownloadButtonPendingLabel',
+  },
+  bulkDownloadButtonRequestArchiveLabel: {
+    defaultMessage: 'Request contracts archive',
+    description: 'The label of the bulk download button to request the generation of a zip archive',
+    id: 'pages.TeacherDashboardContractsLayout.BulkDownloadContractButton.bulkDownloadButtonRequestArchiveLabel',
+  },
+});
+
+interface BulkDownloadContractButtonProps {
+  organizationId: Organization['id'];
+}
+
+const BulkDownloadContractButton = ({ organizationId }: BulkDownloadContractButtonProps) => {
+  const { downloadContractArchive, createContractArchive, status } = useDownloadContractArchive({
+    organizationId,
+  });
+
+  useEffect(() => {
+    // Trigger contract's archive polling when generation had already been requested
+    if (status === ContractDownloadStatus.PENDING) {
+      createContractArchive();
+    }
+  }, [status]);
+
+  if (status === ContractDownloadStatus.PENDING) {
+    return (
+      <Button
+        disabled={true}
+        color="tertiary"
+        size="small"
+        icon={<div className="spinner spinner--small" />}
+      >
+        <FormattedMessage {...messages.bulkDownloadButtonPendingLabel} />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      onClick={downloadContractArchive}
+      disabled={status === ContractDownloadStatus.INITIALIZING}
+      color={status === ContractDownloadStatus.READY ? 'primary' : 'tertiary'}
+      size="small"
+      icon={<span className="material-icons">download</span>}
+    >
+      <FormattedMessage
+        {...(status === ContractDownloadStatus.IDLE
+          ? messages.bulkDownloadButtonRequestArchiveLabel
+          : messages.bulkDownloadButtonDownloadLabel)}
+      />
+    </Button>
+  );
+};
+
+export default BulkDownloadContractButton;

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/components/ContractActionsBar/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/components/ContractActionsBar/index.spec.tsx
@@ -1,0 +1,166 @@
+import { faker } from '@faker-js/faker';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { PropsWithChildren } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import JoanieApiProvider from 'contexts/JoanieApiContext';
+
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { ContractDownloadStatus } from 'pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive';
+import ContractActionsBar from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+let mockCanSignContracts: boolean;
+let mockContractsToSignCount: number;
+jest.mock('pages/TeacherDashboardContractsLayout/hooks/useTeacherContractsToSign', () => ({
+  __esModule: true,
+  default: () => ({
+    canSignContracts: mockCanSignContracts,
+    contractsToSignCount: mockContractsToSignCount,
+  }),
+}));
+
+let mockDownloadContractArchive: () => Promise<void>;
+let mockCreateContractArchive: () => Promise<void>;
+let mockDownloadContractArchiveStatus: ContractDownloadStatus;
+jest.mock('pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive', () => ({
+  __esModule: true,
+  ...jest.requireActual('pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive'),
+  default: () => ({
+    downloadArchive: mockDownloadContractArchive,
+    createContractArchive: mockCreateContractArchive,
+    status: mockDownloadContractArchiveStatus,
+  }),
+}));
+
+let mockHasContractToDownload: boolean;
+jest.mock('pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload/index.tsx', () => ({
+  __esModule: true,
+  default: () => mockHasContractToDownload,
+}));
+
+describe('TeacherDashboardContractsLayout/ContractActionsBar', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <IntlProvider locale="en">
+        <QueryClientProvider client={createTestQueryClient({ user: true })}>
+          <JoanieApiProvider>{children}</JoanieApiProvider>
+        </QueryClientProvider>
+      </IntlProvider>
+    );
+  };
+
+  beforeAll(() => {
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
+
+  beforeEach(() => {
+    // useTeacherContractsToSign mocked values
+    mockCanSignContracts = true;
+    mockContractsToSignCount = 1;
+
+    // useDownloadContractArchive mocked values
+    mockHasContractToDownload = false;
+    mockDownloadContractArchive = jest.fn(() => Promise.resolve());
+    mockCreateContractArchive = jest.fn(() => Promise.resolve());
+    mockDownloadContractArchiveStatus = ContractDownloadStatus.IDLE;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shouldn't display both sign and download button", () => {
+    mockHasContractToDownload = true;
+    mockCanSignContracts = true;
+    mockContractsToSignCount = 1;
+
+    render(
+      <Wrapper>
+        <ContractActionsBar
+          courseProductRelationId={faker.string.uuid()}
+          organizationId={faker.string.uuid()}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId('teacher-contracts-list-actionsBar')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign all pending contracts/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Request contracts archive/ })).toBeInTheDocument();
+  });
+
+  it("shouldn't only display sign button", () => {
+    mockHasContractToDownload = false;
+    mockCanSignContracts = true;
+    mockContractsToSignCount = 1;
+
+    render(
+      <Wrapper>
+        <ContractActionsBar
+          courseProductRelationId={faker.string.uuid()}
+          organizationId={faker.string.uuid()}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId('teacher-contracts-list-actionsBar')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sign all pending contracts/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Request contracts archive/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shouldn't only display download button", () => {
+    mockHasContractToDownload = true;
+    mockCanSignContracts = false;
+    mockContractsToSignCount = 0;
+
+    render(
+      <Wrapper>
+        <ContractActionsBar
+          courseProductRelationId={faker.string.uuid()}
+          organizationId={faker.string.uuid()}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId('teacher-contracts-list-actionsBar')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Request contracts archive/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Sign all pending contracts/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should return nothing when no actions are available', () => {
+    mockHasContractToDownload = false;
+    mockCanSignContracts = false;
+    mockContractsToSignCount = 0;
+
+    render(
+      <Wrapper>
+        <ContractActionsBar
+          courseProductRelationId={faker.string.uuid()}
+          organizationId={faker.string.uuid()}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByTestId('teacher-contracts-list-actionsBar')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Request contracts archive/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Sign all pending contracts/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/components/ContractActionsBar/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/components/ContractActionsBar/index.tsx
@@ -1,6 +1,9 @@
+import classNames from 'classnames';
 import { Organization, CourseProductRelation } from 'types/Joanie';
 import useTeacherContractsToSign from 'pages/TeacherDashboardContractsLayout/hooks/useTeacherContractsToSign';
+import useHasContractToDownload from 'pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload';
 import SignOrganizationContractButton from '../SignOrganizationContractButton';
+import BulkDownloadContractButton from '../BulkDownloadContractButton';
 
 interface ContractActionsProps {
   organizationId: Organization['id'];
@@ -12,15 +15,27 @@ const ContractActionsBar = ({ organizationId, courseProductRelationId }: Contrac
     organizationId,
     courseProductRelationId,
   });
+  const hasContractToDownload = useHasContractToDownload(organizationId);
+
+  const nbAvailableActions = [canSignContracts, hasContractToDownload].filter((val) => val).length;
   return (
-    canSignContracts && (
-      <div className="dashboard__page__actions-row dashboard__page__actions-row--space-between">
-        <div>
-          <SignOrganizationContractButton
-            organizationId={organizationId}
-            contractToSignCount={contractsToSignCount}
-          />
-        </div>
+    nbAvailableActions > 0 && (
+      <div
+        className={classNames('dashboard__page__actions-row', {
+          'dashboard__page__actions-row--space-between': nbAvailableActions > 1,
+          'dashboard__page__actions-row--end': nbAvailableActions === 1,
+        })}
+        data-testid="teacher-contracts-list-actionsBar"
+      >
+        {canSignContracts && (
+          <div>
+            <SignOrganizationContractButton
+              organizationId={organizationId}
+              contractToSignCount={contractsToSignCount}
+            />
+          </div>
+        )}
+        {hasContractToDownload && <BulkDownloadContractButton organizationId={organizationId} />}
       </div>
     )
   );

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/components/SignOrganizationContractButton/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/components/SignOrganizationContractButton/index.spec.tsx
@@ -1,0 +1,74 @@
+import { faker } from '@faker-js/faker';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { PropsWithChildren } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import JoanieApiProvider from 'contexts/JoanieApiContext';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+
+import SignOrganizationContractButton from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+describe('TeacherDashboardContractsLayout/SignOrganizationContractButton', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <IntlProvider locale="en">
+        <QueryClientProvider client={createTestQueryClient({ user: true })}>
+          <JoanieApiProvider>{children}</JoanieApiProvider>
+        </QueryClientProvider>
+      </IntlProvider>
+    );
+  };
+
+  beforeAll(() => {
+    const modalExclude = document.createElement('div');
+    modalExclude.setAttribute('id', 'modal-exclude');
+    document.body.appendChild(modalExclude);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shouldn't render sign button and <OrganizationContractFrame/> when contractToSignCount > 0", () => {
+    render(
+      <Wrapper>
+        <SignOrganizationContractButton
+          organizationId={faker.string.uuid()}
+          contractToSignCount={1}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.getByRole('button', { name: /Sign all pending contracts/ })).toBeInTheDocument();
+
+    const DashboardContractFramePortal = document.getElementsByClassName('ReactModalPortal');
+    expect(DashboardContractFramePortal).toHaveLength(1);
+  });
+
+  it("shouldn't only render <OrganizationContractFrame/> when contractToSignCount is 0", () => {
+    render(
+      <Wrapper>
+        <SignOrganizationContractButton
+          organizationId={faker.string.uuid()}
+          contractToSignCount={0}
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /Sign all pending contracts/ }),
+    ).not.toBeInTheDocument();
+
+    const DashboardContractFramePortal = document.getElementsByClassName('ReactModalPortal');
+    expect(DashboardContractFramePortal).toHaveLength(1);
+  });
+});

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useCheckContractArchiveExists/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useCheckContractArchiveExists/index.spec.tsx
@@ -1,0 +1,124 @@
+import { faker } from '@faker-js/faker';
+import fetchMock from 'fetch-mock';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { PropsWithChildren } from 'react';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import JoanieApiProvider from 'contexts/JoanieApiContext';
+import {
+  storeContractArchiveId,
+  unstoreContractArchiveId,
+} from '../useDownloadContractArchive/contractArchiveLocalStorage';
+import useCheckContractArchiveExists from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+jest.mock('settings', () => ({
+  ...jest.requireActual('settings'),
+  CONTRACT_DOWNLOAD_SETTINGS: {
+    ...jest.requireActual('settings').CONTRACT_DOWNLOAD_SETTINGS,
+    pollInterval: 100,
+  },
+}));
+
+const mockCheckArchive = jest.fn();
+jest.mock('hooks/useContractArchive', () => ({
+  __esModule: true,
+  default: () => ({
+    methods: { get: jest.fn(), create: jest.fn(), check: mockCheckArchive },
+  }),
+}));
+
+describe('useCheckContractArchiveExists', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <IntlProvider locale="en">
+        <JoanieApiProvider>{children}</JoanieApiProvider>
+      </IntlProvider>
+    );
+  };
+  beforeEach(() => {
+    // Joanie providers calls
+    fetchMock.get('https://joanie.test/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/credit-cards/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/addresses/', []);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    fetchMock.restore();
+    unstoreContractArchiveId();
+  });
+
+  it('should do nothing and return default value when no contractArchiveId is stored', () => {
+    const { result } = renderHook(useCheckContractArchiveExists, {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.isContractArchiveExists).toBe(false);
+    expect(mockCheckArchive).not.toHaveBeenCalled();
+  });
+
+  it('should check if archive exist when a id is stored', async () => {
+    storeContractArchiveId(faker.string.uuid());
+    mockCheckArchive.mockResolvedValue(true);
+
+    const { result } = renderHook(useCheckContractArchiveExists, {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.isContractArchiveExists).toBeNull();
+    await waitFor(() => {
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current.isPolling).toBe(false);
+    expect(result.current.isContractArchiveExists).toBe(true);
+  });
+
+  it('should do nothing when enable is false', () => {
+    storeContractArchiveId(faker.string.uuid());
+    mockCheckArchive.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useCheckContractArchiveExists({ enable: false }), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.isContractArchiveExists).toBe(false);
+    expect(mockCheckArchive).not.toHaveBeenCalled();
+  });
+
+  it('should trigger polling when checkArchiveExist is call', async () => {
+    const { result, rerender } = renderHook(useCheckContractArchiveExists, {
+      wrapper: Wrapper,
+    });
+
+    mockCheckArchive.mockResolvedValue(false);
+    act(() => {
+      result.current.checkArchiveExists(faker.string.uuid());
+    });
+
+    await waitFor(() => {
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current.isContractArchiveExists).toBe(false);
+
+    // isPolling it need's a rerender to be updated
+    rerender();
+    expect(result.current.isPolling).toBe(true);
+
+    mockCheckArchive.mockResolvedValue(true);
+    await waitFor(() => {
+      expect(mockCheckArchive).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current.isPolling).toBe(false);
+    expect(result.current.isContractArchiveExists).toBe(true);
+  });
+});

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useCheckContractArchiveExists/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useCheckContractArchiveExists/index.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react';
+import useContractArchive from 'hooks/useContractArchive';
+import { CONTRACT_DOWNLOAD_SETTINGS } from 'settings';
+import { Nullable } from 'types/utils';
+import { getStoredContractArchiveId } from '../useDownloadContractArchive/contractArchiveLocalStorage';
+
+export interface UseCheckContractArchiveExistsProps {
+  enable: boolean;
+}
+
+const useCheckContractArchiveExist = (
+  { enable }: UseCheckContractArchiveExistsProps = { enable: true },
+) => {
+  // Contract's archive api interface
+  const {
+    methods: { check: checkArchiveExist },
+  } = useContractArchive();
+
+  // Store if the contract's archive exists or not on the server
+  // stay null until fetched
+  const [isContractArchiveExists, setIsContractArchiveExists] = useState<Nullable<boolean>>(null);
+
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  // This method will check if the archive exists on the server
+  // option.polling === true will recursivly poll archive existence
+  const checkArchiveExists = async (
+    archiveId: string,
+    options: { polling: boolean } = { polling: true },
+  ) => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = undefined;
+
+    const isExists = await checkArchiveExist(archiveId);
+    setIsContractArchiveExists(isExists);
+
+    if (!options.polling) {
+      return;
+    }
+
+    if (!isExists) {
+      timeoutRef.current = setTimeout(
+        () => checkArchiveExists(archiveId),
+        CONTRACT_DOWNLOAD_SETTINGS.pollInterval,
+      );
+    }
+  };
+
+  // This effect will initialize isContractArchiveExists value
+  useEffect(() => {
+    const storedContractArchiveId = getStoredContractArchiveId();
+    if (enable && storedContractArchiveId) {
+      checkArchiveExists(storedContractArchiveId, { polling: false });
+    } else {
+      setIsContractArchiveExists(false);
+    }
+  }, [enable]);
+
+  // Be sure to clear any timeout before unmouting the hook.
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  return {
+    isPolling: !!timeoutRef.current,
+    isContractArchiveExists,
+    checkArchiveExists,
+  };
+};
+
+export default useCheckContractArchiveExist;

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/contractArchiveLocalStorage.spec.ts
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/contractArchiveLocalStorage.spec.ts
@@ -1,0 +1,85 @@
+import { faker } from '@faker-js/faker';
+import { CONTRACT_DOWNLOAD_SETTINGS } from 'settings';
+import {
+  getStoredContractArchiveId,
+  isStoredContractArchiveIdExpired,
+  storeContractArchiveId,
+  unstoreContractArchiveId,
+} from './contractArchiveLocalStorage';
+
+describe('contractArchiveLocalStorage', () => {
+  afterEach(() => {
+    unstoreContractArchiveId();
+  });
+
+  it('should store and unstore contractArchiveId and creation date in localStorage', () => {
+    expect(
+      localStorage.getItem(CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalStorageKey),
+    ).toBeNull();
+
+    const contractArchiveId = faker.string.uuid();
+    storeContractArchiveId(contractArchiveId);
+    expect(localStorage.getItem(CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalStorageKey)).toMatch(
+      new RegExp(`[0-9]+::${contractArchiveId}`),
+    );
+
+    unstoreContractArchiveId();
+    expect(
+      localStorage.getItem(CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalStorageKey),
+    ).toBeNull();
+  });
+
+  it('should retrieve contractArchiveId from localStorage', () => {
+    const contractArchiveId = faker.string.uuid();
+    storeContractArchiveId(contractArchiveId);
+
+    const retrievedcontractArchiveId = getStoredContractArchiveId();
+    expect(retrievedcontractArchiveId).toBe(contractArchiveId);
+  });
+
+  it.each([
+    {
+      label: 'outdated creation date in the past',
+      now: Date.now(),
+      storageCreationTime:
+        Date.now() - CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalVaklidityDurationMs * 2,
+    },
+    {
+      label: 'outdated creation date in the future',
+      now: Date.now(),
+      storageCreationTime:
+        Date.now() + CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalVaklidityDurationMs * 2,
+    },
+  ])(
+    'isStoredContractArchiveIdExpired should be true for $label',
+    ({ now, storageCreationTime }) => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(storageCreationTime));
+      const contractArchiveId = faker.string.uuid();
+      storeContractArchiveId(contractArchiveId);
+
+      jest.setSystemTime(new Date(now));
+      expect(isStoredContractArchiveIdExpired()).toBe(true);
+
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    },
+  );
+
+  it("isStoredContractArchiveIdExpired should be true false storage isn't expired", () => {
+    const now = Date.now();
+    const validCreationTime =
+      now - CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalVaklidityDurationMs / 2;
+
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(validCreationTime));
+    const contractArchiveId = faker.string.uuid();
+    storeContractArchiveId(contractArchiveId);
+
+    jest.setSystemTime(new Date(now));
+    expect(isStoredContractArchiveIdExpired()).toBe(false);
+
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+});

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/contractArchiveLocalStorage.ts
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/contractArchiveLocalStorage.ts
@@ -1,0 +1,50 @@
+import { CONTRACT_DOWNLOAD_SETTINGS } from 'settings';
+
+const generateLocalStorageId = (contractArchiveId: string) => {
+  return `${Date.now()}::${contractArchiveId}`;
+};
+
+const storeContractArchiveId = (contractArchiveId: string) => {
+  localStorage.setItem(
+    CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalStorageKey,
+    generateLocalStorageId(contractArchiveId),
+  );
+};
+
+const unstoreContractArchiveId = () => {
+  localStorage.removeItem(CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalStorageKey);
+};
+
+const getStoredContractArchiveId = () => {
+  const value = localStorage.getItem(CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalStorageKey);
+  if (value === null) {
+    return value;
+  }
+
+  const [, contractArchiveId] = value.split('::');
+  return contractArchiveId;
+};
+
+const isStoredContractArchiveIdExpired = () => {
+  const value = localStorage.getItem(CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalStorageKey);
+  if (value === null) {
+    return false;
+  }
+  const [creationTimestamp] = value.split('::');
+
+  const bounds: number[] = [Date.now(), parseInt(creationTimestamp, 10)];
+  // reverse bounds when computer time change.
+  if (bounds[0] > bounds[1]) {
+    bounds.reverse();
+  }
+
+  const [begin, end] = bounds;
+  return end - begin > CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalVaklidityDurationMs;
+};
+
+export {
+  storeContractArchiveId,
+  unstoreContractArchiveId,
+  getStoredContractArchiveId,
+  isStoredContractArchiveIdExpired,
+};

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/index.spec.tsx
@@ -1,0 +1,266 @@
+import { faker } from '@faker-js/faker';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { PropsWithChildren } from 'react';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import JoanieApiProvider from 'contexts/JoanieApiContext';
+import { CONTRACT_DOWNLOAD_SETTINGS } from 'settings';
+import {
+  getStoredContractArchiveId,
+  storeContractArchiveId,
+  unstoreContractArchiveId,
+} from './contractArchiveLocalStorage';
+import useDownloadContractArchive, { ContractDownloadStatus } from '.';
+
+jest.mock('settings', () => ({
+  ...jest.requireActual('settings'),
+  CONTRACT_DOWNLOAD_SETTINGS: {
+    ...jest.requireActual('settings').CONTRACT_DOWNLOAD_SETTINGS,
+    pollInterval: 100,
+  },
+}));
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+const mockCheckArchive = jest.fn();
+const mockCreateArchive = jest.fn();
+const mockGetArchive = jest.fn();
+jest.mock('hooks/useContractArchive', () => ({
+  __esModule: true,
+  default: () => ({
+    methods: { get: mockGetArchive, create: mockCreateArchive, check: mockCheckArchive },
+  }),
+}));
+
+let mockHasContractToDownload: boolean;
+jest.mock('pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload/index.tsx', () => ({
+  __esModule: true,
+  default: () => mockHasContractToDownload,
+}));
+
+describe('useDownloadContractArchive', () => {
+  let organizationId: string;
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <IntlProvider locale="en">
+        <JoanieApiProvider>{children}</JoanieApiProvider>
+      </IntlProvider>
+    );
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    unstoreContractArchiveId();
+  });
+
+  describe('with no contract available for download', () => {
+    beforeEach(() => {
+      organizationId = faker.string.uuid();
+      mockHasContractToDownload = false;
+    });
+
+    it('should return IDLE status when no contractArchiveId is stored', async () => {
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+      expect(result.current.status).toBe(ContractDownloadStatus.IDLE);
+
+      // no api call should have been done.
+      expect(mockCheckArchive).not.toHaveBeenCalled();
+      expect(mockGetArchive).not.toHaveBeenCalled();
+      expect(mockCreateArchive).not.toHaveBeenCalled();
+    });
+
+    it('should return IDLE status when contractArchiveId is stored', async () => {
+      const contractArchiveId = faker.string.uuid();
+      storeContractArchiveId(contractArchiveId);
+
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+
+      expect(result.current.status).toBe(ContractDownloadStatus.IDLE);
+
+      // no api call should have been done.
+      expect(mockCheckArchive).not.toHaveBeenCalled();
+      expect(mockGetArchive).not.toHaveBeenCalled();
+      expect(mockCreateArchive).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with contracts available for download', () => {
+    beforeEach(() => {
+      organizationId = faker.string.uuid();
+      mockHasContractToDownload = true;
+    });
+
+    it('should return IDLE status when no contractArchiveId is stored', async () => {
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+
+      // ensure that initial effects are done
+      expect(result.current.status).toBe(ContractDownloadStatus.IDLE);
+
+      // no api call should have been done.
+      expect(mockCheckArchive).not.toHaveBeenCalled();
+      expect(mockGetArchive).not.toHaveBeenCalled();
+      expect(mockCreateArchive).not.toHaveBeenCalled();
+    });
+
+    it('should return PENDING status when a contractArchiveId is stored', async () => {
+      const contractArchiveId = faker.string.uuid();
+      storeContractArchiveId(contractArchiveId);
+      mockCheckArchive.mockResolvedValue(false);
+
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe(ContractDownloadStatus.PENDING);
+      });
+
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+      expect(mockGetArchive).not.toHaveBeenCalled();
+      expect(mockCreateArchive).not.toHaveBeenCalled();
+    });
+
+    it('should return READY status when a contractArchiveId is stored and it exists on the server', async () => {
+      const contractArchiveId = faker.string.uuid();
+      storeContractArchiveId(contractArchiveId);
+      mockCheckArchive.mockResolvedValue(true);
+
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+
+      // ensure that initial effects are done
+      await waitFor(() => {
+        expect(result.current.status).toBe(ContractDownloadStatus.READY);
+      });
+
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+      expect(mockGetArchive).not.toHaveBeenCalled();
+      expect(mockCreateArchive).not.toHaveBeenCalled();
+    });
+
+    it("doDownloadArchive should call 'getArchive' if the archive is ready for download", async () => {
+      const contractArchiveId = faker.string.uuid();
+      storeContractArchiveId(contractArchiveId);
+      mockCheckArchive.mockResolvedValue(true);
+
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+
+      // ensure that initial effects are done
+      await waitFor(() => {
+        expect(result.current.status).toBe(ContractDownloadStatus.READY);
+      });
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        result.current.downloadContractArchive();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe(ContractDownloadStatus.IDLE);
+      });
+
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+      // backend is called to download the archive
+      expect(mockGetArchive).toHaveBeenCalledTimes(1);
+
+      // but not to generate the archive
+      expect(mockCreateArchive).not.toHaveBeenCalled();
+    });
+
+    it("doDownloadArchive should call 'createArchive' if no contractArchiveId is stored", async () => {
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+
+      mockCheckArchive.mockResolvedValue(true);
+      mockCreateArchive.mockResolvedValue(faker.string.uuid());
+      act(() => {
+        result.current.downloadContractArchive();
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe(ContractDownloadStatus.IDLE);
+      });
+
+      expect(mockCreateArchive).toHaveBeenCalledTimes(1);
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+      expect(mockGetArchive).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('with contracts available for download and expired contractArchiveId', () => {
+    let contractArchiveId: string;
+    beforeEach(() => {
+      organizationId = faker.string.uuid();
+      mockHasContractToDownload = true;
+
+      const now = Date.now();
+      const unvalidCreationTime =
+        now - CONTRACT_DOWNLOAD_SETTINGS.contractArchiveLocalVaklidityDurationMs * 2;
+
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(unvalidCreationTime));
+      contractArchiveId = faker.string.uuid();
+      storeContractArchiveId(contractArchiveId);
+      jest.setSystemTime(new Date(now));
+    });
+
+    afterEach(() => {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    });
+
+    it('should return READY status when archive exists on the server', async () => {
+      mockCheckArchive.mockResolvedValue(true);
+
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+
+      // ensure that initial effects are done
+      await waitFor(() => {
+        expect(result.current.status).toBe(ContractDownloadStatus.READY);
+      });
+
+      expect(getStoredContractArchiveId()).toBe(contractArchiveId);
+
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+      expect(mockGetArchive).not.toHaveBeenCalled();
+      expect(mockCreateArchive).not.toHaveBeenCalled();
+    });
+
+    it("should return IDLE status and clear stored id when archive doesn't exists on the server", async () => {
+      mockCheckArchive.mockResolvedValue(false);
+
+      const { result } = renderHook(() => useDownloadContractArchive({ organizationId }), {
+        wrapper: Wrapper,
+      });
+
+      // ensure that initial effects are done
+      await waitFor(() => {
+        expect(result.current.status).toBe(ContractDownloadStatus.IDLE);
+      });
+
+      expect(getStoredContractArchiveId()).toBe(null);
+
+      expect(mockCheckArchive).toHaveBeenCalledTimes(1);
+      expect(mockGetArchive).not.toHaveBeenCalled();
+      expect(mockCreateArchive).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useDownloadContractArchive/index.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useMemo, useState } from 'react';
+import useContractArchive from 'hooks/useContractArchive';
+import useCheckContractArchiveExists from '../useCheckContractArchiveExists';
+import useHasContractToDownload from '../useHasContractToDownload';
+import {
+  storeContractArchiveId,
+  unstoreContractArchiveId,
+  getStoredContractArchiveId,
+  isStoredContractArchiveIdExpired,
+} from './contractArchiveLocalStorage';
+
+export enum ContractDownloadStatus {
+  INITIALIZING = 'initializing',
+  IDLE = 'idle',
+  PENDING = 'pending',
+  READY = 'ready',
+}
+
+interface UseTeacherContractsBulkDownloadProps {
+  organizationId: string;
+}
+
+const useDownloadContractArchive = ({ organizationId }: UseTeacherContractsBulkDownloadProps) => {
+  // Contract's archive api interface
+  const {
+    methods: { get: getArchive, create: createArchive },
+  } = useContractArchive();
+
+  // Simple hook that verifiy if current user have some fully signed contracts to download.
+  const hasContractToDownload = useHasContractToDownload(organizationId);
+
+  // Component state of the localstorage contract's archive id
+  const [contractArchiveId, setContractArchiveId] = useState<string | null>(
+    getStoredContractArchiveId(),
+  );
+
+  // Hook that handle contract archive existence check and recursive polling of it.
+  const { isPolling, isContractArchiveExists, checkArchiveExists } = useCheckContractArchiveExists({
+    enable: !!hasContractToDownload,
+  });
+
+  // Stored contract's archive id have to be cleanup at some point.
+  // this expired logic is handle by ./contractArchiveLocalStorage and
+  // this isContractArchiveIdExpired track it at a component level.
+  const [isContractArchiveIdExpired, setIsContractArchiveIdExpired] = useState<boolean | null>(
+    null,
+  );
+
+  // This state track if the user have request the download or not.
+  // if he have click the download button, it will be true.
+  // if he just load the page, it will be false.
+  const [isDownloadRequest, setIsDownloadRequest] = useState(false);
+
+  // Here we compute the download status.
+  // It stay as INITIALIZING until all needed data get fetched.
+  // Then it become either:
+  // * READY: the archive is ready to be download from the server
+  // * PENDING: the archive is generating on the server
+  // * IDLE: A fresh new download process
+  const contractDownloadStatus = useMemo(() => {
+    if (
+      [hasContractToDownload, isContractArchiveExists, isContractArchiveIdExpired].includes(null)
+    ) {
+      return ContractDownloadStatus.INITIALIZING;
+    }
+
+    if (hasContractToDownload && contractArchiveId) {
+      if (isContractArchiveExists) {
+        return ContractDownloadStatus.READY;
+      }
+
+      return ContractDownloadStatus.PENDING;
+    }
+
+    return ContractDownloadStatus.IDLE;
+  }, [
+    hasContractToDownload,
+    contractArchiveId,
+    isContractArchiveExists,
+    isContractArchiveIdExpired,
+  ]);
+
+  const clearContractArchive = () => {
+    setIsDownloadRequest(false);
+    setContractArchiveId(null);
+    unstoreContractArchiveId();
+  };
+
+  // Either download the archive
+  // or flag the download as requested and request the archive's creation
+  const downloadContractArchive = async () => {
+    if (isContractArchiveExists && contractArchiveId !== null) {
+      await getArchive(contractArchiveId);
+      clearContractArchive();
+    } else {
+      // When archive is ready and download is requested
+      // a useEffect will trigger the download.
+      setIsDownloadRequest(true);
+      createContractArchive();
+    }
+  };
+
+  // Request the archive's creation if needed
+  // then can start archive's polling (if option.polling === true)
+  const createContractArchive = async () => {
+    let newContractArchiveId;
+    if (contractArchiveId === null) {
+      newContractArchiveId = await createArchive(organizationId);
+      setContractArchiveId(newContractArchiveId);
+      storeContractArchiveId(newContractArchiveId);
+    } else {
+      newContractArchiveId = contractArchiveId;
+    }
+
+    if (!isPolling) {
+      checkArchiveExists(newContractArchiveId, { polling: true });
+    }
+  };
+
+  // Here we check the validity of stored id timestamp
+  // if an id is expired, we'll either:
+  // * when it exists on the server: switch expired state but nothing else
+  // * when didn't exists on the server: switch expired state and clear download data.
+  useEffect(() => {
+    if (isContractArchiveExists === null) {
+      return;
+    }
+
+    if (isStoredContractArchiveIdExpired() && isContractArchiveExists === false) {
+      setIsContractArchiveIdExpired(true);
+      clearContractArchive();
+    } else {
+      setIsContractArchiveIdExpired(false);
+    }
+  }, [contractDownloadStatus, isContractArchiveExists]);
+
+  // When the archive become ready for download
+  // this effect will trigger the download
+  // if it have been previously requested by the user
+  useEffect(() => {
+    if (isDownloadRequest && isContractArchiveExists) {
+      downloadContractArchive();
+    }
+  }, [isDownloadRequest, isContractArchiveExists]);
+
+  return {
+    status: contractDownloadStatus,
+    downloadContractArchive,
+    createContractArchive,
+  };
+};
+
+export default useDownloadContractArchive;

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload/index.spec.tsx
@@ -1,0 +1,100 @@
+import fetchMock from 'fetch-mock';
+import { faker } from '@faker-js/faker';
+import { renderHook, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { PropsWithChildren } from 'react';
+import { PER_PAGE } from 'settings';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { ContractState } from 'types/Joanie';
+import { ContractFactory } from 'utils/test/factories/joanie';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
+import useHasContractToDownload from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+describe('hooks/useHasContractToDownload', () => {
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <IntlProvider locale="en">
+        <QueryClientProvider client={createTestQueryClient({ user: true })}>
+          <JoanieSessionProvider>{children}</JoanieSessionProvider>
+        </QueryClientProvider>
+      </IntlProvider>
+    );
+  };
+
+  beforeEach(() => {
+    // Joanie providers calls
+    fetchMock.get('https://joanie.test/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/credit-cards/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/addresses/', []);
+  });
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('should return null when joanie request is pending', async () => {
+    const organizationId = faker.string.uuid();
+    const contractListUrl = `https://joanie.test/api/v1.0/organizations/${organizationId}/contracts/?signature_state=${ContractState.SIGNED}&page=1&page_size=${PER_PAGE.teacherContractList}`;
+    fetchMock.get(contractListUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [ContractFactory().one()],
+    });
+
+    const { result } = renderHook(() => useHasContractToDownload(organizationId), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should return true when joanie return some signed contracts', async () => {
+    const organizationId = faker.string.uuid();
+    const contractListUrl = `https://joanie.test/api/v1.0/organizations/${organizationId}/contracts/?signature_state=${ContractState.SIGNED}&page=1&page_size=${PER_PAGE.teacherContractList}`;
+    fetchMock.get(contractListUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [ContractFactory().one()],
+    });
+
+    const { result } = renderHook(() => useHasContractToDownload(organizationId), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.calls().map((call) => call[0])).toContain(contractListUrl);
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it("should return false when joanie doesn't return any signed contracts", async () => {
+    const organizationId = faker.string.uuid();
+    const contractListUrl = `https://joanie.test/api/v1.0/organizations/${organizationId}/contracts/?signature_state=${ContractState.SIGNED}&page=1&page_size=${PER_PAGE.teacherContractList}`;
+    fetchMock.get(contractListUrl, {
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+
+    const { result } = renderHook(() => useHasContractToDownload(organizationId), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => {
+      expect(fetchMock.calls().map((call) => call[0])).toContain(contractListUrl);
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useHasContractToDownload/index.tsx
@@ -1,0 +1,23 @@
+import { useOrganizationContracts } from 'hooks/useContracts';
+import { PER_PAGE } from 'settings';
+import { ContractState, Organization } from 'types/Joanie';
+
+const useHasContractToDownload = (organizationId: Organization['id']) => {
+  const {
+    items: contracts,
+    states: { isFetched },
+  } = useOrganizationContracts({
+    organization_id: organizationId,
+    signature_state: ContractState.SIGNED,
+    page: 1,
+    page_size: PER_PAGE.teacherContractList,
+  });
+
+  if (!isFetched) {
+    return null;
+  }
+
+  return contracts.length > 0;
+};
+
+export default useHasContractToDownload;

--- a/src/frontend/js/settings.ts
+++ b/src/frontend/js/settings.ts
@@ -46,6 +46,13 @@ export const CONTRACT_SETTINGS = {
   dummySignatureSignTimeout: 2000,
 };
 
+export const CONTRACT_DOWNLOAD_SETTINGS = {
+  // Interval in ms to poll the related contract's archive.
+  pollInterval: 1000,
+  contractArchiveLocalStorageKey: 'RICHIE_CONTRACT_ARCHIVE',
+  contractArchiveLocalVaklidityDurationMs: 10 * 60 * 60 * 1000, // 10min
+};
+
 const DEFAULT_PER_PAGE = 50;
 export const PER_PAGE = {
   teacherContractList: 25,

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -520,6 +520,11 @@ interface APIUser {
       ? Promise<Nullable<Contract>>
       : Promise<PaginatedResponse<Contract>>;
     download(id: string): Promise<File>;
+    zip_archive: {
+      check: (id: string) => Promise<Response>;
+      create: ({ organization_id }: { organization_id: string }) => Promise<{ url: string }>;
+      get: (id: string) => Promise<File>;
+    };
   };
 }
 

--- a/src/frontend/js/utils/errors/HttpError.ts
+++ b/src/frontend/js/utils/errors/HttpError.ts
@@ -25,6 +25,7 @@ export function isHttpError(error: any): error is HttpError {
 
 export enum HttpStatusCode {
   OK = 200,
+  NO_CONTENT = 204,
   UNAUTHORIZED = 401,
   BAD_REQUEST = 400,
   FORBIDDEN = 403,


### PR DESCRIPTION
## Purpose

Our organizations need to transfer signed contract to they administration.
We decide to let them download all fully signed contract from the
contracts page with this new "bulk download" feature.

![image](https://github.com/openfun/richie/assets/139848/9424eca7-e912-40d4-bb32-7ffdf905c63b)


Button label: 
* Download fully signed contracts
* Waiting zip archive generation...
* Request zip archive generation
  
![image](https://github.com/openfun/richie/assets/139848/4c0aa1a2-888e-49ef-9c21-69a0ca97f7cf)
![image](https://github.com/openfun/richie/assets/139848/b4cbc557-2fb2-44de-a294-518ac32a0c70)
![image](https://github.com/openfun/richie/assets/139848/b00cd7eb-ae5d-4bfc-8616-f53d7e895a36)


