### PR TITLE
💄(frontend) improve order group message color and layout

### DIFF
--- a/src/frontend/js/components/PurchaseButton/index.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.tsx
@@ -111,7 +111,6 @@ const PurchaseButton = ({
       {!disabled && (
         <>
           <Button
-            size="small"
             data-testid="PurchaseButton__cta"
             className={c('purchase-button__cta', className)}
             onClick={() => hasAtLeastOneCourseRun && setIsSaleTunnelOpen(true)}

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/CourseProductItemFooter/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/CourseProductItemFooter/index.tsx
@@ -62,7 +62,7 @@ const CourseProductItemFooter = ({
         orderGroup={orderGroup}
         buttonProps={{ fullWidth: true }}
       />
-      <p>
+      <p className="product-widget__footer__message">
         <FormattedMessage
           {...messages.nbSeatsAvailable}
           values={{ nb: orderGroup.nb_available_seats }}

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/_styles.scss
@@ -143,14 +143,19 @@
     gap: 0.5rem;
 
     &__message {
+      color: r-theme-val(product-item, base-color);
       text-align: center;
     }
 
     &__order-group {
       text-align: center;
 
-      p {
-        margin-top: 0.25rem;
+      .product-widget__footer__message {
+        margin: 0.5rem 0;
+      }
+
+      &:last-child {
+        margin-bottom: -1rem;
       }
     }
   }


### PR DESCRIPTION
## Purpose

Currently, the order group message in CourseProductItem has no color set. That mean we are not able to customize it from our factory that is weird. We decide to use the base color of the CourseProductItem. Furthermore, the spacing around the message is pretty weird so we propose an improvement of margin.

| Before | After |
|--------|-------|
|<img width="350" alt="image" src="https://github.com/openfun/richie/assets/9265241/366c31b8-1233-4f69-9c49-06af62d02560">|<img width="350" alt="image" src="https://github.com/openfun/richie/assets/9265241/b00027c1-e5b0-49e5-83ce-79d3679d72ab">|


## Proposal

- [x] Set a color for order group message element
- [x] Propose an improvement of spacing in CourseProductItem footer.
