### PR TITLE
🧪(frontend) fix credit card flacky test

### DIFF
--- a/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
@@ -68,7 +68,10 @@ describe('<DashboardCreditCardsManagement/>', () => {
   });
 
   it('renders the correct label for expired date', async () => {
-    const date = faker.date.past();
+    const now = new Date();
+    const date = faker.date.past({
+      refDate: new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59),
+    });
     const creditCard: CreditCard = CreditCardFactory({
       expiration_month: date.getMonth() + 1,
       expiration_year: date.getFullYear(),


### PR DESCRIPTION
The past date generated was sometimes not within the previous month, which was making the test to fail.

