### PR TITLE
💄(frontend) reorder learner dashbaord menu link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Change menu link order on the learner dashboard sidebar.
 - Organization bulk contract signature
 - Add a Badge React component
 - Add a footer on enrollment's item in the learner dashboard. It give the

--- a/src/frontend/js/widgets/Dashboard/components/LearnerDashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/LearnerDashboardSidebar/index.tsx
@@ -36,9 +36,9 @@ export const LearnerDashboardSidebar = (props: Partial<DashboardSidebarProps>) =
     () =>
       [
         LearnerDashboardPaths.COURSES,
-        LearnerDashboardPaths.PREFERENCES,
         LearnerDashboardPaths.CERTIFICATES,
         LearnerDashboardPaths.CONTRACTS,
+        LearnerDashboardPaths.PREFERENCES,
       ].map((path) => ({
         to: getRoutePath(path),
         label: getRouteLabel(path),


### PR DESCRIPTION
## Purpose
   
The order of learner dashboard link weren't perfect.
It's prettier like this, everyone whould agree.

![image](https://github.com/openfun/richie/assets/139848/aee0ef97-2b4e-41a6-9595-883548d25edb)
