### PR TITLE
🚑(template) fix duplicated placeholder in course detail template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Duplicated `course_format` placeholder in `course_detail` template
+
 ## [2.25.0]
 
 ### Added

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -283,7 +283,6 @@
                             <section class="course-detail__row course-detail__format" property="about" typeof="Thing">
                                 <h2 class="course-detail__title" property="name">{% blocktrans context "course_detail__title" %}Format{% endblocktrans %}</h2>
                                 <div property="description">
-                                    {% placeholder "course_format" %}
                                     {% placeholder "course_format" or %}
                                     <p>{% trans 'How is the course structured?' %}</p>
                                     {% endplaceholder %}


### PR DESCRIPTION
## Purpose

During the last update of the course detail template a typo has been added and it causes to display twice a the `course_format` placeholder ...

## Proposal

- [x] Remove typo in course_detail template
