### PR TITLE
🔨(backend) migration docker compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -863,7 +863,7 @@ jobs:
           name: Build app container
           command: |
             cd fun-richie-site-factory
-            docker-compose build app
+            docker compose build app
 
 
   lint-front:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Upgrade docker compose to v2.24.5
 - remove dashboard i18n routing
 - Complete `course_detail` RDFa markups
 - Require to accept terms when purchasing product of any kind
@@ -1788,7 +1789,7 @@ through `context_processor`
 - Change the order of placeholders on the course page following feedback from
   our support team,
 - Simplify the Docker development stack to have a single `Dockerfile` and
-  docker-compose configuration for testing either with MySQL or PostgreSQL
+  docker compose configuration for testing either with MySQL or PostgreSQL
   database backend
 - Standardize the project's `Makefile` to make it more easily maintainable by
   our peers

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ RUN rm -rf .git*
 ARG DOCKER_USER
 USER ${DOCKER_USER}
 
-# Target database host (e.g. database engine following docker-compose services
+# Target database host (e.g. database engine following docker compose services
 # name) & port
 ENV DB_HOST=postgresql \
     DB_PORT=5432

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 
 # -- Database
 # Database engine switch: if the DB_HOST=mysql environment variable is defined,
-# we'll use the mysql docker-compose service as a database backend instead of
+# we'll use the mysql docker compose service as a database backend instead of
 # postgresql (default).
 ifeq ($(DB_HOST), mysql)
   DB_PORT            = 3306
@@ -42,7 +42,7 @@ endif
 DOCKER_UID           = $(shell id -u)
 DOCKER_GID           = $(shell id -g)
 DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
-COMPOSE              = DOCKER_USER=$(DOCKER_USER) DB_HOST=$(DB_HOST) DB_PORT=$(DB_PORT) docker-compose
+COMPOSE              = DOCKER_USER=$(DOCKER_USER) DB_HOST=$(DB_HOST) DB_PORT=$(DB_PORT) docker compose
 COMPOSE_SSL          = NGINX_CONF=ssl DEV_ENV_FILE=dev-ssl $(COMPOSE)
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_RUN_SSL      = $(COMPOSE_SSL) run --rm
@@ -124,7 +124,7 @@ run-ssl: ## start the development server over TLS
 	@$(WAIT_APP)
 .PHONY: run-ssl
 
-status: ## an alias for "docker-compose ps"
+status: ## an alias for "docker compose ps"
 	@$(COMPOSE) ps
 .PHONY: status
 
@@ -326,7 +326,7 @@ i18n-generate-front: build-ts
 # -- Database
 
 dbshell: ## connect to database shell 
-	docker-compose exec app python sandbox/manage.py dbshell
+	docker compose exec app python sandbox/manage.py dbshell
 .PHONY: dbshell
 
 # -- Misc

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -36,28 +36,28 @@ function _set_user() {
     echo "🙋(user) ID: ${USER_ID}"
 }
 
-# docker_compose: wrap docker-compose command
+# docker_compose: wrap docker compose command
 #
 # usage: docker_compose [options] [ARGS...]
 #
-# options: docker-compose command options
-# ARGS   : docker-compose command arguments
+# options: docker compose command options
+# ARGS   : docker compose command arguments
 function _docker_compose() {
 
     echo "🐳(compose) project: '${COMPOSE_PROJECT}' file: '${COMPOSE_FILE}'"
-    docker-compose \
+    docker compose \
         -p "${COMPOSE_PROJECT}" \
         -f "${COMPOSE_FILE}" \
         --project-directory "${REPO_DIR}" \
         "$@"
 }
 
-# _dc_run: wrap docker-compose run command
+# _dc_run: wrap docker compose run command
 #
 # usage: _dc_run [options] [ARGS...]
 #
