### PR TITLE
🧑‍💻(frontend) add test wrappers

### DIFF
--- a/src/frontend/jest/setup.ts
+++ b/src/frontend/jest/setup.ts
@@ -1,5 +1,6 @@
 // Extend jest matchers with jest-dom's
 import '@testing-library/jest-dom';
+import fetchMock from 'fetch-mock';
 import { Request, Response } from 'node-fetch';
 import { FactoryConfig } from 'utils/test/factories/factories';
 
@@ -33,4 +34,6 @@ beforeAll(() => {
 
 afterEach(() => {
   FactoryConfig.resetUniqueStore();
+  fetchMock.restore();
+  jest.clearAllMocks();
 });

--- a/src/frontend/js/utils/test/render.tsx
+++ b/src/frontend/js/utils/test/render.tsx
@@ -1,0 +1,72 @@
+import { RenderResult, screen, render as testingLibraryRender } from '@testing-library/react';
+import React, { ReactElement } from 'react';
+import { Nullable } from 'types/utils';
+import { AppWrapperProps } from './wrappers/types';
+import { JoanieAppWrapper } from './wrappers/JoanieAppWrapper';
+
+//  ------- setup -------
+
+type CustomRenderResult = Omit<RenderResult, 'rerender'> & {
+  elementContainer: Nullable<HTMLElement>;
+  rerender: (
+    element: ReactElement,
+    options?: Partial<Omit<AppWrapperProps, 'testingLibraryOptions'>>,
+  ) => void;
+};
+
+type RenderFunction = (
+  element: ReactElement,
+  options?: Partial<AppWrapperProps>,
+) => CustomRenderResult;
+
+/**
+ *
+ * Custom render method base on react-testing-library render method.
+ * This will render {@param element} in JSDom and read options to configure context and render.
+ * It also override react-testing-library rerender method to also wrap the provided component in
+ * the same contexts.
+ *
+ * The provided {@param element} is to be wrapped in :
+ * - react router (react-router-dom)
+ * - react i18n context (react-intl)
+ * - query context (react-query)
+ *
+ * This function uses default values:
+ * options.intlOptions.locale : 'en'
+ * options.routerOptions.path : '/'
+ * options.queryOptions.client : {@see queryClient}
+ *
+ *
+ * @param element element to wrap in application contexts and test
+ * @param options options to configure and/or customize wrapped context for the test {@see RenderOptions}
+ * @returns an object with all values return by react-testing-library render methods
+ * and an other property {@property elementContainer} refering to the exact element containing the {@param element} to test
+ *
+ *
+ * @example
+ * customRender(<SomeComponentToTest />);
+ * customRender(<SomeComponentToTest />, { wrapper: WrapperPresentationalApp });
+ */
+export const render: RenderFunction = (
+  element: ReactElement,
+  options?: Partial<AppWrapperProps>,
+) => {
+  const Wrapper = options?.wrapper === undefined ? JoanieAppWrapper : options?.wrapper;
+  const renderResult = testingLibraryRender(
+    Wrapper === null ? element : <Wrapper {...options}>{element}</Wrapper>,
+    options?.testingLibraryOptions,
+  );
+
+  return {
+    ...renderResult,
+    elementContainer: screen.queryByTestId('test-component-container'),
+    rerender: (
+      rerenderElement: ReactElement,
+      rerenderOptions?: Partial<Omit<AppWrapperProps, 'testingLibraryOptions'>>,
+    ) => {
+      return renderResult.rerender(
+        Wrapper === null ? element : <Wrapper {...rerenderOptions}>{rerenderElement}</Wrapper>,
+      );
+    },
+  };
+};

--- a/src/frontend/js/utils/test/wrappers/IntlWrapper.tsx
+++ b/src/frontend/js/utils/test/wrappers/IntlWrapper.tsx
@@ -1,0 +1,23 @@
+import { ComponentProps, PropsWithChildren } from 'react';
+import { IntlProvider, ReactIntlErrorCode } from 'react-intl';
+
+export interface IntlWrapperProps extends PropsWithChildren, ComponentProps<typeof IntlProvider> {}
+
+export const IntlWrapper = ({ children, ...options }: IntlWrapperProps) => (
+  <IntlProvider
+    onError={(err) => {
+      // https://github.com/formatjs/formatjs/issues/465
+      if (
+        err.code === ReactIntlErrorCode.MISSING_TRANSLATION ||
+        err.code === ReactIntlErrorCode.MISSING_DATA
+      ) {
+        return;
+      }
+      throw err;
+    }}
+    {...options}
+    locale={options?.locale || 'en'}
+  >
+    {children}
+  </IntlProvider>
+);

--- a/src/frontend/js/utils/test/wrappers/JoanieAppWrapper.tsx
+++ b/src/frontend/js/utils/test/wrappers/JoanieAppWrapper.tsx
@@ -1,0 +1,42 @@
+import { CunninghamProvider } from '@openfun/cunningham-react';
+import { PropsWithChildren } from 'react';
+import fetchMock from 'fetch-mock';
+import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
+import { IntlWrapper } from './IntlWrapper';
+import { ReactQueryWrapper } from './ReactQueryWrapper';
+import { RouterWrapper } from './RouterWrapper';
+import { AppWrapperProps } from './types';
+
+export const setupJoanieSession = () => {
+  beforeEach(() => {
+    // JoanieSessionProvider inital requests
+    fetchMock.get('https://joanie.endpoint/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
+    fetchMock.get('https://joanie.endpoint/api/v1.0/credit-cards/', []);
+  });
+
+  return {
+    nbSessionApiRequest: 3,
+  };
+};
+
+export const JoanieSessionWrapper = ({ children }: PropsWithChildren) => {
+  return <JoanieSessionProvider>{children}</JoanieSessionProvider>;
+};
+
+export const JoanieAppWrapper = ({
+  children,
+  options,
+}: PropsWithChildren<{ options?: AppWrapperProps }>) => {
+  return (
+    <IntlWrapper {...(options?.intlOptions || { locale: 'en' })}>
+      <CunninghamProvider>
+        <ReactQueryWrapper {...(options?.queryOptions || {})}>
+          <JoanieSessionWrapper>
+            <RouterWrapper {...options?.routerOptions}>{children}</RouterWrapper>
+          </JoanieSessionWrapper>
+        </ReactQueryWrapper>
+      </CunninghamProvider>
+    </IntlWrapper>
+  );
+};

--- a/src/frontend/js/utils/test/wrappers/PresentationalAppWrapper.tsx
+++ b/src/frontend/js/utils/test/wrappers/PresentationalAppWrapper.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from 'react';
+import { CunninghamProvider } from '@openfun/cunningham-react';
+import { IntlWrapper } from './IntlWrapper';
+import { RouterWrapper } from './RouterWrapper';
+import { AppWrapperProps } from './types';
+
+export const PresentationalAppWrapper = ({
+  children,
+  options,
+}: PropsWithChildren<{ options?: AppWrapperProps }>) => {
+  return (
+    <IntlWrapper {...(options?.intlOptions || { locale: 'en' })}>
+      <CunninghamProvider>
+        <RouterWrapper {...options?.routerOptions}>{children}</RouterWrapper>
+      </CunninghamProvider>
+    </IntlWrapper>
+  );
+};

--- a/src/frontend/js/utils/test/wrappers/ReactQueryWrapper.tsx
+++ b/src/frontend/js/utils/test/wrappers/ReactQueryWrapper.tsx
@@ -1,0 +1,16 @@
+import { QueryClient } from '@tanstack/query-core';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { PropsWithChildren } from 'react';
+import { createTestQueryClient } from '../createTestQueryClient';
+
+interface ReactQueryWrapperProps extends PropsWithChildren {
+  client?: QueryClient;
+}
+
+export const ReactQueryWrapper = ({ children, client }: ReactQueryWrapperProps) => {
+  return (
+    <QueryClientProvider client={client ?? createTestQueryClient({ user: true })}>
+      {children}
+    </QueryClientProvider>
+  );
+};

--- a/src/frontend/js/utils/test/wrappers/RouterWrapper.tsx
+++ b/src/frontend/js/utils/test/wrappers/RouterWrapper.tsx
@@ -1,0 +1,29 @@
+import { PropsWithChildren } from 'react';
+import { RouteObject, RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { Maybe } from 'types/utils';
+
+export interface RouterWrapperProps extends PropsWithChildren {
+  routes?: RouteObject[];
+  path?: string;
+  initialEntries?: Maybe<string[]>;
+}
+
+export const RouterWrapper = ({
+  children,
+  routes = [],
+  path = '/',
+  initialEntries,
+}: RouterWrapperProps) => {
+  const router = createMemoryRouter(
+    routes.length > 0
+      ? routes
+      : [
+          {
+            path,
+            element: children,
+          },
+        ],
+    { initialEntries: initialEntries || [path] },
+  );
+  return <RouterProvider router={router} />;
+};

--- a/src/frontend/js/utils/test/wrappers/types.ts
+++ b/src/frontend/js/utils/test/wrappers/types.ts
@@ -1,0 +1,26 @@
+import { PropsWithChildren } from 'react';
+import { QueryClient } from '@tanstack/query-core';
+import { RenderOptions as TestingLibraryRenderOptions } from '@testing-library/react';
+import { Nullable } from 'types/utils';
+import { IntlWrapperProps } from './IntlWrapper';
+import { RouterWrapperProps } from './RouterWrapper';
+
+interface QueryOptions {
+  client: QueryClient;
+}
+
+/**
+ * Options to configure the render of a component for a test
+ *
+ * @property testingLibraryOptions options provided by react-testing-library to the render method
+ * @property intlOptions options to configure i18n context
+ * @property routerOptions options to configure router and routes in the test
+ * @property queryOptions options to configure a custom client used by react-query for a test
+ */
+export interface AppWrapperProps {
+  wrapper?: Nullable<(props: PropsWithChildren<{ options?: AppWrapperProps }>) => JSX.Element>;
+  intlOptions?: IntlWrapperProps;
+  queryOptions?: QueryOptions;
+  routerOptions?: RouterWrapperProps;
+  testingLibraryOptions?: TestingLibraryRenderOptions;
+}

--- a/src/frontend/js/widgets/Dashboard/components/NavigateWithParams/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/NavigateWithParams/index.spec.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react';
-import { createMemoryRouter, Outlet, RouterProvider } from 'react-router-dom';
+import { screen } from '@testing-library/react';
+import { Outlet } from 'react-router-dom';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import LocationDisplay from 'utils/test/LocationDisplay';
+import { render } from 'utils/test/render';
+import { RouterWrapper } from 'utils/test/wrappers/RouterWrapper';
 import NavigateWithParams from '.';
 
 jest.mock('utils/context', () => ({
@@ -15,46 +17,35 @@ jest.mock('utils/indirection/window', () => ({
   },
 }));
 
-interface RenderTestRouterProps {
-  url?: string;
-}
-
-const renderTestRouter = ({ url = '/myTestId' }: RenderTestRouterProps = {}) => {
-  const routes = [
-    {
-      path: '/:testId',
-      element: (
-        <div>
-          <h1>NavigateWithParams test</h1>
-          <Outlet />
-        </div>
-      ),
-      children: [
-        {
-          index: true,
-          element: <NavigateWithParams to="/:testId/childRoute" replace />,
-        },
-        {
-          path: '/:testId/childRoute',
-          element: (
-            <div>
-              <h2>NavigateWithParams child route</h2>
-              <LocationDisplay />
-            </div>
-          ),
-        },
-      ],
-    },
-  ];
-
-  const router = createMemoryRouter(routes, { initialEntries: [url] });
-
-  return render(<RouterProvider router={router} />);
-};
-
 describe('<NavigateWithParams />', () => {
   it('should navigate with parent route params', async () => {
-    renderTestRouter();
+    const routes = [
+      {
+        path: '/:testId',
+        element: (
+          <div>
+            <h1>NavigateWithParams test</h1>
+            <Outlet />
+          </div>
+        ),
+        children: [
+          {
+            index: true,
+            element: <NavigateWithParams to="/:testId/childRoute" replace />,
+          },
+          {
+            path: '/:testId/childRoute',
+            element: (
+              <div>
+                <h2>NavigateWithParams child route</h2>
+                <LocationDisplay />
+              </div>
+            ),
+          },
+        ],
+      },
+    ];
+    render(<RouterWrapper routes={routes} initialEntries={['/myTestId']} />, { wrapper: null });
     expect(await screen.findByRole('heading', { name: /NavigateWithParams test/ }));
     expect(screen.getByRole('heading', { name: /NavigateWithParams child route/ }));
     expect(screen.getByTestId('test-location-display')).toHaveTextContent('/myTestId/childRoute');

--- a/src/frontend/js/widgets/Dashboard/components/TeacherDashboardProfileSidebar/components/OrganizationLinks/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherDashboardProfileSidebar/components/OrganizationLinks/index.spec.tsx
@@ -1,20 +1,16 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
-import { IntlProvider } from 'react-intl';
+import { screen } from '@testing-library/react';
 import { OrganizationFactory } from 'utils/test/factories/joanie';
+import { render } from 'utils/test/render';
+import { PresentationalAppWrapper } from 'utils/test/wrappers/PresentationalAppWrapper';
 import OrganizationLinks from '.';
 
 describe('OrganizationLinks', () => {
   it('should render successfully organization with logo', () => {
     const organization = OrganizationFactory({ title: 'Organization 1' }).one();
 
-    render(
-      <IntlProvider locale="en">
-        <MemoryRouter>
-          <OrganizationLinks organizations={[organization]} />
-        </MemoryRouter>
-      </IntlProvider>,
-    );
+    render(<OrganizationLinks organizations={[organization]} />, {
+      wrapper: PresentationalAppWrapper,
+    });
 
     // A link to the organization should be rendered
     const link = screen.getByRole('link', { name: 'Organization 1' });
@@ -34,13 +30,9 @@ describe('OrganizationLinks', () => {
   it('should render successfully organization with abbr', () => {
     const organization = OrganizationFactory({ title: 'Organization 1', logo: null }).one();
 
-    render(
-      <IntlProvider locale="en">
-        <MemoryRouter>
-          <OrganizationLinks organizations={[organization]} />
-        </MemoryRouter>
-      </IntlProvider>,
-    );
+    render(<OrganizationLinks organizations={[organization]} />, {
+      wrapper: PresentationalAppWrapper,
+    });
 
     // A link to the organization should be rendered
     const link = screen.getByRole('link', { name: 'Organization 1' });


### PR DESCRIPTION
We repeate application wrappers code in every single test. It's time to normalize theses usages.

A live review return about adding the modal div creation into jest/setup.ts have been made in it's own PR:
🧑‍💻[(frontend) jest/setup: create modal div](https://github.com/openfun/richie/pull/2296)