### PR TITLE
✅(frontend) fix flaky test

### DIFF
--- a/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
@@ -105,7 +105,7 @@ describe('<DashboardCreditCardsManagement/>', () => {
     const refDate = new Date();
     refDate.setMonth(refDate.getMonth() + 1);
     refDate.setDate(1);
-    const futureLessThan3Months = faker.date.future({ years: 2.99 / 12, refDate });
+    const futureLessThan3Months = faker.date.future({ years: 2.5 / 12, refDate });
     const creditCard: CreditCard = CreditCardFactory({
       expiration_month: futureLessThan3Months.getMonth() + 1,
       expiration_year: futureLessThan3Months.getFullYear(),


### PR DESCRIPTION
`DashboardCreditCardsManagement` test about credit card expiration date use a date in less than 3 month in the future.
This date some time happen to be exactly 3 month, just a few hours before the treshold of 3 month.
As `CreditCardHelper.isExpiredSoon` only check year and month and not hours, the test failed.
