### PR TITLE
🐛(frontend) fix logout issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix impossible logout issue 
+- Add signature polling description
 - Fix malformed CourseProductItem Order dashboard links
 - Await logout authentication request logout trigger
 - Fix search facets count metadata issue (ignore not listed courses)

--- a/src/frontend/js/api/lms/dummy.spec.ts
+++ b/src/frontend/js/api/lms/dummy.spec.ts
@@ -36,7 +36,15 @@ describe('Dummy API', () => {
 
   describe('user', () => {
     it('simulates that authenticated user is admin', async () => {
-      const response = await BaseAPI.user.me();
+      // Not logged-in.
+      let response = await BaseAPI.user.me();
+      expect(response).toBeNull();
+
+      // Log-in.
+      await BaseAPI.user.login();
+
+      // Is logged-in.
+      response = await BaseAPI.user.me();
       expect(response?.username).toBe('admin');
       expect(response?.access_token).toBeDefined();
     });

--- a/src/frontend/js/api/lms/dummy.ts
+++ b/src/frontend/js/api/lms/dummy.ts
@@ -38,6 +38,8 @@ const JOANIE_DEV_DEMO_USER_JWT_TOKENS = {
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzMzOTI4MjE0LCJpYXQiOjE3MDIzOTIyMTQsImp0aSI6ImNkZjAyMGM4ODdjOTQxYzU5ZmExN2FkZGExNjNjMDIzIiwiZW1haWwiOiJqZWFuLWJhcHRpc3RlLnBlbnJhdGgrc3R1ZGVudF91c2VyQGZ1bi1tb29jLmZyIiwibGFuZ3VhZ2UiOiJmci1mciIsInVzZXJuYW1lIjoic3R1ZGVudF91c2VyIiwiZnVsbF9uYW1lIjoiXHUwMGM5dHVkaWFudCJ9.JMdnC2VXwq2VbNPrIYxj8PEq0oJJ4LZZT_ywWyE1lBM',
 };
 
+export const RICHIE_DUMMY_IS_LOGGED_IN = 'RICHIE_DUMMY_IS_LOGGED_IN';
+
 function getUserInfo(username: keyof typeof JOANIE_DEV_DEMO_USER_JWT_TOKENS): Maybe<User> {
   const accessToken = JOANIE_DEV_DEMO_USER_JWT_TOKENS[username];
   const JWTPayload: JWTPayload = JSON.parse(base64Decode(accessToken.split('.')[1]));
@@ -71,11 +73,19 @@ const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
               "username": "admin",
             }
         */
+        if (!localStorage.getItem(RICHIE_DUMMY_IS_LOGGED_IN)) {
+          return null;
+        }
         return getUserInfo(CURRENT_JOANIE_DEV_DEMO_USER) || null;
       },
-      login: () => location.reload(),
+      login: () => {
+        localStorage.setItem(RICHIE_DUMMY_IS_LOGGED_IN, 'true');
+        location.reload();
+      },
       register: () => location.reload(),
-      logout: async () => undefined,
+      logout: async () => {
+        localStorage.removeItem(RICHIE_DUMMY_IS_LOGGED_IN);
+      },
       accessToken: () => sessionStorage.getItem(RICHIE_USER_TOKEN),
     },
     enrollment: {

--- a/src/frontend/js/contexts/SessionContext/BaseSessionProvider.tsx
+++ b/src/frontend/js/contexts/SessionContext/BaseSessionProvider.tsx
@@ -47,29 +47,21 @@ const BaseSessionProvider = ({ children }: PropsWithChildren<any>) => {
     AuthenticationApi!.register();
   }, [queryClient]);
 
-  const invalidate = useCallback(() => {
-    /*
-      Invalidate all queries except 'user' as we can set it to null manually
-      after logout to avoid extra requests
-    */
+  const destroy = useCallback(async () => {
+    await AuthenticationApi!.logout();
+    sessionStorage.removeItem(REACT_QUERY_SETTINGS.cacheStorage.key);
     queryClient.removeQueries({
       predicate: (query: any) =>
         query.options.queryKey.includes('user') && query.options.queryKey.length > 1,
     });
     queryClient.setQueryData(['user'], null);
-  }, [queryClient]);
-
-  const destroy = useCallback(async () => {
-    invalidate();
-    await AuthenticationApi!.logout();
-  }, [invalidate]);
+  }, []);
 
   const context = useMemo(
     () => ({
       user,
       isPending,
       destroy,
-      invalidate,
       login,
       register,
     }),

--- a/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.tsx
+++ b/src/frontend/js/contexts/SessionContext/JoanieSessionProvider.tsx
@@ -75,23 +75,16 @@ const JoanieSessionProvider = ({ children }: React.PropsWithChildren<{}>) => {
     AuthenticationApi!.register();
   }, [queryClient]);
 
-  const invalidate = useCallback(() => {
-    /*
-      Invalidate all queries except 'user' as we can set it to null manually
-      after logout to avoid extra requests
-    */
+  const destroy = useCallback(async () => {
+    await AuthenticationApi!.logout();
+    sessionStorage.removeItem(REACT_QUERY_SETTINGS.cacheStorage.key);
     sessionStorage.removeItem(RICHIE_USER_TOKEN);
     queryClient.removeQueries({
       predicate: (query: any) =>
         query.options.queryKey.includes('user') && query.options.queryKey.length > 1,
     });
     queryClient.setQueryData(['user'], null);
-  }, [queryClient]);
-
-  const destroy = useCallback(async () => {
-    invalidate();
-    await AuthenticationApi!.logout();
-  }, [invalidate]);
+  }, []);
 
   useEffect(() => {
     if (user) {

--- a/src/frontend/js/contexts/SessionContext/index.spec.tsx
+++ b/src/frontend/js/contexts/SessionContext/index.spec.tsx
@@ -169,10 +169,8 @@ describe('SessionProvider', () => {
         jest.runOnlyPendingTimers();
       });
 
-      expect(result.current.user).toBeNull();
-      expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toMatch(
-        /"data":null,.*"queryKey":\["user"]/,
-      );
+      await waitFor(() => expect(result.current.user).toBeNull());
+      expect(sessionStorage.getItem(REACT_QUERY_SETTINGS.cacheStorage.key)).toBeNull();
     });
 
     it('does not make request if there is a valid session in cache', async () => {


### PR DESCRIPTION
We realized that, on logout, setting react query ["user"] to null was taking too much time to be persisted in SessionStorage resulting in a redirection to the homepage before the data being flushed into the SessionStorage. (It is caused by throttleTime of the persister ) Sometimes the user was not able to logout due to this issue.
