### PR TITLE
Fix issue #2232

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.25.0-beta.1]
 
+### Added
+
+- Add Course run link into Order detail view
+
 ### Fixed
 
 - Fix malformed CourseProductItem Order dashboard links

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
@@ -13,7 +13,7 @@ import {
 } from 'types/Joanie';
 import { Spinner } from 'components/Spinner';
 import Banner, { BannerType } from 'components/Banner';
-import useDateFormat, { DATETIME_FORMAT } from 'hooks/useDateFormat';
+import useDateFormat, { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { orderNeedsSignature } from 'widgets/Dashboard/components/DashboardItem/utils/order';
 import { RouterButton } from '../RouterButton';
@@ -233,8 +233,8 @@ const DashboardItemCourseEnrollingRun = ({
           <FormattedMessage
             {...messages.runPeriod}
             values={{
-              startDate: formatDate(courseRun.start, DATETIME_FORMAT),
-              endDate: formatDate(courseRun.end, DATETIME_FORMAT),
+              startDate: formatDate(courseRun.start, DEFAULT_DATE_FORMAT),
+              endDate: formatDate(courseRun.end, DEFAULT_DATE_FORMAT),
             }}
           />
         </div>
@@ -345,8 +345,8 @@ const EnrolledStatus = ({ enrollment }: { enrollment: Enrollment }) => {
     <FormattedMessage
       {...messages.enrolledRunPeriod}
       values={{
-        startDate: formatDate(enrollment.course_run.start, DATETIME_FORMAT),
-        endDate: formatDate(enrollment.course_run.end, DATETIME_FORMAT),
+        startDate: formatDate(enrollment.course_run.start, DEFAULT_DATE_FORMAT),
+        endDate: formatDate(enrollment.course_run.end, DEFAULT_DATE_FORMAT),
       }}
     />
   );

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
@@ -39,7 +39,7 @@ const messages = defineMessages({
   accessCourse: {
     id: 'components.DashboardItemEnrollment.gotoCourse',
     description: 'Button to access course when the user is enrolled',
-    defaultMessage: 'Access course',
+    defaultMessage: 'Access to course',
   },
   runPeriod: {
     id: 'components.DashboardItemEnrollment.runPeriod',
@@ -230,8 +230,17 @@ const DashboardItemCourseEnrollingRun = ({
     >
       <div>
         <div>
+          <p className="dashboard-item__course-enrolling__run_title">
+            {selected && (
+              <Icon
+                className="dashboard-item__course-enrolling__run__icon-enrolled"
+                name={IconTypeEnum.CHECK}
+              />
+            )}
+            <strong>{courseRun.title}</strong>
+          </p>
           <FormattedMessage
-            {...messages.runPeriod}
+            {...(selected ? messages.enrolledRunPeriod : messages.runPeriod)}
             values={{
               startDate: formatDate(courseRun.start, DEFAULT_DATE_FORMAT),
               endDate: formatDate(courseRun.end, DEFAULT_DATE_FORMAT),
@@ -249,14 +258,19 @@ const DashboardItemCourseEnrollingRun = ({
       </div>
       <div>
         {selected ? (
-          <div className="dashboard-item__course-enrolling__run__enrolled">
-            <FormattedMessage {...messages.enrolled} />
-            <Icon name={IconTypeEnum.CHECK} size="small" />
-          </div>
+          <Button
+            color="secondary"
+            size="small"
+            href={courseRun.resource_link}
+            data-testid="dashboard-item-enrollment__button"
+            className="dashboard-item__button"
+          >
+            <FormattedMessage {...messages.accessCourse} />
+          </Button>
         ) : (
           <Button
             disabled={!isOpenedForEnrollment || haveToSignContract}
-            color="secondary"
+            color="tertiary"
             size="small"
             onClick={enroll}
             title={haveToSignContract ? intl.formatMessage(messages.contractUnsigned) : ''}

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.spec.tsx
@@ -8,7 +8,7 @@ import {
   RichieContextFactory as mockRichieContextFactory,
 } from 'utils/test/factories/richie';
 import { CourseRunWithCourseFactory, EnrollmentFactory } from 'utils/test/factories/joanie';
-import { DATETIME_FORMAT } from 'hooks/useDateFormat';
+import { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
 import { Priority } from 'types';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
@@ -47,17 +47,19 @@ describe('<DashboardItemEnrollment/>', () => {
     render(<Wrapper enrollment={enrollment} />);
     screen.getByText(enrollment.course_run.course!.title);
     screen.getByText('Ref. ' + enrollment.course_run.course!.code);
-    const link = screen.getByRole('link', { name: 'Access course' });
+    const link = screen.getByRole('link', { name: 'Access to course' });
     expect(link).toBeEnabled();
     expect(link).toHaveAttribute('href', enrollment.course_run.resource_link);
 
     screen.getByText(
       'You are enrolled for the session from ' +
-        new Intl.DateTimeFormat('en', DATETIME_FORMAT).format(
+        new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(
           new Date(enrollment.course_run.start),
         ) +
         ' to ' +
-        new Intl.DateTimeFormat('en', DATETIME_FORMAT).format(new Date(enrollment.course_run.end)),
+        new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(
+          new Date(enrollment.course_run.end),
+        ),
     );
   });
 
@@ -75,16 +77,18 @@ describe('<DashboardItemEnrollment/>', () => {
     render(<Wrapper enrollment={enrollment} />);
     screen.getByText(enrollment.course_run.course!.title);
     screen.getByText('Ref. ' + enrollment.course_run.course!.code);
-    const link = screen.getByRole('link', { name: 'Access course' });
+    const link = screen.getByRole('link', { name: 'Access to course' });
     expect(link).toBeEnabled();
     expect(link).toHaveAttribute('href', enrollment.course_run.resource_link);
     screen.getByText(
       'You are enrolled for the session from ' +
-        new Intl.DateTimeFormat('en', DATETIME_FORMAT).format(
+        new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(
           new Date(enrollment.course_run.start),
         ) +
         ' to ' +
-        new Intl.DateTimeFormat('en', DATETIME_FORMAT).format(new Date(enrollment.course_run.end)),
+        new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(
+          new Date(enrollment.course_run.end),
+        ),
     );
   });
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -15,7 +15,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
 import fetchMock from 'fetch-mock';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { DATETIME_FORMAT, DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
+import { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import {
   CertificateFactory,
@@ -217,11 +217,11 @@ describe('<DashboardItemOrder/>', () => {
       await screen.findByRole('heading', { level: 6, name: course.title });
       screen.getByText(
         'You are enrolled for the session from ' +
-          new Intl.DateTimeFormat('en', DATETIME_FORMAT).format(
+          new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(
             new Date(order.target_enrollments[0].course_run.start),
           ) +
           ' to ' +
-          new Intl.DateTimeFormat('en', DATETIME_FORMAT).format(
+          new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(
             new Date(order.target_enrollments[0].course_run.end),
           ),
       );
@@ -296,9 +296,9 @@ describe('<DashboardItemOrder/>', () => {
         getByText(
           runElement,
           'From ' +
-            new Intl.DateTimeFormat('en', DATETIME_FORMAT).format(new Date(courseRun.start)) +
+            new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(new Date(courseRun.start)) +
             ' to ' +
-            new Intl.DateTimeFormat('en', DATETIME_FORMAT).format(new Date(courseRun.end)),
+            new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(new Date(courseRun.end)),
         );
         // Expect the first courseRun to be enrolled but not the others.
         if (i === 0) {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -225,7 +225,7 @@ describe('<DashboardItemOrder/>', () => {
             new Date(order.target_enrollments[0].course_run.end),
           ),
       );
-      screen.getByRole('link', { name: 'Access course' });
+      screen.getByRole('link', { name: 'Access to course' });
     });
   });
   it('renders a non-writable order with not enrolled target course', async () => {
@@ -293,19 +293,27 @@ describe('<DashboardItemOrder/>', () => {
           container,
           'dashboard-item__course-enrolling__run__' + courseRun.id,
         );
-        getByText(
-          runElement,
-          'From ' +
-            new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(new Date(courseRun.start)) +
-            ' to ' +
-            new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(new Date(courseRun.end)),
-        );
+        getByText(runElement, courseRun.title);
         // Expect the first courseRun to be enrolled but not the others.
         if (i === 0) {
-          getByText(runElement, 'Enrolled');
           expect(queryByRole(runElement, 'button', { name: 'Enroll' })).toBeNull();
+          getByText(
+            runElement,
+            'You are enrolled for the session from ' +
+              new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(new Date(courseRun.start)) +
+              ' to ' +
+              new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(new Date(courseRun.end)),
+          );
+          const button = getByRole(runElement, 'link', { name: 'Access to course' });
+          expect(button).toHaveAttribute('href', courseRun.resource_link);
         } else {
-          expect(queryByText(runElement, 'Enrolled')).toBeNull();
+          getByText(
+            runElement,
+            'From ' +
+              new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(new Date(courseRun.start)) +
+              ' to ' +
+              new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(new Date(courseRun.end)),
+          );
           getByRole(runElement, 'button', { name: 'Enroll' });
         }
       });
@@ -384,7 +392,7 @@ describe('<DashboardItemOrder/>', () => {
       runElement = await screen.findByTestId(
         'dashboard-item__course-enrolling__run__' + courseRun.id,
       );
-      getByText(runElement, 'Enrolled');
+      getByRole(runElement, 'link', { name: 'Access to course' });
     });
 
     expect(queryByRole(runElement, 'button', { name: 'Enroll' })).toBeNull();
@@ -533,7 +541,7 @@ describe('<DashboardItemOrder/>', () => {
       runElement = await screen.findByTestId(
         'dashboard-item__course-enrolling__run__' + newEnrolledCourseRun.id,
       );
-      getByText(runElement, 'Enrolled');
+      getByRole(runElement, 'link', { name: 'Access to course' });
     });
 
     expect(queryByRole(runElement, 'button', { name: 'Enroll' })).toBeNull();
@@ -568,14 +576,14 @@ describe('<DashboardItemOrder/>', () => {
     let runElement = await screen.findByTestId(
       'dashboard-item__course-enrolling__run__' + courseRun.id,
     );
-    getByText(runElement, 'Enrolled');
+    getByRole(runElement, 'link', { name: 'Access to course' });
 
     // Make sure the new courseRun is not enrolled.
     const newRunElement = await screen.findByTestId(
       'dashboard-item__course-enrolling__run__' + newEnrolledCourseRun.id,
     );
     const enrollButton = getByRole(newRunElement, 'button', { name: 'Enroll' });
-    expect(queryByText(newRunElement, 'Enrolled')).toBeNull();
+    expect(queryByRole(runElement, 'button', { name: 'Access to course' })).toBeNull();
 
     expect(
       fetchMock.called('https://joanie.endpoint/api/v1.0/enrollments/', { method: 'post' }),
@@ -600,7 +608,7 @@ describe('<DashboardItemOrder/>', () => {
     runElement = await screen.findByTestId(
       'dashboard-item__course-enrolling__run__' + courseRun.id,
     );
-    getByText(runElement, 'Enrolled');
+    getByRole(runElement, 'link', { name: 'Access to course' });
 
     // Expect the enrollment to not be created and orders not invalided.
     expect(
@@ -686,7 +694,7 @@ describe('<DashboardItemOrder/>', () => {
       runElement = await screen.findByTestId(
         'dashboard-item__course-enrolling__run__' + courseRun.id,
       );
-      getByText(runElement, 'Enrolled');
+      getByRole(runElement, 'link', { name: 'Access to course' });
     });
 
     expect(queryByRole(runElement, 'button', { name: 'Enroll' })).toBeNull();
@@ -751,7 +759,7 @@ describe('<DashboardItemOrder/>', () => {
 
     // The course run should be shown as enrolled even if is it past.
     const runElement = screen.getByTestId('dashboard-item__course-enrolling__run__' + courseRun.id);
-    getByText(runElement, 'Enrolled');
+    getByRole(runElement, 'link', { name: 'Access to course' });
     expect(queryByRole(runElement, 'button', { name: 'Enroll' })).toBeNull();
   });
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -171,6 +171,14 @@
     justify-content: space-between;
     align-items: center;
     padding: 0.5rem 1rem;
+    font-size: rem-calc(13px);
+
+    &_title {
+      align-items: flex-start;
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 0;
+    }
 
     &:not(:last-child) {
       border-bottom: $onepixel solid r-theme-val(dashboard-item, base-border);
@@ -180,12 +188,10 @@
       color: r-theme-val(product-item, feedback-color);
     }
 
-    &__enrolled {
-      display: flex;
-      gap: 0.5rem;
-      padding: 0.7rem 1.3rem;
+    &__icon-enrolled {
       color: r-theme-val(dashboard-item-course-enrolling-run, enrolled-color);
-      font-family: $r-font-family-montserrat;
+      height: 1rem;
+      width: 1rem;
     }
   }
 }


### PR DESCRIPTION
## Purpose

Currently, in the order detail view, if a user is enrolled to a course run we
only display a labelled to tell it, it is enrolled but there is no link to
access to the course that is weird. So we revamp this UI to add this link and
keep information that the user is enrolled.

| Before | After |
|--------|-------|
|<img width="800" alt="image" src="https://github.com/openfun/richie/assets/9265241/da601e9d-7c0f-408b-b21b-a0758d13103f">|<img width="800" alt="image" src="https://github.com/openfun/richie/assets/9265241/3050cca1-c788-4748-aac2-924ac3c5cf6c">|

## Proposal

- [x] Only display course run dates (not time)
- [x] Revamp course run order detail to add course link
