### PR TITLE
✨(backend) allow to display related organizations on organization page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix Organization glimpse card variant logo size
 - Fix joanie's course run link to LMS course in the syllabus page.
 - Fix enrollment cache not invalided after buying certificate product.
 - Fix a typo on ContractStatus component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- `related_organizations` placeholder on organization detail page
+
 ### Changed
 
 - Upgrade to node 20

--- a/src/frontend/scss/objects/_organization_glimpses.scss
+++ b/src/frontend/scss/objects/_organization_glimpses.scss
@@ -131,18 +131,12 @@
   }
 
   &__logo {
-    position: relative;
+    height: 100%;
     width: 100%;
-    padding-bottom: 56.25%; // Aspect ratio 16/9
 
     & > img {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      width: 100%;
       height: 100%;
+      width: 100%;
       object-fit: contain;
       object-position: center;
     }

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -271,6 +271,10 @@ CMS_PLACEHOLDER_CONF = {
         "plugins": ["PlainTextPlugin"],
         "limits": {"PlainTextPlugin": 1},
     },
+    "courses/cms/organization_detail.html related_organizations": {
+        "name": _("Organizations"),
+        "plugins": ["OrganizationPlugin"],
+    },
     # Category detail
     "courses/cms/category_detail.html banner": {
         "name": _("Banner"),

--- a/src/richie/apps/courses/templates/courses/cms/organization_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/organization_detail.html
@@ -111,6 +111,27 @@
             </div>
         </div>
 
+    {% block related_organizations %}
+        {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"related_organizations" %}
+        <div class="organization-detail__organizations organization-detail__block">
+            <section class="section organization-detail__row">
+                <h2 class="organization-detail__title">
+                    {% blocktrans context "organization_detail__title" %}Related organizations{% endblocktrans %}
+                </h2>
+                <div class="section__items section__items--organizations">
+                    {% with header_level=3 %}
+                        {% placeholder "related_organizations" or %}
+                        <p class="organization-detail__empty">
+                            {% trans "Are there organizations affiliated to this organization?" %}
+                        </p>
+                        {% endplaceholder %}
+                    {% endwith %}
+                </div>
+            </section>
+        </div>
+        {% endif %}
+    {% endblock related_organizations %}
+
     {% with courses=organization.get_courses %}
         {% if courses %}
             {% autopaginate courses GLIMPSE_PAGINATION_COURSES %}


### PR DESCRIPTION
## Purpose

Actually, some organization can be a consortium of organizations. In this case, it can be interesting to list all organizations affiliated to this consortium. That's why we add a new placeholder `related_organizations` into organization_detail template.

<img width="1327" alt="Capture d’écran 2024-01-31 à 16 03 05" src="https://github.com/openfun/richie/assets/9265241/9942a8c6-bbd3-4650-80f8-392c199fd5be">
<img width="1327" alt="Capture d’écran 2024-01-31 à 16 03 05" src="https://github.com/openfun/richie/assets/9265241/3e84d59a-56cb-4a00-9cc7-654c6817318c">


## Proposal

- [x] Add a `related_organizations` placeholder on Organization detail page
- [x] Fix organization glimpse card variant
