### PR TITLE
🐛(frontend) remove enrollment start on some course run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Remove enrollment start on some course run
 - Fix Organization glimpse card variant logo size
 - Fix joanie's course run link to LMS course in the syllabus page.
 - Fix enrollment cache not invalided after buying certificate product.

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/DashboardItemCourseEnrolling.tsx
@@ -1,15 +1,15 @@
-import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useMemo } from 'react';
 import { Button } from '@openfun/cunningham-react';
 import { CoursesHelper } from 'utils/CoursesHelper';
 import { Priority } from 'types';
 import {
-  CourseRun,
-  Enrollment,
-  CredentialOrder,
   AbstractCourse,
-  Product,
   CertificateOrder,
+  CourseRun,
+  CredentialOrder,
+  Enrollment,
+  Product,
 } from 'types/Joanie';
 import { Spinner } from 'components/Spinner';
 import Banner, { BannerType } from 'components/Banner';
@@ -208,7 +208,7 @@ interface DashboardItemCourseEnrollingRunProps {
   product?: Product;
 }
 
-const DashboardItemCourseEnrollingRun = ({
+export const DashboardItemCourseEnrollingRun = ({
   courseRun,
   selected,
   enroll,
@@ -247,7 +247,7 @@ const DashboardItemCourseEnrollingRun = ({
             }}
           />
         </div>
-        {!isOpenedForEnrollment && (
+        {courseRun.state.priority === Priority.FUTURE_NOT_YET_OPEN && (
           <div className="dashboard-item__course-enrolling__run__not-opened">
             <FormattedMessage
               {...messages.enrollmentNotYetOpened}


### PR DESCRIPTION
We were displaying "enrollment starts on ..." on course run with wrong priorities which resulted in situation where it wasn't making any sense. Additionnally this commit fixes the existing tests that were not passing due to missing await clauses.

Fixes #2254

