### PR TITLE
🐛(frontend) useUnionResource refetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixed
 
+- Fix an issue on dashboard search when no results were reached 
 - Ongoing product displayed on the syllabus with an active enrollment
   now link to the order details page in the learner dashboard instead of
   OpenEdx course.

--- a/src/frontend/js/hooks/useUnionResource/index.spec.tsx
+++ b/src/frontend/js/hooks/useUnionResource/index.spec.tsx
@@ -336,6 +336,7 @@ describe('useUnionResource', () => {
 
     calledUrls = fetchMock.calls().map((call) => call[0]);
     expectedQueries += 1; // fetch dataA first page
+    expectedQueries += 1; // fetch dataB first page
     expect(calledUrls).toHaveLength(expectedQueries);
     expect(calledUrls).toContain('http://data.a/?isFiltered=true&page=1');
     expect(result.current.hasMore).toBe(false);

--- a/src/frontend/js/hooks/useUnionResource/index.ts
+++ b/src/frontend/js/hooks/useUnionResource/index.ts
@@ -94,11 +94,8 @@ const useUnionResource = <
 
   // to force execution of useEffect::fetchNewPage(),
   // reset need to generate a uniq key that is part of it's dependencies.
-  const reset = (eofKey?: string) => {
-    if (eofKey) {
-      delete eofRef.current[eofKey];
-    }
-
+  const reset = () => {
+    eofRef.current = {};
     setStack([]);
     setPage(0);
     setTotalCount(undefined);
@@ -112,10 +109,10 @@ const useUnionResource = <
   // by generating a new update key
   if (refetchOnInvalidation) {
     useQueryKeyInvalidateListener(queryAConfig.queryKey, () => {
-      reset(queryAConfig.queryKey.join('-'));
+      reset();
     });
     useQueryKeyInvalidateListener(queryBConfig.queryKey, () => {
-      reset(queryBConfig.queryKey.join('-'));
+      reset();
     });
   }
 

--- a/src/frontend/js/hooks/useUnionResource/utils/fetchEntity.ts
+++ b/src/frontend/js/hooks/useUnionResource/utils/fetchEntity.ts
@@ -60,6 +60,7 @@ export const fetchEntity = async <
   }
 
   if (data) {
+    eofRef.current = { ...eofRef.current, [queryKeyString]: Math.ceil(data.count / perPage) };
     return data;
   }
   try {


### PR DESCRIPTION
eof must be reset on each reset (aka filters changes or query invalidation).
If it's not, we can arrive to a point where queries are set to eof === 0 (aka maximum page).

Also, on useUnionResource's fetchEntity function, we can have a case where we're retrieving data from react query cache, juste after a reset().
In that case, we must set eof with the right value, otherwise useUnionResource can try to fetch a page that does't exists and it will blow a error.
