### PR TITLE
✨(frontend) link to terms and conditions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1130,6 +1130,7 @@ through `context_processor`
 
 ### Added
 
+- Bind terms and conditions url into frontend context and use it in sale tunnel
 - Add checkmark icon to course skills bullet lists.
 
 ### Changed

--- a/src/frontend/js/components/PaymentButton/hooks/useTerms.tsx
+++ b/src/frontend/js/components/PaymentButton/hooks/useTerms.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { PaymentErrorMessageId } from 'components/PaymentButton/index';
 import { Product } from 'types/Joanie';
-import { useJoanieApi } from 'contexts/JoanieApiContext';
+import context from 'utils/context';
 
 const messages = defineMessages({
   termsMessage: {
@@ -33,7 +33,6 @@ export const useTerms = ({
   error?: PaymentErrorMessageId;
 }) => {
   const intl = useIntl();
-  const api = useJoanieApi();
   const [termsAccepted, setTermsAccepted] = useState(false);
   const validateTerms = () => {
     if (!product.contract_definition) {
@@ -42,18 +41,6 @@ export const useTerms = ({
     if (!termsAccepted) {
       onError(PaymentErrorMessageId.ERROR_TERMS);
     }
-  };
-
-  const openContract = async (e: React.MouseEvent) => {
-    if (!product.contract_definition) {
-      return;
-    }
-    e.stopPropagation();
-    e.preventDefault();
-    const blob = await api.contractDefinitions.previewTemplate(product.contract_definition.id);
-    // eslint-disable-next-line compat/compat
-    const file = window.URL.createObjectURL(blob);
-    window.open(file);
   };
 
   return {
@@ -66,12 +53,14 @@ export const useTerms = ({
             label={
               <>
                 {intl.formatMessage(messages.termsMessage)}{' '}
-                <button
-                  onClick={openContract}
+                <a
+                  href={context.site_urls.terms_and_conditions ?? '#'}
+                  target="_blank"
+                  rel="noopener noreferrer"
                   title={intl.formatMessage(messages.termsMessageLinkTitle)}
                 >
                   {intl.formatMessage(messages.termsMessageLink)}
-                </button>
+                </a>
               </>
             }
             onChange={(e) => setTermsAccepted(e.target.checked)}

--- a/src/frontend/js/components/PaymentButton/index.spec.tsx
+++ b/src/frontend/js/components/PaymentButton/index.spec.tsx
@@ -54,6 +54,9 @@ jest.mock('utils/context', () => ({
     joanie_backend: {
       endpoint: 'https://joanie.test',
     },
+    site_urls: {
+      terms_and_conditions: '/en/about/terms-and-conditions/',
+    },
   }).one(),
 }));
 
@@ -177,7 +180,9 @@ describe.each([
         </Wrapper>,
       );
 
-      const $terms = screen.getByLabelText('By checking this box, you accept the');
+      const $terms = screen.getByLabelText(
+        'By checking this box, you accept the General Terms of Sale',
+      );
       await act(async () => {
         fireEvent.click($terms);
       });
@@ -330,7 +335,9 @@ describe.each([
       nbApiCalls += 1; // fetch order for useProductOrder
       expect(fetchMock.calls()).toHaveLength(nbApiCalls);
 
-      const $terms = screen.getByLabelText('By checking this box, you accept the');
+      const $terms = screen.getByLabelText(
+        'By checking this box, you accept the General Terms of Sale',
+      );
       await act(async () => {
         fireEvent.click($terms);
       });
@@ -455,7 +462,9 @@ describe.each([
         expect(screen.getByTestId('payment-button-order-loaded')).toBeInTheDocument();
       });
 
-      const $terms = screen.getByLabelText('By checking this box, you accept the');
+      const $terms = screen.getByLabelText(
+        'By checking this box, you accept the General Terms of Sale',
+      );
       await act(async () => {
         fireEvent.click($terms);
       });
@@ -590,7 +599,9 @@ describe.each([
         `https://joanie.test/api/v1.0/orders/?${queryString.stringify(fetchOrderQueryParams)}`,
       );
 
-      const $terms = screen.getByLabelText('By checking this box, you accept the');
+      const $terms = screen.getByLabelText(
+        'By checking this box, you accept the General Terms of Sale',
+      );
       await act(async () => {
         fireEvent.click($terms);
       });
@@ -703,7 +714,9 @@ describe.each([
       nbApiCalls += 1; // useProductOrder get order with filters
       expect(fetchMock.calls()).toHaveLength(nbApiCalls);
 
-      const $terms = screen.getByLabelText('By checking this box, you accept the');
+      const $terms = screen.getByLabelText(
+        'By checking this box, you accept the General Terms of Sale',
+      );
       await act(async () => {
         fireEvent.click($terms);
       });
@@ -802,16 +815,8 @@ describe.each([
     });
 
     it('should be able to preview the contract if product has a contract definition', async () => {
-      // eslint-disable-next-line compat/compat
-      URL.createObjectURL = jest.fn((blob) => blob) as any;
-      window.open = jest.fn();
-
       const product: Joanie.Product = ProductFactory().one();
       const billingAddress: Joanie.Address = AddressFactory().one();
-
-      const PREVIEW_URL = `https://joanie.test/api/v1.0/contract_definitions/${
-        product.contract_definition!.id
-      }/preview_template/`;
 
       const fetchOrderQueryParams =
         product.type === ProductType.CREDENTIAL
@@ -826,12 +831,10 @@ describe.each([
               state: ['pending', 'validated', 'submitted'],
             };
 
-      fetchMock
-        .get(
-          `https://joanie.test/api/v1.0/orders/?${queryString.stringify(fetchOrderQueryParams)}`,
-          [],
-        )
-        .get(PREVIEW_URL, 'preview content');
+      fetchMock.get(
+        `https://joanie.test/api/v1.0/orders/?${queryString.stringify(fetchOrderQueryParams)}`,
+        [],
+      );
 
       render(
         <Wrapper client={createTestQueryClient({ user: true })} product={product}>
@@ -839,25 +842,8 @@ describe.each([
         </Wrapper>,
       );
 
-      const $terms = screen.getByRole('button', { name: 'General Terms of Sale' });
-
-      // eslint-disable-next-line compat/compat
-      expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
-      expect(window.open).toHaveBeenCalledTimes(0);
-      expect(fetchMock.called(PREVIEW_URL)).toBe(false);
-
-      // console.log($terms);
-      await act(async () => {
-        fireEvent.click($terms);
-      });
-
-      expect(fetchMock.called(PREVIEW_URL)).toBe(true);
-      // eslint-disable-next-line compat/compat
-      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
-      // eslint-disable-next-line compat/compat
-      expect(URL.createObjectURL).toHaveBeenCalledWith('preview content');
-      expect(window.open).toHaveBeenCalledTimes(1);
-      expect(window.open).toHaveBeenCalledWith('preview content');
+      const $terms = screen.getByRole('link', { name: 'General Terms of Sale' });
+      expect($terms).toHaveAttribute('href', '/en/about/terms-and-conditions/');
     });
 
     it('should not show terms checkbox if the product does not have a contract definition', async () => {
@@ -959,7 +945,9 @@ describe.each([
           name: `Pay ${formatPrice(product.price, product.price_currency)}`,
         }) as HTMLButtonElement;
 
-        const $terms = screen.getByLabelText('By checking this box, you accept the');
+        const $terms = screen.getByLabelText(
+          'By checking this box, you accept the General Terms of Sale',
+        );
         await act(async () => {
           fireEvent.click($terms);
         });

--- a/src/frontend/js/types/commonDataProps.ts
+++ b/src/frontend/js/types/commonDataProps.ts
@@ -31,6 +31,9 @@ export interface RichieContext {
   release: string;
   sentry_dsn: Nullable<string>;
   web_analytics_providers?: Nullable<string[]>;
+  site_urls: {
+    terms_and_conditions: Nullable<string>;
+  };
 }
 
 export interface CommonDataProps {

--- a/src/frontend/js/utils/test/factories/richie.ts
+++ b/src/frontend/js/utils/test/factories/richie.ts
@@ -181,6 +181,9 @@ export const RichieContextFactory = factory<CommonDataProps['context']>(() => ({
   release: faker.system.semver(),
   sentry_dsn: null,
   web_analytics_providers: null,
+  site_urls: {
+    terms_and_conditions: null,
+  },
 }));
 
 export const CourseLightFactory = factory<Course>(() => {

--- a/tests/apps/courses/test_templatetags_category_tags_get_related_categories.py
+++ b/tests/apps/courses/test_templatetags_category_tags_get_related_categories.py
@@ -81,7 +81,7 @@ class GetRelatedCategoriesTemplateTagsTestCase(CMSTestCase):
         # 1. Test categories present on the draft page
 
         # - Linked with one of the pages
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             output = self.render_template_obj(
                 template, {"current_page": page_main, "pages": [page1]}, request
             )
@@ -89,7 +89,7 @@ class GetRelatedCategoriesTemplateTagsTestCase(CMSTestCase):
         self.assertEqual(output, "".join([str(c.id) for c in expected]))
 
         # - Linked with either of the 2 pages
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             output = self.render_template_obj(
                 template, {"current_page": page_main, "pages": [page1, page2]}, request
             )
@@ -102,7 +102,7 @@ class GetRelatedCategoriesTemplateTagsTestCase(CMSTestCase):
         self.assertEqual(output, "".join([str(c.id) for c in expected]))
 
         # - Linked with a page in a different publication status
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             output = self.render_template_obj(
                 template,
                 {"current_page": page_main, "pages": [page1.get_public_object()]},
@@ -115,7 +115,7 @@ class GetRelatedCategoriesTemplateTagsTestCase(CMSTestCase):
         current_page = page_main.get_public_object()
 
         # - Linked with one of the pages
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             output = self.render_template_obj(
                 template,
                 {"current_page": current_page, "pages": [page1.get_public_object()]},
@@ -126,7 +126,7 @@ class GetRelatedCategoriesTemplateTagsTestCase(CMSTestCase):
         )
 
         # - Linked with either of the 2 pages
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             output = self.render_template_obj(
                 template,
                 {
@@ -142,7 +142,7 @@ class GetRelatedCategoriesTemplateTagsTestCase(CMSTestCase):
         self.assertEqual(output, "".join([str(c.id) for c in expected]))
 
         # - Linked with a page in a different publication status
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             output = self.render_template_obj(
                 template,
                 {"current_page": current_page, "pages": [page1]},

--- a/tests/apps/courses/test_templatetags_extra_tags_block_plugin.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_block_plugin.py
@@ -41,7 +41,7 @@ class BlockPluginTemplateTagsTestCase(CMSTestCase):
             "{% endblockplugin %}"
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             output = self.render_template_obj(
                 template, {"plugin": plugin}, request
             ).replace("\n", "")
@@ -70,7 +70,7 @@ class BlockPluginTemplateTagsTestCase(CMSTestCase):
             "{% endblockplugin %}"
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             output = self.render_template_obj(
                 template, {"plugin": plugin}, request
             ).replace("\n", "")


### PR DESCRIPTION
## Purpose

Currently, into the sale tunnel when there is a contract to sign, the user must accept our terms and conditions. We allow the user to download a preview of the contract which include those terms and conditions.

This is not a proper solution for ux. Instead we decide to create a dedicated page on our platform then we just have to link this page in the sale tunnel. Simpler, better.


## Proposal

- [x] Bind terms-and-conditions url to frontend context
- [x] Replace the download contract preview logic by a link to our terms and conditions page. 
