### PR TITLE
🩹(frontend) await logout request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Await logout authentication request logout trigger
 - Fix search facets count metadata issue (ignore not listed courses)
 - Fix `getCourseGlimpseProps` method to handle localized course urls
 

--- a/src/frontend/js/contexts/SessionContext/BaseSessionProvider.tsx
+++ b/src/frontend/js/contexts/SessionContext/BaseSessionProvider.tsx
@@ -60,8 +60,8 @@ const BaseSessionProvider = ({ children }: PropsWithChildren<any>) => {
   }, [queryClient]);
 
   const destroy = useCallback(async () => {
-    AuthenticationApi!.logout();
     invalidate();
+    await AuthenticationApi!.logout();
   }, [invalidate]);
 
   const context = useMemo(

--- a/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.tsx
+++ b/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.tsx
@@ -89,8 +89,8 @@ const JoanieSessionProvider = ({ children }: React.PropsWithChildren<{}>) => {
   }, [queryClient]);
 
   const destroy = useCallback(async () => {
-    AuthenticationApi!.logout();
     invalidate();
+    await AuthenticationApi!.logout();
   }, [invalidate]);
 
   useEffect(() => {


### PR DESCRIPTION
## Purpose

The authentication logout is async but we do not wait the promise resolve when the user triggers logout method. But in some case it could lead to bug. Indeed, if the user query invalidation trigger a redirect, not await the promise resolve, lead to refetch user data before the authentication server has really logout the user so the session is populated with outdated user information...

## Proposal

- [x] Await logout authentication request 
