### PR TITLE
💚(circle) update removed docker versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
       - <<: *generate-version-file
       # Activate docker-in-docker
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
 
       # Login to Docker Hub with encrypted credentials stored as secret
       # environment variables (set in CircleCI project settings) if the expected
@@ -810,7 +810,7 @@ jobs:
     steps:
       # Activate docker-in-docker
       - setup_remote_docker:
-          version: 19.03.13
+          version: default
       - checkout
       - run:
          name: Is a release or master branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
   # Check that the CHANGELOG has been updated in the current branch
   check-changelog:
     docker:
-      - image: cimg/base:2022.06
+      - image: cimg/base:current
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -118,7 +118,7 @@ jobs:
   # Build the Docker image ready for production
   build-docker:
     docker:
-      - image: cimg/base:2023.10
+      - image: cimg/base:current
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS


### PR DESCRIPTION
## Purpose

Docker versions have been removed from circle-ci. We can use the default tags to replace them.

Furthermore, the cimg/base image has a current tag we can use to avoid to have to
update them when circle will decide to remove old tags.
