### PR TITLE
✨(frontend) learner courses search with query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add search bar on learner dashboard courses pages.
 - Add a `CertificateHelper` implementing a `getCourse` method
 - Add search bar on teacher dashboard courses pages.
 - Add background colors to default user's avatar when they're used 

--- a/src/frontend/js/hooks/useLearnerCoursesSearch/index.tsx
+++ b/src/frontend/js/hooks/useLearnerCoursesSearch/index.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Enrollment, CredentialOrder, OrderState, ProductType } from 'types/Joanie';
+import { Maybe, Nullable } from 'types/utils';
+import { useOrdersEnrollments } from 'pages/DashboardCourses/useOrdersEnrollments';
+
+const useLearnerCoursesSearch = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [count, setCount] = useState<Maybe<number>>(0);
+  const [orderAndEnrollmentList, setOrderAndEnrollmentList] = useState<
+    (CredentialOrder | Enrollment)[]
+  >([]);
+  const [isNewSearchLoading, setIsNewSearchLoading] = useState(false);
+  const query = searchParams.get('query') || undefined;
+  const {
+    data,
+    isLoading,
+    next,
+    hasMore,
+    count: currentCount,
+    error,
+  } = useOrdersEnrollments({
+    query,
+    orderFilters: {
+      product_type: [ProductType.CREDENTIAL],
+      state_exclude: [OrderState.CANCELED],
+    },
+  });
+
+  useEffect(() => {
+    if (!data.length && isLoading) {
+      setIsNewSearchLoading(true);
+    }
+
+    if (isLoading) {
+      return;
+    }
+
+    if (isNewSearchLoading) {
+      setIsNewSearchLoading(false);
+    }
+
+    if (isNewSearchLoading || data.length > orderAndEnrollmentList?.length) {
+      setOrderAndEnrollmentList(data as (CredentialOrder | Enrollment)[]);
+
+      // research counter should not be displayed when query is empty
+      if (query) {
+        setCount(currentCount);
+      }
+    }
+  }, [data.length, isLoading, isNewSearchLoading, query]);
+
+  const submitSearch = (newQuery: Nullable<string>) => {
+    if (newQuery === null) {
+      searchParams.delete('query');
+    } else {
+      searchParams.set('query', newQuery);
+    }
+
+    setSearchParams(searchParams);
+    if (!newQuery) {
+      setCount(undefined);
+    }
+  };
+
+  return {
+    submitSearch,
+    data: orderAndEnrollmentList,
+    isNewSearchLoading,
+    isLoadingMore: isLoading && !isNewSearchLoading,
+    next,
+    hasMore,
+    count,
+    error,
+  };
+};
+export default useLearnerCoursesSearch;

--- a/src/frontend/js/hooks/useLearnerCoursesSearch/index.tsx
+++ b/src/frontend/js/hooks/useLearnerCoursesSearch/index.tsx
@@ -6,7 +6,7 @@ import { useOrdersEnrollments } from 'pages/DashboardCourses/useOrdersEnrollment
 
 const useLearnerCoursesSearch = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [count, setCount] = useState<Maybe<number>>(0);
+  const [count, setCount] = useState<Maybe<number>>();
   const [orderAndEnrollmentList, setOrderAndEnrollmentList] = useState<
     (CredentialOrder | Enrollment)[]
   >([]);
@@ -42,11 +42,7 @@ const useLearnerCoursesSearch = () => {
 
     if (isNewSearchLoading || data.length > orderAndEnrollmentList?.length) {
       setOrderAndEnrollmentList(data as (CredentialOrder | Enrollment)[]);
-
-      // research counter should not be displayed when query is empty
-      if (query) {
-        setCount(currentCount);
-      }
+      setCount(currentCount);
     }
   }, [data.length, isLoading, isNewSearchLoading, query]);
 
