### PR TITLE
✨(frontend) improve contrat's organization filter

### DIFF
--- a/src/frontend/js/hooks/useDefaultOrganizationId/index.tsx
+++ b/src/frontend/js/hooks/useDefaultOrganizationId/index.tsx
@@ -1,6 +1,6 @@
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useOrganizations } from 'hooks/useOrganizations';
-import { Organization } from 'types/Joanie';
+import { CourseProductRelation, Organization } from 'types/Joanie';
 
 /**
  * return organization id with this priority:
@@ -9,14 +9,21 @@ import { Organization } from 'types/Joanie';
  * * first organization of user's organizations
  */
 const useDefaultOrganizationId = () => {
-  const { organizationId: routeOrganizationId } = useParams<{
+  const {
+    organizationId: routeOrganizationId,
+    courseProductRelationId: routeCourseProductRelationId,
+  } = useParams<{
     organizationId?: Organization['id'];
+    courseProductRelationId: CourseProductRelation['id'];
   }>();
   const [searchParams] = useSearchParams();
   const queryOrganizationId = searchParams.get('organization_id') || undefined;
-  const { items: organizations } = useOrganizations(undefined, {
-    enabled: !routeOrganizationId && !queryOrganizationId,
-  });
+  const { items: organizations } = useOrganizations(
+    { course_product_relation_id: routeCourseProductRelationId },
+    {
+      enabled: !routeOrganizationId && !queryOrganizationId,
+    },
+  );
 
   return (
     routeOrganizationId ||

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/TeacherDashboardContracts/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/TeacherDashboardContracts/index.tsx
@@ -42,14 +42,20 @@ const TeacherDashboardContracts = () => {
     defaultPage: page ? parseInt(page, 10) : 1,
     pageSize: PER_PAGE.teacherContractList,
   });
-  const { organizationId: routeOrganizationId } = useParams<TeacherDashboardContractsParams>();
+  const {
+    organizationId: routeOrganizationId,
+    courseProductRelationId: routeCourseProductRelationId,
+  } = useParams<TeacherDashboardContractsParams>();
   // organization list is used to show/hide organization filter.
   // when organizationId is in route's params this filter is always hidden.
   // therefore we don't need to enable this query.
   const {
     items: organizationList,
     states: { isFetched: isOrganizationListFetched },
-  } = useOrganizations(undefined, { enabled: !!routeOrganizationId });
+  } = useOrganizations(
+    { course_product_relation_id: routeCourseProductRelationId },
+    { enabled: !routeOrganizationId },
+  );
   const hasMultipleOrganizations = isOrganizationListFetched && organizationList.length > 1;
   const { initialFilters, filters, setFilters } = useTeacherContractFilters();
   const {
@@ -97,6 +103,7 @@ const TeacherDashboardContracts = () => {
         <ContractFiltersBar
           defaultValues={initialFilters}
           onFiltersChange={handleFiltersChange}
+          organizationList={organizationList}
           hideFilterOrganization={!!(routeOrganizationId || !hasMultipleOrganizations)}
         />
       </div>

--- a/src/frontend/js/pages/TeacherDashboardContractsLayout/components/ContractFiltersBar/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardContractsLayout/components/ContractFiltersBar/index.tsx
@@ -1,7 +1,7 @@
 import { Select, SelectProps } from '@openfun/cunningham-react';
 import { defineMessages, useIntl } from 'react-intl';
 import FiltersBar from 'widgets/Dashboard/components/FiltersBar';
-import { ContractState } from 'types/Joanie';
+import { ContractState, Organization } from 'types/Joanie';
 import { ContractHelper, ContractStatePoV } from 'utils/ContractHelper';
 import FilterOrganization from 'widgets/Dashboard/components/FilterOrganization';
 
@@ -28,11 +28,13 @@ interface ContractFiltersBarProps {
   defaultValues?: ContractListFilters;
   hideFilterOrganization?: boolean;
   hideFilterSignatureState?: boolean;
+  organizationList?: Organization[];
 }
 
 const ContractFiltersBar = ({
   defaultValues,
   onFiltersChange,
+  organizationList,
   hideFilterOrganization = false,
   hideFilterSignatureState = false,
 }: ContractFiltersBarProps) => {
@@ -42,6 +44,7 @@ const ContractFiltersBar = ({
         <FilterOrganization
           defaultValue={defaultValues?.organization_id}
           onChange={onFiltersChange}
+          organizationList={organizationList}
         />
       )}
       {!hideFilterSignatureState && (

--- a/src/frontend/js/widgets/Dashboard/components/TeacherDashboardCourseSidebar/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/TeacherDashboardCourseSidebar/index.spec.tsx
@@ -129,7 +129,10 @@ describe('<TeacherDashboardCourseSidebar/>', () => {
           courseProductRelation,
         );
         nbApiRequest += 1;
-        fetchMock.get('https://joanie.endpoint/api/v1.0/organizations/', []);
+        fetchMock.get(
+          `https://joanie.endpoint/api/v1.0/organizations/?course_product_relation_id=${courseProductRelation.id}`,
+          [],
+        );
       } else {
         // mock api for course
         nbApiRequest += 1;


### PR DESCRIPTION
## Purpose
If a course_product_relation_id is found in the route,
organization filter's options in contract listing page should only
contain organization that sell the current training.