-# options: docker-compose run command options
-# ARGS   : docker-compose run command arguments
+# options: docker compose run command options
+# ARGS   : docker compose run command arguments
 function _dc_run() {
     _set_user
 
@@ -69,12 +69,12 @@ function _dc_run() {
     _docker_compose run --rm $user_args "$@"
 }
 
-# _dc_exec: wrap docker-compose exec command
+# _dc_exec: wrap docker compose exec command
 #
 # usage: _dc_exec [options] [ARGS...]
 #
-# options: docker-compose exec command options
-# ARGS   : docker-compose exec command arguments
+# options: docker compose exec command options
+# ARGS   : docker compose exec command arguments
 function _dc_exec() {
     _set_user
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Makefile
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Makefile
@@ -12,7 +12,7 @@ COMPOSE              = \
   NGINX_IMAGE_NAME="$(NGINX_IMAGE_NAME)" \
   NGINX_IMAGE_TAG="$(NGINX_IMAGE_TAG)" \
   DOCKER_USER="$(DOCKER_UID):$(DOCKER_GID)" \
-  docker-compose
+  docker compose
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_RUN_APP      = $(COMPOSE_RUN) app-dev
 COMPOSE_EXEC         = $(COMPOSE) exec

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/README.md
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/README.md
@@ -12,8 +12,8 @@ Compose](https://docs.docker.com/compose/install) installed on your laptop:
 $ docker -v
   Docker version 19.03.10, build 9424aeaee9
 
-$ docker-compose --version
-  docker-compose version 1.25.5, build 8a1c60f6
+$ docker compose --version
+  docker compose version 1.25.5, build 8a1c60f6
 ```
 
 ## Getting started

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/manage
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/manage
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Run Django management command using docker-compose configuration (for
+# Run Django management command using docker compose configuration (for
 # development only)
-docker-compose run --rm dockerize -wait tcp://db:5432 -timeout 60s
-docker-compose run --rm dockerize -wait tcp://elasticsearch:9200 -timeout 60s
+docker compose run --rm dockerize -wait tcp://db:5432 -timeout 60s
+docker compose run --rm dockerize -wait tcp://elasticsearch:9200 -timeout 60s
 DOCKER_USER="$(id -u):$(id -g)" \
-    docker-compose run --rm app-dev python manage.py "$@"
+    docker compose run --rm app-dev python manage.py "$@"

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/pytest
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/pytest
@@ -3,11 +3,11 @@
 # source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
 # Recreate the redis sentinel service to avoid inconsistent state
-docker-compose up -d -V redis-sentinel
+docker compose up -d -V redis-sentinel
 
-docker-compose run --rm dockerize -wait tcp://db:5432 -timeout 60s
-docker-compose run --rm dockerize -wait tcp://elasticsearch:9200 -timeout 60s
-docker-compose run --rm \
+docker compose run --rm dockerize -wait tcp://db:5432 -timeout 60s
+docker compose run --rm dockerize -wait tcp://elasticsearch:9200 -timeout 60s
+docker compose run --rm \
     -e DJANGO_CONFIGURATION=Test \
     -e PYTHONPATH=/app \
     app-dev pytest "$@"

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/state
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/state
@@ -5,8 +5,8 @@ set -eo pipefail
 # docker container, passing our environment variables
 
 
-docker-compose pull terraform-state
+docker compose pull terraform-state
 
 # Run Terraform commands in the Hashicorp docker container via docker compose
 DOCKER_USER="$(id -u):$(id -g)" \
-    docker-compose run --rm terraform-state "$@"
+    docker compose run --rm terraform-state "$@"

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/terraform
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/bin/terraform
@@ -15,9 +15,9 @@ case "$1" in
         ;;
 esac
 
-docker-compose pull terraform
+docker compose pull terraform
 
 # Run Terraform commands in the Hashicorp docker container via docker compose
 # shellcheck disable=SC2068
 DOCKER_USER="$(id -u):$(id -g)" \
-    docker-compose run --rm terraform ${args[@]}
+    docker compose run --rm terraform ${args[@]}

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   db:
     image: postgres:9.6

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker/files/usr/local/bin/entrypoint
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker/files/usr/local/bin/entrypoint
@@ -17,7 +17,7 @@
 #     docker run --rm -e USER_NAME=foo -e HOME='/home/foo' foo:latest python manage.py migrate
 #
 # or define new variables in an environment file to use with docker or
-# docker-compose:
+# docker compose:
 #
 #     # env.d/development
 #     USER_NAME=foo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   postgresql:
     image: postgres:9.6
@@ -129,4 +127,4 @@ services:
 networks:
   lms_outside:
     driver: bridge
-    name: "${RICHIE_LMS_NETWORK:-edx_outside}"
+    name: "${RICHIE_LMS_NETWORK:-edx-lms-outside}"

--- a/docker/files/usr/local/bin/entrypoint
+++ b/docker/files/usr/local/bin/entrypoint
@@ -15,7 +15,7 @@
 #
 #     docker run --rm -e USER_NAME=foo -e HOME='/home/foo' richie:latest python manage.py migrate
 #
-# or define new variables in an environment file to use with docker or docker-compose:
+# or define new variables in an environment file to use with docker or docker compose:
 #
 #     # env.d/production
 #     USER_NAME=foo

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,7 @@ To see all available commands, run:
 
     $ make
 
-We also provide shortcuts for docker-compose commands as sugar scripts in the
+We also provide shortcuts for docker compose commands as sugar scripts in the
 `bin/` directory:
 
 ```

--- a/docs/docker-development.md
+++ b/docs/docker-development.md
@@ -39,24 +39,24 @@ $ make watch-ts
 
 You can stop/start/restart a container:
 
-    $ docker-compose [stop|start|restart] [app|postgresql|mysql|elasticsearch]
+    $ docker compose [stop|start|restart] [app|postgresql|mysql|elasticsearch]
 
 or stop/start/restart all containers in one command:
 
-    $ docker-compose [stop|start|restart]
+    $ docker compose [stop|start|restart]
 
 ## Debugging
 
 You can easily see the latest logs for a container:
 
-    $ docker-compose logs [app|postgresql|mysql|elasticsearch]
+    $ docker compose logs [app|postgresql|mysql|elasticsearch]
 
 Or follow the stream of logs:
 
-    $ docker-compose logs --follow [app|postgresql|mysql|elasticsearch]
+    $ docker compose logs --follow [app|postgresql|mysql|elasticsearch]
 
 If you need to debug a running container, you can open a Linux shell with the
-`docker-compose exec` command (we use a sugar script here, see next section):
+`docker compose exec` command (we use a sugar script here, see next section):
 
     $ bin/exec [app|postgresql|mysql|elasticsearch] bash
 
@@ -73,16 +73,16 @@ the code directory as a volume in the container. Indeed, the Docker engine will,
 by default, run the containers using the `root` user. Any file created or
 updated by the app container on your host, as a result of the volume mounts,
 will be owned by the local root user. One way to solve this is to use the
-`--user="$(id -u)"` flag when calling the `docker-compose run` or
-`docker-compose exec` commands. By using the user flag trick, the running
+`--user="$(id -u)"` flag when calling the `docker compose run` or
+`docker compose exec` commands. By using the user flag trick, the running
 container user ID will match your local user ID. But, as it's repetitive and
 error-prone, we provide shortcuts that we call our "sugar scripts":
 
-- `bin/run`: is a shortcut for `docker-compose run --rm --user="$(id -u)"`
-- `bin/exec`: is a shortcut for `docker-compose exec --user="$(id -u)"`
-- `bin/pylint`: runs `pylint` in the `app` service using the test docker-compose
+- `bin/run`: is a shortcut for `docker compose run --rm --user="$(id -u)"`
+- `bin/exec`: is a shortcut for `docker compose exec --user="$(id -u)"`
+- `bin/pylint`: runs `pylint` in the `app` service using the test docker compose
   file
-- `bin/pytest`: runs `pytest` in the `app` service using the test docker-compose
+- `bin/pytest`: runs `pytest` in the `app` service using the test docker compose
   file
 
 ## Cleanup
@@ -101,7 +101,7 @@ running:
 If your `elasticsearch` container fails at booting, checkout the logs via:
 
 ```bash
-$ docker-compose logs elasticsearch
+$ docker compose logs elasticsearch
 ```
 
 You may see entries similar to:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,10 +35,10 @@ laptop:
 
 ```bash
 $ docker -v
-  Docker version 20.10.12, build e91ed57
+  Docker version 26.0.0, build 2ae903e
 
-$ docker-compose --version
-  docker-compose version 1.29.2, build 5becea4c
+$ docker compose --version
+  Docker Compose version v2.25.0
 ```
 
 ⚠️ You may need to run the following commands with `sudo` but this can be

--- a/docs/lms-connection.md
+++ b/docs/lms-connection.md
@@ -69,18 +69,18 @@ The project started early 2021, but over time, Joanie will handle:
 
 ## Development
 
-For development purposes, the docker-compose project provided on
+For development purposes, the docker compose project provided on
 [Richie's code repository](https://github.com/openfun/richie) is pre-configured to connect
 with an OpenEdx instance started with
 [OpenEdx Docker](https://github.com/openfun/openedx-docker), which provides a ready-to-use
-docker-compose stack of OpenEdx in several flavors. Head over to
+docker compose stack of OpenEdx in several flavors. Head over to
 [OpenEdx Docker README](https://github.com/openfun/openedx-docker#readme) for instructions on how to bootstrap an OpenEdX instance.
 
 Now, start both the OpenEdX and Richie projects separately with `make run`.
 
 Richie should respond on `http://localhost:8070`, OpenEdx on `http://localhost:8073` and both
 apps should be able to communicate with each other via the network bridge defined in
-docker-compose.
+docker compose.
 
 If you want to activate [seamless enrollment](#2-seamless-enrollment) locally for development,
 you will need to set up TLS domains for both Richie and OpenEdX. To do this, head over to our

--- a/docs/tls-connection.md
+++ b/docs/tls-connection.md
@@ -6,7 +6,7 @@ sidebar_label: TLS connection for development
 
 ## Purpose
 
-By default in the docker-compose environment for development, Richie is hosted on `localhost:8070`
+By default in the docker compose environment for development, Richie is hosted on `localhost:8070`
 and uses a fake LMS backend (`base.BaseLMSBackend`) as you can see if you check the
 `RICHIE_LMS_BACKENDS` setting in `env.d/development`.
 


### PR DESCRIPTION
docker-compose command doesn't work anymore.
we need to switch to docker compose

```sh
git grep -rl docker-compose . | xargs sed -i 's/docker-compose/docker compose/g'
git grep -rl "docker compose file" . | xargs sed -i 's/docker compose file/docker-compose file/g'
git grep -rl "../docker compose.yml" . | xargs sed -i 's/docker compose.yml/docker-compose.yml/g'
```

migration: 
```sh
$ make down
$ docker-compose down
$ make boostrap
$ make stop && make run # postgresql seems to take time to initialize and need a reboot
$ make migrate
$ make demo-site
```

