### PR TITLE
💄(frontend) fix layout issue on DashboardItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixed
 
+- Prevent title to overflow in DashboardItem component
 - Fix an issue on dashboard search when no results were reached 
 - Ongoing product displayed on the syllabus with an active enrollment
   now link to the order details page in the learner dashboard instead of

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -32,9 +32,11 @@
         order: 2;
         margin-top: 0.5rem;
         overflow: hidden;
-        white-space: nowrap;
         text-overflow: ellipsis;
         font-size: 1.25rem;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
       }
 
       &__code {


### PR DESCRIPTION
## Purpose

Within DashboardItem component, if the training title is too long, it is not truncated so the component overflows. The best option seems to use a line clamp to allow the title to go on two lines but truncate it if it exceeds this limit.

| Before | After |
|--------|-------|
|<img width="800" alt="image" src="https://github.com/openfun/richie/assets/9265241/43a937af-d38c-4fe3-afb5-540e5d4b977f">|<img width="800" alt="image" src="https://github.com/openfun/richie/assets/9265241/62e74d47-9e29-4d44-96af-f21d14fd9428">|

_P.S: Even if the `-webkit` prefix let's believe that related CSS property are only supported by webkit browsers, line clamp is currently working with this prefix on Firefox, Safari, Chromium._
https://caniuse.com/css-line-clamp