### PR TITLE
🐛(frontend) redirect on unauthorized pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Teacher dashboard route now redirect to learner dashboard route when
+  the user isn't authorized.
 - Add two new sections in DjangoCMS courses: Accessibility and Required
   Equipment.
 - Ongoing product displayed on the syllabus without active enrollment 

--- a/src/frontend/js/components/ProtectedRoute/index.spec.tsx
+++ b/src/frontend/js/components/ProtectedRoute/index.spec.tsx
@@ -1,0 +1,81 @@
+import { screen } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+import { Link, RouteObject } from 'react-router-dom';
+import { render } from 'utils/test/render';
+import { RouterWrapper } from 'utils/test/wrappers/RouterWrapper';
+import ProtectedRoute from '.';
+
+describe('ProtectedRoute', () => {
+  const routes: RouteObject[] = [
+    {
+      path: '/home',
+      element: (
+        <div>
+          <h1>Home page</h1>
+          <ul>
+            <li>
+              <Link to="/protected/page">To protected page</Link>
+            </li>
+            <li>
+              <Link to="/authorized/page">To authorized page</Link>
+            </li>
+          </ul>
+        </div>
+      ),
+    },
+    {
+      path: '/redirect',
+      element: (
+        <div>
+          <h1>Redirect page</h1>
+        </div>
+      ),
+    },
+    {
+      path: '/authorized',
+      element: <ProtectedRoute isAllowed={true} redirectPath="/redirect" />,
+      children: [
+        {
+          path: '/authorized/page',
+          element: (
+            <div>
+              <h1>Authorized page</h1>
+            </div>
+          ),
+        },
+      ],
+    },
+    {
+      path: '/protected',
+      element: <ProtectedRoute isAllowed={false} redirectPath="/redirect" />,
+      children: [
+        {
+          path: '/protected/page',
+          element: (
+            <div>
+              <h1>Protected page</h1>
+            </div>
+          ),
+        },
+      ],
+    },
+  ];
+
+  it('should redirect to redirectPath when route is protected', async () => {
+    render(<RouterWrapper routes={routes} initialEntries={['/home']} />, {
+      wrapper: null,
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/To protected page/));
+    expect(await screen.findByRole('heading', { name: 'Redirect page' })).toBeInTheDocument();
+  });
+
+  it("should's redirect to redirectPath when route isn't protected", async () => {
+    render(<RouterWrapper routes={routes} initialEntries={['/home']} />, {
+      wrapper: null,
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/To authorized page/));
+    expect(await screen.findByRole('heading', { name: 'Authorized page' })).toBeInTheDocument();
+  });
+});

--- a/src/frontend/js/components/ProtectedRoute/index.tsx
+++ b/src/frontend/js/components/ProtectedRoute/index.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+interface ProtectedRouteProps {
+  isAllowed: boolean;
+  redirectPath: string;
+}
+const ProtectedRoute = ({ isAllowed, redirectPath }: ProtectedRouteProps) => {
+  return isAllowed ? <Outlet /> : <Navigate to={redirectPath} />;
+};
+
+export default ProtectedRoute;

--- a/src/frontend/js/hooks/useJoanieUserAbilities/index.spec.tsx
+++ b/src/frontend/js/hooks/useJoanieUserAbilities/index.spec.tsx
@@ -1,14 +1,13 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
 import { IntlProvider } from 'react-intl';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import { JoanieUserProfileFactory } from 'utils/test/factories/joanie';
-import { JoanieUserApiAbilityActions } from 'types/User';
+import { JoanieUserApiAbilityActions, JoanieUserProfile } from 'types/User';
 import { JoanieUserProfileActions } from 'utils/AbilitiesHelper/types';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
-import { Deferred } from 'utils/test/deferred';
 import JoanieSessionProvider from 'contexts/SessionContext/JoanieSessionProvider';
 import { useJoanieUserAbilities } from '.';
 
