### PR TITLE
🐛(frontend) fix routes to redirect user to its dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix malformed CourseProductItem Order dashboard links
 - Await logout authentication request logout trigger
 - Fix search facets count metadata issue (ignore not listed courses)
 - Fix `getCourseGlimpseProps` method to handle localized course urls

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepResume/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepResume/index.spec.tsx
@@ -76,6 +76,7 @@ describe('SaleTunnelStepResume', () => {
 
     // Click on the button trigger the next function
     const button = screen.getByRole('link', { name: 'Sign the training contract' });
+    expect(button).toHaveAttribute('href', `/en/dashboard/courses/orders/${order.id}`);
     fireEvent.click(button);
     expect(mockNext).toHaveBeenCalledTimes(0);
   });

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepResume/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepResume/index.tsx
@@ -4,6 +4,7 @@ import { SuccessIcon } from 'components/SuccessIcon';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import { getDashboardBasename } from 'widgets/Dashboard/hooks/useDashboardRouter/getDashboardBasename';
 import { useSaleTunnelContext } from 'components/SaleTunnel/context';
+import { getDashboardRoutePath } from 'widgets/Dashboard/utils/dashboardRoutes';
 
 const messages = defineMessages({
   congratulations: {
@@ -71,7 +72,7 @@ export const SaleTunnelStepResume = ({ next }: SaleTunnelStepResumeProps) => {
           <Button
             href={
               getDashboardBasename(intl.locale) +
-              LearnerDashboardPaths.ORDER.replace(':orderId', order!.id)
+              getDashboardRoutePath(intl)(LearnerDashboardPaths.ORDER, { orderId: order!.id })
             }
           >
             <FormattedMessage {...messages.ctaSignature} />

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/ProductSignatureHeader/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/ProductSignatureHeader/index.tsx
@@ -4,6 +4,7 @@ import Banner, { BannerType } from 'components/Banner';
 import { getDashboardBasename } from 'widgets/Dashboard/hooks/useDashboardRouter/getDashboardBasename';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRouteMessages';
 import { Order } from 'types/Joanie';
+import { getDashboardRoutePath } from 'widgets/Dashboard/utils/dashboardRoutes';
 
 const messages = defineMessages({
   signatureNeeded: {
@@ -29,7 +30,7 @@ export const ProductSignatureHeader = ({ order }: { order?: Order }) => {
         size="small"
         href={
           getDashboardBasename(intl.locale) +
-          LearnerDashboardPaths.ORDER.replace(':orderId', order!.id)
+          getDashboardRoutePath(intl)(LearnerDashboardPaths.ORDER, { orderId: order!.id })
         }
       >
         <FormattedMessage {...messages.contractSignActionLabel} />


### PR DESCRIPTION
## Purpose

After a user purchased a training, if this one has a contract to sign, the UI invites the user to go to its dashboard to sign this one. But currently, the URL
 is malformed according to the current locale. Indeed, dashboard urls are
 localized so if the current locale is something else than english the link will
  be wrong.

## Proposal

- [x] Localized dashboard links into `CourseProductItem`
