### PR TITLE
✅(frontend) async expectBanner helpers

### DIFF
--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -123,7 +123,7 @@ describe('<DashboardCourses/>', () => {
     enrollmentsDeferred.resolve({ results: [], next: null, previous: null, count: 0 });
 
     await expectNoSpinner('Loading orders and enrollments...');
-    expectBannerInfo('You have no enrollments nor orders yet.');
+    await expectBannerInfo('You have no enrollments nor orders yet.');
     expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
   });
 

--- a/src/frontend/js/utils/test/expectBanner.ts
+++ b/src/frontend/js/utils/test/expectBanner.ts
@@ -1,34 +1,34 @@
 import { screen, waitFor } from '@testing-library/react';
 import { BannerType, getBannerTestId } from 'components/Banner';
 
-export const expectBannerError = async (message: string, rootElement: ParentNode = document) => {
+export const expectBannerError = (message: string, rootElement: ParentNode = document) => {
   return expectBanner(BannerType.ERROR, message, rootElement);
 };
-export const expectBannerInfo = async (message: string, rootElement: ParentNode = document) => {
+export const expectBannerInfo = (message: string, rootElement: ParentNode = document) => {
   return expectBanner(BannerType.INFO, message, rootElement);
 };
 
-export const expectBanner = async (
+export const expectBanner = (
   type: BannerType,
   message: string,
   rootElement: ParentNode = document,
 ) => {
-  await waitFor(async () => {
+  return waitFor(async () => {
     const banner = rootElement.querySelector('.banner--' + type) as HTMLElement;
     expect(banner).not.toBeNull();
     expect(banner).toHaveTextContent(message);
   });
 };
 
-export const expectNoBannerError = async (message: string) => {
+export const expectNoBannerError = (message: string) => {
   return expectNoBanner(BannerType.ERROR, message);
 };
-export const expectNoBannerInfo = async (message: string) => {
+export const expectNoBannerInfo = (message: string) => {
   return expectNoBanner(BannerType.INFO, message);
 };
 
-export const expectNoBanner = async (type: BannerType, message: string) => {
-  await waitFor(() => {
+export const expectNoBanner = (type: BannerType, message: string) => {
+  return waitFor(() => {
     expect(screen.queryByTestId(getBannerTestId(message, type))).toBeNull();
   });
 };


### PR DESCRIPTION
our expectBanner's helpers weren't properly async.
by returning waitFor, these functions can now be await.
