### PR TITLE
🐛(back) fully define STORAGES settings

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
@@ -197,9 +197,12 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
     STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
         "staticfiles": {
-            "BACKEND": values.Value("base.storage.CDNManifestStaticFilesStorage")
-        }
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
     }
 
     AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
@@ -724,9 +727,12 @@ class Test(Base):
     """Test environment settings"""
 
     STORAGES = {
-        "staticfile": {
-            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
-        }
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
     }
 
 
@@ -754,7 +760,14 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    STORAGES = {"default": {"BACKEND": "base.storage.MediaStorage"}}
+    STORAGES = {
+        "default": {
+            "BACKEND": "base.storage.MediaStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -714,9 +714,12 @@ class Production(Base):
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
     STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
         "staticfiles": {
-            "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
-        }
+            "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+        },
     }
 
     # For more details about CMS_CACHE_DURATION, see :


### PR DESCRIPTION
## Purpose

    
In order to use django 4.2 we have to fully define the settings
STORAGES. We can't simply override the default or the static key. By
fully defining it, the deprecated settings DEFAULT_FILE_STORAGE and
STATICFILES_STORAGE are defined by django once setup by using the one
defined in STORAGES. And the django filer correctly use them.


## Proposal

- [x] fully define STORAGES settings