### PR TITLE
fix cache enrollment product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   courseProductRelationId instead of courseId and productId.
 - Switch from setup.cfg to pyproject.toml 
 
+### Fixed
+
+- Fix enrollment cache not invalided after buying certificate product.
+
 ## [2.25.0-beta.1]
 
 ### Added

--- a/src/frontend/js/components/PurchaseButton/index.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 import { Button, ButtonProps } from '@openfun/cunningham-react';
 import { useSession } from 'contexts/SessionContext';
 import * as Joanie from 'types/Joanie';
-import SaleTunnel from 'components/SaleTunnel';
+import SaleTunnel, { SaleTunnelProps } from 'components/SaleTunnel';
 import { isOpenedCourseRunCertificate, isOpenedCourseRunCredential } from 'utils/CourseRuns';
 
 const messages = defineMessages({
@@ -45,6 +45,7 @@ interface PurchaseButtonPropsBase {
   disabled?: boolean;
   className?: string;
   buttonProps?: ButtonProps;
+  onFinish?: SaleTunnelProps['onFinish'];
 }
 
 interface CredentialPurchaseButtonProps extends PurchaseButtonPropsBase {
@@ -67,6 +68,7 @@ const PurchaseButton = ({
   disabled = false,
   className,
   buttonProps,
+  onFinish,
 }: CredentialPurchaseButtonProps | CertificatePurchaseButtonProps) => {
   const intl = useIntl();
   const { user, login } = useSession();
@@ -147,6 +149,7 @@ const PurchaseButton = ({
         enrollment={enrollment}
         orderGroup={orderGroup}
         course={course}
+        onFinish={onFinish}
       />
     </>
   );

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -50,13 +50,14 @@ const focusCurrentStep = (container: HTMLElement) => {
   }
 };
 
-interface SaleTunnelProps {
+export interface SaleTunnelProps {
   isOpen: boolean;
   onClose: () => void;
   course?: CourseLight;
   enrollment?: Enrollment;
   product: CredentialProduct | CertificateProduct;
   orderGroup?: OrderGroup;
+  onFinish?: (order: Order) => void;
 }
 
 const SaleTunnel = ({
@@ -66,6 +67,7 @@ const SaleTunnel = ({
   onClose,
   enrollment,
   orderGroup,
+  onFinish,
 }: SaleTunnelProps) => {
   const intl = useIntl();
   const {
@@ -111,6 +113,7 @@ const SaleTunnel = ({
           invalidateOrders();
           refetchOmniscientOrders();
           queryClient.invalidateQueries({ queryKey: ['user', 'enrollments'] });
+          onFinish?.(order!);
         },
         onExit: () => {
           handleModalClose();

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import { useQueryClient } from '@tanstack/react-query';
 import { Modal } from 'components/Modal';
 import {
   CourseLight,
@@ -76,6 +77,7 @@ const SaleTunnel = ({
   const key = `${product.type === ProductType.CREDENTIAL ? course!.code : enrollment!.id}+${
     product.id
   }`;
+  const queryClient = useQueryClient();
 
   const [order, setOrder] = useState<Maybe<Order>>();
 
@@ -108,6 +110,7 @@ const SaleTunnel = ({
           // to update the ordersQuery cache
           invalidateOrders();
           refetchOmniscientOrders();
+          queryClient.invalidateQueries({ queryKey: ['user', 'enrollments'] });
         },
         onExit: () => {
           handleModalClose();

--- a/src/frontend/js/components/TeacherDashboardCourseList/index.spec.tsx
+++ b/src/frontend/js/components/TeacherDashboardCourseList/index.spec.tsx
@@ -102,7 +102,7 @@ describe('components/TeacherDashboardCourseList', () => {
     );
 
     expect(
-      screen.getByRole('heading', { name: /One lesson about: How to cook birds/ }),
+      await screen.findByRole('heading', { name: /One lesson about: How to cook birds/ }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: /One lesson about: Let's dance, the online lesson/ }),

--- a/src/frontend/js/hooks/useCourseProductUnion/index.ts
+++ b/src/frontend/js/hooks/useCourseProductUnion/index.ts
@@ -51,5 +51,6 @@ export const useCourseProductUnion = ({
     },
     perPage,
     errorGetMessage: messages.errorGet,
+    refetchOnInvalidation: false,
   });
 };

--- a/src/frontend/js/hooks/useQueryKeyInvalidateListener.tsx
+++ b/src/frontend/js/hooks/useQueryKeyInvalidateListener.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import usePrevious from 'hooks/usePrevious';
+
+export const useQueryKeyInvalidateListener = (queryKey: string[], callback: Function) => {
+  const { data: refreshFlag } = useQuery({
+    queryKey: [...queryKey, 'refresh-flag'],
+    queryFn: () => Math.random(),
+  });
+  const previousRefreshFlag = usePrevious(refreshFlag);
+  useEffect(() => {
+    if (previousRefreshFlag) {
+      callback();
+    }
+  }, [refreshFlag]);
+};

--- a/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
+++ b/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
@@ -68,5 +68,6 @@ export const useOrdersEnrollments = ({
     },
     perPage,
     errorGetMessage: messages.errorGet,
+    refetchOnInvalidation: false,
   });
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
@@ -1,4 +1,5 @@
 import { FormattedMessage, defineMessages } from 'react-intl';
+import { useState } from 'react';
 import PurchaseButton from 'components/PurchaseButton';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { CertificateProduct, Enrollment, ProductType } from 'types/Joanie';
@@ -35,7 +36,9 @@ const ProductCertificateFooter = ({ product, enrollment }: ProductCertificateFoo
   if (product.type !== ProductType.CERTIFICATE) {
     return null;
   }
-  const activeOrder = getActiveEnrollmentOrder(enrollment.orders || [], product.id);
+  const [activeOrder, setActiveOrder] = useState(
+    getActiveEnrollmentOrder(enrollment.orders || [], product.id),
+  );
   const { item: certificate } = useCertificate(activeOrder?.certificate_id);
 
   // The course run is no longer available
@@ -69,6 +72,14 @@ const ProductCertificateFooter = ({ product, enrollment }: ProductCertificateFoo
           className="dashboard-item__button"
           product={product}
           enrollment={enrollment}
+          onFinish={(order) => {
+            /**
+             * As we do not refetch enrollments in DashboardCourses after SaleTunnel cache invalidation ( to avoid
+             * scroll reset - and SaleTunnel modal unmounting too early caused by list reset ) we need to manually
+             * update the active order in the enrollment in order to hide the buy button and display the download button.
+             */
+            setActiveOrder(order);
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
The payment button was still shown after buying the associcated product certificate. So this refactor aims to do some optimistic UI updates in order to hide it after SaleTunnel payment.