### PR TITLE
🐛(frontend) filter learner list by organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Learner list in teacher dashboard are always fitered by
+  organization id.
 - Upgrade docker compose to v2.24.5
 - remove dashboard i18n routing
 - Complete `course_detail` RDFa markups

--- a/src/frontend/js/hooks/useCourseOrders/index.ts
+++ b/src/frontend/js/hooks/useCourseOrders/index.ts
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
-import { useResource, useResources, UseResourcesProps } from 'hooks/useResources';
+import { useResource, useResources, UseResourcesProps, QueryOptions } from 'hooks/useResources';
 import { API, CourseOrderResourceQuery, NestedCourseOrder } from 'types/Joanie';
 
 const messages = defineMessages({
@@ -27,6 +27,27 @@ const props: UseResourcesProps<
   messages,
 };
 
-export const useCourseOrder = useResource(props);
+export const useCourseOrder = (
+  id: string,
+  filters?: CourseOrderResourceQuery,
+  queryOptions?: QueryOptions<NestedCourseOrder>,
+) => {
+  return useResource(props)(id, filters, {
+    ...queryOptions,
+    enabled:
+      !!id &&
+      !!filters?.organization_id &&
+      (queryOptions?.enabled === undefined || queryOptions.enabled),
+  });
+};
 
-export const useCourseOrders = useResources(props);
+export const useCourseOrders = (
+  filters?: CourseOrderResourceQuery,
+  queryOptions?: QueryOptions<NestedCourseOrder>,
+) => {
+  return useResources(props)(filters, {
+    ...queryOptions,
+    enabled:
+      !!filters?.organization_id && (queryOptions?.enabled === undefined || queryOptions.enabled),
+  });
+};

--- a/src/frontend/js/pages/TeacherDashboardCourseLearnersLayout/hooks/useCourseLearnersFilters/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardCourseLearnersLayout/hooks/useCourseLearnersFilters/index.spec.tsx
@@ -135,7 +135,7 @@ describe('useCourseLearnersFilters', () => {
     });
 
     const expectedInitialFilters = {
-      organization_id: undefined,
+      organization_id: defaultOrganization.id,
       course_id: undefined,
       course_product_relation_id: undefined,
     };
@@ -152,7 +152,9 @@ describe('useCourseLearnersFilters', () => {
       result.current.setFilters(newFilters);
     });
 
-    expect(result.current.filters).toStrictEqual(newFilters);
-    expect(result.current.initialFilters).toStrictEqual(expectedInitialFilters);
+    await waitFor(() => {
+      expect(result.current.filters).toStrictEqual(newFilters);
+      expect(result.current.initialFilters).toStrictEqual(expectedInitialFilters);
+    });
   });
 });

--- a/src/frontend/js/pages/TeacherDashboardCourseLearnersLayout/hooks/useCourseLearnersFilters/index.ts
+++ b/src/frontend/js/pages/TeacherDashboardCourseLearnersLayout/hooks/useCourseLearnersFilters/index.ts
@@ -30,7 +30,7 @@ const useCourseLearnersFilters = () => {
       organization_id: organizationId || searchFilters.organization_id,
       course_product_relation_id: courseProductRelationId,
     };
-  }, []);
+  }, [defaultOrganizationId]);
   const [filters, setFilters] = useState<CourseOrderResourceQuery>(initialFilters);
 
   // update current filter with initial value when it's ready

--- a/src/frontend/js/pages/TeacherDashboardCourseLearnersLayout/hooks/useCourseLearnersFilters/index.ts
+++ b/src/frontend/js/pages/TeacherDashboardCourseLearnersLayout/hooks/useCourseLearnersFilters/index.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
+import useDefaultOrganizationId from 'hooks/useDefaultOrganizationId';
 import {
   CourseListItem,
   CourseOrderResourceQuery,
@@ -14,7 +15,7 @@ export type CourseLearnersParams = {
 };
 
 const useCourseLearnersFilters = () => {
-  const { courseId, courseProductRelationId, organizationId } = useParams<CourseLearnersParams>();
+  const { courseId, courseProductRelationId } = useParams<CourseLearnersParams>();
   const [searchParams] = useSearchParams();
   const searchFilters: CourseOrderResourceQuery = useMemo(() => {
     return {
@@ -24,10 +25,13 @@ const useCourseLearnersFilters = () => {
     };
   }, Array.from(searchParams.entries()));
 
+  // default organizationId between (ordered by priority): route, query, first user's organization.
+  const defaultOrganizationId = useDefaultOrganizationId();
+
   const initialFilters = useMemo(() => {
     return {
       ...searchFilters,
-      organization_id: organizationId || searchFilters.organization_id,
+      organization_id: defaultOrganizationId,
       course_product_relation_id: courseProductRelationId,
     };
   }, [defaultOrganizationId]);

--- a/src/frontend/js/pages/TeacherDashboardCourseLearnersLayout/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardCourseLearnersLayout/index.spec.tsx
@@ -182,7 +182,7 @@ describe('pages/TeacherDashboardCourseLearnersLayout', () => {
     const organizationList = [defaultOrganization, otherOrganization];
     const courseProductRelation = CourseProductRelationFactory().one();
     const courseOrderList = NestedCourseOrderFactory().many(3);
-    // https://joanie.endpoint/api/v1.0/organizations/?course_product_relation_id=d390d6a9-8437-4f92-8897-982e12f97259
+
     // Course sidebar queries
     fetchMock.get(
       `https://joanie.endpoint/api/v1.0/organizations/${defaultOrganization.id}/contracts/?course_product_relation_id=${courseProductRelation.id}&signature_state=half_signed&page=1&page_size=${PER_PAGE.teacherContractList}`,


### PR DESCRIPTION
Users mustn't see learner for organization they don't have access to. This will be handle by joanie's backend but for now, we need to add a filter on all available organization id for the logged user

FIXME:
Joanie don't have needed filter on organization_ids ([see filters on joanie](https://github.com/openfun/joanie/blob/main/src/backend/joanie/core/filters/client.py#L197-L229))