### PR TITLE
✨(frontend) require terms consent on all purchase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Require to accept terms when purchasing product of any kind
 - Rename trainings root menu entry label
 - Upgrade to node 20
 - Contract list in the teacher dashbaord are now filtered by 

--- a/src/frontend/js/components/PaymentButton/index.tsx
+++ b/src/frontend/js/components/PaymentButton/index.tsx
@@ -114,12 +114,7 @@ const PaymentButton = ({ billingAddress, creditCard, onSuccess }: PaymentButtonP
   });
 
   const isReadyToPay = useMemo(() => {
-    return (
-      (course || enrollment) &&
-      product &&
-      billingAddress &&
-      (termsAccepted || !product.contract_definition)
-    );
+    return (course || enrollment) && product && billingAddress && termsAccepted;
   }, [product, course, enrollment, billingAddress, termsAccepted]);
 
   /**
@@ -201,10 +196,12 @@ const PaymentButton = ({ billingAddress, creditCard, onSuccess }: PaymentButtonP
           ? {
               product_id: product.id,
               enrollment_id: enrollment!.id,
+              has_consent_to_terms: termsAccepted,
             }
           : {
               product_id: product.id,
               course_code: course!.code,
+              has_consent_to_terms: termsAccepted,
               ...(orderGroup ? { order_group_id: orderGroup.id } : {}),
             };
 
@@ -284,7 +281,7 @@ const PaymentButton = ({ billingAddress, creditCard, onSuccess }: PaymentButtonP
 
   return (
     <div className="payment-button" data-testid={order && 'payment-button-order-loaded'}>
-      {product.contract_definition && renderTermsCheckbox()}
+      {renderTermsCheckbox()}
       <Button
         disabled={state === ComponentStates.LOADING}
         onClick={createOrder}

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -376,6 +376,7 @@ export interface AddressCreationPayload extends Omit<Address, 'id' | 'is_main'> 
 interface AbstractOrderProductCreationPayload {
   product_id: Product['id'];
   order_group_id?: OrderGroup['id'];
+  has_consent_to_terms: boolean;
 }
 
 interface OrderCertificateCreationPayload extends AbstractOrderProductCreationPayload {


### PR DESCRIPTION
## Purpose

Previously, only product having a contract definition link required to accept terms before pay. Since terms and conditions are available from a dedicated page
 on our catalog, it seems relevant to require this consent on any kind of
 product.

Related work : https://github.com/openfun/joanie/pull/617

## Proposal

- [x] Require terms consent on any kind of product
- [x] Upload order creation payload to send the consent state
