### PR TITLE
⬆️(backend) upgrade to Django 4.x (4.0, 4.1, <5)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,7 +450,7 @@ jobs:
           DB_PASSWORD: pass
           DB_PORT: 5432
       # services
-      - image: cimg/postgres:9.6
+      - image: cimg/postgres:12.10
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -531,7 +531,7 @@ jobs:
           DB_PASSWORD: pass
           DB_PORT: 5432
       # services
-      - image: cimg/postgres:9.6
+      - image: cimg/postgres:12.10
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,99 +246,6 @@ jobs:
           name: upload files to crowdin
           command: crowdin upload sources -c crowdin/config.yml
 
-  test-back-mysql-5:
-    docker:
-      - image: cimg/python:3.10
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-        environment:
-          DJANGO_SETTINGS_MODULE: settings
-          DJANGO_CONFIGURATION: Test
-          DJANGO_SECRET_KEY: ThisIsAnExampleKeyForTestPurposeOnly
-          PYTHONPATH: /home/circleci/fun/sandbox
-          RICHIE_ES_HOST: localhost
-          DB_ENGINE: django.db.backends.mysql
-          # The DB_HOST should match the host name and cannot be set from here
-          # where it will be escaped. See the test command instead:
-          # DB_HOST=${HOSTNAME}
-          DB_HOST:
-          DB_NAME: richie
-          DB_USER: fun
-          DB_PASSWORD: pass
-          DB_PORT: 3306
-      # services
-      - image: cimg/mysql:5.7
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-        environment:
-          MYSQL_ROOT_PASSWORD:
-          MYSQL_DATABASE: test_richie
-          MYSQL_USER: fun
-          MYSQL_PASSWORD: pass
-        command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci
-      - image: elasticsearch:7.14.0
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-        environment:
-          discovery.type: single-node
-      - image: docker.io/bitnami/redis:6.0-debian-10
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-        name: redis-primary
-        environment:
-          ALLOW_EMPTY_PASSWORD: yes
-          REDIS_REPLICATION_MODE: master
-      - image: docker.io/bitnami/redis-sentinel:6.0-debian-10
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-        name: redis-sentinel
-        environment:
-          REDIS_MASTER_HOST: redis-primary
-    working_directory: ~/fun
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v2-back-dependencies-{{ .Revision }}
-      # Attach the frontend production build
-      - attach_workspace:
-          at: ~/fun
-      - *install-libcairo2-dev
-      # While running tests, we need to make the /data directory writable for
-      # the circleci user
-      - run:
-          name: Create writable /data
-          command: |
-            sudo mkdir /data && \
-            sudo chown circleci:circleci /data
-      # Run back-end (Django) test suite
-      #
-      # Nota bene:
-      #
-      # 1. to run the django test suite, we need to ensure that both MySQL and
-      #    ElasticSearch services are up and ready. To achieve this, we wrap the
-      #    pytest command execution with dockerize, a tiny tool installed in the
-      #    CircleCI image. In our case, dockerize will wait up to one minute
-      #    that both the database and elastisearch containers opened their
-      #    expected tcp port (3306 and 9200 resp.).
-      # 2. We should avoid using localhost for the DB_HOST with MySQL as the
-      #    client will try to use a local socket (_e.g._
-      #    `/var/run/mysqld/mysqld.sock`) instead of the database host and port
-      #    ¯\_(ツ)_/¯.
-      - run:
-          name: Run tests
-          command: |
-            DB_HOST=${HOSTNAME} dockerize \
-              -wait tcp://${HOSTNAME}:3306 \
-              -wait tcp://${HOSTNAME}:9200 \
-              -timeout 60s \
-                ~/.local/bin/pytest
-
   test-back-mysql-8:
     docker:
       - image: cimg/python:3.10
@@ -1082,13 +989,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-back-mysql-5:
-          requires:
-            - build-back
-            - build-front-production
-          filters:
-            tags:
-              only: /.*/
       - test-back-mysql-8:
           requires:
             - build-back
@@ -1139,7 +1039,6 @@ workflows:
       - package-back:
           requires:
             - test-front
-            - test-back-mysql-5
             - test-back-mysql-8
             - test-back-postgresql
             - test-back-postgresql-es6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
+- Upgrade to Django version 4.2 (pin version < 5)
 - Migrate to Sentry SDK 2.0
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   the user isn't authorized.
 - Add two new sections in DjangoCMS courses: Accessibility and Required
   Equipment.
-- Ongoing product displayed on the syllabus without active enrollment 
+- Ongoing product displayed on the syllabus without active enrollment
   now link to the order details page in the learner dashboard.
 
 ## Changed
@@ -24,11 +24,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixed
 
-- Ongoing product displayed on the syllabus with an active enrollment 
-  now link to the order details page in the learner dashboard instead of 
+- Ongoing product displayed on the syllabus with an active enrollment
+  now link to the order details page in the learner dashboard instead of
   OpenEdx course.
 - Downloaded contract archive on product page was broken, it now works
-  properly by sending the course_product_relation_id in the archive 
+  properly by sending the course_product_relation_id in the archive
   creation request.
 - Fix a bug in the learner dashboard contract page where an alert
   message was displayed on successful download.
@@ -46,7 +46,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Add a form to edit user fullname in the payment step of the sale 
+- Add a form to edit user fullname in the payment step of the sale
   tunnel.
 - Add ready-only user profile in the learner dashboard preferences page.
   This profile display data from LMS profile.
@@ -54,15 +54,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add search bar on learner dashboard courses pages.
 - Add a `CertificateHelper` implementing a `getCourse` method
 - Add search bar on teacher dashboard courses pages.
-- Add background colors to default user's avatar when they're used 
-  in a list. Theses colors are generated from user's fullname and 
+- Add background colors to default user's avatar when they're used
+  in a list. Theses colors are generated from user's fullname and
   configurable with cunningham tokens.
 - Add dedicated messages for order's status when they're visualized on
   the teacher dashbaord.
 - Add Organization block to order details.
-- Add teacher dashboard page to list training's learners. This listing 
+- Add teacher dashboard page to list training's learners. This listing
   can be accessed under a training or an organization's training.