@@ -21,9 +20,12 @@ jest.mock('utils/context', () => ({
 }));
 
 describe('useJoanieUserAbilities', () => {
-  const Wrapper = ({ children }: PropsWithChildren) => (
+  const Wrapper = ({
+    children,
+    joanieUserProfile,
+  }: PropsWithChildren & { joanieUserProfile: JoanieUserProfile }) => (
     <IntlProvider locale="en">
-      <QueryClientProvider client={createTestQueryClient({ user: true })}>
+      <QueryClientProvider client={createTestQueryClient({ user: true, joanieUserProfile })}>
         <JoanieSessionProvider>{children}</JoanieSessionProvider>
       </QueryClientProvider>
     </IntlProvider>
@@ -41,26 +43,20 @@ describe('useJoanieUserAbilities', () => {
   });
 
   it("should return an entity with joanie's profile rights", async () => {
-    const responseDeferred = new Deferred();
-    fetchMock.get('https://joanie.endpoint/api/v1.0/users/me/', responseDeferred.promise);
-
     const { result } = renderHook(() => useJoanieUserAbilities(), {
-      wrapper: Wrapper,
+      wrapper: ({ children }: PropsWithChildren) => (
+        <Wrapper
+          joanieUserProfile={JoanieUserProfileFactory({
+            abilities: {
+              [JoanieUserApiAbilityActions.HAS_ORGANIZATION_ACCESS]: false,
+              [JoanieUserApiAbilityActions.HAS_COURSE_ACCESS]: true,
+            },
+          }).one()}
+        >
+          {children}
+        </Wrapper>
+      ),
     });
-    expect(result.current).toBeUndefined();
-
-    await act(async () => {
-      responseDeferred.resolve(
-        JoanieUserProfileFactory({
-          abilities: {
-            [JoanieUserApiAbilityActions.HAS_ORGANIZATION_ACCESS]: false,
-            [JoanieUserApiAbilityActions.HAS_COURSE_ACCESS]: true,
-          },
-        }).one(),
-      );
-    });
-
-    await waitFor(() => expect(result.current).not.toBeUndefined());
 
     expect(result.current?.can(JoanieUserProfileActions.ACCESS_TEACHER_DASHBOARD)).toBe(true);
     expect(result.current?.cannot(JoanieUserProfileActions.ACCESS_TEACHER_DASHBOARD)).toBe(false);

--- a/src/frontend/js/utils/test/createTestQueryClient.ts
+++ b/src/frontend/js/utils/test/createTestQueryClient.ts
@@ -4,11 +4,38 @@ import { QueryStateFactory, PersistedClientFactory } from 'utils/test/factories/
 import createQueryClient, { QueryClientOptions } from 'utils/react-query/createQueryClient';
 import { User } from 'types/User';
 import { Maybe, Nullable } from 'types/utils';
+import { JoanieUserProfileFactory } from './factories/joanie';
 
 export interface CreateTestQueryClientParams extends QueryClientOptions {
   user?: Maybe<Nullable<User | boolean>>;
+  joanieUserProfile?: Maybe<Nullable<User>>;
   queriesCallback?: (queries: DehydratedState['queries']) => void;
 }
+
+const getUserToUser = (user: Maybe<Nullable<User | boolean>>) => {
+  if (user === true) {
+    return UserFactory().one();
+  } else if (user) {
+    return user;
+  } else if (user === null) {
+    return null;
+  }
+};
+
+const getJoanieUserProfileToUser = (
+  user: Nullable<User>,
+  joanieUserProfile: Maybe<Nullable<User>>,
+) => {
+  if (user === null) {
+    return null;
+  }
+
+  return JoanieUserProfileFactory({
+    ...(joanieUserProfile || {}),
+    username: user.username,
+    full_name: user.full_name,
+  }).one();
+};
 
 /**
  * user typeof User put user in cache.
@@ -19,18 +46,23 @@ export interface CreateTestQueryClientParams extends QueryClientOptions {
  * @param params
  */
 export const createTestQueryClient = (params: CreateTestQueryClientParams = {}) => {
-  let userToUse: Maybe<Nullable<User>>;
-  if (params.user === true) {
-    userToUse = UserFactory().one();
-  } else if (params.user) {
-    userToUse = params.user;
-  } else if (params.user === null) {
-    userToUse = null;
-  }
+  const userToUse = getUserToUser(params.user);
 
   const queries: DehydratedState['queries'] = [];
   if (userToUse !== undefined) {
     queries.push(QueryStateFactory(['user'], { data: userToUse }));
+    if (userToUse !== null) {
+      const joanieUserProfileToUser = getJoanieUserProfileToUser(
+        userToUse,
+        params.joanieUserProfile,
+      );
+
+      queries.push(
+        QueryStateFactory(['user', 'profile', '{}'], {
+          data: joanieUserProfileToUser,
+        }),
+      );
+    }
   }
 
   params.queriesCallback?.(queries);

--- a/src/frontend/js/widgets/UserLogin/index.spec.tsx
+++ b/src/frontend/js/widgets/UserLogin/index.spec.tsx
@@ -97,17 +97,18 @@ describe('<UserLogin />', () => {
       dashboard_teacher: { label: 'Teacher dashboard', action: 'https://dashboard.teacher.url' },
     };
 
-    fetchMock.get(
-      'https://endpoint.test/api/v1.0/users/me/',
-      JoanieUserProfileFactory({
-        abilities: {
-          [JoanieUserApiAbilityActions.HAS_ORGANIZATION_ACCESS]: false,
-          [JoanieUserApiAbilityActions.HAS_COURSE_ACCESS]: false,
-        },
-      }).one(),
-    );
     render(<UserLogin context={context} profileUrls={profileUrls} />, {
-      queryOptions: { client: createTestQueryClient({ user }) },
+      queryOptions: {
+        client: createTestQueryClient({
+          user,
+          joanieUserProfile: JoanieUserProfileFactory({
+            abilities: {
+              [JoanieUserApiAbilityActions.HAS_ORGANIZATION_ACCESS]: false,
+              [JoanieUserApiAbilityActions.HAS_COURSE_ACCESS]: false,
+            },
+          }).one(),
+        }),
+      },
     });
 
     const button = await screen.findByLabelText(`Access to your profile settings`, {
@@ -132,16 +133,17 @@ describe('<UserLogin />', () => {
       dashboard_teacher: { label: 'Teacher dashboard', action: 'https://dashboard.teacher.url' },
     };
 
-    fetchMock.get(
-      'https://endpoint.test/api/v1.0/users/me/',
-      JoanieUserProfileFactory({
-        abilities: {
-          [JoanieUserApiAbilityActions.HAS_ORGANIZATION_ACCESS]: true,
-        },
-      }).one(),
-    );
     render(<UserLogin context={context} profileUrls={profileUrls} />, {
-      queryOptions: { client: createTestQueryClient({ user }) },
+      queryOptions: {
+        client: createTestQueryClient({
+          user,
+          joanieUserProfile: JoanieUserProfileFactory({
+            abilities: {
+              [JoanieUserApiAbilityActions.HAS_ORGANIZATION_ACCESS]: true,
+            },
+          }).one(),
+        }),
+      },
     });
 
     const button = await screen.findByLabelText(`Access to your profile settings`, {


### PR DESCRIPTION
Teacher dashboard route should redirect to learner dashbaord route when
the user isn't authorized.
