### PR TITLE
🐛(frontend) Certicate products should not be listed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Certificate products are not listed anymore in teacher dashboard
 - Fix several SaleTunnel cache issues
 - Fix course access link in learner dashboard. This link must not be 
   display when the course isn't open.

--- a/src/frontend/js/components/TeacherDashboardCourseList/index.spec.tsx
+++ b/src/frontend/js/components/TeacherDashboardCourseList/index.spec.tsx
@@ -68,7 +68,7 @@ describe('components/TeacherDashboardCourseList', () => {
       title: "Full training: Let's dance, the online lesson",
     }).one();
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/course-product-relations/?page=1&page_size=${perPage}`,
+      `https://joanie.endpoint/api/v1.0/course-product-relations/?product_type=credential&page=1&page_size=${perPage}`,
       mockPaginatedResponse([productCooking, productDancing], 15, false),
     );
 
@@ -98,7 +98,7 @@ describe('components/TeacherDashboardCourseList', () => {
       `https://joanie.endpoint/api/v1.0/courses/?has_listed_course_runs=true&page=1&page_size=${perPage}`,
     );
     expect(calledUrls).toContain(
-      `https://joanie.endpoint/api/v1.0/course-product-relations/?page=1&page_size=${perPage}`,
+      `https://joanie.endpoint/api/v1.0/course-product-relations/?product_type=credential&page=1&page_size=${perPage}`,
     );
 
     expect(
@@ -124,7 +124,7 @@ describe('components/TeacherDashboardCourseList', () => {
       },
     );
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/course-product-relations/?page=1&page_size=${perPage}`,
+      `https://joanie.endpoint/api/v1.0/course-product-relations/?product_type=credential&page=1&page_size=${perPage}`,
       mockPaginatedResponse([], 0, false),
       {
         overwriteRoutes: true,
@@ -154,7 +154,7 @@ describe('components/TeacherDashboardCourseList', () => {
       `https://joanie.endpoint/api/v1.0/courses/?has_listed_course_runs=true&page=1&page_size=${perPage}`,
     );
     expect(calledUrls).toContain(
-      `https://joanie.endpoint/api/v1.0/course-product-relations/?page=1&page_size=${perPage}`,
+      `https://joanie.endpoint/api/v1.0/course-product-relations/?product_type=credential&page=1&page_size=${perPage}`,
     );
 
     expect(await screen.findByText('You have no courses yet.')).toBeInTheDocument();

--- a/src/frontend/js/components/TeacherDashboardCourseList/index.tsx
+++ b/src/frontend/js/components/TeacherDashboardCourseList/index.tsx
@@ -6,6 +6,7 @@ import { Spinner } from 'components/Spinner';
 import context from 'utils/context';
 import { useCourseProductUnion } from 'hooks/useCourseProductUnion';
 import { useIntersectionObserver } from 'hooks/useIntersectionObserver';
+import { ProductType } from 'types/Joanie';
 
 const messages = defineMessages({
   loading: {
@@ -41,7 +42,7 @@ const TeacherDashboardCourseList = ({
     isLoading,
     next,
     hasMore,
-  } = useCourseProductUnion({ perPage: 25, organizationId });
+  } = useCourseProductUnion({ perPage: 25, organizationId, productType: ProductType.CREDENTIAL });
   useIntersectionObserver({
     target: loadMoreButtonRef,
     onIntersect: next,

--- a/src/frontend/js/hooks/useCourseProductUnion/index.ts
+++ b/src/frontend/js/hooks/useCourseProductUnion/index.ts
@@ -6,6 +6,7 @@ import {
   CourseProductRelation,
   CourseQueryFilters,
   CourseProductRelationQueryFilters,
+  ProductType,
 } from 'types/Joanie';
 import useUnionResource, { ResourceUnionPaginationProps } from 'hooks/useUnionResource';
 
@@ -26,11 +27,13 @@ const messages = defineMessages({
 
 interface UseCourseProductUnionProps extends ResourceUnionPaginationProps {
   organizationId?: string;
+  productType?: ProductType;
 }
 
 export const useCourseProductUnion = ({
   perPage = 50,
   organizationId,
+  productType,
 }: UseCourseProductUnionProps = {}) => {
   const api = useJoanieApi();
   return useUnionResource<
@@ -47,7 +50,7 @@ export const useCourseProductUnion = ({
     queryBConfig: {
       queryKey: ['user', 'course_product_relations'],
       fn: api.courseProductRelations.get,
-      filters: { organization_id: organizationId },
+      filters: { organization_id: organizationId, product_type: productType },
     },
     perPage,
     errorGetMessage: messages.errorGet,

--- a/src/frontend/js/pages/TeacherDashboardCoursesLoader/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardCoursesLoader/index.spec.tsx
@@ -57,7 +57,7 @@ describe('components/TeacherDashboardCoursesLoader', () => {
       mockPaginatedResponse(CourseListItemFactory().many(15), 15, false),
     );
     fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/course-product-relations/?page=1&page_size=${perPage}`,
+      `https://joanie.endpoint/api/v1.0/course-product-relations/?product_type=credential&page=1&page_size=${perPage}`,
       mockPaginatedResponse(CourseProductRelationFactory().many(15), 15, false),
     );
 
@@ -87,7 +87,7 @@ describe('components/TeacherDashboardCoursesLoader', () => {
     const calledUrls = fetchMock.calls().map((call) => call[0]);
     expect(calledUrls).toHaveLength(nbApiCalls);
     expect(calledUrls).toContain(
-      `https://joanie.endpoint/api/v1.0/course-product-relations/?page=1&page_size=${perPage}`,
+      `https://joanie.endpoint/api/v1.0/course-product-relations/?product_type=credential&page=1&page_size=${perPage}`,
     );
 
     // section titles

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -435,6 +435,7 @@ export interface CourseProductQueryFilters extends ResourcesQuery {
 export interface CourseProductRelationQueryFilters extends PaginatedResourceQuery {
   id?: CourseProductRelation['id'];
   organization_id?: Organization['id'];
+  product_type?: ProductType;
 }
 
 export enum ContractState {


### PR DESCRIPTION
⚠️ Awaiting `product_type` filter to be added on Joanie API side

We do not want to show certificate products inside the teacher dashboard, only credentials ones and plain courses.

Fixes #2253