-- Add a "more" button to DashboardItem and Orders containing a link to 
+- Add a "more" button to DashboardItem and Orders containing a link to
   go to syllabus
 - `related_organizations` placeholder on organization detail page
 
@@ -76,18 +76,18 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Require to accept terms when purchasing product of any kind
 - Rename trainings root menu entry label
 - Upgrade to node 20
-- Contract list in the teacher dashbaord are now filtered by 
+- Contract list in the teacher dashbaord are now filtered by
   courseProductRelationId instead of courseId and productId.
-- Switch from setup.cfg to pyproject.toml 
+- Switch from setup.cfg to pyproject.toml
 
 ### Fixed
 
-- No results message is no longer displayed on initial loading in 
+- No results message is no longer displayed on initial loading in
   learner and teacher courses list pages.
 - Manage certificate linked to an enrollment
 - Certificate products are not listed anymore in teacher dashboard
 - Fix several SaleTunnel cache issues
-- Fix course access link in learner dashboard. This link must not be 
+- Fix course access link in learner dashboard. This link must not be
   display when the course isn't open.
 - Fix CreditCardHelper
 - Remove enrollment start on some course run
@@ -106,9 +106,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Fix on teacher dashboard courses list. During infinit scroll loading the 
+- Fix on teacher dashboard courses list. During infinit scroll loading the
   window scroll was reset at the top of the page.
-- Fix impossible logout issue 
+- Fix impossible logout issue
 - Add signature polling description
 - Fix malformed CourseProductItem Order dashboard links
 - Await logout authentication request logout trigger
@@ -126,7 +126,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add a footer on enrollment's item in the learner dashboard. It give the
   possibility to purchase linked product or download linked certificate.
 - Add download contracts pages on the teacher dashboard.
-- Add a contract information and actions in learner dashboard order's 
+- Add a contract information and actions in learner dashboard order's
   listing and details.
 - In the learner dashboard, enroll actions are disabled when an unsigned
   contract is linked to the order.
@@ -137,14 +137,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Teacher dashboard access is restricted to user which has access to a course 
+- Teacher dashboard access is restricted to user which has access to a course
   or an organization.
-- Frontend Order type have been split into two: CredentialOrder and 
+- Frontend Order type have been split into two: CredentialOrder and
   CertificateOrder.
 - Update PurchaseButton messages to aid with translation.
 - Update courses and organizations default permissions
 - Update cunningham to 2.0.0
-- Update frontend components OrderStateMessage with new computed state 
+- Update frontend components OrderStateMessage with new computed state
   'waiting signature'
 - Update SaleTunnel to add certificate product course run information.
 - Update SaleTunnel to display product instructions.
@@ -161,7 +161,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix typo on the DashboardOrderLoader component.
 - Prevent LTIConsumer component to rerender on user session update
-- Fix Order interface against changed field 'target_enrollments' and 
+- Fix Order interface against changed field 'target_enrollments' and
   'enrollment'
 - Fix dashboard mobile layout.
 - Course details characteristics overflow issue
@@ -203,7 +203,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add cunningham and design system.
 - Specific sidebar for order related routes
 - List teacher's course's course runs in the teacher course dashboard page.
-- Teacher dashboard course list now includes courses and courses product 
+- Teacher dashboard course list now includes courses and courses product
 relations.
 - Add a page for training details (courseProductRelation) in the teacher
 dashboard.
@@ -211,9 +211,9 @@ dashboard.
 - Finalize the design of teacher dashboard organization sidebar.
 - Use union of organization courses and course product relations on organization
 course's listing page.
-- The product purchase button is now disabled and display a contextual 
+- The product purchase button is now disabled and display a contextual
 information message when the product have no remaining order.
-- Add all available languages for the course in the characteristics section 
+- Add all available languages for the course in the characteristics section
 on the course details page.
 - Change footer text and remove datime on glimpse course according state.
 
@@ -264,7 +264,7 @@ through `context_processor`
 - Add CourseAddToWishlist button to add/remove a course from users wishlist
 - Added Enrollment's pagination in the dashboard
 - Allow multiple web analytics providers at the same time.
-- Display `localizedMessage` on Course Enrollment when backend has 
+- Display `localizedMessage` on Course Enrollment when backend has
   `localizedMessage` on the 400 error payload
 - Navigation skeleton of the teacher dashboard
 
@@ -347,7 +347,7 @@ through `context_processor`
 - Prevent product course run enrollment when user owns the product
   through an invalid order
 - Display a message in the sales tunnel when at least one course has no course
-  runs, to say that this product is not currently available for sale. 
+  runs, to say that this product is not currently available for sale.
 - Show error message when user tries to enroll or unroll to a
   course run and the requests fails
 - Fix courses badges css.
@@ -437,7 +437,7 @@ through `context_processor`
 ### Changed
 
 - Migrate code and type to comply with the new Joanie API
-- On blogpost detail view, move categories list on the right side 
+- On blogpost detail view, move categories list on the right side
 - Fake authentication interface when using the `base` api interface
 - Avoid lag experienced by user on logout by not waiting for the logout request
   to succeed
@@ -482,7 +482,7 @@ through `context_processor`
 - Add a `CourseProductList` Component
 - Add a `SaleTunnel` component
 - Add an `AddressesManagement` component
-- Add a `PaymentButton` component 
+- Add a `PaymentButton` component
 - Add a `PaymentInterface` component to lazy load the right payment component
   according to the provider used
 - Create a `StepBreadcrumb` component to display progress within a step process

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ i18n-generate-front: build-ts
 
 # -- Database
 
-dbshell: ## connect to database shell 
+dbshell: ## connect to database shell
 	docker compose exec app python sandbox/manage.py dbshell
 .PHONY: dbshell
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,8 @@ $ make migrate
 
 ## Unreleased
 
+- Dropped support for postgres version < 12
+- Dropped support for MySQL version < 8
 - Add new `dashboard-splitted-card` theme scheme
 ```
   dashboard-splitted-card: (
@@ -45,7 +47,7 @@ $ make migrate
   `scss/trumps/_bootstrap.scss` file. You have to import it in your `_main.scss` file.
   ```scss
   // ...
