### PR TITLE
🐛(frontend) fix syllabus "Go to course" link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix joanie's course run link to LMS course in the syllabus page.
 - Fix enrollment cache not invalided after buying certificate product.
 - Fix a typo on ContractStatus component
 

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -1,4 +1,4 @@
-import type { CourseState } from 'types';
+import type { CourseState, OpenEdXEnrollment } from 'types';
 import type { Maybe, Nullable } from 'types/utils';
 import { Resource, ResourcesQuery } from 'hooks/useResources';
 import { OrderResourcesQuery } from 'hooks/useOrders';
@@ -190,8 +190,23 @@ export interface Enrollment {
   created_on: string;
   orders: OrderEnrollment[];
   product_relations: CourseProductRelation[];
-  certificate_id?: string;
+  certificate_id: Nullable<string>;
 }
+export const isEnrollment = (obj: unknown | Enrollment | OpenEdXEnrollment): obj is Enrollment => {
+  if (!obj || typeof obj !== 'object') {
+    return false;
+  }
+  return (
+    'is_active' in obj &&
+    'state' in obj &&
+    'course_run' in obj &&
+    'was_created_by_order' in obj &&
+    'created_on' in obj &&
+    'orders' in obj &&
+    'product_relations' in obj &&
+    'certificate_id' in obj
+  );
+};
 
 export interface EnrollmentLight {
   id: string;

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -69,4 +69,5 @@ export interface OpenEdXEnrollment {
  * Use an unknown type to make sure we do not depend on any LMS-specific fields
  * on enrollment objects, just use HTTP response codes.
  */
+// TODO(rlecellier): rename into UnknownEnrollment
 export type Enrollment = unknown;

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -81,6 +81,7 @@ export const EnrollmentFactory = factory((): Enrollment => {
     was_created_by_order: false,
     created_on: faker.date.past({ years: 1 }).toISOString(),
     orders: [],
+    certificate_id: null,
   };
 });
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/stories.mock.ts
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/stories.mock.ts
@@ -26,4 +26,5 @@ export const enrollment: Enrollment = {
     languages: ['en'],
   },
   product_relations: [],
+  certificate_id: null,
 };

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/index.joanie.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunEnrollment/index.joanie.spec.tsx
@@ -3,6 +3,7 @@ import fetchMock from 'fetch-mock';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { IntlProvider } from 'react-intl';
 
+import { faker } from '@faker-js/faker';
 import { Deferred } from 'utils/test/deferred';
 import {
   CourseRunFactory,
@@ -96,10 +97,11 @@ describe('<CourseRunEnrollment /> with joanie backend ', () => {
   it('shows an error message when enrollment get request failed', async () => {
     const user = UserFactory().one();
     const courseRun = CourseRunFactory().one();
-    courseRun.resource_link = `https://joanie.endpoint/api/v1.0/course-runs/${courseRun.id}`;
+    const joanieEnrollmentId = faker.string.uuid();
+    courseRun.resource_link = `https://joanie.endpoint/api/v1.0/course-runs/${joanieEnrollmentId}`;
 
     fetchMock.get(
-      `${endpoint}/api/v1.0/enrollments/?course_run=${courseRun.id}`,
+      `${endpoint}/api/v1.0/enrollments/?course_run_id=${joanieEnrollmentId}`,
       HttpStatusCode.INTERNAL_SERVER_ERROR,
     );
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/hooks/useCourseEnrollment/index.ts
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/hooks/useCourseEnrollment/index.ts
@@ -21,22 +21,18 @@ const useCourseEnrollment = (resourceLink: string) => {
   const queryClient = useQueryClient();
   const EnrollmentAPI = EnrollmentApiInterface(resourceLink);
 
-  const [{ data: enrollment, isError, isLoading }, queryKey] = useSessionQuery(
+  const [{ data: enrollment, isError, isLoading: isEnrollmentLoading }, queryKey] = useSessionQuery(
     ['enrollment', resourceLink],
     async () => {
       return EnrollmentAPI.get(resourceLink, user!);
     },
   );
 
-  const [{ data: isActive, refetch: refetchIsActive }] = useSessionQuery(
-    [...queryKey, 'is_active'],
-    async () => EnrollmentAPI.isEnrolled(enrollment),
-    {
+  const [{ data: isActive, refetch: refetchIsActive, isLoading: isActiveLoading }] =
+    useSessionQuery([...queryKey, 'is_active'], async () => EnrollmentAPI.isEnrolled(enrollment), {
       // Enrollment is null if it has been fetched
-      enabled: !!user && enrollment !== undefined && !isLoading,
-    },
-  );
-
+      enabled: !!user && enrollment !== undefined && !isEnrollmentLoading,
+    });
   const { mutateAsync } = useSessionMutation({
     mutationFn: (activeEnrollment: boolean = true) =>
       EnrollmentAPI.set(resourceLink, user!, enrollment, activeEnrollment),
@@ -61,6 +57,7 @@ const useCourseEnrollment = (resourceLink: string) => {
       errors: {
         get: isError,
       },
+      isLoading: isEnrollmentLoading || isActiveLoading,
     },
   };
 };


### PR DESCRIPTION
When a course run is managed by Joanie if the user is enrolled to a Course Run the link "Go to course" is not set properly. Indeed, the link targets the joanie course run endpoint instead of the lms course page.

resolve #2267
