### PR TITLE
✅(frontend) fix flaky test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix CreditCardHelper
 - Remove enrollment start on some course run
 - Fix Organization glimpse card variant logo size
 - Fix joanie's course run link to LMS course in the syllabus page.

--- a/src/frontend/js/utils/CreditCardHelper/index.spec.tsx
+++ b/src/frontend/js/utils/CreditCardHelper/index.spec.tsx
@@ -27,9 +27,10 @@ describe('CreditCardHelper', () => {
   });
 
   it('is soon expired', () => {
-    const expirationDate = faker.date.future({
-      refDate: new Date(),
-      years: 2.99 / 12,
+    const now = new Date();
+    const expirationDate = faker.date.between({
+      from: now,
+      to: new Date(now.getFullYear(), now.getMonth() + 4, 0, 23, 59, 59),
     });
 
     expect(
@@ -43,7 +44,10 @@ describe('CreditCardHelper', () => {
   });
 
   it('is expired', () => {
-    const date = faker.date.past();
+    const now = new Date();
+    const date = faker.date.past({
+      refDate: new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59),
+    });
     expect(
       CreditCardHelper.getExpirationState(
         CreditCardFactory({

--- a/src/frontend/js/utils/CreditCardHelper/index.tsx
+++ b/src/frontend/js/utils/CreditCardHelper/index.tsx
@@ -15,16 +15,29 @@ export class CreditCardHelper {
     if (!creditCard.expiration_month || !creditCard.expiration_year) {
       return false;
     }
-    const expirationDate = new Date(creditCard.expiration_year, creditCard.expiration_month - 1, 1);
-    const limitDate = new Date();
-    limitDate.setMonth(limitDate.getMonth() + 3);
-    return limitDate.getTime() > expirationDate.getTime();
+    const expirationDate = new Date(
+      creditCard.expiration_year,
+      creditCard.expiration_month,
+      0,
+      23,
+      59,
+      59,
+    );
+    const limitDate = new Date(new Date().getFullYear(), new Date().getMonth() + 4, 0, 23, 59, 59);
+    return limitDate.getTime() >= expirationDate.getTime();
   }
 
   static isExpired(creditCard: CreditCard): boolean {
-    const expirationDate = new Date(creditCard.expiration_year, creditCard.expiration_month - 1, 1);
+    const expirationDate = new Date(
+      creditCard.expiration_year,
+      creditCard.expiration_month,
+      0,
+      23,
+      59,
+      59,
+    );
     const now = new Date();
-    return expirationDate.getTime() < now.getTime();
+    return expirationDate.getTime() <= now.getTime();
   }
 
   static getExpirationState(creditCard: CreditCard): CreditCardExpirationStatus {


### PR DESCRIPTION
`DashboardCreditCardsManagement` test about credit card expiration date use a date in less than 3 month in the future.
This date some time happen to be exactly 3 month, just a few hours before the treshold of 3 month.
As `CreditCardHelper.isExpiredSoon` only check year and month and not hours, the test failed.