-  
+
   // Import bootstrap reset
   @import 'richie-education/scss/trumps/bootstrap';
   ```
@@ -67,7 +69,7 @@ $ make migrate
   the urls module of your app.
   ```python
   from richie.apps.courses.urls import redirects_urlpatterns as courses_redirects_urlpatterns
-  
+
   urlpatterns += [
     re_path(r"^redirects/", include([*courses_redirects_urlpatterns])),
   ]
@@ -81,7 +83,7 @@ $ make migrate
   @import '@openfun/cunningham-react/dist/style';
   @import 'richie-education/scss/vendors/cunningham-tokens';
   @import 'richie-education/scss/vendors/css/cunningham-tokens';
-  
+
   // Override default Richie settings variables
   @import 'richie-education/scss/colors/palette';
   // ...
@@ -89,12 +91,12 @@ $ make migrate
   `yarn build-theme` command generates tokens files `scss/vendors/cunningham-tokens.scss` and
   `scss/vendors/css/cunningham-tokens.css`. `$palette` variable is now deprecated and will be
   removed in the next major release. Currently this is only an alias to the
-  `map.get($theme, colors)` ($theme is a sass variable exported by `cunninghtam-tokens.scss`). 
-- Components `CourseGlimpse` and `CourseGlimpseList` has been moved from `js/widgets/Search` folder to 
+  `map.get($theme, colors)` ($theme is a sass variable exported by `cunninghtam-tokens.scss`).
+- Components `CourseGlimpse` and `CourseGlimpseList` has been moved from `js/widgets/Search` folder to
   `js/components` folder. Update your overrides.json and path in your custom scss files accordingly.
-- `js/utils/test/factories.ts` have been split into multiple files: joanie.ts, richie.ts and 
+- `js/utils/test/factories.ts` have been split into multiple files: joanie.ts, richie.ts and
   reactQuery.ts. Update your import accordingly.
- 
+
 ## 2.20.1 to 2.21.0
 
 - Frontend folder architecture has been totally reworked. If you have overridden
@@ -141,7 +143,7 @@ $ make migrate
 
 ## 2.18.x to 2.19.x
 
-- In `_theme.scss`, `course-detail` scheme now accepts two new optional properties to style 
+- In `_theme.scss`, `course-detail` scheme now accepts two new optional properties to style
   the course run CTA and feedback color in the course detail subheader:
   - `subheader-run-cta`
   - `subheader-run-feedback-color`
@@ -179,7 +181,7 @@ $ make migrate
     "JS_COURSE_REGEX": r"^.*/api/v1.0/(course-runs|products)/([^/]*)/?$",
     # A list of course run properties to not update
     "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
-    # The synchronization mode ("manual", "sync_to_public" or "sync_to_draft") 
+    # The synchronization mode ("manual", "sync_to_public" or "sync_to_draft")
     "DEFAULT_COURSE_RUN_SYNC_MODE": "sync_to_public",
   }
   ```
@@ -224,7 +226,7 @@ $ make migrate
   - `_main.scss`
   ```diff
   +   @import 'richie-education/scss/tools/utils';
-  
+
   +   @import 'richie-education/js/components/AddressesManagement/styles';
   +   @import 'richie-education/js/components/CourseProductCertificateItem/styles';
   +   @import 'richie-education/js/components/CourseProductCourseRuns/styles';
