### PR TITLE
🐛(frontend) fix "Go to course" link in syllabus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add two new sections in DjangoCMS courses: Accessibility and Required
   Equipment.
+- Ongoing product displayed on the syllabus without active enrollment 
+  now link to the order details page in the learner dashboard.
 
 ## Fixed
 
+- Ongoing product displayed on the syllabus with an active enrollment 
+  now link to the order details page in the learner dashboard instead of 
+  OpenEdx course.
 - Downloaded contract archive on product page was broken, it now works
   properly by sending the course_product_relation_id in the archive 
   creation request.
@@ -22,6 +27,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   message was displayed on successful download.
 
 ## [2.25.1]
+
+## Added
+
 
 ### Fixed
 

--- a/src/frontend/js/hooks/useCourseRunOrder/index.spec.tsx
+++ b/src/frontend/js/hooks/useCourseRunOrder/index.spec.tsx
@@ -1,0 +1,55 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import {
+  RichieContextFactory as mockRichieContextFactory,
+  CourseRunFactory,
+} from 'utils/test/factories/richie';
+import {
+  CourseLightFactory,
+  CredentialOrderFactory,
+  ProductFactory,
+} from 'utils/test/factories/joanie';
+import { BaseJoanieAppWrapper } from 'utils/test/wrappers/BaseJoanieAppWrapper';
+import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
+import useCourseRunOrder from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://demo.endpoint' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint' },
+    lms_backends: [
+      {
+        backend: 'joanie',
+        course_regexp: '^.*/api/v1.0((?:/(?:courses|course-runs|products)/[^/]+)+)/?$',
+        endpoint: 'https://joanie.endpoint',
+      },
+    ],
+  }).one(),
+}));
+
+describe('useCourseRunOrder', () => {
+  setupJoanieSession();
+
+  it('should return an order for a joanie product course run', async () => {
+    const product = ProductFactory().one();
+    const joanieCourse = CourseLightFactory().one();
+    const richieCourseRun = CourseRunFactory({
+      resource_link: `https://joanie.endpoint/api/v1.0/courses/${joanieCourse.code}/products/${product.id}`,
+    }).one();
+    const order = CredentialOrderFactory().one();
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/orders/?course_code=${joanieCourse.code}&product_id=${product.id}`,
+      [order],
+    );
+    const { result } = renderHook(() => useCourseRunOrder(richieCourseRun), {
+      wrapper: BaseJoanieAppWrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.states.isFetched).toBe(true);
+    });
+
+    expect(result.current.item).toStrictEqual(order);
+  });
+});

--- a/src/frontend/js/hooks/useCourseRunOrder/index.tsx
+++ b/src/frontend/js/hooks/useCourseRunOrder/index.tsx
@@ -1,0 +1,27 @@
+import { isJoanieEnabled } from 'api/joanie';
+import { extractResourceMetadata } from 'api/lms/joanie';
+import { useSession } from 'contexts/SessionContext';
+import { useOrders } from 'hooks/useOrders';
+import { CourseRun } from 'types';
+
+const useCourseRunOrder = (courseRun: CourseRun) => {
+  const { user } = useSession();
+  const resourceLinkResources = extractResourceMetadata(courseRun.resource_link);
+  const isProduct = !!(resourceLinkResources?.course && resourceLinkResources?.product);
+
+  if (!isJoanieEnabled || !isProduct || !user) {
+    return { item: undefined, undefined, states: { fetching: false, isFetched: true } };
+  }
+
+  const {
+    items: orders,
+    states: { fetching, isFetched },
+  } = useOrders({
+    course_code: resourceLinkResources?.course,
+    product_id: resourceLinkResources?.product,
+  });
+
+  return { item: orders.length > 0 ? orders[0] : undefined, states: { fetching, isFetched } };
+};
+
+export default useCourseRunOrder;

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -1,5 +1,5 @@
 import type { CourseState, OpenEdXEnrollment } from 'types';
-import type { Maybe, Nullable } from 'types/utils';
+import type { Nullable } from 'types/utils';
 import { Resource, ResourcesQuery } from 'hooks/useResources';
 import { OrderResourcesQuery } from 'hooks/useOrders';
 import { Course as RichieCourse } from 'types/Course';
@@ -272,8 +272,8 @@ export interface Order {
   state: OrderState;
   product_id: Product['id'];
   target_courses: TargetCourse[];
-  course: Maybe<CourseLight>;
-  enrollment: Maybe<EnrollmentLight>;
+  course: Nullable<CourseLight>;
+  enrollment: Nullable<EnrollmentLight>;
   organization_id: Organization['id'];
   organization: Organization;
   order_group_id?: OrderGroup['id'];
@@ -281,7 +281,7 @@ export interface Order {
 
 export interface CredentialOrder extends Order {
   course: CourseLight;
-  enrollment: undefined;
+  enrollment: null;
 }
 
 export interface CredentialOrderWithPaymentInfo extends CredentialOrder {
@@ -289,9 +289,9 @@ export interface CredentialOrderWithPaymentInfo extends CredentialOrder {
 }
 
 export interface CertificateOrder extends Order {
-  course: undefined;
+  course: null;
   enrollment: EnrollmentLight;
-  target_courses: [];
+  target_courses: never[];
 }
 
 export interface CertificateOrderWithPaymentInfo extends CertificateOrder {

--- a/src/frontend/js/utils/CertificateHelper/index.spec.ts
+++ b/src/frontend/js/utils/CertificateHelper/index.spec.ts
@@ -1,10 +1,10 @@
 import {
   CertificateFactory,
-  CertificateOrderFactory,
   CourseLightFactory,
   CourseRunFactory,
-  CredentialOrderFactory,
   EnrollmentLightFactory,
+  NestedCertificateOrderFactory,
+  NestedCredentialOrderFactory,
 } from 'utils/test/factories/joanie';
 import { CertificateHelper } from '.';
 
@@ -17,31 +17,40 @@ describe('CertificateHelper', () => {
   );
 
   it.each([
-    CertificateFactory({
-      enrollment: EnrollmentLightFactory({
-        course_run: CourseRunFactory({
-          course: CourseLightFactory({ title: 'Course 1' }).one(),
-        }).one(),
-      }).one(),
-      order: null,
-    }).one(),
-    CertificateFactory({
-      enrollment: null,
-      order: CredentialOrderFactory({
-        course: CourseLightFactory({ title: 'Course 1' }).one(),
-      }).one(),
-    }).one(),
-    CertificateFactory({
-      enrollment: null,
-      order: CertificateOrderFactory({
+    {
+      testLabel: 'for enrollment certificate',
+      certificate: CertificateFactory({
         enrollment: EnrollmentLightFactory({
           course_run: CourseRunFactory({
             course: CourseLightFactory({ title: 'Course 1' }).one(),
           }).one(),
         }).one(),
+        order: null,
       }).one(),
-    }).one(),
-  ])('should return the course from the certificate linked to ', (certificate) => {
+    },
+    {
+      testLabel: 'for credential order certificate',
+      certificate: CertificateFactory({
+        enrollment: null,
+        order: NestedCredentialOrderFactory({
+          course: CourseLightFactory({ title: 'Course 1' }).one(),
+        }).one(),
+      }).one(),
+    },
+    {
+      testLabel: 'for certificate order certificate',
+      certificate: CertificateFactory({
+        enrollment: null,
+        order: NestedCertificateOrderFactory({
+          enrollment: EnrollmentLightFactory({
+            course_run: CourseRunFactory({
+              course: CourseLightFactory({ title: 'Course 1' }).one(),
+            }).one(),
+          }).one(),
+        }).one(),
+      }).one(),
+    },
+  ])('should return the course from the certificate linked to $testLabel', ({ certificate }) => {
     expect(CertificateHelper.getCourse(certificate)?.title).toEqual('Course 1');
   });
 });

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -402,19 +402,20 @@ const AbstractOrderFactory = factory((): Order => {
     product_id: faker.string.uuid(),
     target_courses: TargetCourseFactory().many(5),
     target_enrollments: [],
-    enrollment: undefined,
-    course: undefined,
+    enrollment: null,
+    course: null,
     organization_id: faker.string.uuid(),
     organization: OrganizationFactory().one(),
   };
 });
 
 export const CredentialOrderFactory = factory((): CredentialOrder => {
-  return {
+  const order = {
     ...AbstractOrderFactory().one(),
     course: CourseLightFactory().one(),
-    enrollment: undefined,
+    enrollment: null,
   };
+  return order;
 });
 
 export const CredentialOrderWithPaymentFactory = factory((): CredentialOrderWithPaymentInfo => {
@@ -437,12 +438,13 @@ export const CredentialOrderWithOneClickPaymentFactory = factory(
 );
 
 export const CertificateOrderFactory = factory((): CertificateOrder => {
-  return {
+  const order = {
     ...AbstractOrderFactory().one(),
-    course: undefined,
+    course: null,
     target_courses: [],
     enrollment: EnrollmentLightFactory().one(),
   };
+  return order;
 });
 
 export const CertificateOrderWithPaymentFactory = factory((): CertificateOrderWithPaymentInfo => {

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.stories.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.stories.tsx
@@ -5,8 +5,11 @@ import { StorybookHelper } from 'utils/StorybookHelper';
 import {
   CourseLightFactory,
   CourseProductRelationFactory,
+  CourseRunFactory,
   CredentialOrderFactory,
   CredentialProductFactory,
+  EnrollmentFactory,
+  TargetCourseFactory,
 } from 'utils/test/factories/joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { UserFactory } from 'utils/test/factories/richie';
@@ -69,8 +72,24 @@ export const WithValidatedOrder: Story = {
     productId: 'AAA',
     course: CourseLightFactory({ code: 'BBB' }).one(),
   },
-  render: (args) =>
-    render(args, { order: CredentialOrderFactory({ state: OrderState.VALIDATED }).one() }),
+  render: (args) => {
+    const courseRunWithEnrollment = CourseRunFactory().one();
+    return render(args, {
+      order: CredentialOrderFactory({
+        state: OrderState.VALIDATED,
+        target_enrollments: EnrollmentFactory({
+          is_active: true,
+          course_run: courseRunWithEnrollment,
+        }).many(1),
+        target_courses: [
+          TargetCourseFactory({
+            course_runs: [courseRunWithEnrollment, ...CourseRunFactory().many(2)],
+          }).one(),
+          ...TargetCourseFactory().many(2),
+        ],
+      }).one(),
+    });
+  },
 };
 
 export const WithSubmittedOrder: Story = {

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunItemWithEnrollment/index.product.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunItemWithEnrollment/index.product.spec.tsx
@@ -1,0 +1,133 @@
+import { screen, waitFor } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import {
+  CourseRunFactory,
+  RichieContextFactory as mockRichieContextFactory,
+  UserFactory,
+} from 'utils/test/factories/richie';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { BaseJoanieAppWrapper } from 'utils/test/wrappers/BaseJoanieAppWrapper';
+import { render } from 'utils/test/render';
+import {
+  CourseLightFactory,
+  CredentialOrderFactory,
+  EnrollmentFactory,
+  ProductFactory,
+} from 'utils/test/factories/joanie';
+import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
+import { mockPaginatedResponse } from 'utils/test/mockPaginatedResponse';
+import { expectNoSpinner } from 'utils/test/expectSpinner';
+import CourseRunItemWithEnrollment from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://demo.endpoint' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint' },
+    lms_backends: [
+      {
+        backend: 'joanie',
+        course_regexp: '^.*/api/v1.0((?:/(?:courses|course-runs|products)/[^/]+)+)/?$',
+        endpoint: 'https://joanie.endpoint',
+      },
+    ],
+  }).one(),
+}));
+
+// here
+describe("CourseRunItemWithEnrollment for joanie's product's course run", () => {
+  setupJoanieSession();
+
+  it('should not render enrollment information when user is anonymous', async () => {
+    const course = CourseLightFactory().one();
+    const product = ProductFactory().one();
+    const courseRun = CourseRunFactory({
+      title: 'run',
+      start: new Date('2023-01-01').toISOString(),
+      end: new Date('2023-12-31').toISOString(),
+      resource_link: `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}`,
+    }).one();
+
+    render(<CourseRunItemWithEnrollment item={courseRun} />, {
+      wrapper: BaseJoanieAppWrapper,
+      queryOptions: { client: createTestQueryClient({ user: null }) },
+    });
+    await expectNoSpinner();
+
+    // First title letter should have been capitalized
+    // Dates should have been formatted as "Month day, year"
+    screen.getByText('Run, from Jan 01, 2023 to Dec 31, 2023');
+    expect(fetchMock.called()).toBe(false);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should not render enrollment information when user is not enrolled to the course run', async () => {
+    const course = CourseLightFactory().one();
+    const product = ProductFactory().one();
+    const order = CredentialOrderFactory().one();
+    const user = UserFactory().one();
+    const courseRun = CourseRunFactory({
+      title: 'run',
+      start: new Date('2023-01-01').toISOString(),
+      end: new Date('2023-12-31').toISOString(),
+      resource_link: `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}`,
+    }).one();
+
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/orders/?course_code=${course.code}&product_id=${product.id}`,
+      mockPaginatedResponse([order], 1, false),
+    );
+
+    render(<CourseRunItemWithEnrollment item={courseRun} />, {
+      wrapper: BaseJoanieAppWrapper,
+      queryOptions: { client: createTestQueryClient({ user }) },
+    });
+    await expectNoSpinner();
+
+    // Only dates should have been displayed.
+    screen.getByText('Run, from Jan 01, 2023 to Dec 31, 2023');
+    expect(fetchMock.called()).toBe(true);
+    const link = screen.queryByTitle('Go to course') as HTMLAnchorElement;
+    expect(link).toBeInTheDocument();
+    expect(link.href).toBe(`https://localhost/en/dashboard/courses/orders/${order.id}`);
+    expect(screen.queryByLabelText('You are enrolled in this course run')).not.toBeInTheDocument();
+  });
+
+  it('should render enrollment information when user is enrolled to the course run', async () => {
+    const course = CourseLightFactory().one();
+    const product = ProductFactory().one();
+    const order = CredentialOrderFactory({
+      target_enrollments: EnrollmentFactory({ is_active: true }).many(1),
+    }).one();
+    const user = UserFactory().one();
+    const courseRun = CourseRunFactory({
+      title: 'run',
+      start: new Date('2023-01-01').toISOString(),
+      end: new Date('2023-12-31').toISOString(),
+      resource_link: `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}`,
+    }).one();
+
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/orders/?course_code=${course.code}&product_id=${product.id}`,
+      mockPaginatedResponse([order], 1, false),
+    );
+
+    render(<CourseRunItemWithEnrollment item={courseRun} />, {
+      wrapper: BaseJoanieAppWrapper,
+      queryOptions: { client: createTestQueryClient({ user }) },
+    });
+    // session loader
+    await waitFor(() => {
+      expect(screen.queryByText('loading...')).not.toBeInTheDocument();
+    });
+
+    // Only dates should have been displayed.
+    screen.getByText('Run, from Jan 01, 2023 to Dec 31, 2023');
+    expect(fetchMock.called()).toBe(true);
+
+    const link = screen.queryByTitle('Go to course') as HTMLAnchorElement;
+    expect(link).toBeInTheDocument();
+    expect(link.href).toBe(`https://localhost/en/dashboard/courses/orders/${order.id}`);
+    screen.getByLabelText('You are enrolled in this course run');
+  });
+});

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunItemWithEnrollment/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunItemWithEnrollment/index.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
+import { generatePath } from 'react-router-dom';
 import { CourseRun } from 'types';
 import useCourseEnrollment from 'widgets/SyllabusCourseRunsList/hooks/useCourseEnrollment';
 import CourseRunItem from 'widgets/SyllabusCourseRunsList/components/CourseRunItem';
