### PR TITLE
✨(frontend) split dashboard certifiate page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Add a tab in learner dashboard certificate page to render both order
+  certificate and enrollment certificate lists.
 - Add Lyra payment interface
 - Add 404 error page on the dashboard router.
 - Teacher dashboard route now redirect to learner dashboard route when

--- a/src/frontend/cunningham.cjs
+++ b/src/frontend/cunningham.cjs
@@ -66,6 +66,9 @@ module.exports = {
         },
       },
       components: {
+        tabs: {
+          'border-bottom-color': 'ref(theme.colors.greyscale-300)',
+        },
         button: {
           'font-family': 'Montserrat',
         },

--- a/src/frontend/js/components/Tabs/_styles.scss
+++ b/src/frontend/js/components/Tabs/_styles.scss
@@ -1,0 +1,34 @@
+$tabs-scheme: map-get($themes, 'default', 'components', 'tabs');
+
+.tabs {
+  display: flex;
+  gap: rem-calc(16px);
+  border-bottom: 2px solid map-get($tabs-scheme, 'border-bottom-color');
+
+  &__tab {
+    margin-bottom: rem-calc(-2px);
+    flex: 0 0 auto;
+  }
+}
+
+.c__button {
+  &--tab {
+    border-bottom: 2px solid transparent;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+    &:hover,
+    &:focus-visible,
+    &:active,
+    &.c__button--active,
+    &:disabled {
+      border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+
+    &.c__button--active {
+      border-left-color: transparent;
+      border-top-color: transparent;
+      border-right-color: transparent;
+    }
+  }
+}

--- a/src/frontend/js/components/Tabs/index.stories.tsx
+++ b/src/frontend/js/components/Tabs/index.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { RouterWrapper } from 'utils/test/wrappers/RouterWrapper';
+import Tabs from './index';
+
+export default {
+  component: Tabs,
+} as Meta<typeof Tabs>;
+
+type Story = StoryObj<typeof Tabs>;
+
+export const Default: Story = {
+  render: () => {
+    const [tabContent, setTabContent] = useState('This is the first tab content');
+    return (
+      <RouterWrapper>
+        <Tabs initialActiveTabName="first-tab">
+          <Tabs.Tab name="first-tab" onClick={() => setTabContent('This is the first tab content')}>
+            First tab
+          </Tabs.Tab>
+          <Tabs.Tab
+            name="second-tab"
+            onClick={() => setTabContent('This is the second tab content')}
+          >
+            Second tab
+          </Tabs.Tab>
+        </Tabs>
+        {tabContent}
+      </RouterWrapper>
+    );
+  },
+};

--- a/src/frontend/js/components/Tabs/index.tsx
+++ b/src/frontend/js/components/Tabs/index.tsx
@@ -1,0 +1,80 @@
+import { Button } from '@openfun/cunningham-react';
+import classNames from 'classnames';
+import {
+  Children,
+  Dispatch,
+  PropsWithChildren,
+  ReactElement,
+  SetStateAction,
+  cloneElement,
+  useState,
+} from 'react';
+import { useNavigate } from 'react-router-dom';
+import { noop } from 'utils';
+
+interface TabProps extends PropsWithChildren {
+  name: string;
+  href?: string;
+  isActive?: boolean;
+  setActiveTabName?: Dispatch<SetStateAction<string>>;
+  onClick?: () => void;
+}
+
+/**
+ * Tab must be used inside a Tabs component.
+ * `isActive` and `setActiveTabName` shouldn't be given to Tab component.
+ * These props are populated by Tabs parent component.
+ */
+const Tab = ({
+  name,
+  href,
+  onClick,
+  isActive = false,
+  setActiveTabName = noop,
+  children,
+}: TabProps) => {
+  const navigate = useNavigate();
+  const handleOnClick = () => {
+    setActiveTabName?.(name);
+    onClick?.();
+    if (href) {
+      navigate(href);
+    }
+  };
+
+  return (
+    <div className="tabs__tab">
+      <Button
+        color="tertiary-text"
+        onClick={handleOnClick}
+        className={classNames('c__button--tab', {
+          'c__button--active': isActive,
+        })}
+      >
+        {children}
+      </Button>
+    </div>
+  );
+};
+
+interface TabsProps {
+  initialActiveTabName?: string;
+  children: ReactElement<TabProps>[];
+}
+
+const Tabs = ({ initialActiveTabName, children }: TabsProps) => {
+  const [activeTabName, setActiveTabName] = useState(
+    initialActiveTabName ?? children[0].props.name,
+  );
+  return (
+    <div className="tabs" data-testid="tabs-header">
+      {Children.map(children, (child) =>
+        cloneElement(child, { isActive: child.props.name === activeTabName, setActiveTabName }),
+      )}
+    </div>
+  );
+};
+
+Tabs.Tab = Tab;
+
+export default Tabs;

--- a/src/frontend/js/hooks/useCertificates/index.tsx
+++ b/src/frontend/js/hooks/useCertificates/index.tsx
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl';
-import { useResource, useResources, UseResourcesProps } from 'hooks/useResources';
-import { API, Certificate, PaginatedResourceQuery } from 'types/Joanie';
+import { QueryOptions, useResource, useResources, UseResourcesProps } from 'hooks/useResources';
+import { API, Certificate, CertificateResourcesQuery } from 'types/Joanie';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
 
 const messages = defineMessages({
@@ -16,12 +16,22 @@ const messages = defineMessages({
   },
 });
 
-const props: UseResourcesProps<Certificate, PaginatedResourceQuery, API['user']['certificates']> = {
+const props: UseResourcesProps<
+  Certificate,
+  CertificateResourcesQuery,
+  API['user']['certificates']
+> = {
   queryKey: ['certificates'],
   apiInterface: () => useJoanieApi().user.certificates,
   session: true,
   messages,
 };
 
-export const useCertificates = useResources(props);
+export const useCertificates = (
+  filters: CertificateResourcesQuery,
+  queryOptions?: QueryOptions<Certificate>,
+) => {
+  return useResources(props)(filters, queryOptions);
+};
+
 export const useCertificate = useResource(props);

--- a/src/frontend/js/pages/DashboardCertificates/_styles.scss
+++ b/src/frontend/js/pages/DashboardCertificates/_styles.scss
@@ -1,4 +1,8 @@
 .dashboard-certificates {
+  &__content {
+    margin-top: rem-calc(8px);
+  }
+
   &__list {
     display: flex;
     flex-direction: column;

--- a/src/frontend/js/pages/DashboardCertificates/components/CertificateList/index.tsx
+++ b/src/frontend/js/pages/DashboardCertificates/components/CertificateList/index.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { keepPreviousData } from '@tanstack/query-core';
+import classNames from 'classnames';
+import { Pagination, usePagination } from 'components/Pagination';
+import { useCertificates } from 'hooks/useCertificates';
+import { Spinner } from 'components/Spinner';
+import Banner, { BannerType } from 'components/Banner';
+import { DashboardItemCertificate } from 'widgets/Dashboard/components/DashboardItem/Certificate';
+import { CertificateType } from 'types/Joanie';
+
+const messages = defineMessages({
+  loading: {
+    defaultMessage: 'Loading certificates...',
+    description: 'Message displayed while loading certificates',
+    id: 'components.DashboardCertificates.loading',
+  },
+  empty: {
+    defaultMessage: 'You have no certificates yet.',
+    description: 'Message displayed when there are no certificates',
+    id: 'components.DashboardCertificates.empty',
+  },
+});
+
+interface CertificatesListProps {
+  certificateType: CertificateType;
+}
+const CertificatesList = ({ certificateType }: CertificatesListProps) => {
+  const intl = useIntl();
+  const pagination = usePagination({});
+  const certificates = useCertificates(
+    {
+      type: certificateType,
+      page: pagination.currentPage,
+      page_size: pagination.itemsPerPage,
+    },
+    { placeholderData: keepPreviousData },
+  );
+
+  useEffect(() => {
+    if (certificates.meta?.pagination?.count) {
+      pagination.setItemsCount(certificates.meta.pagination.count);
+    }
+  }, [certificates.meta?.pagination?.count]);
+
+  if (certificates.states.error) {
+    return <Banner message={certificates.states.error} type={BannerType.ERROR} />;
+  }
+
+  return (
+    <div>
+      {certificates.items.length === 0 && certificates.states.fetching ? (
+        <Spinner aria-labelledby="loading-certificates-data">
+          <span id="loading-certificates-data">
+            <FormattedMessage {...messages.loading} />
+          </span>
+        </Spinner>
+      ) : (
+        certificates.items.length === 0 && (
+          <Banner message={intl.formatMessage(messages.empty)} type={BannerType.INFO} />
+        )
+      )}
+
+      {certificates.items.length > 0 && (
+        <>
+          <div
+            className={classNames('dashboard-certificates__list', {
+              'dashboard__list--loading': certificates.states.fetching,
+            })}
+          >
+            {certificates.items.map((certificate) => (
+              <DashboardItemCertificate key={certificate.id} certificate={certificate} />
+            ))}
+          </div>
+          <Pagination {...pagination} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default CertificatesList;

--- a/src/frontend/js/pages/DashboardCertificates/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCertificates/index.spec.tsx
@@ -56,7 +56,7 @@ describe('<DashboardCertificates/>', () => {
   });
 
   it('renders an empty list of certificates', async () => {
-    fetchMock.get('https://joanie.endpoint/api/v1.0/certificates/?page=1&page_size=10', {
+    fetchMock.get('https://joanie.endpoint/api/v1.0/certificates/?type=order&page=1&page_size=10', {
       results: [],
       next: null,
       previous: null,
@@ -88,7 +88,7 @@ describe('<DashboardCertificates/>', () => {
     const certificatesPage1 = certificates.slice(0, 10);
     const certificatesPage2 = certificates.slice(10, 20);
 
-    fetchMock.get('https://joanie.endpoint/api/v1.0/certificates/?page=1&page_size=10', {
+    fetchMock.get('https://joanie.endpoint/api/v1.0/certificates/?type=order&page=1&page_size=10', {
       results: certificatesPage1,
       next: null,
       previous: null,
@@ -97,7 +97,7 @@ describe('<DashboardCertificates/>', () => {
 
     const page2Deferred = new Deferred();
     fetchMock.get(
-      'https://joanie.endpoint/api/v1.0/certificates/?page=2&page_size=10',
+      'https://joanie.endpoint/api/v1.0/certificates/?type=order&page=2&page_size=10',
       page2Deferred.promise,
     );
 
@@ -156,7 +156,7 @@ describe('<DashboardCertificates/>', () => {
   });
 
   it('shows an error when request to retrieve certificates fails', async () => {
-    fetchMock.get('https://joanie.endpoint/api/v1.0/certificates/?page=1&page_size=10', {
+    fetchMock.get('https://joanie.endpoint/api/v1.0/certificates/?type=order&page=1&page_size=10', {
       status: HttpStatusCode.INTERNAL_SERVER_ERROR,
       body: 'Internal Server Error',
     });

--- a/src/frontend/js/pages/DashboardCertificates/index.tsx
+++ b/src/frontend/js/pages/DashboardCertificates/index.tsx
@@ -1,74 +1,49 @@
-import { useEffect } from 'react';
-import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
-import { keepPreviousData } from '@tanstack/query-core';
-import { Pagination, usePagination } from 'components/Pagination';
-import { useCertificates } from 'hooks/useCertificates';
-import { Spinner } from 'components/Spinner';
-import Banner, { BannerType } from 'components/Banner';
-import { DashboardItemCertificate } from 'widgets/Dashboard/components/DashboardItem/Certificate';
+import { FormattedMessage, defineMessages } from 'react-intl';
+import { CertificateType } from 'types/Joanie';
+import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRoutesPaths';
+import Tabs from '../../components/Tabs';
+import CertificatesList from './components/CertificateList';
 
 const messages = defineMessages({
-  loading: {
-    defaultMessage: 'Loading certificates...',
-    description: 'Message displayed while loading certificates',
-    id: 'components.DashboardCertificates.loading',
+  orderCertificateTabLabel: {
+    id: 'components.DashboardCertificates.orderCertificateTabLabel',
+    description: 'The label of the order certificate tab',
+    defaultMessage: 'Certificates',
   },
-  empty: {
-    defaultMessage: 'You have no certificates yet.',
-    description: 'Message displayed when there are no certificates',
-    id: 'components.DashboardCertificates.empty',
+  enrollmentCertificateTabLabel: {
+    id: 'components.DashboardCertificates.enrollmentCertificateTabLabel',
+    description: 'The label of the enrollment certificate tab',
+    defaultMessage: 'Attestations of achievement',
   },
 });
 
-export const DashboardCertificates = () => {
-  const intl = useIntl();
-  const pagination = usePagination({});
-  const certificates = useCertificates(
-    {
-      page: pagination.currentPage,
-      page_size: pagination.itemsPerPage,
-    },
-    { placeholderData: keepPreviousData },
-  );
-  useEffect(() => {
-    if (certificates.meta?.pagination?.count) {
-      pagination.setItemsCount(certificates.meta.pagination.count);
-    }
-  }, [certificates.meta?.pagination?.count]);
+interface DashboardCertificatesProps {
+  certificateType: CertificateType;
+}
 
-  if (certificates.states.error) {
-    return <Banner message={certificates.states.error} type={BannerType.ERROR} />;
-  }
-
+export const DashboardCertificates = ({ certificateType }: DashboardCertificatesProps) => {
   return (
     <div className="dashboard-certificates">
-      {certificates.items.length === 0 && certificates.states.fetching ? (
-        <Spinner aria-labelledby="loading-certificates-data">
-          <span id="loading-certificates-data">
-            <FormattedMessage {...messages.loading} />
-          </span>
-        </Spinner>
-      ) : (
-        <div>
-          {certificates.items.length === 0 ? (
-            <Banner message={intl.formatMessage(messages.empty)} type={BannerType.INFO} />
-          ) : (
-            <>
-              <div
-                className={[
-                  'dashboard-certificates__list',
-                  certificates.states.fetching ? 'dashboard__list--loading' : '',
-                ].join(' ')}
-              >
-                {certificates.items.map((certificate) => (
-                  <DashboardItemCertificate key={certificate.id} certificate={certificate} />
-                ))}
-              </div>
-              <Pagination {...pagination} />
-            </>
-          )}
-        </div>
-      )}
+      <Tabs
+        initialActiveTabName={
+          certificateType === CertificateType.ORDER
+            ? 'order-certificate-tab'
+            : 'enrollment-certificate-tab'
+        }
+      >
+        <Tabs.Tab name="order-certificate-tab" href={LearnerDashboardPaths.ORDER_CERTIFICATES}>
+          <FormattedMessage {...messages.orderCertificateTabLabel} />
+        </Tabs.Tab>
+        <Tabs.Tab
+          name="enrollment-certificate-tab"
+          href={LearnerDashboardPaths.ENROLLMENT_CERTIFICATES}
+        >
+          <FormattedMessage {...messages.enrollmentCertificateTabLabel} />
+        </Tabs.Tab>
+      </Tabs>
+      <div className="dashboard-certificates__content">
+        <CertificatesList certificateType={certificateType} />
+      </div>
     </div>
   );
 };

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -114,6 +114,14 @@ export type Certificate = {
     }
 );
 
+export enum CertificateType {
+  ORDER = 'order',
+  ENROLLMENT = 'enrollment',
+}
+export interface CertificateResourcesQuery extends PaginatedResourceQuery {
+  type?: CertificateType;
+}
+
 // - Organization
 export interface OrganizationLight {
   code: string;
@@ -551,7 +559,7 @@ interface APIUser {
   };
   certificates: {
     download(id: string): Promise<File>;
-    get<Filters extends PaginatedResourceQuery = PaginatedResourceQuery>(
+    get<Filters extends CertificateResourcesQuery = CertificateResourcesQuery>(
       filters?: Filters,
     ): Filters extends { id: string }
       ? Promise<Certificate>

--- a/src/frontend/js/utils/cunningham-tokens.ts
+++ b/src/frontend/js/utils/cunningham-tokens.ts
@@ -138,6 +138,7 @@ export const tokens = {
         breakpoints: { xs: 0, sm: '576px', md: '768px', lg: '992px', xl: '1200px', xxl: '1400px' },
       },
       components: {
+        tabs: { 'border-bottom-color': '#E7E8EA' },
         button: { 'font-family': 'Montserrat' },
         dashboardListAvatar: { saturation: 30, lightness: 55 },
       },

--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/components/MenuNavLink/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/components/MenuNavLink/index.tsx
@@ -11,10 +11,13 @@ interface MenuNavLinkProps {
 
 const MenuNavLink = ({ link, badgeCount }: MenuNavLinkProps) => {
   const location = useLocation();
+  const activePaths = [...(link.activePaths || []), link.to];
+  const isMenuNavLinkActive = activePaths.some((path) => isMenuLinkActive(path, location));
+
   return (
     <li
       className={classNames('dashboard-sidebar__container__nav__item', {
-        active: isMenuLinkActive(link.to, location),
+        active: isMenuNavLinkActive,
       })}
     >
       <NavLink to={link.to} end>

--- a/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardSidebar/index.tsx
@@ -8,6 +8,7 @@ export interface MenuLink {
   to: string;
   label: string;
   component?: ReactNode;
+  activePaths?: string[];
 }
 
 export interface DashboardSidebarProps extends PropsWithChildren {

--- a/src/frontend/js/widgets/Dashboard/components/LearnerDashboardSidebar/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/LearnerDashboardSidebar/index.tsx
@@ -40,6 +40,13 @@ export const LearnerDashboardSidebar = (props: Partial<DashboardSidebarProps>) =
       ].map((path) => ({
         to: generatePath(path),
         label: getRouteLabel(path),
+        activePaths:
+          path === LearnerDashboardPaths.CERTIFICATES
+            ? [
+                LearnerDashboardPaths.ORDER_CERTIFICATES,
+                LearnerDashboardPaths.ENROLLMENT_CERTIFICATES,
+              ]
+            : undefined,
       })),
     [],
   );

--- a/src/frontend/js/widgets/Dashboard/utils/learnerRoutes.tsx
+++ b/src/frontend/js/widgets/Dashboard/utils/learnerRoutes.tsx
@@ -1,5 +1,5 @@
 import { MessageDescriptor, useIntl } from 'react-intl';
-import { Outlet, RouteObject } from 'react-router-dom';
+import { Navigate, Outlet, RouteObject } from 'react-router-dom';
 import RouteInfo from 'widgets/Dashboard/components/RouteInfo';
 import { DashboardCreateAddressLoader } from 'pages/DashboardAddressesManagement/DashboardCreateAddressLoader';
 import { DashboardEditAddressLoader } from 'pages/DashboardAddressesManagement/DashboardEditAddressLoader';
@@ -15,6 +15,7 @@ import {
   LEARNER_DASHBOARD_ROUTE_LABELS,
   LearnerDashboardPaths,
 } from 'widgets/Dashboard/utils/learnerRoutesPaths';
+import { CertificateType } from 'types/Joanie';
 
 export interface DashboardRouteHandle {
   crumbLabel?: MessageDescriptor;
@@ -54,8 +55,26 @@ export function getLearnerDashboardRoutes() {
     },
     {
       path: LearnerDashboardPaths.CERTIFICATES,
-      handle: { crumbLabel: LEARNER_DASHBOARD_ROUTE_LABELS[LearnerDashboardPaths.CERTIFICATES] },
-      element: <DashboardCertificates />,
+      children: [
+        {
+          index: true,
+          element: <Navigate to={LearnerDashboardPaths.ORDER_CERTIFICATES} replace />,
+        },
+        {
+          path: LearnerDashboardPaths.ORDER_CERTIFICATES,
+          handle: {
+            crumbLabel: LEARNER_DASHBOARD_ROUTE_LABELS[LearnerDashboardPaths.ORDER_CERTIFICATES],
+          },
+          element: <DashboardCertificates certificateType={CertificateType.ORDER} />,
+        },
+        {
+          path: LearnerDashboardPaths.ENROLLMENT_CERTIFICATES,
+          handle: {
+            crumbLabel: LEARNER_DASHBOARD_ROUTE_LABELS[LearnerDashboardPaths.ORDER_CERTIFICATES],
+          },
+          element: <DashboardCertificates certificateType={CertificateType.ENROLLMENT} />,
+        },
+      ],
     },
     {
       path: LearnerDashboardPaths.CONTRACTS,

--- a/src/frontend/js/widgets/Dashboard/utils/learnerRoutesPaths.tsx
+++ b/src/frontend/js/widgets/Dashboard/utils/learnerRoutesPaths.tsx
@@ -9,6 +9,8 @@ export enum LearnerDashboardPaths {
   ORDER_RUNS = `${ORDER}/runs`,
   COURSE = `${COURSES}/:code`,
   CERTIFICATES = '/certificates',
+  ORDER_CERTIFICATES = '/certificates/order',
+  ENROLLMENT_CERTIFICATES = '/certificates/enrollment',
   CONTRACTS = '/training-contracts',
   PREFERENCES = '/preferences',
   PREFERENCES_ADDRESS_EDITION = `${PREFERENCES}/addresses/:addressId`,
@@ -41,6 +43,16 @@ export const LEARNER_DASHBOARD_ROUTE_LABELS = defineMessages<LearnerDashboardPat
     id: 'components.Dashboard.DashboardRoutes.certificates.label',
     description: 'Label of the certificates view used in navigation components.',
     defaultMessage: 'My certificates',
+  },
+  [LearnerDashboardPaths.ORDER_CERTIFICATES]: {
+    id: 'components.Dashboard.DashboardRoutes.certificates.order.label',
+    description: 'Label of the order certificates view used in navigation components.',
+    defaultMessage: 'My certificates',
+  },
+  [LearnerDashboardPaths.ENROLLMENT_CERTIFICATES]: {
+    id: 'components.Dashboard.DashboardRoutes.certificates.enrollment.label',
+    description: 'Label of the enrollment certificates view used in navigation components.',
+    defaultMessage: 'My attestations of achievement',
   },
   [LearnerDashboardPaths.CONTRACTS]: {
     id: 'components.Dashboard.DashboardRoutes.contracts.label',

--- a/src/frontend/scss/components/_index.scss
+++ b/src/frontend/scss/components/_index.scss
@@ -1,5 +1,6 @@
 @import '../../js/components/AddressesManagement/styles';
 @import '../../js/components/ContractFrame/styles';
+@import '../../js/components/Tabs/styles';
 @import '../../js/components/TeacherDashboardCourseList/styles';
 @import '../../js/components/Modal/styles';
 @import '../../js/components/PaymentButton/styles';

--- a/src/frontend/scss/vendors/cunningham-tokens.scss
+++ b/src/frontend/scss/vendors/cunningham-tokens.scss
@@ -154,6 +154,9 @@ $themes: (
       ),
     ),
     'components': (
+      'tabs': (
+        'border-bottom-color': #e7e8ea,
+      ),
       'button': (
         'font-family': Montserrat,
       ),


### PR DESCRIPTION
## Purpose

joanie's certificate endpoint now return only order's certificate by
default.
to retrive enrollments certificate we need a second request with the
right filter.
Here we add tab in learner dashboard certificate page to render both
list: order and enrollments certificates

![image](https://github.com/openfun/richie/assets/139848/a8dfd50e-6f95-43e2-89dd-0718e7b7604f)
[Capture vidéo du 25-04-2024 16:39:29.webm](https://github.com/openfun/richie/assets/139848/de8bb7d2-a448-465e-a70c-5886ff0b000b)
