### PR TITLE
🔍️(backend) complete course detail RDFa markups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Complete `course_detail` RDFa markups
 - Require to accept terms when purchasing product of any kind
 - Rename trainings root menu entry label
 - Upgrade to node 20

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -65,7 +65,7 @@
                     {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_icons" or not current_page|is_empty_placeholder:"course_categories" %}
                     <div class="category-badge-list subheader__badges">
                         <div class="category-badge-list__container">
-                        {% with category_variant="badge" %}
+                        {% with category_variant="badge" is_keywords_property=True %}
                             {% placeholder "course_icons" %}
                             {% placeholder "course_categories" or %}
                                 {% if current_page.publisher_is_draft and current_page|is_empty_placeholder:"course_icons" %}
@@ -82,7 +82,7 @@
 
                     <div class="subheader__content">
                         {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_introduction" %}
-                            <div property="description">{% placeholder "course_introduction" or %}<p>{% trans 'Enter here an introduction to your course.' %}</p>{% endplaceholder %}</div>
+                            <div property="abstract">{% placeholder "course_introduction" or %}<p>{% trans 'Enter here an introduction to your course.' %}</p>{% endplaceholder %}</div>
                         {% endif %}
                         {% block synopsis %}
                         {% if course.duration or course.effort or current_page.publisher_is_draft %}
@@ -119,12 +119,12 @@
                                     <svg role="img" class="characteristics__icon" aria-hidden="true">
                                         <use href="#icon-languages" />
                                     </svg>
-                                    <span class="characteristics__term">{% trans "Languages:" %} {{ course.languages_display|default:"NA" }}</span>
+                                    <span class="characteristics__term" property="availableLanguage" content="{{ course.languages_display|default:'NA' }}">{% trans "Languages:" %} {{ course.languages_display|default:"NA" }}</span>
                                 </li>
                                 {% block enrollment_count %}
                                     {% with enrollment_count=course.course_runs_enrollment_count %}
                                         {% if enrollment_count > 0 and RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT > 0 and enrollment_count >= RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT %}
-                                                <li class="characteristics__item">
+                                                <li class="characteristics__item" property="totalHistoricalEnrollment" content="{{ enrollment_count }}">
                                                     <svg role="img" class="characteristics__icon" aria-hidden="true">
                                                         <use href="#icon-groups" />
                                                     </svg>
@@ -257,10 +257,12 @@
                 <div class="course-detail__block course-detail__primary-group">
                     {% block skills %}
                         {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_skills" %}
-                        <div class="course-detail__row course-detail__skills">
-                            <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}What you will learn{% endblocktrans %}</h2>
-                            <p>{% trans "At the end of this course, you will be able to:" %}</p>
-                            {% placeholder "course_skills" %}
+                        <div class="course-detail__row course-detail__skills" property="about" typeof="Thing">
+                            <h2 class="course-detail__title" property="name">{% blocktrans context "course_detail__title" %}What you will learn{% endblocktrans %}</h2>
+                            <div property="description">
+                                <p>{% trans "At the end of this course, you will be able to:" %}</p>
+                                {% placeholder "course_skills" %}
+                            </div>
                         </div>
                         {% endif %}
                     {% endblock skills %}
@@ -269,7 +271,7 @@
                         {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_description" %}
                         <div class="course-detail__row course-detail__description">
                             <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}Description{% endblocktrans %}</h2>
-                            <div{% if current_page|is_empty_placeholder:'course_introduction' %} property="description"{% endif %}>
+                            <div property="description">
                                 {% placeholder "course_description" %}
                             </div>
                         </div>
@@ -278,11 +280,14 @@
 
                     {% block format %}
                         {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_format" %}
-                            <section class="course-detail__row course-detail__format">
-                                <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}Format{% endblocktrans %}</h2>
-                                {% placeholder "course_format" or %}
-                                <p>{% trans 'How is the course structured?' %}</p>
-                                {% endplaceholder %}
+                            <section class="course-detail__row course-detail__format" property="about" typeof="Thing">
+                                <h2 class="course-detail__title" property="name">{% blocktrans context "course_detail__title" %}Format{% endblocktrans %}</h2>
+                                <div property="description">
+                                    {% placeholder "course_format" %}
+                                    {% placeholder "course_format" or %}
+                                    <p>{% trans 'How is the course structured?' %}</p>
+                                    {% endplaceholder %}
+                                </div>
                             </section>
                         {% endif %}
                     {% endblock format %}
@@ -304,11 +309,13 @@
                         {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_assessment" %}
                         <section class="course-detail__row course-detail__assessment">
                             <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}Assessment and certification{% endblocktrans %}</h2>
-                            {% placeholder "course_assessment" or %}
-                                <p class="course-detail__assessment__placeholder">
-                                    {% trans "How is progress evaluated and/or certified?" %}
-                                </p>
-                            {% endplaceholder %}
+                            <div property="educationalCredentialAwarded">
+                                {% placeholder "course_assessment" or %}
+                                    <p class="course-detail__assessment__placeholder">
+                                        {% trans "How is progress evaluated and/or certified?" %}
+                                    </p>
+                                {% endplaceholder %}
+                            </div>
                         </section>
                         {% endif %}
                     {% endblock assessment %}
@@ -317,13 +324,14 @@
                 {% block plan %}
                     <div class="course-detail__block course-detail__secondary-group">
                         {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_plan" %}
-                        <section class="course-detail__row course-detail__plan">
-                            <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}Course plan{% endblocktrans %}</h2>
-
-                            {% placeholder "course_plan" or %}
-                                <p class="course-detail__empty">{% trans 'Enter here the detailed course plan.' %}</p>
-                            {% endplaceholder %}
-                        </section>
+                            {% with is_syllabus_property=True %}
+                                <section class="course-detail__row course-detail__plan">
+                                    <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}Course plan{% endblocktrans %}</h2>
+                                    {% placeholder "course_plan" or %}
+                                        <p class="course-detail__empty">{% trans 'Enter here the detailed course plan.' %}</p>
+                                    {% endplaceholder %}
+                                </section>
+                            {% endwith %}
                         {% endif %}
                     </div>
                 {% endblock plan %}
@@ -341,7 +349,8 @@
                              -->
                             {% for run in open_visible_runs %}
                                 <span rel="hasCourseInstance" typeof="CourseInstance">
-                                    <meta property="title" content="Run 0"  />
+                                    <meta property="name" content="{{ run.title }}"  />
+                                    <meta property="inLanguage" content="{{ run.get_languages_display }}"  />
                                     <meta property="courseMode" content="online"  />
                                     <meta property="startDate" content="{{ run.start|date:'Y-m-d' }}"  />
                                     <meta property="endDate" content="{{ run.end|date:'Y-m-d' }}"  />

--- a/src/richie/apps/courses/templates/courses/cms/fragment_category_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_category_glimpse.html
@@ -3,11 +3,20 @@
 
 {% with category_page=category.extended_object category_variant=category_variant|default:"glimpse" %}
     {% if has_link or has_link|default_if_none:True %}
-        <a class="category-{{ category_variant }}{% if category_page.publisher_is_draft %} category-{{ category_variant }}--draft{% endif %}" href="{{ category_page.get_absolute_url }}">
+        <a class="category-{{ category_variant }}{% if category_page.publisher_is_draft %} category-{{ category_variant }}--draft{% endif %}" href="{{ category_page.get_absolute_url }}"
+           {% if is_keywords_property|default_if_none:False %} property="keywords" typeof="DefinedTerm"{% endif %}>
     {% else %}
-        <span class="category-{{ category_variant }}{% if category_page.publisher_is_draft %} category-{{ category_variant }}--draft{% endif %}">
+        <span
+          class="category-{{ category_variant }}{% if category_page.publisher_is_draft %} category-{{ category_variant }}--draft{% endif %}"
+          {% if is_keywords_property|default_if_none:False %} property="keywords" typeof="DefinedTerm"{% endif %}
+        >
     {% endif %}
-
+        {% if is_keywords_property|default_if_none:False %}
+            <meta content="{{ category_page.get_title }}" property="name" />
+            {% if has_link or has_link|default_if_none:True %}
+                <meta content="{{ category_page.get_absolute_url }}" property="url" />
+            {% endif %}
+        {% endif %}
         {% if category_variant == "badge" %}
             {% comment %}Small CTA alike, icon + title, commonly horizontal{% endcomment %}
             {% get_placeholder_plugins "icon" category_page as icon_plugins %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_organization_glimpse.html
@@ -3,78 +3,73 @@
 {% with organization_page=organization.extended_object organization_variant=organization_variant|default:"glimpse" %}
 <div
     class="organization-{{ organization_variant }}{% if organization_page.publisher_is_draft is True %} organization-{{ organization_variant }}--draft{% endif %}"
-    property="{{ organization_property|default:'contributor' }}"
-    typeof="CollegeOrUniversity"
 >
-{% if organization_variant == "row" %}
-    <a href="{{ organization_page.get_absolute_url }}" title="{{ organization_page.get_title }}">
-        <meta property="url" content="{{ SITE.web_url }}{{ organization_page.get_absolute_url }}"/>
-        <div class="organization-{{ organization_variant }}__logo">
-            {% get_placeholder_plugins "logo" organization_page as plugins or %}
-                <img src="{% static 'richie/images/empty/organization_logo.png' %}"
-                     class="organization-{{ organization_variant }}__logo--empty"
-                     alt="">
-            {% endget_placeholder_plugins %}
-            {% blockplugin plugins.0 %}
-                <img src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
-                    srcset="
-                        {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 200w
-                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                        {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
-                    "
-                    sizes="(min-width: 576px) 50vw, (min-width: 1200px) 25vw, 100vw"
-                    alt=""
-                    property="logo"
-                />
-            {% endblockplugin %}
-        </div>
-        <div class="organization-{{ organization_variant }}__content">
-            <h{{ header_level|default:3 }} class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</h{{ header_level|default:3 }}>
-            <div class="organization-{{ organization_variant }}__excerpt" property="description">
-                {% get_placeholder_plugins "excerpt" organization_page as plugins %}
+    <a href="{{ organization_page.get_absolute_url }}" title="{{ organization_page.get_title }}" property="{{ organization_property|default:'author' }}" typeof="CollegeOrUniversity">
+        <meta property="url" content="{{ SITE.web_url }}{{ organization_page.get_absolute_url }}" />
+        {% if organization_variant == "row" %}
+            <div class="organization-{{ organization_variant }}__logo">
+                {% get_placeholder_plugins "logo" organization_page as plugins or %}
+                    <img src="{% static 'richie/images/empty/organization_logo.png' %}"
+                         class="organization-{{ organization_variant }}__logo--empty"
+                         alt="" />
+                {% endget_placeholder_plugins %}
                 {% blockplugin plugins.0 %}
-                    <p>{{ instance.body }}</p>
+                    <img src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
+                        srcset="
+                            {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 200w
+                            {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                            {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                            {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+                        "
+                        sizes="(min-width: 576px) 50vw, (min-width: 1200px) 25vw, 100vw"
+                        alt=""
+                        property="logo"
+                    />
                 {% endblockplugin %}
-                {% if not plugins %}
-                    {% get_placeholder_plugins "description" organization_page as plugins %}
+            </div>
+            <div class="organization-{{ organization_variant }}__content">
+                <h{{ header_level|default:3 }} class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</h{{ header_level|default:3 }}>
+                <div class="organization-{{ organization_variant }}__excerpt" property="description">
+                    {% get_placeholder_plugins "excerpt" organization_page as plugins %}
                     {% blockplugin plugins.0 %}
-                        <p>{{ instance.body|truncatewords_html:40|striptags }}</p>
+                        <p>{{ instance.body }}</p>
                     {% endblockplugin %}
                     {% if not plugins %}
-                        <p>{% trans "Excerpt" %}</p>
+                        {% get_placeholder_plugins "description" organization_page as plugins %}
+                        {% blockplugin plugins.0 %}
+                            <p>{{ instance.body|truncatewords_html:40|striptags }}</p>
+                        {% endblockplugin %}
+                        {% if not plugins %}
+                            <p>{% trans "Excerpt" %}</p>
+                        {% endif %}
                     {% endif %}
-                {% endif %}
+                </div>
             </div>
-        </div>
+        {% else %}
+            <div class="organization-{{ organization_variant }}__logo">
+                {% get_placeholder_plugins "logo" organization_page as plugins or %}
+                    <img src="{% static 'richie/images/empty/organization_logo.png' %}"
+                         class="organization-{{ organization_variant }}__logo--empty"
+                         alt="" />
+                {% endget_placeholder_plugins %}
+                {% blockplugin plugins.0 %}
+                    <img src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
+                        srcset="
+                            {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 200w
+                            {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
+                            {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
+                            {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
+                        "
+                        sizes="(min-width: 576px) 50vw, (min-width: 1200px) 25vw, 100vw"
+                        alt=""
+                        property="logo"
+                    />
+                {% endblockplugin %}
+            </div>
+            <div class="organization-{{ organization_variant }}__content">
+                <h{{ header_level|default:3 }} class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</h{{ header_level|default:3 }}>
+            </div>
+        {% endif %}
     </a>
-{% else %}
-    <a href="{{ organization_page.get_absolute_url }}" title="{{ organization_page.get_title }}">
-        <meta property="url" content="{{ SITE.web_url }}{{ organization_page.get_absolute_url }}"/>
-        <div class="organization-{{ organization_variant }}__logo">
-            {% get_placeholder_plugins "logo" organization_page as plugins or %}
-                <img src="{% static 'richie/images/empty/organization_logo.png' %}"
-                     class="organization-{{ organization_variant }}__logo--empty"
-                     alt="">
-            {% endget_placeholder_plugins %}
-            {% blockplugin plugins.0 %}
-                <img src="{% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %}"
-                    srcset="
-                        {% thumbnail instance.picture 200x113 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 200w
-                        {% if instance.picture.width >= 400 %},{% thumbnail instance.picture 400x225 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 400w{% endif %}
-                        {% if instance.picture.width >= 600 %},{% thumbnail instance.picture 600x338 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 600w{% endif %}
-                        {% if instance.picture.width >= 800 %},{% thumbnail instance.picture 800x450 replace_alpha='#FFFFFF' upscale subject_location=instance.picture.subject_location %} 800w{% endif %}
-                    "
-                    sizes="(min-width: 576px) 50vw, (min-width: 1200px) 25vw, 100vw"
-                    alt=""
-                    property="logo"
-                />
-            {% endblockplugin %}
-        </div>
-        <div class="organization-{{ organization_variant }}__content">
-            <h{{ header_level|default:3 }} class="organization-{{ organization_variant }}__title" property="name">{{ organization_page.get_title }}</h{{ header_level|default:3 }}>
-        </div>
-    </a>
-{% endif %}
 </div>
 {% endwith %}

--- a/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
+++ b/src/richie/apps/courses/templates/courses/cms/fragment_person_glimpse.html
@@ -1,10 +1,10 @@
 {% load i18n cms_tags extra_tags static thumbnail %}{% spaceless %}
 {% comment %}Obviously, the context template variable "person" is required and must be a Person page extension{% endcomment %}
 {% with person_page=person.extended_object %}
-<div class="person-glimpse" property="{{ person_property|default:'author' }}" typeof="Person">
-    {% comment %}Use tabindex and aria-hidden on the image link as it is entirely redundant with the title link{% endcomment %}
-    <meta property="url" content="{{ SITE.web_url }}{{ person_page.get_absolute_url }}" />
+<div class="person-glimpse" property="{{ person_property|default:'contributor' }}" typeof="Person">
     <meta property="name" content="{{ person_page.get_title }}" />
+    <meta property="url" content="{{ SITE.web_url }}{{ person_page.get_absolute_url }}" />
+    {% comment %}Use tabindex and aria-hidden on the image link as it is entirely redundant with the title link{% endcomment %}
     <a
       class="person-glimpse__media"
       href="{{ person_page.get_absolute_url }}"

--- a/src/richie/apps/courses/templates/courses/plugins/licence_plugin.html
+++ b/src/richie/apps/courses/templates/courses/plugins/licence_plugin.html
@@ -1,17 +1,24 @@
 {% load thumbnail %}
 
 {% spaceless %}
-<div class="licence-plugin">
+<div class="licence-plugin" {% if is_license_property|default_if_none:True is True %}property="license" typeof="CreativeWork"{% endif %}>
+    {% if is_license_property|default_if_none:True is True %}
+        <meta property="thumbnailUrl" content="{% thumbnail instance.licence.logo 100x50 replace_alpha='#FFFFFF' crop='smart' %}" />
+        <meta property="name" content="{{ instance.licence.name }}" />
+        <meta property="abstract" content="{{ instance.licence.content|striptags }}" />
+        {% if instance.description %}<meta property="abstract" content="{{ instance.description|striptags }}" />{% endif %}
+        {% if instance.licence.url %}<meta property="url" content="{{ instance.licence.url }}" />{% endif %}
+    {% endif %}
     <p class="licence-plugin__logo">
         <img src="{% thumbnail instance.licence.logo 100x50 replace_alpha='#FFFFFF' crop='smart' %}" alt="">
     </p>
     <div class="licence-plugin__wrapper">
         <h{{ header_level|default:2 }} class="licence-plugin__title">
-            {% if instance.licence.url %}<a href="{{ instance.licence.url }}"{% if is_license_property|default_if_none:True is True %} property="license"{% endif %}>{% endif %}
+            {% if instance.licence.url %}<a href="{{ instance.licence.url }}">{% endif %}
             {{ instance.licence.name }}
             {% if instance.licence.url %}</a>{% endif %}
         </h{{ header_level|default:2 }}>
-        <div class="licence-plugin__content"{% if is_license_property|default_if_none:True and not instance.licence.url %} property="license"{% endif %}>
+        <div class="licence-plugin__content">
             {{ instance.licence.content|safe }}
         </div>
         {% if instance.description %}

--- a/src/richie/plugins/nesteditem/templates/richie/nesteditem/nesteditem.html
+++ b/src/richie/plugins/nesteditem/templates/richie/nesteditem/nesteditem.html
@@ -1,6 +1,16 @@
 {% load i18n cms_tags %}{% spaceless %}
 
-<div class="nested-item nested-item--{{ instance.variant }} nested-item--{{ nesting_level }}">
+<div class="nested-item nested-item--{{ instance.variant }} nested-item--{{ nesting_level }}"
+     {% if is_syllabus_property|default_if_none:False is True and is_root|default_if_none:True is True %} property="syllabusSections"{% endif %}
+     {% if is_syllabus_property|default_if_none:False is True and is_root|default_if_none:True is False %} property="hasPart"{% endif %}
+     {% if is_syllabus_property|default_if_none:False is True %} typeof="Syllabus"{% endif %}
+>
+    {% if is_syllabus_property|default_if_none:False is True %}
+        <meta property="name" content="{{ instance.content }}" />
+        {% if position is not None %}
+        <meta property="position" content="{{ position }}" />
+        {% endif %}
+    {% endif %}
     {% if parent_variant == "accordion" and instance.child_plugin_instances %}
         <button class="nested-item__title" data-accordion-button>
             {{ instance.content }}
@@ -15,7 +25,7 @@
         <ul class="nested-item__items">
             {% for plugin in instance.child_plugin_instances %}
                 <li>
-                    {% with nesting_level=nesting_level|add:1 parent_variant=instance.variant %}
+                    {% with nesting_level=nesting_level|add:1 parent_variant=instance.variant is_root=False position=forloop.counter0 %}
                         {% render_plugin plugin %}
                     {% endwith %}
                 </li>

--- a/tests/apps/courses/test_cms_plugins_organization.py
+++ b/tests/apps/courses/test_cms_plugins_organization.py
@@ -100,9 +100,8 @@ class OrganizationPluginTestCase(CMSTestCase):
         # And CMS page title should be in title attribute of the link
         self.assertIn(
             (
-                '<div class="organization-glimpse" property="contributor" '
-                'typeof="CollegeOrUniversity"><a href="/en/public-title/" '
-                'title="public title">'
+                '<div class="organization-glimpse"><a href="/en/public-title/" '
+                'title="public title" property="author" typeof="CollegeOrUniversity">'
             ),
             htmlmin.minify(
                 response.content.decode("UTF-8"), remove_optional_attribute_quotes=False
@@ -287,9 +286,9 @@ class OrganizationPluginTestCase(CMSTestCase):
         # Organization's name should be present as a link to the cms page
         self.assertIn(
             (
-                '<div class="organization-glimpse" property="contributor" '
-                'typeof="CollegeOrUniversity"><a href="/en/organisation-publique/" '
-                'title="organisation publique">'
+                '<div class="organization-glimpse">'
+                '<a href="/en/organisation-publique/" title="organisation publique" '
+                'property="author" typeof="CollegeOrUniversity">'
             ),
             htmlmin.minify(
                 response.content.decode("UTF-8"), remove_optional_attribute_quotes=False

--- a/tests/apps/courses/test_cms_plugins_person.py
+++ b/tests/apps/courses/test_cms_plugins_person.py
@@ -140,6 +140,14 @@ class PersonPluginTestCase(CMSTestCase):
         )
         self.assertNotContains(response, "draft bio")
 
+        # RDFa markup should be present
+        self.assertContains(
+            response,
+            '<meta property="name" content="person title" />'
+            f'<meta property="url" content="http://example.com{href}" />',
+            html=True,
+        )
+
         # Same checks in French
         url = page.get_absolute_url(language="fr")
         response = self.client.get(url)
@@ -164,6 +172,14 @@ class PersonPluginTestCase(CMSTestCase):
         self.assertContains(
             response,
             '<div class="person-glimpse__bio" property="description">résumé public</div>',
+            html=True,
+        )
+
+        # RDFa markup should be present
+        self.assertContains(
+            response,
+            '<meta property="name" content="titre personne" />'
+            f'<meta property="url" content="http://example.com{href}" />',
             html=True,
         )
 

--- a/tests/apps/courses/test_licence_plugin.py
+++ b/tests/apps/courses/test_licence_plugin.py
@@ -101,7 +101,13 @@ class LicencePluginTestCase(CMSPluginTestCase):
         # RDFa markup should be present by default
         self.assertEqual(html.count('property="license"'), 1)
         self.assertEqual(
-            html.count('<a href="https://example.com" property="license">'), 1
+            html.count(
+                '<div class="licence-plugin" property="license" typeof="CreativeWork">'
+            ),
+            1,
+        )
+        self.assertEqual(
+            html.count('<meta property="url" content="https://example.com" />'), 1
         )
 
     @transaction.atomic
@@ -124,11 +130,15 @@ class LicencePluginTestCase(CMSPluginTestCase):
             placeholder, context=context, language="en"
         )
 
-        # RDFa markup should be present but on the content
+        # RDFa markup should be present but not the url property
         self.assertEqual(html.count('property="license"'), 1)
         self.assertEqual(
-            html.count('<div class="licence-plugin__content" property="license">'), 1
+            html.count(
+                '<div class="licence-plugin" property="license" typeof="CreativeWork">'
+            ),
+            1,
         )
+        self.assertEqual(html.count('<meta property="url" '), 0)
 
     @transaction.atomic
     def test_licence_plugin_rdfa_property_deactivated(self):

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -133,16 +133,21 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             html=True,
         )
 
-        # Only published categories should be present on the page
+        # Only published categories should be present on the page with RDFa markup
         for category in categories[:2]:
             self.assertContains(
                 response,
                 (
                     # pylint: disable=consider-using-f-string
-                    '<a class="category-badge" href="{:s}">'
+                    '<a class="category-badge" href="{:s}"'
+                    'property="keywords" typeof="DefinedTerm">'
+                    '<meta content="{:s}" property="name" />'
+                    '<meta content="{:s}" property="url" />'
                     '<span class="offscreen">Category</span>'
                     '<span class="category-badge__title">{:s}</span></a>'
                 ).format(
+                    category.extended_object.get_absolute_url(),
+                    category.extended_object.get_title(),
                     category.extended_object.get_absolute_url(),
                     category.extended_object.get_title(),
                 ),
@@ -193,7 +198,12 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
 
         # Only the published course run should be in response content
         self.assertEqual(CourseRun.objects.count(), 3)
-        self.assertContains(response, course_run.title, count=1)
+        self.assertContains(
+            response,
+            f'<meta property="name" content="{course_run.title}" />',
+            count=1,
+            html=True,
+        )
         self.assertNotContains(response, unpublished_course_run.title)
 
         # Only the published program should be in response content
@@ -309,16 +319,22 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             response, organizations[3].extended_object.get_title(), html=True
         )
 
-        # Draft and published categories should be present on the page
+        # Draft and published categories should be present on the page with RDFa markup
+
         for category in categories[:2]:
             self.assertContains(
                 response,
                 (
                     # pylint: disable=consider-using-f-string
-                    '<a class="category-badge" href="{:s}">'
+                    '<a class="category-badge" href="{:s}" '
+                    'property="keywords" typeof="DefinedTerm">'
+                    '<meta content="{:s}" property="name" />'
+                    '<meta content="{:s}" property="url" />'
                     '<span class="offscreen">Category</span>'
                     '<span class="category-badge__title">{:s}</span></a>'
                 ).format(
+                    category.extended_object.get_absolute_url(),
+                    category.extended_object.get_title(),
                     category.extended_object.get_absolute_url(),
                     category.extended_object.get_title(),
                 ),
@@ -328,10 +344,15 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             response,
             (
                 # pylint: disable=consider-using-f-string
-                '<a class="category-badge category-badge--draft" href="{:s}">'
+                '<a class="category-badge category-badge--draft" href="{:s}"'
+                'property="keywords" typeof="DefinedTerm">'
+                '<meta content="{:s}" property="name" />'
+                '<meta content="{:s}" property="url" />'
                 '<span class="offscreen">Category</span>'
                 '<span class="category-badge__title">{:s}</span></a>'
             ).format(
+                categories[2].extended_object.get_absolute_url(),
+                categories[2].extended_object.get_title(),
                 categories[2].extended_object.get_absolute_url(),
                 categories[2].extended_object.get_title(),
             ),
@@ -342,7 +363,12 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             response, categories[3].extended_object.get_title(), html=True
         )
         # The course run should be in the page
-        self.assertContains(response, course_run.title, count=1)
+        self.assertContains(
+            response,
+            f'<meta property="name" content="{course_run.title}" />',
+            count=1,
+            html=True,
+        )
 
         # Both programs should be in response content
         self.assertContains(response, "course-detail__programs")
@@ -406,7 +432,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         self.assertIsNotNone(re.search(pattern, str(response.content)))
         pattern = (
             r'<div class="subheader__content">'
-            r'<div property="description">'
+            r'<div property="abstract">'
             r'<div class="cms-placeholder'
         )
 

--- a/tests/apps/courses/test_templates_person_detail.py
+++ b/tests/apps/courses/test_templates_person_detail.py
@@ -337,8 +337,9 @@ class PersonCMSTestCase(CMSTestCase):
         # The published organization should be on the page in its published version
         self.assertIn(
             # pylint: disable=consider-using-f-string
-            '<div class="organization-glimpse" property="contributor" '
-            'typeof="CollegeOrUniversity"><a href="{:s}" title="{:s}">'.format(
+            '<div class="organization-glimpse">'
+            '<a href="{:s}" title="{:s}" '
+            'property="author" typeof="CollegeOrUniversity">'.format(
                 published_organization.extended_object.get_absolute_url(),
                 published_organization.extended_object.get_title(),
             ),
@@ -355,7 +356,8 @@ class PersonCMSTestCase(CMSTestCase):
         # The not published organization should not be on the page
         self.assertIn(
             # pylint: disable=consider-using-f-string
-            '<a href="{:s}" title="{:s}">'.format(
+            '<a href="{:s}" title="{:s}" '
+            'property="author" typeof="CollegeOrUniversity">'.format(
                 not_published_organization.extended_object.get_absolute_url(),
                 not_published_organization.extended_object.get_title(),
             ),


### PR DESCRIPTION
## Purpose

The course detail page RDFa markup can be completed to fully describe the syllabus content.
The vocab used is (https://schema.org/Course).

_Note : I update existing markup logic to reverse contributor and author resources. Indeed, I decide to declare as authors the organization declared on the page and as contributor, person declared on the page. IMO, it's fit better our course architecture and it complies with the RDFa vocab used._

## Proposal

- [x] Update `course_detail.html` and related plugin templates
- [x] Update tests
