### PR TITLE
🩹(frontend) prevent to clear address select field

### DIFF
--- a/src/frontend/js/components/RegisteredAddress/index.tsx
+++ b/src/frontend/js/components/RegisteredAddress/index.tsx
@@ -61,7 +61,7 @@ const RegisteredAddress = ({ promote, select, edit, remove, address }: Props) =>
       <Radio
         aria-describedby={`address-${address.id}-infos`}
         aria-label={intl.formatMessage(messages.promoteButtonLabel, { title: address.title })}
-        onClick={() => promote(address)}
+        onChange={() => promote(address)}
         title={intl.formatMessage(messages.promoteButtonLabel, { title: address.title })}
         name="registered-addresses"
         checked={address.is_main}

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.spec.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { CunninghamProvider } from '@openfun/cunningham-react';
 import { PropsWithChildren, useMemo, useState } from 'react';
 import userEvent from '@testing-library/user-event';
+import { queryByRole } from '@testing-library/dom';
 import {
   RichieContextFactory as mockRichieContextFactory,
   UserFactory,
@@ -209,6 +210,9 @@ describe('SaleTunnelStepPayment', () => {
         selector: 'address',
       },
     );
+
+    // The select field should not be clearable
+    expect(queryByRole(dropdown, 'button', { name: 'Clear selection' })).toBeNull();
 
     // A button to add an address should be displayed
     const $button = screen.getByText('Add an address', { selector: 'button' });

--- a/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/components/SaleTunnelStepPayment/index.tsx
@@ -123,7 +123,7 @@ export const SaleTunnelStepPayment = ({ next }: SaleTunnelStepPaymentProps) => {
    * Retrieve address through its `id` provided by the event target value
    * then update `selectedAddress` state
    *
-   * @param {React.ChangeEvent<HTMLSelectElement>} event
+   * @param {string} newValue
    */
   const handleSelectAddress = (newValue: string) => {
     const targetedAddress = addresses.items.find((a) => a.id === newValue);
@@ -220,6 +220,7 @@ export const SaleTunnelStepPayment = ({ next }: SaleTunnelStepPaymentProps) => {
                 <Select
                   className="form-field--minimal"
                   name="invoice_address"
+                  clearable={false}
                   label={intl.formatMessage(messages.userBillingAddressSelectLabel)}
                   onChange={(e) => handleSelectAddress((e.target.value || '') as string)}
                   defaultValue={selectedAddress!.id || ''}


### PR DESCRIPTION
## Purpose

In the sale tunnel, currently the select is clearable but it does not unselect the address so the UX is weird. In order to improve that, we disable the clear feature of the select.


https://github.com/openfun/richie/assets/9265241/5306b81c-ccce-4929-abe9-8cbfa9e6c59d

## Proposal

- [x] Disable select clear feature