@@ -239,7 +241,7 @@ $ make migrate
   ...
   +   @import 'richie-education/scss/components/templates/richie/multiple-columns';
   ```
-  
+
   - Only if you have overridden `_palette.scss`:
   ```diff
   $palette = {
@@ -335,7 +337,7 @@ $ make migrate
 
 ## 2.11.x to 2.12.x
 
-- If you overrode `course-detail` theme within `theme.scss`, you have to add these four 
+- If you overrode `course-detail` theme within `theme.scss`, you have to add these four
   new properties
   ```scss
   view-more-runs-color: r-color('firebrick6'),
@@ -348,8 +350,8 @@ $ make migrate
 
 - If you overrode `richie/base.html`, the `branding_footer` template block has been renamed to
   `body_footer_brand` and the link was integrated in the block so it can be customized.
-- The file `_colors.scss` has been divided into `_palette.scss` for the palette, 
-  `_gradients.scss`, `_schemes.scss`  and `_theme.scss`. Those files are now located in a 
+- The file `_colors.scss` has been divided into `_palette.scss` for the palette,
+  `_gradients.scss`, `_schemes.scss`  and `_theme.scss`. Those files are now located in a
   dedicated folder `colors`.
 
 ## 2.9.x to 2.10.x

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@backend.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@backend.yml
@@ -73,7 +73,7 @@ test-back:
         DB_USER: richie_user
         DB_PASSWORD: pass
         DB_PORT: 5432
-    - image: cimg/postgres:9.6
+    - image: cimg/postgres:12.10
       environment:
         POSTGRES_DB: richie
         POSTGRES_USER: richie_user

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:9.6
+    image: postgres:12
     environment:
       - POSTGRES_DB=richie_${RICHIE_SITE:?}
     env_file:

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
@@ -328,7 +328,6 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # Internationalization
     TIME_ZONE = "Europe/Paris"
     USE_I18N = True
-    USE_L10N = True
     USE_TZ = True
     LOCALE_PATHS = [os.path.join(BASE_DIR, "locale")]
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
@@ -196,7 +196,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # For static files, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
-    STATICFILES_STORAGE = values.Value("base.storage.CDNManifestStaticFilesStorage")
+    STORAGES = {
+        "staticfiles": {
+            "BACKEND": values.Value("base.storage.CDNManifestStaticFilesStorage")
+        }
+    }
 
     AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
 
@@ -719,7 +723,11 @@ class Development(Base):
 class Test(Base):
     """Test environment settings"""
 
-    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+    STORAGES = {
+        "staticfile": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+        }
+    }
 
 
 class ContinuousIntegration(Test):
@@ -746,7 +754,7 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    DEFAULT_FILE_STORAGE = "base.storage.MediaStorage"
+    STORAGES = {"default": {"BACKEND": "base.storage.MediaStorage"}}
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgresql:
-    image: postgres:9.6
+    image: postgres:12
     ports:
       - "5472:5432"
     env_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "arrow",
-    "Django==4.0",
+    "Django==4.1",
     "djangocms-file",
     "djangocms-googlemap",
     "djangocms-link",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "arrow",
-    "Django==4.1",
+    "Django<5",
     "djangocms-file",
     "djangocms-googlemap",
     "djangocms-link",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,16 @@ keywords = ["Django", "Django-CMS", "Open edX"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
-    "Framework :: Django :: 2.2",
+    "Framework :: Django :: 4",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7"
+    "Programming Language :: Python :: 3.10"
 ]
 dependencies = [
     "arrow",
-    "Django<4",
+    "Django==4.0",
     "djangocms-file",
     "djangocms-googlemap",
     "djangocms-link",

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -713,9 +713,11 @@ class Production(Base):
     # For static files in production, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
-    STATICFILES_STORAGE = (
-        "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
-    )
+    STORAGES = {
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+        }
+    }
 
     # For more details about CMS_CACHE_DURATION, see :
     # http://docs.django-cms.org/en/latest/reference/configuration.html#cms-cache-durations

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -358,7 +358,6 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # Internationalization
     TIME_ZONE = "Europe/Paris"
     USE_I18N = True
-    USE_L10N = True
     USE_TZ = True
 
     # Templates

--- a/src/richie/apps/core/templates/richie/pagination_inner.html
+++ b/src/richie/apps/core/templates/richie/pagination_inner.html
@@ -7,7 +7,7 @@ because wrapper tags are missing. See richie/pagination.html
 <ul class="pagination__list">
     {% for page in pages %}
       {% if page %}
-        {% ifequal page page_obj.number %}
+        {% if page == page_obj.number %}
           <li class="pagination__item pagination__item--current">
             <span class="pagination__page-number">
               <span class="offscreen">
@@ -45,7 +45,7 @@ because wrapper tags are missing. See richie/pagination.html
               </a>
             </li>
           {% endif %}
-        {% endifequal %}
+        {% endif %}
       {% else %}
         <li class="pagination__item pagination__item--placeholder">...</li>
       {% endif %}

--- a/src/richie/apps/courses/factories.py
+++ b/src/richie/apps/courses/factories.py
@@ -4,14 +4,13 @@ Courses factories
 
 import random
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.conf import settings
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 from django.utils.translation import gettext_lazy as _
 
 import factory
-import pytz
 from cms.api import add_plugin
 
 from richie.plugins.nesteditem.defaults import ACCORDION
@@ -462,13 +461,13 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         of course be forced if we want something else), then the other significant dates
         for the course run are chosen randomly in periods that make sense with this start date.
         """
-        now = timezone.now()
+        now = django_timezone.now()
         period = timedelta(days=200)
         return datetime.utcfromtimestamp(
             random.randrange(  # nosec
                 int((now - period).timestamp()), int((now + period).timestamp())
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
     @factory.lazy_attribute
     def end(self):
@@ -482,7 +481,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
             random.randrange(  # nosec
                 int(self.start.timestamp()), int((self.start + period).timestamp())
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
     @factory.lazy_attribute
     def enrollment_start(self):
@@ -496,7 +495,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
             random.randrange(  # nosec
                 int((self.start - period).timestamp()), int(self.start.timestamp())
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
     @factory.lazy_attribute
     def enrollment_end(self):
@@ -521,7 +520,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
             random.randrange(  # nosec
                 int(enrollment_start.timestamp()), int(max_enrollment_end.timestamp())
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
     @factory.lazy_attribute
     def enrollment_count(self):

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -4,18 +4,17 @@ Declare and configure the models for the courses application
 
 # pylint: disable=too-many-lines
 from collections.abc import Mapping
-from datetime import MAXYEAR, datetime
+from datetime import MAXYEAR, datetime, timezone
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 from django.db.models import Q, Sum
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 from django.utils.functional import cached_property, lazy
 from django.utils.translation import gettext_lazy as _
 
-import pytz
 from cms.constants import PUBLISHER_STATE_DIRTY
 from cms.extensions.extension_pool import extension_pool
 from cms.models import Page, PagePermission
@@ -35,7 +34,7 @@ from .organization import Organization, OrganizationPluginModel
 from .person import Person, PersonPluginModel
 from .role import PageRole
 
-MAX_DATE = datetime(MAXYEAR, 12, 31, tzinfo=pytz.utc)
+MAX_DATE = datetime(MAXYEAR, 12, 31, tzinfo=timezone.utc)
 
 
 class CourseState(Mapping):
@@ -894,7 +893,7 @@ class CourseRun(TranslatableModel):
         end = end or MAX_DATE
         enrollment_end = enrollment_end or MAX_DATE
 
-        now = timezone.now()
+        now = django_timezone.now()
         if start < now:
             if end > now:
                 if enrollment_end > now:

--- a/tests/apps/courses/test_admin_course_run.py
+++ b/tests/apps/courses/test_admin_course_run.py
@@ -3,13 +3,12 @@ Test suite defining the admin pages for the CourseRun model
 """
 
 import random
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django.test.utils import override_settings
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
-import pytz
 from cms.models import GlobalPagePermission, PagePermission
 from cms.test_utils.testcases import CMSTestCase
 
@@ -350,7 +349,7 @@ class CourseRunAdminTestCase(CMSTestCase):
             "sync_mode": "manual",
             "display_mode": "detailed",
         }
-        with timezone.override(pytz.utc):
+        with django_timezone.override(timezone.utc):
             response = self.client.post(url, data, follow=True)
         self.assertEqual(response.status_code, status_code)
 
@@ -454,7 +453,7 @@ class CourseRunAdminTestCase(CMSTestCase):
             "sync_mode": "manual",
             "display_mode": "detailed",
         }
-        with timezone.override(pytz.utc):
+        with django_timezone.override(timezone.utc):
             response = self.client.post(url, data, follow=True)
         self.assertEqual(response.status_code, status_code)
 
@@ -464,14 +463,19 @@ class CourseRunAdminTestCase(CMSTestCase):
         check_method(course_run.title, "My title")
         check_method(course_run.languages, ["fr", "en"])
         check_method(course_run.resource_link, "https://example.com/my-resource-link")
-        check_method(course_run.start, datetime(2015, 1, 15, 7, 6, 15, tzinfo=pytz.utc))
-        check_method(course_run.end, datetime(2015, 1, 30, 23, 52, 34, tzinfo=pytz.utc))
         check_method(
-            course_run.enrollment_start,
-            datetime(2015, 1, 2, 13, 13, 7, tzinfo=pytz.utc),
+            course_run.start, datetime(2015, 1, 15, 7, 6, 15, tzinfo=timezone.utc)
         )
         check_method(
-            course_run.enrollment_end, datetime(2015, 1, 23, 9, 7, 11, tzinfo=pytz.utc)
+            course_run.end, datetime(2015, 1, 30, 23, 52, 34, tzinfo=timezone.utc)
+        )
+        check_method(
+            course_run.enrollment_start,
+            datetime(2015, 1, 2, 13, 13, 7, tzinfo=timezone.utc),
+        )
+        check_method(
+            course_run.enrollment_end,
+            datetime(2015, 1, 23, 9, 7, 11, tzinfo=timezone.utc),
         )
         check_method(course_run.enrollment_count, 5)
         check_method(course_run.sync_mode, "manual")

--- a/tests/apps/courses/test_admin_course_run.py
+++ b/tests/apps/courses/test_admin_course_run.py
@@ -52,15 +52,15 @@ class CourseRunAdminTestCase(CMSTestCase):
         response = self.client.get(url, follow=True)
 
         # Check that the page includes all our fields
-        self.assertContains(response, "id_title")
-        self.assertContains(response, "id_resource_link")
-        self.assertContains(response, "id_start_", count=3)
-        self.assertContains(response, "id_end_", count=3)
-        self.assertContains(response, "id_enrollment_start_", count=3)
-        self.assertContains(response, "id_enrollment_end_", count=3)
-        self.assertContains(response, "id_languages")
-        self.assertContains(response, "id_enrollment_count")
-        self.assertContains(response, "id_sync_mode")
+        self.assertContains(response, "id_title", count=2)
+        self.assertContains(response, "id_resource_link", count=2)
+        self.assertContains(response, "id_start_", count=2)
+        self.assertContains(response, "id_end_", count=2)
+        self.assertContains(response, "id_enrollment_start_", count=2)
+        self.assertContains(response, "id_enrollment_end_", count=2)
+        self.assertContains(response, "id_languages", count=3)
+        self.assertContains(response, "id_enrollment_count", count=3)
+        self.assertContains(response, "id_sync_mode", count=2)
 
     # List
 
@@ -208,12 +208,12 @@ class CourseRunAdminTestCase(CMSTestCase):
         # Check that the page includes all our fields
         self.assertContains(response, "id_title", count=2)
         self.assertContains(response, "id_resource_link", count=2)
-        self.assertContains(response, "id_start_", count=3)
-        self.assertContains(response, "id_end_", count=3)
-        self.assertContains(response, "id_enrollment_start_", count=3)
-        self.assertContains(response, "id_enrollment_end_", count=3)
-        self.assertContains(response, "id_languages", count=2)
-        self.assertContains(response, "id_enrollment_count", count=2)
+        self.assertContains(response, "id_start_", count=2)
+        self.assertContains(response, "id_end_", count=2)
+        self.assertContains(response, "id_enrollment_start_", count=2)
+        self.assertContains(response, "id_enrollment_end_", count=2)
+        self.assertContains(response, "id_languages", count=3)
+        self.assertContains(response, "id_enrollment_count", count=3)
         self.assertContains(response, "id_sync_mode", count=2)
 
     def test_admin_course_run_change_view_get_superuser_public(self):
@@ -319,12 +319,12 @@ class CourseRunAdminTestCase(CMSTestCase):
         # Check that the page includes all our fields
         self.assertContains(response, "id_title", count=2)
         self.assertContains(response, "id_resource_link", count=2)
-        self.assertContains(response, "id_start_", count=3)
-        self.assertContains(response, "id_end_", count=3)
-        self.assertContains(response, "id_enrollment_start_", count=3)
-        self.assertContains(response, "id_enrollment_end_", count=3)
-        self.assertContains(response, "id_languages", count=2)
-        self.assertContains(response, "id_enrollment_count", count=2)
+        self.assertContains(response, "id_start_", count=2)
+        self.assertContains(response, "id_end_", count=2)
+        self.assertContains(response, "id_enrollment_start_", count=2)
+        self.assertContains(response, "id_enrollment_end_", count=2)
+        self.assertContains(response, "id_languages", count=3)
+        self.assertContains(response, "id_enrollment_count", count=3)
         self.assertContains(response, "id_sync_mode", count=2)
 
     # Add

--- a/tests/apps/courses/test_admin_form_course_run.py
+++ b/tests/apps/courses/test_admin_form_course_run.py
@@ -255,7 +255,7 @@ class CourseRunAdminTestCase(CMSTestCase):
         CourseRunAdminForm.request = request
 
         form = CourseRunAdminForm()
-        self.assertEqual(form.fields["languages"].choices[32][1], "German")
+        self.assertEqual(form.fields["languages"].choices[33][1], "German")
 
         with translation.override("fr"):
             form = CourseRunAdminForm()

--- a/tests/apps/courses/test_api_course_run_sync.py
+++ b/tests/apps/courses/test_api_course_run_sync.py
@@ -179,7 +179,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         self.assertFalse(mock_signal.called)
 
     @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="UTC"
     )
     def test_api_course_run_sync_create_sync_to_public_draft_course(self, mock_signal):
         """
@@ -235,7 +235,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         self.assertFalse(mock_signal.called)
 
     @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="UTC"
     )
     def test_api_course_run_sync_create_sync_to_public_published_course(
         self, mock_signal
@@ -294,7 +294,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         )
 
     @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_draft", TIME_ZONE="utc"
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_draft", TIME_ZONE="UTC"
     )
     def test_api_course_run_sync_create_sync_to_draft(self, mock_signal):
         """
@@ -343,7 +343,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
+    @override_settings(TIME_ZONE="UTC")
     def test_api_course_run_sync_create_partial_required(self, mock_signal):
         """
         If the submitted data is not related to an existing course run and some required fields
@@ -378,7 +378,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
+    @override_settings(TIME_ZONE="UTC")
     def test_api_course_run_sync_create_partial_not_required(self, mock_signal):
         """
         If the submitted data is not related to an existing course run and some optional fields
@@ -536,7 +536,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
+    @override_settings(TIME_ZONE="UTC")
     def test_api_course_run_sync_existing_published_sync_to_public(self, mock_signal):
         """
         If a course run exists in "sync_to_public" mode (draft and public versions),
@@ -598,7 +598,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             sender=Page, instance=course.extended_object, language=None
         )
 
-    @override_settings(TIME_ZONE="utc")
+    @override_settings(TIME_ZONE="UTC")
     def test_api_course_run_sync_existing_draft_sync_to_public(self, mock_signal):
         """
         If a course run exists in "sync_to_public" mode (only draft version), and the course
@@ -653,7 +653,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
+    @override_settings(TIME_ZONE="UTC")
     def test_api_course_run_sync_existing_draft_with_public_course_sync_to_public(
         self, mock_signal
     ):
@@ -716,7 +716,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
             sender=Page, instance=course.extended_object, language=None
         )
 
-    @override_settings(TIME_ZONE="utc")
+    @override_settings(TIME_ZONE="UTC")
     def test_api_course_run_sync_existing_published_sync_to_draft(self, mock_signal):
         """
         If a course run exists in "sync_to_draft" mode (draft and public versions),
@@ -778,7 +778,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
+    @override_settings(TIME_ZONE="UTC")
     def test_api_course_run_sync_existing_draft_sync_to_draft(self, mock_signal):
         """
         If a course run exists in "sync_to_draft" mode (only draft version),
@@ -832,7 +832,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         )
         self.assertFalse(mock_signal.called)
 
-    @override_settings(TIME_ZONE="utc")
+    @override_settings(TIME_ZONE="UTC")
     def test_api_course_run_sync_existing_partial(self, mock_signal):
         """
         If a course run exists, it can be partially updated and the other fields should not
@@ -883,7 +883,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         self.assertFalse(mock_signal.called)
 
     @override_settings(
-        TIME_ZONE="utc",
+        TIME_ZONE="UTC",
         RICHIE_LMS_BACKENDS=[
             {
                 "BASE_URL": "http://localhost:8073",
@@ -957,7 +957,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         self.assertFalse(mock_signal.called)
 
     @override_settings(
-        TIME_ZONE="utc",
+        TIME_ZONE="UTC",
         RICHIE_LMS_BACKENDS=[
             {
                 "BASE_URL": "http://localhost:8073",
@@ -1014,7 +1014,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
     # Bulk
 
     @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="UTC"
     )
     def test_api_course_run_sync_create_bulk_success(self, mock_signal):
         """
@@ -1089,7 +1089,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         self.assertEqual(public_serializer.data, data)
 
     @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="UTC"
     )
     def test_api_course_run_sync_create_bulk_missing_resource_link(self, _mock_signal):
         """
@@ -1134,7 +1134,7 @@ class SyncCourseRunApiTestCase(CMSTestCase):
         self.assertFalse(CourseRun.objects.exists())
 
     @override_settings(
-        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="utc"
+        RICHIE_DEFAULT_COURSE_RUN_SYNC_MODE="sync_to_public", TIME_ZONE="UTC"
     )
     def test_api_course_run_sync_create_bulk_errors(self, mock_signal):
         """

--- a/tests/apps/courses/test_api_course_run_sync_edx.py
+++ b/tests/apps/courses/test_api_course_run_sync_edx.py
@@ -20,7 +20,7 @@ from richie.apps.courses.models import CourseRun, CourseRunCatalogVisibility
 @mock.patch.object(post_publish, "send", wraps=post_publish.send)
 @override_settings(RICHIE_COURSE_RUN_SYNC_SECRETS=["shared secret"])
 @override_settings(
-    TIME_ZONE="utc",
+    TIME_ZONE="UTC",
     RICHIE_LMS_BACKENDS=[
         {
             "BASE_URL": "http://localhost:8073",

--- a/tests/apps/courses/test_api_course_run_sync_joanie.py
+++ b/tests/apps/courses/test_api_course_run_sync_joanie.py
@@ -20,7 +20,7 @@ from richie.apps.courses.models import CourseRun
 @mock.patch.object(post_publish, "send", wraps=post_publish.send)
 @override_settings(RICHIE_COURSE_RUN_SYNC_SECRETS=["shared secret"])
 @override_settings(
-    TIME_ZONE="utc",
+    TIME_ZONE="UTC",
     RICHIE_LMS_BACKENDS=[
         {
             "BASE_URL": "http://localhost:8071",

--- a/tests/apps/courses/test_models_course_run.py
+++ b/tests/apps/courses/test_models_course_run.py
@@ -3,15 +3,15 @@ Unit tests for the Course model
 """
 
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.utils import timezone, translation
+from django.utils import timezone as django_timezone
+from django.utils import translation
 
-import pytz
 from cms.constants import PUBLISHER_STATE_DEFAULT, PUBLISHER_STATE_DIRTY
 from parler.utils.context import switch_language
 
@@ -30,7 +30,7 @@ class CourseRunModelsTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.now = timezone.now()
+        self.now = django_timezone.now()
 
     def test_models_course_run_get_course_direct_child_with_parent(self):
         """
@@ -142,9 +142,9 @@ class CourseRunModelsTestCase(TestCase):
                 int(course_run.enrollment_start.timestamp()) + 1,
                 int(course_run.enrollment_end.timestamp()) - 1,
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
-        with mock.patch.object(timezone, "now", return_value=now):
+        with mock.patch.object(django_timezone, "now", return_value=now):
             state = course_run.state
 
         self.assertIn(dict(state)["priority"], [0, 1])
@@ -155,9 +155,9 @@ class CourseRunModelsTestCase(TestCase):
                 int(course_run.enrollment_end.timestamp()),
                 int(datetime(9999, 12, 31).timestamp()),
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
-        with mock.patch.object(timezone, "now", return_value=now):
+        with mock.patch.object(django_timezone, "now", return_value=now):
             state = course_run.state
 
         self.assertEqual(
@@ -182,9 +182,9 @@ class CourseRunModelsTestCase(TestCase):
                 int(course_run.enrollment_start.timestamp()) + 1,
                 int(course_run.start.timestamp()) - 1,
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
-        with mock.patch.object(timezone, "now", return_value=now):
+        with mock.patch.object(django_timezone, "now", return_value=now):
             state = course_run.state
 
         self.assertEqual(
@@ -203,9 +203,9 @@ class CourseRunModelsTestCase(TestCase):
                 int(course_run.start.timestamp()) + 1,
                 int(course_run.end.timestamp()) - 1,
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
-        with mock.patch.object(timezone, "now", return_value=now):
+        with mock.patch.object(django_timezone, "now", return_value=now):
             state = course_run.state
 
         self.assertEqual(
@@ -224,9 +224,9 @@ class CourseRunModelsTestCase(TestCase):
                 int(course_run.end.timestamp()) + 1,
                 int(datetime(9999, 12, 31).timestamp()) - 1,
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
-        with mock.patch.object(timezone, "now", return_value=now):
+        with mock.patch.object(django_timezone, "now", return_value=now):
             state = course_run.state
 
         self.assertEqual(
@@ -251,9 +251,9 @@ class CourseRunModelsTestCase(TestCase):
                 int(course_run.enrollment_start.timestamp()) + 1,
                 int(course_run.start.timestamp()) - 1,
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
-        with mock.patch.object(timezone, "now", return_value=now):
+        with mock.patch.object(django_timezone, "now", return_value=now):
             state = course_run.state
 
         self.assertEqual(
@@ -272,9 +272,9 @@ class CourseRunModelsTestCase(TestCase):
                 int(course_run.start.timestamp()) + 1,
                 int(datetime(9999, 12, 31).timestamp()) - 1,
             )
-        ).replace(tzinfo=pytz.utc)
+        ).replace(tzinfo=timezone.utc)
 
-        with mock.patch.object(timezone, "now", return_value=now):
+        with mock.patch.object(django_timezone, "now", return_value=now):
             state = course_run.state
 
         self.assertEqual(
@@ -729,7 +729,7 @@ class CourseRunModelsTestCase(TestCase):
         Scheduling a course run that was to be scheduled should mark the related
         course page dirty.
         """
-        now = timezone.now()
+        now = django_timezone.now()
         course_run = CourseRunFactory(start=None, enrollment_start=now)
         self.assertTrue(course_run.direct_course.extended_object.publish("en"))
         title_obj = course_run.direct_course.extended_object.title_set.first()
@@ -750,7 +750,7 @@ class CourseRunModelsTestCase(TestCase):
         self.assertTrue(course_run.direct_course.extended_object.publish("en"))
         title_obj = course_run.direct_course.extended_object.title_set.first()
 
-        course_run.end = timezone.now()
+        course_run.end = django_timezone.now()
         course_run.save()
         course_run.mark_course_dirty()
         title_obj.refresh_from_db()

--- a/tests/apps/courses/test_templates_course_detail_rendering.py
+++ b/tests/apps/courses/test_templates_course_detail_rendering.py
@@ -4,13 +4,12 @@ End-to-end tests for the course detail view
 
 import random
 import re
-from datetime import timedelta
+from datetime import timedelta, timezone
 
 from django.test.utils import override_settings
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
 import lxml.html
-import pytz
 from cms.api import add_plugin
 from cms.test_utils.testcases import CMSTestCase
 
@@ -63,7 +62,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         page = course.extended_object
         # Create an ongoing open course run that will be published (created before
         # publishing the page)
-        now = timezone.now()
+        now = django_timezone.now()
         course_run = CourseRunFactory(
             direct_course=course,
             start=now - timedelta(hours=1),
@@ -274,7 +273,7 @@ class TemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             fill_categories=categories,
         )
         page = course.extended_object
-        now = timezone.now()
+        now = django_timezone.now()
         course_run = CourseRunFactory(
             direct_course=course,
             start=now - timedelta(hours=1),
@@ -646,7 +645,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
 
     def setUp(self):
         super().setUp()
-        self.now = timezone.now()
+        self.now = django_timezone.now()
 
     def create_run_ongoing_open(self, course, **kwargs):
         """
@@ -1056,7 +1055,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
             '<meta name="description"',
         )
 
-    @timezone.override(pytz.utc)
+    @django_timezone.override(timezone.utc)
     def test_templates_course_detail_runs_catalog_visibility(self):
         """
         Check each course run catalog visibility.
@@ -1169,7 +1168,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
             ),
         )
 
-    @timezone.override(pytz.utc)
+    @django_timezone.override(timezone.utc)
     def test_templates_course_detail_hidden_courses(self):
         """
         Check that each run on different state (Open, to be scheduled, hidden, ongoing, archived)
@@ -1260,7 +1259,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
 
         self.assertContains(response, course_run_title_archived_hidden)
 
-    @timezone.override(pytz.utc)
+    @django_timezone.override(timezone.utc)
     def test_templates_course_detail_scroll_to_open_course_runs_single_run(
         self,
     ):
@@ -1289,7 +1288,7 @@ class RunsCourseCMSTestCase(CMSTestCase):
             response, "course runs are currently open for this course"
         )
 
-    @timezone.override(pytz.utc)
+    @django_timezone.override(timezone.utc)
     def test_templates_course_detail_scroll_to_open_course_runs_no_open_runs(
         self,
     ):

--- a/tests/apps/search/test_index_manager.py
+++ b/tests/apps/search/test_index_manager.py
@@ -2,14 +2,13 @@
 Tests for the index_manager utilities
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
-import pytz
 from elasticsearch.exceptions import NotFoundError
 
 from richie.apps.courses.factories import CourseFactory
@@ -126,14 +125,14 @@ class IndexManagerTestCase(TestCase):
         indexable = IndexableClass()
 
         # Set a fake time to check the name of the index
-        now = datetime(2016, 5, 4, 3, 12, 33, 123456, tzinfo=pytz.utc)
+        now = datetime(2016, 5, 4, 3, 12, 33, 123456, tzinfo=timezone.utc)
 
         # Make sure our index is empty before we call the function
         self.assertEqual(ES_INDICES_CLIENT.get_alias("*"), {})
 
         mock_logger = mock.Mock(spec=["info"])
 
-        with mock.patch.object(timezone, "now", return_value=now):
+        with mock.patch.object(django_timezone, "now", return_value=now):
             new_index = perform_create_index(indexable, mock_logger)
         ES_INDICES_CLIENT.refresh()
 
@@ -201,7 +200,7 @@ class IndexManagerTestCase(TestCase):
         # Use a mocked timezone.now to  check the names of our indices as they include a datetime
         creation1_datetime = datetime(2010, 1, 1, tzinfo=timezone.utc)
         creation1_string = creation1_datetime.strftime("%Y-%m-%d-%Hh%Mm%S.%fs")
-        with mock.patch.object(timezone, "now", return_value=creation1_datetime):
+        with mock.patch.object(django_timezone, "now", return_value=creation1_datetime):
             regenerate_indices(None)
 
         expected_indices = [
@@ -223,7 +222,7 @@ class IndexManagerTestCase(TestCase):
         # Now regenerate the indices, replacing the ones we just created
         creation2_datetime = datetime(2011, 2, 2, tzinfo=timezone.utc)
         creation2_string = creation2_datetime.strftime("%Y-%m-%d-%Hh%Mm%S.%fs")
-        with mock.patch.object(timezone, "now", return_value=creation2_datetime):
+        with mock.patch.object(django_timezone, "now", return_value=creation2_datetime):
             regenerate_indices(None)
 
         # All indices were replaced and aliases updated
@@ -252,7 +251,7 @@ class IndexManagerTestCase(TestCase):
         # deleted (not just unaliased)
         creation3_datetime = datetime(2012, 3, 3, tzinfo=timezone.utc)
         creation3_string = creation3_datetime.strftime("%Y-%m-%d-%Hh%Mm%S.%fs")
-        with mock.patch.object(timezone, "now", return_value=creation3_datetime):
+        with mock.patch.object(django_timezone, "now", return_value=creation3_datetime):
             regenerate_indices(None)
 
         # All indices were replaced and had their aliases changed
@@ -314,7 +313,7 @@ class IndexManagerTestCase(TestCase):
         # Call our `regenerate_indices command`
         creation_datetime = datetime(2010, 1, 1, tzinfo=timezone.utc)
         creation_string = creation_datetime.strftime("%Y-%m-%d-%Hh%Mm%S.%fs")
-        with mock.patch.object(timezone, "now", return_value=creation_datetime):
+        with mock.patch.object(django_timezone, "now", return_value=creation_datetime):
             regenerate_indices(None)
 
         # No error was thrown, the courses index (like all others) was bootstrapped

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -2,12 +2,11 @@
 Tests for the course indexer
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 from django.test import TestCase
 
-import pytz
 from cms.api import add_plugin, create_page
 
 from richie.apps.core.helpers import create_i18n_page
@@ -821,7 +820,7 @@ class CoursesIndexersTestCase(TestCase):
                 "organizations": [42, 84],
                 "title": "Duis eu arcu erat",
                 "state": CourseState(
-                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, pytz.utc)
+                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, timezone.utc)
                 ),
             },
         )
@@ -873,7 +872,7 @@ class CoursesIndexersTestCase(TestCase):
                 "organizations": [],
                 "title": "Duis eu arcu erat",
                 "state": CourseState(
-                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, pytz.utc)
+                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, timezone.utc)
                 ),
             },
         )
@@ -924,7 +923,7 @@ class CoursesIndexersTestCase(TestCase):
                 "organizations": [42, 84],
                 "title": "Duis eu arcu erat",
                 "state": CourseState(
-                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, pytz.utc)
+                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, timezone.utc)
                 ),
             },
         )
@@ -975,7 +974,7 @@ class CoursesIndexersTestCase(TestCase):
                 "organizations": [42, 84],
                 "title": "Duis eu arcu erat",
                 "state": CourseState(
-                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, pytz.utc)
+                    0, datetime(2019, 3, 17, 21, 25, 52, 179667, timezone.utc)
                 ),
             },
         )

--- a/tests/apps/search/test_signals.py
+++ b/tests/apps/search/test_signals.py
@@ -37,7 +37,7 @@ class CoursesSignalsTestCase(TestCase):
         Run commit hooks as if the database transaction had been successful.
         """
         while connection.run_on_commit:
-            _sids, func = connection.run_on_commit.pop(0)
+            _sids, func, _published_value = connection.run_on_commit.pop(0)
             func()
 
     def test_signals_courses_publish(self, mock_bulk, *_):

--- a/tests/apps/search/test_viewsets_courses.py
+++ b/tests/apps/search/test_viewsets_courses.py
@@ -2,12 +2,12 @@
 Tests for the course viewset
 """
 
+from datetime import timezone
 from unittest import mock
 
 from django.test.utils import override_settings
-from django.utils import timezone
+from django.utils import timezone as django_timezone
 
-import pytz
 from cms.test_utils.testcases import CMSTestCase
 from elasticsearch.exceptions import NotFoundError
 
@@ -33,7 +33,7 @@ class CoursesViewsetsTestCase(CMSTestCase):
         would be broken if we did not enforce timezone normalization.
         """
         super().setUp()
-        timezone.activate(pytz.utc)
+        django_timezone.activate(timezone.utc)
 
     def test_viewsets_courses_retrieve(self, *_):
         """


### PR DESCRIPTION
## Purpose

**From Django version 3.2.25 to 4.0 :**
The project was using **Django 3.2.25**, it now uses **Django 4.0**, this involved : 
- upgrading postgres image to version 12 (drop support for postgres < 12)
- shift from `pytz` library to `datetime.timezone` instead.
- updated the template tags `{% ifequal %}` in favor of `{% if %}`.
- `USE_L1ON` is deprecated in settings if value is `True`

**From Django 4.0 to 4.1 :**
- Update project.toml file to pin version to 4.1 of Django.
- Adjust admin view tests 

**From Django 4.1 to 4.2:**
- Update project.toml file to pin version Django <5
- Change staticfile settings constant in configuration file.
- Dropped support for mysql < 8
- Dropped circleci test-back-msql-5

## Proposal

- resources : 
1. https://docs.djangoproject.com/en/5.0/releases/4.0/
2. https://docs.djangoproject.com/en/5.0/releases/4.1/
3. https://docs.djangoproject.com/en/5.0/releases/4.2/

