### PR TITLE
 🔧(back) configure renovate with pyproject file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
       "enabled": false,
       "groupName": "ignored python dependencies",
       "matchManagers": [
-        "setup-cfg"
+        "setup-cfg",
+        "pep621"
       ],
       "matchPackageNames": [
         "Django",


### PR DESCRIPTION
## Purpose

The manager declared in the renovate configuration is still setup-cfg but we change the manager used with pyproject. We have to change it in renovate with the pep621 manager:
https://docs.renovatebot.com/modules/manager/pep621/

## Proposal

- [x] configure renovate with pyproject file