@@ -64,6 +60,7 @@ const useLearnerCoursesSearch = () => {
   };
 
   return {
+    query,
     submitSearch,
     data: orderAndEnrollmentList,
     isNewSearchLoading,

--- a/src/frontend/js/hooks/useOrders.ts
+++ b/src/frontend/js/hooks/useOrders.ts
@@ -22,6 +22,7 @@ export type OrderResourcesQuery = PaginatedResourceQuery & {
   state_exclude?: OrderState[];
   product_type?: ProductType[];
   product_type_exclude?: ProductType[];
+  query?: string;
 };
 
 const messages = defineMessages({

--- a/src/frontend/js/pages/DashboardCourses/_styles.scss
+++ b/src/frontend/js/pages/DashboardCourses/_styles.scss
@@ -13,7 +13,6 @@
 .dashboard__courses {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
 
   &__list {
     gap: 1rem;

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -119,10 +119,12 @@ describe('<DashboardCourses/>', () => {
     expect(await screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
     await expectNoBannerInfo('You have no enrollments nor orders yet');
 
-    ordersDeferred.resolve({ results: [], next: null, previous: null, count: 0 });
-    enrollmentsDeferred.resolve({ results: [], next: null, previous: null, count: 0 });
+    act(() => {
+      ordersDeferred.resolve({ results: [], next: null, previous: null, count: 0 });
+      enrollmentsDeferred.resolve({ results: [], next: null, previous: null, count: 0 });
+    });
 
-    await expectNoSpinner('Loading orders and enrollments...');
+    // await expectNoSpinner('Loading orders and enrollments...');
     await expectBannerInfo('You have no enrollments nor orders yet.');
     expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
   });

--- a/src/frontend/js/pages/DashboardCourses/index.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.tsx
@@ -32,8 +32,17 @@ const messages = defineMessages({
 
 export const DashboardCourses = () => {
   const intl = useIntl();
-  const { data, isLoadingMore, isNewSearchLoading, next, hasMore, submitSearch, count, error } =
-    useLearnerCoursesSearch();
+  const {
+    data,
+    query,
+    isLoadingMore,
+    isNewSearchLoading,
+    next,
+    hasMore,
+    submitSearch,
+    count,
+    error,
+  } = useLearnerCoursesSearch();
 
   const loadMoreButtonRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
   useIntersectionObserver({
@@ -48,9 +57,11 @@ export const DashboardCourses = () => {
         <Banner message={error} type={BannerType.ERROR} />
       ) : (
         <>
-          <SearchBar onSubmit={submitSearch} />
-          <SearchResultsCount nbResults={count} />
-          {data.length === 0 && (
+          <SearchBar.Container>
+            <SearchBar onSubmit={submitSearch} />
+            <SearchResultsCount nbResults={count} />
+          </SearchBar.Container>
+          {count === 0 && !query && (
             <div className="dashboard__courses__empty">
               <Banner message={intl.formatMessage(messages.emptyList)} />
             </div>

--- a/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
+++ b/src/frontend/js/pages/DashboardCourses/useOrdersEnrollments.tsx
@@ -1,11 +1,6 @@
 import { defineMessages } from 'react-intl';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
-import {
-  Enrollment,
-  PaginatedResourceQuery,
-  CredentialOrder,
-  CertificateOrder,
-} from 'types/Joanie';
+import { Enrollment, CredentialOrder, CertificateOrder, EnrollmentsQuery } from 'types/Joanie';
 import useUnionResource, { ResourceUnionPaginationProps } from 'hooks/useUnionResource';
 import { PER_PAGE } from 'settings';
 import { OrderResourcesQuery } from 'hooks/useOrders';
@@ -41,29 +36,32 @@ const messages = defineMessages({
 
 interface UseOrdersEnrollmentsProps extends ResourceUnionPaginationProps {
   orderFilters?: OrderResourcesQuery;
+  query?: string;
 }
 
 export const useOrdersEnrollments = ({
   perPage = PER_PAGE.useOrdersEnrollments,
+  query,
   orderFilters = {},
 }: UseOrdersEnrollmentsProps = {}) => {
   const api = useJoanieApi();
   return useUnionResource<
     CredentialOrder | CertificateOrder,
     Enrollment,
-    PaginatedResourceQuery,
-    { was_created_by_order: boolean } & PaginatedResourceQuery
+    OrderResourcesQuery,
+    EnrollmentsQuery
   >({
     queryAConfig: {
       queryKey: ['user', 'orders'],
       fn: api.user.orders.get,
-      filters: orderFilters,
+      filters: { ...orderFilters, query },
     },
     queryBConfig: {
       queryKey: ['user', 'enrollments'],
       fn: api.user.enrollments.get,
       filters: {
         was_created_by_order: false,
+        query,
       },
     },
     perPage,

--- a/src/frontend/js/pages/TeacherDashboardCoursesLoader/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardCoursesLoader/index.tsx
@@ -42,8 +42,10 @@ export const TeacherDashboardCoursesLoader = () => {
           </h1>
         </div>
 
-        <SearchBar onSubmit={submitSearch} />
-        <SearchResultsCount nbResults={count} />
+        <SearchBar.Container>
+          <SearchBar onSubmit={submitSearch} />
+          <SearchResultsCount nbResults={count} />
+        </SearchBar.Container>
       </div>
       <div className="teacher-courses-page">
         <TeacherDashboardCourseList

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -460,6 +460,7 @@ export interface PaginatedResourceQuery extends ResourcesQuery {
 export interface EnrollmentsQuery extends PaginatedResourceQuery {
   course_run_id?: CourseRun['id'];
   was_created_by_order?: boolean;
+  query?: string;
 }
 
 interface EnrollmentCreationPayload {

--- a/src/frontend/js/widgets/Dashboard/components/SearchBar/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/SearchBar/_styles.scss
@@ -1,12 +1,18 @@
 .dashboard-search-bar {
+  $spacing: rem-calc(5px);
+
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: rem-calc(8px);
-  margin-bottom: rem-calc(5px);
+  margin-bottom: $spacing;
 
   // TODO(rlecellier): cunningham should allow className on container
   .c__field {
     flex: 1 1 auto;
+  }
+
+  &__container {
+    padding-bottom: $spacing;
   }
 }

--- a/src/frontend/js/widgets/Dashboard/components/SearchBar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/SearchBar/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Input } from '@openfun/cunningham-react';
-import { MouseEvent, useRef, useState } from 'react';
+import { MouseEvent, PropsWithChildren, useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useSearchParams } from 'react-router-dom';
 import { Nullable } from 'types/utils';
@@ -79,6 +79,10 @@ const SearchBar = ({ onSubmit }: SearchBarProps) => {
       />
     </form>
   );
+};
+
+SearchBar.Container = ({ children }: PropsWithChildren) => {
+  return <div className="dashboard-search-bar__container">{children}</div>;
 };
 
 export default SearchBar;


### PR DESCRIPTION
Note: rebased on ✨[(frontend) teacher courses search with query](https://github.com/openfun/richie/pull/2304)

## Purpose

on learner courses listing page, we can now perform textual research.

![image](https://github.com/openfun/richie/assets/139848/d90a4789-6a8f-4c38-b904-e7eaecde973d)

update: 
![Capture d’écran du 2024-03-12 14-50-49](https://github.com/openfun/richie/assets/139848/cfb3fa0f-5f1e-45f7-983d-3b1cf19f70e9)

