### PR TITLE
✨(frontend) add more button to DashboardItem and Orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add a "more" button to DashboardItem and Orders containing a link to 
+  go to syllabus
 - `related_organizations` placeholder on organization detail page
 
 ### Changed

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -15,6 +15,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
 import fetchMock from 'fetch-mock';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { userEvent } from '@storybook/testing-library';
 import { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
 import {
   CourseStateFactory,
@@ -164,6 +165,25 @@ describe('<DashboardItemOrder/>', () => {
     await screen.findByText('Completed');
     await screen.findByRole('link', { name: 'View details' });
     await expectNoSpinner('Loading certificate ...');
+  });
+
+  it('renders an order with a valid "Go to syllabus" link', async () => {
+    const order: CredentialOrder = CredentialOrderFactory().one();
+    order.target_courses = [];
+    const { product } = mockCourseProductWithOrder(order);
+
+    render(<DashboardItemOrder order={order} />, { wrapper });
+
+    await screen.findByRole('heading', { level: 5, name: product.title });
+    const moreButton = screen.getByRole('combobox', {
+      name: 'See additional options',
+    });
+
+    const user = userEvent.setup();
+    await user.click(moreButton);
+
+    const link = screen.getByRole('link', { name: 'Go to syllabus' });
+    expect(link.getAttribute('href')).toBe('/redirects/courses/' + order.course.code);
   });
 
   /**

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -29,6 +29,11 @@ const messages = defineMessages({
     description: 'Accessible label displayed while certificate is being fetched on the dashboard.',
     defaultMessage: 'Loading certificate...',
   },
+  syllabusLinkLabel: {
+    id: 'components.DashboardItemOrder.syllabusLinkLabel',
+    description: 'Syllabus link label on order details',
+    defaultMessage: 'Go to syllabus',
+  },
 });
 
 interface DashboardItemOrderProps {
@@ -109,6 +114,13 @@ export const DashboardItemOrder = ({
         title={product?.title ?? ''}
         code={'Ref. ' + course.code}
         imageUrl={course.cover?.src}
+        more={
+          <li>
+            <a className="selector__list__link" href={`/redirects/courses/${course.code}`}>
+              <FormattedMessage {...messages.syllabusLinkLabel} />
+            </a>
+          </li>
+        }
         footer={
           <>
             <div className="dashboard-item-order__footer">

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -40,6 +40,16 @@
       &__code {
         order: 1;
       }
+
+      &__more {
+        position: absolute;
+        right: 1rem;
+        top: 0.5rem;
+
+        .selector__list {
+          right: -1rem;
+        }
+      }
     }
 
     &__status {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/index.spec.tsx
@@ -1,4 +1,6 @@
 import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { userEvent } from '@storybook/testing-library';
 import { DashboardSubItemsList } from './DashboardSubItemsList';
 import { DashboardSubItem } from './DashboardSubItem';
 import { DashboardItem, DEMO_IMAGE_URL } from '.';
@@ -57,5 +59,46 @@ describe('<DashboardItem />', () => {
     screen.getByText('Sub 1');
     screen.getByText('Sub 2');
     screen.getByText('Sub 3');
+  });
+
+  it('renders a DashboardItem with more dropdown', async () => {
+    render(
+      <IntlProvider locale="en">
+        <DashboardItem
+          title="Become a React pro"
+          code="Ref. 123"
+          imageUrl={DEMO_IMAGE_URL}
+          more={
+            <>
+              <li>
+                <div className="selector__list__link">Copy</div>
+              </li>
+              <li>
+                <div className="selector__list__link">Duplicate</div>
+              </li>
+              <li>
+                <div className="selector__list__link">Delete</div>
+              </li>
+            </>
+          }
+        />
+        ,
+      </IntlProvider>,
+    );
+
+    expect(screen.queryByText('Copy')).not.toBeInTheDocument();
+    expect(screen.queryByText('Duplicate')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+
+    const moreButton = screen.getByRole('combobox', {
+      name: 'See additional options',
+    });
+
+    const user = userEvent.setup();
+    await user.click(moreButton);
+
+    screen.getByText('Copy');
+    screen.getByText('Duplicate');
+    screen.getByText('Delete');
   });
 });

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/index.stories.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/index.stories.tsx
@@ -22,3 +22,21 @@ export const Default: Story = {};
 export const WithImage: Story = {
   args: { imageUrl: DEMO_IMAGE_URL },
 };
+export const WithMore: Story = {
+  args: {
+    imageUrl: DEMO_IMAGE_URL,
+    more: (
+      <>
+        <li>
+          <div className="selector__list__link">Copy</div>
+        </li>
+        <li>
+          <div className="selector__list__link">Duplicate</div>
+        </li>
+        <li>
+          <div className="selector__list__link">Delete</div>
+        </li>
+      </>
+    ),
+  },
+};

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/index.tsx
@@ -1,6 +1,18 @@
 import { PropsWithChildren, ReactNode } from 'react';
+import { Button } from '@openfun/cunningham-react';
+import { useSelect } from 'downshift';
+import { defineMessages, useIntl } from 'react-intl';
 import { JoanieFile } from 'types/Joanie';
 import { Nullable, PropsWithTestId } from 'types/utils';
+import { Icon, IconTypeEnum } from 'components/Icon';
+
+const messages = defineMessages({
+  moreLabel: {
+    id: 'components.DashboardItem.more_label',
+    description: 'Accessible label for the more button on the dashboard item',
+    defaultMessage: 'See additional options',
+  },
+});
 
 export type DashboardItemProps = PropsWithTestId<{
   title: ReactNode;
@@ -9,6 +21,7 @@ export type DashboardItemProps = PropsWithTestId<{
   imageFile?: Nullable<JoanieFile>;
   footer?: ReactNode;
   mode?: 'full' | 'compact';
+  more?: ReactNode;
 }>;
 
 // This is temporary due to the fact that backend doesn't give this attribute yet.
@@ -23,6 +36,7 @@ export const DashboardItem = ({
   footer,
   mode = 'full',
   children,
+  more,
   ...props
 }: PropsWithChildren<DashboardItemProps>) => {
   return (
@@ -58,11 +72,37 @@ export const DashboardItem = ({
               <h5 className="dashboard-item__block__head__title">{title}</h5>
               <div className="dashboard-item__block__head__code">{code}</div>
             </div>
+            {more && <DashboardItemMore more={more} />}
           </header>
         )}
         <footer className="dashboard-item__block__footer">{footer}</footer>
       </div>
       {children}
+    </div>
+  );
+};
+
+const DashboardItemMore = ({ more }: { more: ReactNode }) => {
+  const intl = useIntl();
+  const { isOpen, getToggleButtonProps, getMenuProps } = useSelect({
+    items: [],
+  });
+
+  return (
+    <div className="selector dashboard-item__block__head__more">
+      <Button
+        icon={<Icon name={IconTypeEnum.MORE} />}
+        color="tertiary"
+        size="small"
+        aria-label={intl.formatMessage(messages.moreLabel)}
+        {...getToggleButtonProps()}
+      />
+      <ul
+        {...getMenuProps()}
+        className={`selector__list ${isOpen ? '' : 'selector__list--is-closed'}`}
+      >
+        {isOpen && more}
+      </ul>
     </div>
   );
 };


### PR DESCRIPTION
## Purpose

We need a generic "more" button to DashboardItem in order to display various advanced options.

We want to add a "Go to syllabus" button on orders in order to allow the users to go back to the course's main page directly from their dashboard.
<img width="844" alt="Capture d’écran 2024-02-01 à 16 00 40" src="https://github.com/openfun/richie/assets/9628870/d90cbc08-99c7-4cd7-9894-076b4bd5ad2a">

<img width="848" alt="Capture d’écran 2024-02-01 à 16 00 22" src="https://github.com/openfun/richie/assets/9628870/9222c6b4-7fdd-40ee-a000-6e5c7a15e440">
