### PR TITLE
🐛(frontend) fix settings

### DIFF
--- a/src/frontend/js/settings/index.ts
+++ b/src/frontend/js/settings/index.ts
@@ -13,12 +13,6 @@ if (process.env.NODE_ENV === 'development') {
   settingsOverride = testSettings;
 }
 
-try {
-  settingsOverride = require('./settings.dev.ts');
-} catch {
-  // no local settings found, do nothing
-}
-
 const settings = mergeWith({}, prodSettings, settingsOverride);
 
 export const {


### PR DESCRIPTION
> settings.dev should not be load outside of 'development environment.

Another mistake from previous settings merge