### PR TITLE
⬆️(backend) upgrade to python 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
   # Check that the git history is clean and complies with our expectations
   lint-git:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -155,7 +155,7 @@ jobs:
   # Build backend development environment
   build-back:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -177,7 +177,7 @@ jobs:
   # Build backend translations
   build-back-i18n:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -203,7 +203,7 @@ jobs:
 
   lint-back:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -248,7 +248,7 @@ jobs:
 
   test-back-mysql-8:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -341,7 +341,7 @@ jobs:
 
   test-back-postgresql:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -422,7 +422,7 @@ jobs:
 
   test-back-postgresql-es6:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -504,7 +504,7 @@ jobs:
   # ---- Packaging jobs ----
   check-versions:
     docker:
-      - image: cimg/python:3.10-node
+      - image: cimg/python:3.11-node
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -549,7 +549,7 @@ jobs:
 
   package-back:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -580,7 +580,7 @@ jobs:
   #     environment variables in CircleCI UI (with your PyPI credentials)
   pypi:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -707,7 +707,7 @@ jobs:
 
   cookiecutter-bootstrap:
     docker:
-      - image: cimg/python:3.10-node
+      - image: cimg/python:3.11-node
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -831,7 +831,7 @@ jobs:
   # environment variables in CircleCI UI (with your PyPI credentials)
   npm:
     docker:
-      - image: cimg/python:3.10-node
+      - image: cimg/python:3.11-node
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
+- Upgrade to Python 3.11
 - Upgrade to Django version 4.2 (pin version < 5)
 - Migrate to Sentry SDK 2.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # ---- Base image to inherit from ----
-FROM python:3.10-buster as base
+FROM python:3.11-bookworm as base
 
 # ---- Front-end builder image ----
 FROM node:20.11 as front-builder

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@backend.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@backend.yml
@@ -5,7 +5,7 @@ build-back:
     site:
       type: string
   docker:
-    - image: cimg/python:3.10
+    - image: cimg/python:3.11
   working_directory: ~/fun/sites/<< parameters.site >>
   steps:
     - checkout:
@@ -30,7 +30,7 @@ lint-back:
     site:
       type: string
   docker:
-    - image: cimg/python:3.10
+    - image: cimg/python:3.11
   working_directory: ~/fun/sites/<< parameters.site >>/src/backend/
   steps:
     - checkout:
@@ -62,7 +62,7 @@ test-back:
     site:
       type: string
   docker:
-    - image: cimg/python:3.10
+    - image: cimg/python:3.11
       environment:
         DJANGO_SETTINGS_MODULE: << parameters.site >>.settings
         PYTHONPATH: /home/circleci/fun/src/backend

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@project.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/.circleci/src/jobs/@project.yml
@@ -2,7 +2,7 @@
 # Check that the git history is clean and complies with our expectations
 lint-git:
   docker:
-    - image: cimg/python:3.10
+    - image: cimg/python:3.11
   working_directory: ~/fun
   steps:
     - checkout

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Dockerfile
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/Dockerfile
@@ -7,7 +7,7 @@ ARG SITE
 ARG DOCKER_USER=10000
 
 # ---- base image to inherit from ----
-FROM python:3.10-buster as base
+FROM python:3.11-bookworm as base
 
 # ---- front-end builder image ----
 FROM node:20.11 as front-builder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10"
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
+requires-python = ">=3.8"
 dependencies = [
     "arrow",
     "Django<5",

--- a/tests/apps/search/test_indexers_courses.py
+++ b/tests/apps/search/test_indexers_courses.py
@@ -585,7 +585,7 @@ class CoursesIndexersTestCase(TestCase):
             course_icons_placeholder,
             CategoryPlugin,
             "en",
-            **{"page": category.extended_object}
+            **{"page": category.extended_object},
         )
         course.extended_object.publish("en")
         # Make sure we associate an image-less picture with the category through


### PR DESCRIPTION
The application was running in python 3.10, it was about time to upgrade it into python 3.11. 

In this upgrade, we have upgraded  the cookiecutter folder with the version of python to 3.11.

## Purpose

Upgrading the application to python 3.11
Make bootstrap works. When using the slim version of `python:3.11-slim-bookworm`, the command who failed saying that there is an issue with the package :  `setuptools-scm>=8.0`. I've tried to take the heavier version, and make bootstrap works like a charm.

## Proposal
- [x] Update Circle CI to use python 3.11 image for main project.
- [x] Update pyproject.toml classifiers to mention the possible use of python 3.11.
- [x] Update cookiecutter section for its DockerFile and CircleCi .yml configuration files.

Must wait for this [PR](https://github.com/openfun/richie/pull/2399) to be merged before merging this one.


Version of Docker image for python 3.11 : 
- **python:3.11-bookworm** :  `make bootstrap`  works (will use this one because 3.11.9 has the same hash with 3.11)
- **python:3.11.9-bookworm** :  `make bootstrap` works 
- **python:3.11-slim-bookworm** : fails when `make bootstrap` with this package `setuptools-scm>=8.0`.
- **python:3.11.9-slim-bookworm** : fails when `make bootstrap` with this package  `setuptools-scm>=8.0`.
- **python:3.11.9-bullseye** : `make bootstrap` works
