### PR TITLE
🐛(frontend) fix Enroll now translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Switch from setup.cfg to pyproject.toml 
 
+### Fixed
+
+- Fix frontend translation of Enroll now for external LMS backend
+
 ## [2.25.0-beta.1]
 
 ### Added

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRun/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRun/index.tsx
@@ -11,6 +11,11 @@ import CourseRunEnrollment from '../CourseRunEnrollment';
 import CourseProductItem from '../CourseProductItem';
 
 const messages = defineMessages({
+  enroll: {
+    id: 'components.SyllabusCourseRun.enroll',
+    description: 'CTA for users to enroll in the course run for external LMS backend.',
+    defaultMessage: 'Enroll now',
+  },
   enrollment: {
     id: 'components.SyllabusCourseRun.enrollment',
     description: 'Title of the enrollment dates section of an opened course run block',
@@ -84,7 +89,7 @@ const OpenedCourseRun = ({ courseRun }: { courseRun: CourseRun }) => {
         <CourseRunEnrollment courseRun={courseRun} />
       ) : (
         <a className="course-run-enrollment__cta" href={courseRun.resource_link}>
-          {StringHelper.capitalizeFirst(courseRun.state.call_to_action)}
+          <FormattedMessage {...messages.enroll} />
         </a>
       )}
     </>

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/index.spec.tsx
@@ -27,7 +27,6 @@ import JoanieApiProvider from 'contexts/JoanieApiContext';
 import { CourseProductRelation } from 'types/Joanie';
 import { CourseLightFactory, CourseProductRelationFactory } from 'utils/test/factories/joanie';
 import { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
-import { StringHelper } from 'utils/StringHelper';
 import { computeStates } from 'utils/CourseRuns';
 import { User } from 'types/User';
 import { Nullable } from 'types/utils';
@@ -138,7 +137,7 @@ describe('<SyllabusCourseRunsList/>', () => {
 
     expect(languagesContainer.nextSibling).toBeNull();
     getByRole(runContainer, 'link', {
-      name: StringHelper.capitalizeFirst(courseRun.state.call_to_action)!,
+      name: 'Enroll now',
     });
   };
 


### PR DESCRIPTION
When using an external LMS, the CTA `Enroll now` on course runs isn't being translated.

Screenshot on french, is still showing the `Enroll now` on english.
![image](https://github.com/openfun/richie/assets/67018/611309d7-09cc-4712-9d84-f0fc0ec3a90b)

After applying this fix and translate it on `src/frontend/i18n/locales/fr-FR.json`:
```json
"components.SyllabusCourseRun.enroll": {
    "description": "CTA for users who can enroll in the course run or could enroll if they logged in.",
    "message": "S’inscrire maintenant"
  },
```
![image](https://github.com/openfun/richie/assets/67018/5c7f3c64-bd28-4f32-8d9b-f2f0479bf3c4)
