### PR TITLE
SaleTunnel various cache issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fix several SaleTunnel cache issues
 - Fix course access link in learner dashboard. This link must not be 
   display when the course isn't open.
 - Fix CreditCardHelper

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -306,7 +306,7 @@ const API = (): Joanie.API => {
       },
       orders: {
         abort: async ({ id, payment_id }) => {
-          fetchWithJWT(ROUTES.user.orders.abort.replace(':id', id), {
+          return fetchWithJWT(ROUTES.user.orders.abort.replace(':id', id), {
             method: 'POST',
             body: payment_id ? JSON.stringify({ payment_id }) : undefined,
           }).then(checkStatus);

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepResume/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepResume/index.spec.tsx
@@ -6,7 +6,6 @@ import {
   ProductFactory,
 } from 'utils/test/factories/joanie';
 import { SaleTunnelContext } from 'components/SaleTunnel/context';
-import { noop } from 'utils';
 import { SaleTunnelStepResume } from '.';
 
 describe('SaleTunnelStepResume', () => {
@@ -24,7 +23,6 @@ describe('SaleTunnelStepResume', () => {
         <SaleTunnelContext.Provider
           value={{
             product,
-            setOrder: noop,
             course: CourseLightFactory({ code: '00000' }).one(),
             key: `00000+${product.id}`,
           }}
@@ -56,7 +54,6 @@ describe('SaleTunnelStepResume', () => {
           value={{
             product,
             order,
-            setOrder: noop,
             course: CourseLightFactory({ code: '00000' }).one(),
             key: `00000+${product.id}`,
           }}

--- a/src/frontend/js/components/SaleTunnel/context.tsx
+++ b/src/frontend/js/components/SaleTunnel/context.tsx
@@ -12,7 +12,6 @@ interface SaleTunnelContextBase {
   product: CredentialProduct | CertificateProduct;
   orderGroup?: OrderGroup;
   order?: Order;
-  setOrder: (order: Order) => void;
   key: string;
   enrollment?: Enrollment;
   course?: CourseLight;

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useQueryClient } from '@tanstack/react-query';
 import { Modal } from 'components/Modal';
@@ -16,7 +16,7 @@ import { IconTypeEnum } from 'components/Icon';
 import WebAnalyticsAPIHandler from 'api/web-analytics';
 import { CourseProductEvent } from 'types/web-analytics';
 import { Manifest, useStepManager } from 'hooks/useStepManager';
-import { Maybe } from 'types/utils';
+import useProductOrder from 'hooks/useProductOrder';
 import { SaleTunnelContext, SaleTunnelContextType } from './context';
 import { StepBreadcrumb } from './components/StepBreadcrumb';
 import { SaleTunnelStepValidation } from './components/SaleTunnelStepValidation';
@@ -80,8 +80,11 @@ const SaleTunnel = ({
     product.id
   }`;
   const queryClient = useQueryClient();
-
-  const [order, setOrder] = useState<Maybe<Order>>();
+  const { item: order } = useProductOrder({
+    courseCode: course?.code,
+    enrollmentId: enrollment?.id,
+    productId: product.id,
+  });
 
   const manifest: Manifest<TunnelSteps, 'resume'> = {
     start: 'validation',
@@ -138,7 +141,6 @@ const SaleTunnel = ({
       return {
         product: product as CredentialProduct,
         order,
-        setOrder,
         key,
         course: course!,
         enrollment: undefined,
@@ -147,25 +149,23 @@ const SaleTunnel = ({
       return {
         product: product as CertificateProduct,
         order,
-        setOrder,
         key,
         course: undefined,
         enrollment: enrollment!,
       };
     }
-  }, [product, order, setOrder]);
+  }, [product, order]);
 
   useMemo(
     () => ({
       product,
       order,
-      setOrder,
       key,
       course,
       enrollment,
       orderGroup,
     }),
-    [product, order, setOrder, key, course, enrollment, orderGroup],
+    [product, order, key, course, enrollment, orderGroup],
   );
 
   /**

--- a/src/frontend/js/hooks/useOrders.ts
+++ b/src/frontend/js/hooks/useOrders.ts
@@ -73,7 +73,12 @@ const useOrdersBase =
     queryOptions?: QueryOptions<CredentialOrder | CertificateOrder>,
   ) => {
     const custom = useResourcesCustom({ ...props, filters, queryOptions });
-    const abortHandler = useSessionMutation({ mutationFn: useJoanieApi().user.orders.abort });
+    const abortHandler = useSessionMutation({
+      mutationFn: useJoanieApi().user.orders.abort,
+      onSuccess: () => {
+        custom.methods.invalidate();
+      },
+    });
     const submitHandler = useSessionMutation({ mutationFn: useJoanieApi().user.orders.submit });
     return {
       ...custom,

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/CourseProductItemFooter/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/CourseProductItemFooter/index.tsx
@@ -24,7 +24,7 @@ other {# remaining seats}
 interface CourseProductItemFooterProps {
   course: CourseLight;
   product: CredentialProduct;
-  isPendingState: boolean;
+  canPurchase: boolean;
   orderGroups: OrderGroup[];
   orderGroupsAvailable: OrderGroup[];
 }
@@ -34,14 +34,14 @@ const CourseProductItemFooter = ({
   product,
   orderGroups,
   orderGroupsAvailable,
-  isPendingState,
+  canPurchase,
 }: CourseProductItemFooterProps) => {
   if (orderGroups.length === 0) {
     return (
       <PurchaseButton
         course={course}
         product={product}
-        disabled={!isPendingState}
+        disabled={!canPurchase}
         buttonProps={{ fullWidth: true }}
       />
     );
@@ -58,7 +58,7 @@ const CourseProductItemFooter = ({
       <PurchaseButton
         course={course}
         product={product}
-        disabled={!isPendingState}
+        disabled={!canPurchase}
         orderGroup={orderGroup}
         buttonProps={{ fullWidth: true }}
       />

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
@@ -62,11 +62,11 @@ export interface CourseProductItemProps {
 type HeaderProps = {
   compact: boolean;
   hasPurchased: boolean;
-  isPendingState: boolean;
+  canPurchase: boolean;
   order: Maybe<CredentialOrder>;
   product: Product;
 };
-const Header = ({ product, order, hasPurchased, isPendingState, compact }: HeaderProps) => {
+const Header = ({ product, order, hasPurchased, canPurchase, compact }: HeaderProps) => {
   const intl = useIntl();
   const formatDate = useDateFormat();
 
@@ -92,7 +92,7 @@ const Header = ({ product, order, hasPurchased, isPendingState, compact }: Heade
         <strong className="product-widget__price h6">
           {order?.state === OrderState.VALIDATED && <FormattedMessage {...messages.purchased} />}
           {order?.state === OrderState.SUBMITTED && <FormattedMessage {...messages.pending} />}
-          {isPendingState && (
+          {canPurchase && (
             <FormattedNumber
               currency={product.price_currency}
               value={product.price}
@@ -171,8 +171,7 @@ const CourseProductItem = ({ productId, course, compact = false }: CourseProduct
   });
 
   const order = productOrder as CredentialOrder;
-  // TODO: Rename this, how having no order is a pending state? It's hard to understand imo.
-  const isPendingState = !order || order.state === OrderState.PENDING;
+  const canPurchase = !order || order.state === OrderState.PENDING;
   const hasPurchased = (order && order.state === OrderState.VALIDATED) ?? false;
 
   const hasError = Boolean(productQueryStates.error);
@@ -229,7 +228,7 @@ const CourseProductItem = ({ productId, course, compact = false }: CourseProduct
           <Header
             product={product}
             order={order}
-            isPendingState={isPendingState}
+            canPurchase={canPurchase}
             hasPurchased={hasPurchased}
             compact={compact}
           />
@@ -240,7 +239,7 @@ const CourseProductItem = ({ productId, course, compact = false }: CourseProduct
               product={product as CredentialProduct}
               orderGroups={orderGroups}
               orderGroupsAvailable={orderGroupsAvailable}
-              isPendingState={isPendingState}
+              canPurchase={canPurchase}
             />
           </footer>
         </>

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
@@ -171,6 +171,7 @@ const CourseProductItem = ({ productId, course, compact = false }: CourseProduct
   });
 
   const order = productOrder as CredentialOrder;
+  // TODO: Rename this, how having no order is a pending state? It's hard to understand imo.
   const isPendingState = !order || order.state === OrderState.PENDING;
   const hasPurchased = (order && order.state === OrderState.VALIDATED) ?? false;
 


### PR DESCRIPTION
🐛(fix) SaleTunnel several cache issues

We encountered several issues in specific use cases with the SaleTunnel:

- Open and close the payment interface, when trying to open again the
frontend tries to create a new order, but there is already an existing
order: we should simply re-submit it. 
Fixed by: invalidate cache after aborting.

- Open and close payment interface and SaleTunnel, the PurchaseButton
is not displayed: it should because the order is pending.
Fixed by: invalidate cache after aborting.

- If we open a new tab and there is already an existing pending order,
the last step of the SaleTunnel (resume) crashes because the order
variable it uses is not defined.
Fixed by: Bring up useProductOrder to SaleTunnel in order to make the
existing order available accross the context.