### PR TITLE
🐛(frontend) use CB logo as fallback if credit card is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Use CB logo as fallback if credit card is unknown
+
 ## [2.26.0]
 
 ### Added

--- a/src/frontend/js/pages/DashboardCreditCardsManagement/CreditCardBrandLogo.spec.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/CreditCardBrandLogo.spec.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { CreditCardFactory } from 'utils/test/factories/joanie';
+import { CreditCardBrand } from 'types/Joanie';
+import { CreditCardBrandLogo } from './CreditCardBrandLogo';
+
+describe('CreditCardBrandLogo', () => {
+  it.each(Object.values(CreditCardBrand))('should display the %s brand logo', (brand) => {
+    const creditCard = CreditCardFactory({ brand }).one();
+
+    render(<CreditCardBrandLogo creditCard={creditCard} />);
+
+    expect(screen.getByRole('presentation')).toHaveAttribute(
+      'src',
+      `/static/richie/images/components/DashboardCreditCardsManagement/logo_${brand}.svg`,
+    );
+  });
+
+  it('should fallback to CB brand if the credit card brand is unknown', () => {
+    const creditCard = CreditCardFactory({
+      brand: 'unknown',
+    }).one();
+
+    render(<CreditCardBrandLogo creditCard={creditCard} />);
+    expect(screen.getByRole('presentation')).toHaveAttribute(
+      'src',
+      '/static/richie/images/components/DashboardCreditCardsManagement/logo_CB.svg',
+    );
+  });
+});

--- a/src/frontend/js/pages/DashboardCreditCardsManagement/CreditCardBrandLogo.tsx
+++ b/src/frontend/js/pages/DashboardCreditCardsManagement/CreditCardBrandLogo.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { CreditCard } from 'types/Joanie';
+import { CreditCard, CreditCardBrand } from 'types/Joanie';
 
 export const CreditCardBrandLogo = ({
   creditCard,
@@ -8,13 +8,17 @@ export const CreditCardBrandLogo = ({
   creditCard: CreditCard;
   variant?: 'default' | 'inline';
 }) => {
+  const creditCardBrand = Object.values<string>(CreditCardBrand).includes(creditCard.brand)
+    ? creditCard.brand
+    : CreditCardBrand.CB;
+
   return (
     <div className={classNames('credit-card-brand-logo', 'credit-card-brand-logo--' + variant)}>
       <img
         alt=""
         src={
           '/static/richie/images/components/DashboardCreditCardsManagement/logo_' +
-          creditCard.brand +
+          creditCardBrand +
           '.svg'
         }
       />

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -379,7 +379,7 @@ export enum CreditCardBrand {
 
 // Credit Card
 export interface CreditCard {
-  brand: CreditCardBrand;
+  brand: CreditCardBrand | string;
   expiration_month: number;
   expiration_year: number;
   id: string;


### PR DESCRIPTION
## Purpose

Currently, if the credit card brand does not exist in CreditCardBrand enum a broken image is displayed. As a workaround, we decide to use the CB logo as a fallback when the brand is unknown.

| Before | After |
|--------|-------|
|<img width="600" alt="image" src="https://github.com/openfun/richie/assets/9265241/11b5c736-6efd-47c5-9441-5537b03bdc9f">|<img width="600" alt="image" src="https://github.com/openfun/richie/assets/9265241/9b2f7746-f585-4545-84bb-08f34a033d88">|