+import { getDashboardBasename } from 'widgets/Dashboard/hooks/useDashboardRouter/getDashboardBasename';
+import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRoutesPaths';
+import useCourseRunOrder from 'hooks/useCourseRunOrder';
+import { Spinner } from 'components/Spinner';
 
 const messages = defineMessages({
   goToCourse: {
@@ -28,13 +33,34 @@ type Props = {
 
 const CourseRunItemWithEnrollment = ({ item }: Props) => {
   const intl = useIntl();
-  const { enrollmentIsActive } = useCourseEnrollment(item.resource_link);
+  const {
+    item: order,
+    states: { isFetched },
+  } = useCourseRunOrder(item);
+  const courseUrl = order
+    ? `${getDashboardBasename(intl.locale)}${generatePath(LearnerDashboardPaths.ORDER, { orderId: order.id })}`
+    : item.resource_link;
+
+  const { enrollmentIsActive: courseRunEnrollmentIsActive } = useCourseEnrollment(
+    item.resource_link,
+    isFetched && !order,
+  );
+
+  // user is enroll to a product if any of the product's target course have a active enrollment
+  const productEnrollmentIsActive = order?.target_enrollments.some((enrollment) => {
+    return enrollment.is_active;
+  });
+  const enrollmentIsActive = !!(courseRunEnrollmentIsActive || productEnrollmentIsActive);
+
+  if (!isFetched) {
+    return <Spinner />;
+  }
 
   return (
     <>
-      {enrollmentIsActive ? (
+      {enrollmentIsActive || !!order ? (
         // eslint-disable-next-line jsx-a11y/control-has-associated-label
-        <a href={item.resource_link} title={intl.formatMessage(messages.goToCourse)}>
+        <a href={courseUrl} title={intl.formatMessage(messages.goToCourse)}>
           <CourseRunItem item={item} />
         </a>
       ) : (

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/hooks/useCourseEnrollment/index.ts
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/hooks/useCourseEnrollment/index.ts
@@ -16,7 +16,7 @@ import { useSessionMutation } from 'utils/react-query/useSessionMutation';
  *
  * @param resourceLink
  */
-const useCourseEnrollment = (resourceLink: string) => {
+const useCourseEnrollment = (resourceLink: string, enabled: boolean = true) => {
   const { user } = useSession();
   const queryClient = useQueryClient();
   const EnrollmentAPI = EnrollmentApiInterface(resourceLink);
@@ -26,12 +26,13 @@ const useCourseEnrollment = (resourceLink: string) => {
     async () => {
       return EnrollmentAPI.get(resourceLink, user!);
     },
+    { enabled: enabled && !!user },
   );
 
   const [{ data: isActive, refetch: refetchIsActive, isLoading: isActiveLoading }] =
     useSessionQuery([...queryKey, 'is_active'], async () => EnrollmentAPI.isEnrolled(enrollment), {
       // Enrollment is null if it has been fetched
-      enabled: !!user && enrollment !== undefined && !isEnrollmentLoading,
+      enabled: enabled && !!user && enrollment !== undefined && !isEnrollmentLoading,
     });
   const { mutateAsync } = useSessionMutation({
     mutationFn: (activeEnrollment: boolean = true) =>


### PR DESCRIPTION
"Go to course" link displayed under enrollment when a user have purchased it were targeting the resource link that is an api endpoint. Here we replace the target by the learner dashboard order details page.

