### PR TITLE
🐛(frontend) Fix contract reload after signing

### DIFF
--- a/src/frontend/js/components/ContractFrame/OrganizationContractFrame.spec.tsx
+++ b/src/frontend/js/components/ContractFrame/OrganizationContractFrame.spec.tsx
@@ -94,11 +94,11 @@ describe('OrganizationContractFrame', () => {
       user: true,
       queriesCallback: (queries) => {
         // Push contract and orders queries
-        queries.push(QueryStateFactory(['user', 'contracts'], { data: [] }));
+        queries.push(QueryStateFactory(['user', 'organization_contracts'], { data: [] }));
       },
     });
 
-    let contractsQueryState = client.getQueryState(['user', 'contracts']);
+    let contractsQueryState = client.getQueryState(['user', 'organization_contracts']);
     expect(contractsQueryState?.isInvalidated).toBe(false);
 
     await act(async () => {
@@ -126,7 +126,7 @@ describe('OrganizationContractFrame', () => {
 
     // onDone should be tweaked to invalidate the user orders and contracts queries
     // and passed down to AbstractContractFrame
-    contractsQueryState = client.getQueryState(['user', 'contracts']);
+    contractsQueryState = client.getQueryState(['user', 'organization_contracts']);
     expect(contractsQueryState?.isInvalidated).toBe(true);
     expect(handleDone).toHaveBeenCalledTimes(1);
 
@@ -158,11 +158,11 @@ describe('OrganizationContractFrame', () => {
       user: true,
       queriesCallback: (queries) => {
         // Push contract and orders queries
-        queries.push(QueryStateFactory(['user', 'contracts'], { data: [] }));
+        queries.push(QueryStateFactory(['user', 'organization_contracts'], { data: [] }));
       },
     });
 
-    let contractsQueryState = client.getQueryState(['user', 'contracts']);
+    let contractsQueryState = client.getQueryState(['user', 'organization_contracts']);
     expect(contractsQueryState?.isInvalidated).toBe(false);
 
     await act(async () => {
@@ -191,7 +191,7 @@ describe('OrganizationContractFrame', () => {
 
     // onDone should be tweaked to invalidate the user orders and contracts queries
     // and passed down to AbstractContractFrame
-    contractsQueryState = client.getQueryState(['user', 'contracts']);
+    contractsQueryState = client.getQueryState(['user', 'organization_contracts']);
     expect(contractsQueryState?.isInvalidated).toBe(true);
     expect(handleDone).toHaveBeenCalledTimes(1);
 

--- a/src/frontend/js/components/ContractFrame/OrganizationContractFrame.tsx
+++ b/src/frontend/js/components/ContractFrame/OrganizationContractFrame.tsx
@@ -45,7 +45,7 @@ const OrganizationContractFrame = ({ organizationId, contractIds, onDone, ...pro
   };
 
   const onDoneWithInvalidation = () => {
-    queryClient.invalidateQueries({ queryKey: ['user', 'contracts'] });
+    queryClient.invalidateQueries({ queryKey: ['user', 'organization_contracts'] });
     onDone?.();
   };
 


### PR DESCRIPTION
Since useContract have been split into two (useUserContract and
useOrganizationContract), the list of contract on the teacher dashboard
wasn't refreshing after signing contracts.
It came from the query key that change after hook spliting.
