### PR TITLE
🐛(frontend) fix useUnionResource loadMore

### DIFF
--- a/src/frontend/js/hooks/useUnionResource/index.ts
+++ b/src/frontend/js/hooks/useUnionResource/index.ts
@@ -94,7 +94,11 @@ const useUnionResource = <
 
   // to force execution of useEffect::fetchNewPage(),
   // reset need to generate a uniq key that is part of it's dependencies.
-  const reset = () => {
+  const reset = (eofKey?: string) => {
+    if (eofKey) {
+      delete eofRef.current[eofKey];
+    }
+
     setStack([]);
     setPage(0);
     setTotalCount(undefined);
@@ -107,8 +111,12 @@ const useUnionResource = <
   // we manualy observe key invalidation to trigger new search
   // by generating a new update key
   if (refetchOnInvalidation) {
-    useQueryKeyInvalidateListener(queryAConfig.queryKey, reset);
-    useQueryKeyInvalidateListener(queryBConfig.queryKey, reset);
+    useQueryKeyInvalidateListener(queryAConfig.queryKey, () => {
+      reset(queryAConfig.queryKey.join('-'));
+    });
+    useQueryKeyInvalidateListener(queryBConfig.queryKey, () => {
+      reset(queryBConfig.queryKey.join('-'));
+    });
   }
 
   // filters have changes, new results will be fetch.

--- a/src/frontend/js/hooks/useUnionResource/utils/fetchEntity.ts
+++ b/src/frontend/js/hooks/useUnionResource/utils/fetchEntity.ts
@@ -65,14 +65,11 @@ export const fetchEntity = async <
   try {
     const res = await fn(filters);
     queryClient.setQueryData(QUERY_KEY, res);
-
-    // If we reached the end of the list, we set the eof flag to prevent future requests.
-    if (!res.next) {
-      eofRef.current = { ...eofRef.current, [queryKeyString]: filters.page! };
-      // Eof is cached based, the same way, we cache the fetching data. Otherwise there would
-      // be request to non existing pages after reload.
-      queryClient.setQueryData(eofQueryKey, eofRef.current);
-    }
+    // Eof is cached based, the same way, we cache the fetching data. Otherwise there would
+    // be request to non existing pages after reload.
+    const totalPages = Math.ceil(res.count / perPage);
+    eofRef.current = { ...eofRef.current, [queryKeyString]: totalPages };
+    queryClient.setQueryData(eofQueryKey, eofRef.current);
     return res;
   } catch (err) {
     if (isHttpError(err)) {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.useUnionResource.cache.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.useUnionResource.cache.spec.tsx
@@ -59,7 +59,7 @@ describe('<DashboardItemOrder/> Contract', () => {
       // overwrite useOmniscientOrders call
       fetchMock.get(
         'https://joanie.endpoint/api/v1.0/orders/',
-        { results: [order], next: null, previous: null, count: null },
+        { results: [order], next: null, previous: null, count: 1 },
         { overwriteRoutes: true },
       );
 
@@ -68,12 +68,12 @@ describe('<DashboardItemOrder/> Contract', () => {
         results: [],
         next: null,
         previous: null,
-        count: null,
+        count: 0,
       });
 
       fetchMock.get(
         'https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=1&page_size=50',
-        { results: [order], next: null, previous: null, count: null },
+        { results: [order], next: null, previous: null, count: 1 },
       );
 
       const submitDeferred = new Deferred();
@@ -238,7 +238,7 @@ describe('<DashboardItemOrder/> Contract', () => {
         results: [signedOrder],
         next: null,
         previous: null,
-        count: null,
+        count: 1,
       });
 
       // Contract signing is removed.
@@ -249,7 +249,7 @@ describe('<DashboardItemOrder/> Contract', () => {
       // Go back to the list view to make sure the sign button is not shown anymore.
       fetchMock.get(
         'https://joanie.endpoint/api/v1.0/orders/?product_type=credential&state_exclude=canceled&page=1&page_size=50',
-        { results: [signedOrder], next: null, previous: null, count: null },
+        { results: [signedOrder], next: null, previous: null, count: 1 },
         { overwriteRoutes: true },
       );
 


### PR DESCRIPTION
Because our Eof wasn't reset correctly, useUnionResource would never fetch the seconds pages and always return loadMore flag as true.

resolve #2317
