### PR TITLE
🐛(frontend) fix teacher courses list scroll top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix on teacher dashboard courses list. During infinit scroll loading the 
+  window scroll was reset at the top of the page.
 - Fix impossible logout issue 
 - Add signature polling description
 - Fix malformed CourseProductItem Order dashboard links

--- a/src/frontend/js/components/TeacherDashboardCourseList/index.tsx
+++ b/src/frontend/js/components/TeacherDashboardCourseList/index.tsx
@@ -53,6 +53,16 @@ const TeacherDashboardCourseList = ({
       {titleTranslated && (
         <h2 className="dashboard-course-list__title dashboard__page_title">{titleTranslated}</h2>
       )}
+      {courseAndProductList.length > 0 ? (
+        <CourseGlimpseList
+          courses={getCourseGlimpseListProps(courseAndProductList, intl, organizationId)}
+          context={context}
+          className="dashboard__course-glimpse-list"
+        />
+      ) : (
+        <FormattedMessage {...messages.emptyList} />
+      )}
+
       {isLoading && (
         <Spinner aria-labelledby="loading-courses-data">
           <span id="loading-courses-data">
@@ -60,28 +70,17 @@ const TeacherDashboardCourseList = ({
           </span>
         </Spinner>
       )}
-      {!isLoading &&
-        (courseAndProductList.length > 0 ? (
-          <>
-            <CourseGlimpseList
-              courses={getCourseGlimpseListProps(courseAndProductList, intl, organizationId)}
-              context={context}
-              className="dashboard__course-glimpse-list"
-            />
-            {hasMore && (
-              <Button
-                onClick={() => next()}
-                disabled={isLoading}
-                ref={loadMoreButtonRef}
-                color="tertiary"
-              >
-                <FormattedMessage {...messages.loadMore} />
-              </Button>
-            )}
-          </>
-        ) : (
-          <FormattedMessage {...messages.emptyList} />
-        ))}
+
+      {hasMore && (
+        <Button
+          onClick={() => next()}
+          disabled={isLoading}
+          ref={loadMoreButtonRef}
+          color="tertiary"
+        >
+          <FormattedMessage {...messages.loadMore} />
+        </Button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
We had a bug where the courses list scroll was reset at the top of the page.
`useUnionResource` `isLoading` is switching between `true` and `false` each time it load a new chunk of results.
As `isLoading` was used in `TeacherDashboardCourseList` to switch display between the spinner and the courses list, the page scroll was sometime reset when the list disappear.

