### PR TITLE
🔥(frontend) remove nb_seller_organizations from course glimpse props

### DIFF
--- a/src/frontend/js/components/CourseGlimpse/index.spec.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.spec.tsx
@@ -46,7 +46,6 @@ describe('widgets/Search/components/CourseGlimpse', () => {
         srcset: 'some srcset',
       },
     },
-    nb_seller_organizations: 1,
     state: {
       call_to_action: 'enroll now',
       datetime: '2019-03-14T10:35:47.823Z',

--- a/src/frontend/js/components/CourseGlimpse/index.tsx
+++ b/src/frontend/js/components/CourseGlimpse/index.tsx
@@ -28,7 +28,6 @@ export interface CourseGlimpseCourse {
       srcset?: string;
     }>;
   };
-  nb_seller_organizations: number;
   icon?: Nullable<{
     title: string;
     src: string;
@@ -67,11 +66,6 @@ const messages = defineMessages({
     defaultMessage: 'Category',
     description: 'Category label text for screen reader users',
     id: 'components.CourseGlimpse.categoryLabel',
-  },
-  organizationsTitle: {
-    defaultMessage: 'Produced by {nbOrganizations} partners',
-    description: 'Organizations title for multiple organizations',
-    id: 'components.CourseGlimpse.organizationsTitle',
   },
 });
 
@@ -114,7 +108,7 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
               <span className="course-glimpse__title-text">{course.title}</span>
             </CourseLink>
           </h3>
-          {course.nb_seller_organizations === 1 && course.organization.image ? (
+          {course.organization.image ? (
             <div className="course-glimpse__organization-logo">
               {/* alt forced to empty string because the organization name is rendered after */}
               <img
@@ -131,16 +125,7 @@ const CourseGlimpseBase = ({ context, course }: CourseGlimpseProps & CommonDataP
               title={intl.formatMessage(messages.organizationIconAlt)}
               size="small"
             />
-            <span className="title">
-              {course.nb_seller_organizations === 1 ? (
-                course.organization.title
-              ) : (
-                <FormattedMessage
-                  {...messages.organizationsTitle}
-                  values={{ nbOrganizations: course.nb_seller_organizations }}
-                />
-              )}
-            </span>
+            <span className="title">{course.organization.title}</span>
           </div>
           <div className="course-glimpse__metadata course-glimpse__metadata--code">
             <Icon

--- a/src/frontend/js/components/CourseGlimpse/utils.ts
+++ b/src/frontend/js/components/CourseGlimpse/utils.ts
@@ -38,7 +38,6 @@ const getCourseGlimpsePropsFromCourseProductRelation = (
       title: courseProductRelation.organizations[0].title,
       image: courseProductRelation.organizations[0].logo || null,
     },
-    nb_seller_organizations: courseProductRelation.organizations.length,
     product_id: courseProductRelation.product.id,
     course_route: courseRoute,
     state: courseProductRelation.product.state,
@@ -55,7 +54,6 @@ const getCourseGlimpsePropsFromRichieCourse = (course: RichieCourse): CourseGlim
     title: course.organization_highlighted,
     image: course.organization_highlighted_cover_image,
   },
-  nb_seller_organizations: course.organizations.length,
   icon: course.icon,
   state: course.state,
   duration: course.duration,
@@ -93,7 +91,6 @@ const getCourseGlimpsePropsFromJoanieCourse = (
       title: course.organizations[0].title,
       image: course.organizations[0].logo || null,
     },
-    nb_seller_organizations: course.organizations.length,
     state: course.state,
     nb_course_runs: course.course_run_ids.length,
   };


### PR DESCRIPTION
## Purpose

After some acceptance tests, it appears we should always display an organization
 logo and the name of the main organization. In the case of Richie course run,
 the `highlighted_organization` is the main ine. From Joanie, for now, we take the
 first organization then later we add this notion of "main organization".

|Before|After|
|------|-----|
|<img width="300" alt="image" src="https://github.com/openfun/richie/assets/9265241/7865d0a1-1a4f-4c0f-a33d-372d9dae7177">|<img width="300" alt="image" src="https://github.com/openfun/richie/assets/9265241/fc425ada-181b-4b68-a1bb-41c6ddc54b24">|


## Proposal

- [x] Remove `nb_seller_organizations` prop
