### PR TITLE
💬(frontend) update root menu entry label of training views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Rename trainings root menu entry label
 - Upgrade to node 20
 - Contract list in the teacher dashbaord are now filtered by 
   courseProductRelationId instead of courseId and productId.

--- a/src/frontend/js/api/lms/dummy.ts
+++ b/src/frontend/js/api/lms/dummy.ts
@@ -38,9 +38,11 @@ const JOANIE_DEV_DEMO_USER_JWT_TOKENS = {
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzMzOTI4MjE0LCJpYXQiOjE3MDIzOTIyMTQsImp0aSI6ImNkZjAyMGM4ODdjOTQxYzU5ZmExN2FkZGExNjNjMDIzIiwiZW1haWwiOiJqZWFuLWJhcHRpc3RlLnBlbnJhdGgrc3R1ZGVudF91c2VyQGZ1bi1tb29jLmZyIiwibGFuZ3VhZ2UiOiJmci1mciIsInVzZXJuYW1lIjoic3R1ZGVudF91c2VyIiwiZnVsbF9uYW1lIjoiXHUwMGM5dHVkaWFudCJ9.JMdnC2VXwq2VbNPrIYxj8PEq0oJJ4LZZT_ywWyE1lBM',
 };
 
+export type DevDemoUser = keyof typeof JOANIE_DEV_DEMO_USER_JWT_TOKENS;
+
 export const RICHIE_DUMMY_IS_LOGGED_IN = 'RICHIE_DUMMY_IS_LOGGED_IN';
 
-function getUserInfo(username: keyof typeof JOANIE_DEV_DEMO_USER_JWT_TOKENS): Maybe<User> {
+function getUserInfo(username: DevDemoUser): Maybe<User> {
   const accessToken = JOANIE_DEV_DEMO_USER_JWT_TOKENS[username];
   const JWTPayload: JWTPayload = JSON.parse(base64Decode(accessToken.split('.')[1]));
 

--- a/src/frontend/js/settings.dev.dist.ts
+++ b/src/frontend/js/settings.dev.dist.ts
@@ -1,12 +1,3 @@
-/**
- * Available users:
- *  * admin
- *  * user0
- *  * user1
- *  * user2
- *  * user3
- *  * user4
- *  * organization_owner
- *  * student_user
- */
-export const CURRENT_JOANIE_DEV_DEMO_USER = 'admin';
+import { DevDemoUser } from 'api/lms/dummy';
+
+export const CURRENT_JOANIE_DEV_DEMO_USER: DevDemoUser = 'admin';

--- a/src/frontend/js/widgets/Dashboard/utils/teacherRouteMessages.tsx
+++ b/src/frontend/js/widgets/Dashboard/utils/teacherRouteMessages.tsx
@@ -141,7 +141,7 @@ export const TEACHER_DASHBOARD_ROUTE_LABELS = defineMessages<TeacherDashboardPat
   [TeacherDashboardPaths.ORGANIZATION_PRODUCT]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.organization.course.product.label',
     description: 'Label of the organization product view.',
-    defaultMessage: 'Training',
+    defaultMessage: 'General information',
   },
   [TeacherDashboardPaths.COURSE]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.label',
@@ -156,7 +156,7 @@ export const TEACHER_DASHBOARD_ROUTE_LABELS = defineMessages<TeacherDashboardPat
   [TeacherDashboardPaths.COURSE_PRODUCT]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.product.label',
     description: 'Label of the product view.',
-    defaultMessage: 'Training',
+    defaultMessage: 'General information',
   },
   [TeacherDashboardPaths.COURSE_CONTRACTS]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.contracts.label',


### PR DESCRIPTION
## Purpose

In teacher dashboard, the related sidebar menu entry to the root view of a 
training is labelled "Training". It should be labelled "General information" 
like free courses.

## Proposal

- [x] Improve DX of settings.dev.ts
- [x] Rename training sidebar menu entry label
