### PR TITLE
✨(frontend) add signature polling description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Add signature polling description
 - Fix malformed CourseProductItem Order dashboard links
 - Await logout authentication request logout trigger
 - Fix search facets count metadata issue (ignore not listed courses)

--- a/src/frontend/js/components/ContractFrame/AbstractContractFrame.spec.tsx
+++ b/src/frontend/js/components/ContractFrame/AbstractContractFrame.spec.tsx
@@ -151,6 +151,11 @@ describe('<AbstractContractFrame />', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Verifying signature ...' })).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(
+        'We are waiting for the signature to be validated from our signature platform. It can take up to few minutes. Do not close this page.',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole('status')).toBeInTheDocument();
 
     checkSignatureDeferred.resolve({ isSigned: true });
@@ -207,6 +212,11 @@ describe('<AbstractContractFrame />', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Verifying signature ...' })).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(
+        'We are waiting for the signature to be validated from our signature platform. It can take up to few minutes. Do not close this page.',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole('status')).toBeInTheDocument();
 
     checkSignatureDeferred.reject(new HttpError(500, 'Interval server error'));
@@ -263,6 +273,11 @@ describe('<AbstractContractFrame />', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Verifying signature ...' })).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(
+        'We are waiting for the signature to be validated from our signature platform. It can take up to few minutes. Do not close this page.',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole('status')).toBeInTheDocument();
 
     checkSignatureDeferred.resolve({ isSigned: false });

--- a/src/frontend/js/components/ContractFrame/AbstractContractFrame.tsx
+++ b/src/frontend/js/components/ContractFrame/AbstractContractFrame.tsx
@@ -50,6 +50,12 @@ export const messages = defineMessages({
     description: 'Message displayed inside the contract signin modal when polling the order.',
     id: 'components.DashboardItem.Order.ContractFrame.polling',
   },
+  pollingDescription: {
+    defaultMessage:
+      'We are waiting for the signature to be validated from our signature platform. It can take up to few minutes. Do not close this page.',
+    description: 'Message displayed inside the contract signin modal when polling the order.',
+    id: 'components.DashboardItem.Order.ContractFrame.pollingDescription',
+  },
   finishedCaption: {
     defaultMessage: 'Congratulations!',
     description: 'Title displayed inside the contract signin modal when the contract is signed.',
@@ -251,9 +257,14 @@ const ContractFrameContent = ({
       )}
       {step === ContractSteps.POLLING && (
         <div className="ContractFrame__loading-container">
-          <h3 className="ContractFrame__caption">
-            <FormattedMessage {...messages.polling} />
-          </h3>
+          <div>
+            <h3 className="ContractFrame__caption">
+              <FormattedMessage {...messages.polling} />
+            </h3>
+            <p className="ContractFrame__content">
+              <FormattedMessage {...messages.pollingDescription} />
+            </p>
+          </div>
           <Loader />
         </div>
       )}


### PR DESCRIPTION
We want to add a bit of explanations to the user becasue this step can take some time.

<img width="1110" alt="Capture d’écran 2024-01-22 à 17 10 38" src="https://github.com/openfun/richie/assets/9628870/fdcfd059-4d85-4e7e-b09f-ce0d3323bcdb">



Closes #2243

