### PR TITLE
♻️(frontend) rename types/Enrollment

### DIFF
--- a/src/frontend/js/api/lms/dummy.ts
+++ b/src/frontend/js/api/lms/dummy.ts
@@ -2,7 +2,7 @@ import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
 import { Maybe, Nullable } from 'types/utils';
 import { User } from 'types/User';
 import { APILms } from 'types/api';
-import { Enrollment, OpenEdXEnrollment } from 'types';
+import { UnknownEnrollment, OpenEdXEnrollment } from 'types';
 import { location } from 'utils/indirection/window';
 import { CURRENT_JOANIE_DEV_DEMO_USER, RICHIE_USER_TOKEN } from 'settings';
 import { base64Decode } from 'utils/base64Parser';
@@ -139,7 +139,7 @@ const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
           }
           resolve(null);
         }),
-      isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) =>
+      isEnrolled: async (enrollment: Maybe<Nullable<UnknownEnrollment>>) =>
         new Promise((resolve) => resolve(!!(enrollment as OpenEdXEnrollment)?.is_active)),
       set: (url: string, user: User): Promise<boolean> =>
         new Promise((resolve) => {

--- a/src/frontend/js/api/lms/openedx-hawthorn.ts
+++ b/src/frontend/js/api/lms/openedx-hawthorn.ts
@@ -7,7 +7,7 @@ import { APILms, APIOptions } from 'types/api';
 import { location } from 'utils/indirection/window';
 import { handle } from 'utils/errors/handle';
 import { EDX_CSRF_TOKEN_COOKIE_NAME } from 'settings';
-import { Enrollment, OpenEdXEnrollment } from 'types';
+import { UnknownEnrollment, OpenEdXEnrollment } from 'types';
 import { HttpError, HttpStatusCode } from 'utils/errors/HttpError';
 
 /**
@@ -88,7 +88,7 @@ const API = (APIConf: AuthenticationBackend | LMSBackend, options?: APIOptions):
           throw new HttpError(response.status, response.statusText);
         });
       },
-      isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) => {
+      isEnrolled: async (enrollment: Maybe<Nullable<UnknownEnrollment>>) => {
         return new Promise((resolve) => resolve(!!(enrollment as OpenEdXEnrollment)?.is_active));
       },
       set: async (url: string, user: User): Promise<boolean> => {

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -1,6 +1,6 @@
 import { Maybe, Nullable } from 'types/utils';
 import { User } from 'types/User';
-import { Enrollment } from 'types';
+import { UnknownEnrollment } from 'types';
 
 export interface APIListRequestParams {
   [key: string]: Maybe<string | string[]>;
@@ -23,12 +23,12 @@ export interface APIAuthentication {
 }
 
 export interface APIEnrollment {
-  get(url: string, user: Nullable<User>): Promise<Nullable<Enrollment>>;
-  isEnrolled(enrollment: Maybe<Nullable<Enrollment>>): Promise<Maybe<boolean>>;
+  get(url: string, user: Nullable<User>): Promise<Nullable<UnknownEnrollment>>;
+  isEnrolled(enrollment: Maybe<Nullable<UnknownEnrollment>>): Promise<Maybe<boolean>>;
   set(
     url: string,
     user: User,
-    enrollment?: Maybe<Nullable<Enrollment>>,
+    enrollment?: Maybe<Nullable<UnknownEnrollment>>,
     isActive?: boolean,
   ): Promise<boolean>;
   meta?: {

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -69,5 +69,4 @@ export interface OpenEdXEnrollment {
  * Use an unknown type to make sure we do not depend on any LMS-specific fields
  * on enrollment objects, just use HTTP response codes.
  */
-// TODO(rlecellier): rename into UnknownEnrollment
-export type Enrollment = unknown;
+export type UnknownEnrollment = unknown;

--- a/src/frontend/js/utils/test/factories/richie.ts
+++ b/src/frontend/js/utils/test/factories/richie.ts
@@ -2,14 +2,7 @@ import { faker } from '@faker-js/faker';
 import { User } from 'types/User';
 import { APIBackend } from 'types/api';
 import { CommonDataProps } from 'types/commonDataProps';
-import {
-  CourseRun,
-  CourseRunDisplayMode,
-  CourseState,
-  CourseStateTextEnum,
-  Enrollment,
-  Priority,
-} from 'types';
+import { CourseRun, CourseRunDisplayMode, CourseState, CourseStateTextEnum, Priority } from 'types';
 import { Course } from 'types/Course';
 import { FactoryHelper } from 'utils/test/factories/helper';
 import { factory } from './factories';
@@ -141,15 +134,6 @@ export const CourseRunFactoryFromPriority = (priority: Priority) => {
     return courseRun;
   });
 };
-
-export const EnrollmentFactory = factory<Enrollment>(() => {
-  return {
-    id: faker.string.uuid(),
-    created_at: faker.date.past().toISOString(),
-    user: faker.string.uuid(),
-    course_run: faker.string.uuid(),
-  };
-});
 
 export const UserFactory = factory<User>(() => ({
   access_token: faker.lorem.word(12),


### PR DESCRIPTION
richie's `Enrollment` was wrongly name.
As it's always undefined, we renamed it `UnknownEnrollment`, this make it usage more readable.

