### PR TITLE
✨(frontend) refetch user profile after edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- User profile in the learner dashboard is now always synchronized with 
+  openEdx profile informations.
 - Add a tab in learner dashboard certificate page to render both order
   certificate and enrollment certificate lists.
 - Add Lyra payment interface

--- a/src/frontend/js/pages/DashboardAddressesManagement/DashboardCreateAddress.spec.tsx
+++ b/src/frontend/js/pages/DashboardAddressesManagement/DashboardCreateAddress.spec.tsx
@@ -128,6 +128,7 @@ describe('<DashboardCreateAddress/>', () => {
   });
 
   it('creates an address and redirect to preferences', async () => {
+    fetchMock.get('https://demo.endpoint/api/v1.0/user/me', richieUser);
     fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
     fetchMock.post('https://joanie.endpoint/api/v1.0/addresses/', []);
 

--- a/src/frontend/js/pages/DashboardAddressesManagement/DashboardEditAddress.spec.tsx
+++ b/src/frontend/js/pages/DashboardAddressesManagement/DashboardEditAddress.spec.tsx
@@ -10,6 +10,7 @@ import {
   within,
 } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
+import userEvent from '@testing-library/user-event';
 import {
   UserFactory,
   RichieContextFactory as mockRichieContextFactory,
@@ -54,6 +55,7 @@ describe('<DashboardEditAddress/>', () => {
     fetchMock.put(updateUrl, HttpStatusCode.OK);
 
     const richieUser = UserFactory().one();
+    fetchMock.get('https://demo.endpoint/api/v1.0/user/me', richieUser);
     fetchMock.get(`https://demo.endpoint/api/user/v1/accounts/${richieUser.username}`, {});
     fetchMock.get(`https://demo.endpoint/api/user/v1/preferences/${richieUser.username}`, {});
 
@@ -111,11 +113,10 @@ describe('<DashboardEditAddress/>', () => {
 
     // Submit of the form calls the API edit route.
     expect(fetchMock.called(updateUrl, { method: 'put' })).toBe(false);
-    await act(async () => {
-      // it is not necessary to update all fields as it is mocked above.
-      fireEvent.change($titleInput, { target: { value: addressUpdated.title } });
-      fireEvent.click($button);
-    });
+    const user = userEvent.setup();
+    await user.clear($titleInput);
+    await user.type($titleInput, addressUpdated.title);
+    await user.click($button);
     expect(fetchMock.called(updateUrl, { method: 'put' })).toBe(true);
 
     // The API is called with correct body.

--- a/src/frontend/js/pages/DashboardAddressesManagement/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardAddressesManagement/index.spec.tsx
@@ -52,6 +52,7 @@ describe('<DashAddressesManagement/>', () => {
     }).one();
     const { 'pref-lang': prefLang, ...openEdxAccount } = openEdxProfile;
 
+    fetchMock.get('https://endpoint.test/api/v1.0/user/me', richieUser);
     fetchMock.get(
       `https://endpoint.test/api/user/v1/accounts/${richieUser.username}`,
       openEdxAccount,

--- a/src/frontend/js/pages/DashboardCreditCardsManagement/DashboardEditCreditCard.spec.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/DashboardEditCreditCard.spec.tsx
@@ -97,6 +97,7 @@ describe('<DahsboardEditCreditCard/>', () => {
   });
 
   it('updates a credit card name', async () => {
+    fetchMock.get('https://endpoint.test/api/v1.0/user/me', richieUser);
     const creditCard = CreditCardFactory().one();
     const creditCards = [...CreditCardFactory().many(5), creditCard];
     const creditCardUpdated = CreditCardFactory().one();
@@ -195,6 +196,7 @@ describe('<DahsboardEditCreditCard/>', () => {
   });
 
   it('sets credit card as main', async () => {
+    fetchMock.get('https://endpoint.test/api/v1.0/user/me', richieUser);
     const creditCard = CreditCardFactory().one();
     const creditCards = [...CreditCardFactory().many(5), creditCard];
     const creditCardUpdated = { ...creditCard };
@@ -282,6 +284,7 @@ describe('<DahsboardEditCreditCard/>', () => {
   });
 
   it('deletes a credit card', async () => {
+    fetchMock.get('https://endpoint.test/api/v1.0/user/me', richieUser);
     const creditCard = CreditCardFactory().one();
     let creditCards = [...CreditCardFactory().many(5), creditCard];
 

--- a/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/index.spec.tsx
@@ -55,6 +55,7 @@ describe('<DashboardCreditCardsManagement/>', () => {
     }).one();
     const { 'pref-lang': prefLang, ...openEdxAccount } = openEdxProfile;
 
+    fetchMock.get('https://endpoint.test/api/v1.0/user/me', richieUser);
     fetchMock.get(
       `https://endpoint.test/api/user/v1/accounts/${richieUser.username}`,
       openEdxAccount,

--- a/src/frontend/js/pages/DashboardOpenEdxProfile/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardOpenEdxProfile/index.spec.tsx
@@ -12,6 +12,7 @@ import { OpenEdxApiProfileFactory } from 'utils/test/factories/openEdx';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { genderMessages, levelOfEducationMessages } from 'hooks/useOpenEdxProfile/utils';
 import { HttpStatusCode } from 'utils/errors/HttpError';
+import { User } from 'types/User';
 import DashboardOpenEdxProfile, { DEFAULT_DISPLAYED_FORM_VALUE } from '.';
 
 jest.mock('utils/errors/handle');
@@ -29,12 +30,17 @@ jest.mock('utils/context', () => ({
 }));
 
 describe('pages.DashboardOpenEdxProfile', () => {
+  let richieUser: User;
   setupJoanieSession();
+
+  beforeEach(() => {
+    richieUser = UserFactory().one();
+    fetchMock.get('https://endpoint.test/api/v1.0/user/me', richieUser);
+  });
 
   it('should render profile informations', async () => {
     const intl = createIntl({ locale: 'en' });
     const languageNames = new Intl.DisplayNames([intl.locale], { type: 'language' });
-    const richieUser = UserFactory().one();
     const openEdxProfile = OpenEdxApiProfileFactory({
       username: richieUser.username,
       email: richieUser.email,
@@ -82,7 +88,6 @@ describe('pages.DashboardOpenEdxProfile', () => {
   });
 
   it('should render empty profile informations', async () => {
-    const richieUser = UserFactory().one();
     const openEdxProfile = OpenEdxApiProfileFactory({
       name: '',
       country: null,
@@ -121,8 +126,6 @@ describe('pages.DashboardOpenEdxProfile', () => {
   });
 
   it('should display get error when account request fail', async () => {
-    const richieUser = UserFactory().one();
-
     fetchMock.get(
       `https://endpoint.test/api/user/v1/accounts/${richieUser.username}`,
       new Response('', { status: HttpStatusCode.NOT_FOUND }),
@@ -141,7 +144,6 @@ describe('pages.DashboardOpenEdxProfile', () => {
   });
 
   it('should display get error when preferences request fail', async () => {
-    const richieUser = UserFactory().one();
     const openEdxProfile = OpenEdxApiProfileFactory({
       username: richieUser.username,
       email: richieUser.email,

--- a/src/frontend/js/pages/DashboardOpenEdxProfile/index.tsx
+++ b/src/frontend/js/pages/DashboardOpenEdxProfile/index.tsx
@@ -1,13 +1,13 @@
-import { Input } from '@openfun/cunningham-react';
+import { Button, Input } from '@openfun/cunningham-react';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 import { useSession } from 'contexts/SessionContext';
 import useOpenEdxProfile from 'hooks/useOpenEdxProfile';
 import { DashboardBox } from 'widgets/Dashboard/components/DashboardBox';
 import { DashboardCard } from 'widgets/Dashboard/components/DashboardCard';
-import { RouterButton } from 'widgets/Dashboard/components/RouterButton';
 import Form from 'components/Form';
 import context from 'utils/context';
 import Banner, { BannerType } from 'components/Banner';
+import { REACT_QUERY_SETTINGS } from 'settings';
 
 const messages = defineMessages({
   // page elements
@@ -111,7 +111,12 @@ export const DEFAULT_DISPLAYED_FORM_VALUE = ' - ';
 const DashboardOpenEdxProfile = () => {
   const intl = useIntl();
   const { user } = useSession();
+
   const { data: openEdxProfileData, error } = useOpenEdxProfile({ username: user!.username });
+
+  const onClickModifyProfile = () => {
+    sessionStorage.removeItem(REACT_QUERY_SETTINGS.cacheStorage.key);
+  };
 
   if (error) {
     return (
@@ -225,13 +230,13 @@ const DashboardOpenEdxProfile = () => {
       </DashboardBox.List>
 
       <Form.Footer>
-        <RouterButton
+        <Button
           fullWidth
-          target="_blank"
+          onClick={onClickModifyProfile}
           href={`${context.authentication.endpoint}/account/settings`}
         >
           <FormattedMessage {...messages.editButtonLabel} />
-        </RouterButton>
+        </Button>
       </Form.Footer>
     </DashboardCard>
   );


### PR DESCRIPTION
On click on modify profile, we open a new window in OpenEdx profile page.
When modification are done, we would like to refresh informations display on this page.

This onWindowFocus event will be trigger the first time the user came back from OpenEdx profile page to refresh the informations. /!\ It's not perfect as it'll not work it he go and back from one tab to the other.
