### PR TITLE
✨(frontend) add page 404 not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Add 404 error page on the dashboard router.
 - Teacher dashboard route now redirect to learner dashboard route when
   the user isn't authorized.
 - Add two new sections in DjangoCMS courses: Accessibility and Required

--- a/src/frontend/js/pages/DashboardPageNotFound/index.tsx
+++ b/src/frontend/js/pages/DashboardPageNotFound/index.tsx
@@ -1,0 +1,45 @@
+import { FormattedMessage, defineMessages } from 'react-intl';
+import { DashboardLayout } from 'widgets/Dashboard/components/DashboardLayout';
+
+const messages = defineMessages({
+  pageNotFoundTitle: {
+    id: 'page.PageNotFound.pageNotFoundTitle',
+    description: 'Title of the page not found page',
+    defaultMessage: 'Page not found',
+  },
+  pageNotFoundSubTitle: {
+    id: 'page.PageNotFound.pageNotFoundSubTitle',
+    description: 'Subtitle of the page not found page',
+    defaultMessage: 'The requested content does not exist.',
+  },
+  pageNotFoundHomeLink: {
+    id: 'page.PageNotFound.pageNotFoundHomeLink',
+    description: 'Home link of the page not found page',
+    defaultMessage: 'Back to the home page',
+  },
+});
+
+const DashboardPageNotFound = () => {
+  return (
+    <DashboardLayout sidebar={null}>
+      <div className="error">
+        <svg className="error-icon">
+          <use href="#icon-search-fail" />
+        </svg>
+        <section>
+          <h2>
+            <FormattedMessage {...messages.pageNotFoundTitle} />
+          </h2>
+          <p>
+            <FormattedMessage {...messages.pageNotFoundSubTitle} />
+          </p>
+          <a href="/">
+            <FormattedMessage {...messages.pageNotFoundHomeLink} />
+          </a>
+        </section>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default DashboardPageNotFound;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardLayout/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardLayout/index.tsx
@@ -6,6 +6,7 @@ import { DashboardBreadcrumbs } from 'widgets/Dashboard/components/DashboardBrea
 
 interface DashboardLayoutProps extends PropsWithChildren<any> {
   sidebar?: ReactNode;
+  hideSidebar?: boolean;
   filters?: ReactNode;
   className?: string;
 }
@@ -15,11 +16,14 @@ export const DashboardLayout = ({
   sidebar,
   filters,
   className,
+  hideSidebar = false,
 }: DashboardLayoutProps) => {
   const location = useLocation();
   return (
     <div className={c('dashboard', className)}>
-      <div className="dashboard__sidebar">{sidebar || <LearnerDashboardSidebar />}</div>
+      <div className="dashboard__sidebar">
+        {!hideSidebar && (sidebar || <LearnerDashboardSidebar />)}
+      </div>
       <main className="dashboard__main">
         <header>
           <DashboardBreadcrumbs />

--- a/src/frontend/js/widgets/Dashboard/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/index.spec.tsx
@@ -196,4 +196,13 @@ describe('<Dashboard />', () => {
     const sidebar = screen.getByTestId('dashboard__sidebar');
     getByText(sidebar, user.full_name!, { exact: false });
   });
+
+  it("should redirect to 404 page when route doesn't exist", async () => {
+    render(<DashboardTest initialRoute="/dummy/route" />, {
+      wrapper: BaseJoanieAppWrapper,
+    });
+
+    expectUrlMatchLocationDisplayed('/dummy/route');
+    expect(screen.getByRole('heading', { name: /Page not found/ }));
+  });
 });

--- a/src/frontend/js/widgets/Dashboard/utils/dashboardRoutes.tsx
+++ b/src/frontend/js/widgets/Dashboard/utils/dashboardRoutes.tsx
@@ -5,6 +5,7 @@ import type {
   PrimitiveType,
 } from 'intl-messageformat';
 import { generatePath, Navigate, RouteObject } from 'react-router-dom';
+import DashboardPageNotFound from 'pages/DashboardPageNotFound';
 import { DashboardLayoutRoute } from 'widgets/Dashboard/components/DashboardLayoutRoute';
 import { getLearnerDashboardRoutes } from 'widgets/Dashboard/utils/learnerRoutes';
 import { getTeacherDashboardRoutes } from 'widgets/Dashboard/utils/teacherRoutes';
@@ -33,6 +34,13 @@ export function getDashboardRoutes() {
       path: '/',
       element: <DashboardLayoutRoute />,
       children: [
+        {
+          path: '*',
+          element: <DashboardPageNotFound />,
+          handle: {
+            renderLayout: true,
+          },
+        },
         {
           index: true,
           element: <Navigate to={generatePath(LearnerDashboardPaths.COURSES)} replace />,


### PR DESCRIPTION
We're currently using react router default 404 page. Let's design our own.

![image](https://github.com/openfun/richie/assets/139848/b8371522-0837-4012-9eaf-f92284de493f)
