### PR TITLE
🚧(frontend) Split useContract into useContract and useOrganizationContract 

### DIFF
--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -177,6 +177,9 @@ export const getRoutes = () => {
       products: {
         get: `${baseUrl}/courses/:course_id/products/:id/`,
       },
+      contracts: {
+        get: `${baseUrl}/courses/:organization_id/contracts/:id/`,
+      },
     },
     courseRuns: {
       get: `${baseUrl}/course-runs/:id/`,
@@ -370,12 +373,9 @@ const API = (): Joanie.API => {
       contracts: {
         get: async ({ contract_ids, ...filters } = {}) => {
           const endpointFilters = { ...filters, queryParameters: { id: contract_ids } };
-          return fetchWithJWT(
-            filters?.organization_id
-              ? buildApiUrl(ROUTES.organizations.contracts.get, endpointFilters)
-              : buildApiUrl(ROUTES.user.contracts.get, filters),
-            { method: 'GET' },
-          ).then(checkStatus);
+          return fetchWithJWT(buildApiUrl(ROUTES.user.contracts.get, endpointFilters), {
+            method: 'GET',
+          }).then(checkStatus);
         },
         download(id: string): Promise<any> {
           return fetchWithJWT(ROUTES.user.contracts.download.replace(':id', id), {
@@ -391,6 +391,12 @@ const API = (): Joanie.API => {
         }).then(checkStatus);
       },
       contracts: {
+        get: async ({ contract_ids, ...filters } = {}) => {
+          const endpointFilters = { ...filters, queryParameters: { id: contract_ids } };
+          return fetchWithJWT(buildApiUrl(ROUTES.organizations.contracts.get, endpointFilters), {
+            method: 'GET',
+          }).then(checkStatus);
+        },
         getSignatureLinks: async (filters) => {
           return fetchWithJWT(
             buildApiUrl(ROUTES.organizations.contracts.getSignatureLinks, filters),
@@ -422,6 +428,14 @@ const API = (): Joanie.API => {
           }
 
           return fetchWithJWT(buildApiUrl(ROUTES.courses.products.get, filters)).then(checkStatus);
+        },
+      },
+      contracts: {
+        get: async ({ contract_ids, ...filters } = {}) => {
+          const endpointFilters = { ...filters, queryParameters: { id: contract_ids } };
+          return fetchWithJWT(buildApiUrl(ROUTES.courses.contracts.get, endpointFilters), {
+            method: 'GET',
+          }).then(checkStatus);
         },
       },
     },

--- a/src/frontend/js/api/lms/dummy.ts
+++ b/src/frontend/js/api/lms/dummy.ts
@@ -71,7 +71,7 @@ const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
               "username": "admin",
             }
         */
-        return getUserInfo('admin') || null;
+        return getUserInfo('organization_owner') || null;
       },
       login: () => location.reload(),
       register: () => location.reload(),

--- a/src/frontend/js/hooks/useContracts/index.tsx
+++ b/src/frontend/js/hooks/useContracts/index.tsx
@@ -22,8 +22,35 @@ const props: UseResourcesProps<Contract, ContractFilters, API['user']['contracts
   session: true,
   messages,
 };
+
 /**
  * Joanie Api hook to retrieve/update a contract owned by the authenticated user.
  */
 export const useContract = useResource(props);
 export const useContracts = useResources(props);
+
+/**
+ * Joanie Api hook to retrieve/update a contracts related to a course.
+ */
+const courseProps: UseResourcesProps<Contract, ContractFilters, API['courses']['contracts']> = {
+  ...props,
+  queryKey: ['course_contracts'],
+  apiInterface: () => useJoanieApi().courses.contracts,
+};
+export const useCourseContract = useResource(courseProps);
+export const useCourseContracts = useResources(courseProps);
+
+/**
+ * Joanie Api hook to retrieve/update a contracts related to a course.
+ */
+const organizationProps: UseResourcesProps<
+  Contract,
+  ContractFilters,
+  API['organizations']['contracts']
+> = {
+  ...props,
+  queryKey: ['organization_contracts'],
+  apiInterface: () => useJoanieApi().organizations.contracts,
+};
+export const useOrganizationContract = useResource(organizationProps);
+export const useOrganizationContracts = useResources(organizationProps);

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/TeacherDashboardCourseContractsLayout/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/TeacherDashboardCourseContractsLayout/index.tsx
@@ -13,6 +13,19 @@ const messages = defineMessages({
 });
 
 export const TeacherDashboardCourseContractsLayout = () => {
+  const {
+    items: contracts,
+    meta,
+    states: { fetching, isFetched, error },
+  } = useContracts(
+    {
+      ...filters,
+      page: pagination.page,
+      page_size: PER_PAGE.teacherContractList,
+    },
+    { enabled: !!filters.organization_id },
+  );
+
   return (
     <DashboardLayout sidebar={<TeacherDashboardCourseSidebar />}>
       <div className="dashboard__page_title_container">

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/TeacherDashboardOrganizationContractsLayout/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/TeacherDashboardOrganizationContractsLayout/index.tsx
@@ -1,8 +1,16 @@
 import { defineMessages, FormattedMessage } from 'react-intl';
 
+import { usePagination } from '@openfun/cunningham-react';
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { DashboardLayout } from 'widgets/Dashboard/components/DashboardLayout';
 import { TeacherDashboardOrganizationSidebar } from 'widgets/Dashboard/components/TeacherDashboardOrganizationSidebar';
+import Banner, { BannerType } from 'components/Banner';
+import { PER_PAGE } from 'settings';
+import { useOrganizationContracts } from 'hooks/useContracts';
+import { ContractFilters } from 'types/Joanie';
 import TeacherDashboardContracts from '../TeacherDashboardContracts';
+import useTeacherContractFilters from '../hooks/useTeacherContractFilters';
 
 const messages = defineMessages({
   pageTitle: {
@@ -13,6 +21,42 @@ const messages = defineMessages({
 });
 
 export const TeacherDashboardOrganizationContractsLayout = () => {
+  const { initialFilters, filters, setFilters } = useTeacherContractFilters();
+  const [searchParams] = useSearchParams();
+  const page = searchParams.get('page') ?? '1';
+  const pagination = usePagination({
+    defaultPage: page ? parseInt(page, 10) : 1,
+    pageSize: PER_PAGE.teacherContractList,
+  });
+  const {
+    items: contracts,
+    meta,
+    states: { fetching, isFetched, error },
+  } = useOrganizationContracts(
+    {
+      ...filters,
+      page: pagination.page,
+      page_size: PER_PAGE.teacherContractList,
+    },
+    { enabled: !!filters.organization_id },
+  );
+
+  const handleFiltersChange = (newFilters: Partial<ContractFilters>) => {
+    // Reset pagination
+    pagination.setPage(1);
+    setFilters((prevFilters) => ({ ...prevFilters, ...newFilters }));
+  };
+
+  useEffect(() => {
+    if (isFetched && meta?.pagination?.count !== undefined) {
+      pagination.setPagesCount(Math.ceil(meta!.pagination!.count / PER_PAGE.teacherContractList));
+    }
+  }, [isFetched, meta?.pagination?.count]);
+
+  if (error) {
+    return <Banner message={error} type={BannerType.ERROR} rounded />;
+  }
+
   return (
     <DashboardLayout sidebar={<TeacherDashboardOrganizationSidebar />}>
       <div className="dashboard__page_title_container">
@@ -20,7 +64,14 @@ export const TeacherDashboardOrganizationContractsLayout = () => {
           <FormattedMessage {...messages.pageTitle} />
         </h1>
       </div>
-      <TeacherDashboardContracts />
+      <TeacherDashboardContracts
+        contracts={contracts}
+        pagination={pagination}
+        isLoading={fetching}
+        filters={filters}
+        initialFilters={initialFilters}
+        handleFiltersChange={handleFiltersChange}
+      />
     </DashboardLayout>
   );
 };

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/components/ContractActionsBar/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/components/ContractActionsBar/index.tsx
@@ -1,5 +1,5 @@
 import { CourseListItem, Organization, Product } from 'types/Joanie';
-import useTeacherContractsToSign from 'pages/TeacherDashboardContractsLayout/hooks/useTeacherContractsToSign';
+import useOrganizationContractsToSign from 'pages/TeacherDashboardContractsLayout/hooks/useTeacherContractsToSign';
 import SignOrganizationContractButton from '../SignOrganizationContractButton';
 
 interface ContractActionsProps {
@@ -9,7 +9,7 @@ interface ContractActionsProps {
 }
 
 const ContractActionsBar = ({ courseId, productId, organizationId }: ContractActionsProps) => {
-  const { canSignContracts, contractsToSignCount } = useTeacherContractsToSign({
+  const { canSignContracts, contractsToSignCount } = useOrganizationContractsToSign({
     organizationId,
     courseId,
     productId,

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useOrganizationContractsToSign.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/hooks/useOrganizationContractsToSign.tsx
@@ -1,20 +1,20 @@
 import useContractAbilities from 'hooks/useContractAbilities';
-import { useContracts } from 'hooks/useContracts';
+import { useOrganizationContracts } from 'hooks/useContracts';
 import { ContractState, CourseListItem, Organization, Product } from 'types/Joanie';
 import { ContractActions } from 'utils/AbilitiesHelper/types';
 
-interface UseTeacherContractsToSignProps {
+interface UseOrganizationContractsToSignProps {
   courseId?: CourseListItem['id'];
   productId?: Product['id'];
   organizationId?: Organization['id'];
 }
 
-const useTeacherContractsToSign = ({
+const useOrganizationContractsToSign = ({
   courseId,
   productId,
   organizationId,
-}: UseTeacherContractsToSignProps) => {
-  const { items: contractsToSign, meta: contractsToSignMeta } = useContracts(
+}: UseOrganizationContractsToSignProps) => {
+  const { items: contractsToSign, meta: contractsToSignMeta } = useOrganizationContracts(
     {
       signature_state: ContractState.LEARNER_SIGNED,
       organization_id: organizationId,
@@ -32,4 +32,4 @@ const useTeacherContractsToSign = ({
   };
 };
 
-export default useTeacherContractsToSign;
+export default useOrganizationContractsToSign;

--- a/src/frontend/js/settings.ts
+++ b/src/frontend/js/settings.ts
@@ -23,8 +23,8 @@ export const REACT_QUERY_SETTINGS = {
     // session lifetime should be synchronized with the access token lifetime of your authentication
     // service. For example if you are using djangorestframework-simplejwt default value
     // is 5 minutes.
-    session: 5 * 60 * 1000, // 5 minutes in ms
-    sessionItems: 20 * 60 * 1000, // 20 minutes, items related to the session should not be refreshed as the frequency than session information.
+    session: 0, // 5 minutes in ms
+    sessionItems: 0, // 20 minutes, items related to the session should not be refreshed as the frequency than session information.
   },
 };
 

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -535,12 +535,24 @@ export interface API {
     products: {
       get(filters?: CourseProductQueryFilters): Promise<Nullable<CourseProductRelation>>;
     };
+    contracts: {
+      get(
+        filters?: ContractFilters,
+      ): ContractFilters extends { id: string }
+        ? Promise<Nullable<Contract>>
+        : Promise<PaginatedResponse<Contract>>;
+    };
   };
   organizations: {
     get<Filters extends ResourcesQuery = ResourcesQuery>(
       filters?: Filters,
     ): Filters extends { id: string } ? Promise<Nullable<Organization>> : Promise<Organization[]>;
     contracts: {
+      get(
+        filters?: ContractFilters,
+      ): ContractFilters extends { id: string }
+        ? Promise<Nullable<Contract>>
+        : Promise<PaginatedResponse<Contract>>;
       getSignatureLinks(
         filters?: OrganizationContractSignatureLinksFilters,
       ): Promise<OrganizationContractInvitationLinkResponse>;

--- a/src/frontend/js/widgets/Dashboard/components/TeacherDashboardOrganizationSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherDashboardOrganizationSidebar/index.tsx
@@ -4,7 +4,7 @@ import { createSearchParams, generatePath, useParams } from 'react-router-dom';
 import Badge from 'components/Badge';
 import { Spinner } from 'components/Spinner';
 import useContractAbilities from 'hooks/useContractAbilities';
-import { useContracts } from 'hooks/useContracts';
+import { useOrganizationContracts } from 'hooks/useContracts';
 import { useOrganization } from 'hooks/useOrganizations';
 import { ContractState } from 'types/Joanie';
 import { ContractActions } from 'utils/AbilitiesHelper/types';
@@ -39,7 +39,7 @@ export const TeacherDashboardOrganizationSidebar = () => {
     states: { fetching },
   } = useOrganization(organizationId);
 
-  const { items: contracts, meta } = useContracts({
+  const { items: contracts, meta } = useOrganizationContracts({
     organization_id: organizationId,
     signature_state: ContractState.LEARNER_SIGNED,
   });


### PR DESCRIPTION
## Purpose

We have three routes to interact with contracts:
* /contracts/id : return current user orders's contrats
* /organizations/id/contracts/id: return contract for a organization, check `OrganizationAccess`.
* /courses/id/contracts/id: return contract for a organization, check `CourseAccess`.

The current implementation of theses route use a unique hook that check filters to decide which route to use between contract and organizations/contracts. 
In order to implement courses's contract page and action, we need to interact with `courses/contracts` route and it's filters like : 
`courses/course_id/contracts/contract_id/?organization_id=organization_id`.
This isn't possible with the current implementation of contracts.get routes.

I decide here to split `useContract` hook in three to get one hook per routes


