### PR TITLE
🐛(frontend) fix alert error on success download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add two new sections in DjangoCMS courses: Accessibility and Required
   Equipment.
 
+## Fixed
+
+- Fix a bug in the learner dashboard contract page where an alert
+  message was displayed on successful download.
+
 ## [2.25.1]
 
 ### Fixed

--- a/src/frontend/js/components/DownloadContractButton/index.spec.tsx
+++ b/src/frontend/js/components/DownloadContractButton/index.spec.tsx
@@ -13,6 +13,8 @@ import { alert } from 'utils/indirection/window';
 import { HttpStatusCode } from 'utils/errors/HttpError';
 import DownloadContractButton from '.';
 
+jest.mock('utils/errors/handle');
+
 jest.mock('utils/context', () => ({
   __esModule: true,
   default: mockRichieContextFactory({
@@ -101,6 +103,7 @@ describe('<DownloadContractButton/>', () => {
     expect(URL.createObjectURL).toHaveBeenCalledWith(expectedFile);
     expect(window.open).toHaveBeenCalledTimes(1);
     expect(window.open).toHaveBeenCalledWith(expectedFile);
+    expect(alert).toHaveBeenCalledTimes(0);
   });
 
   it('fails downloading the contract and shows an error', async () => {

--- a/src/frontend/js/utils/download.ts
+++ b/src/frontend/js/utils/download.ts
@@ -19,7 +19,7 @@ export const browserDownloadFromBlob = async (
 
     if (newWindow) {
       window.open(url);
-      return;
+      return true;
     }
 
     const $link = document.createElement('a');


### PR DESCRIPTION
On the learner dashboard contract page, we had a alert "an error append" after a successfull download.

resolve #2369
