### PR TITLE
✨(frontend) retrieve estimated payment schedule in sale tunnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Display Payment Schedule into SaleTunnel
+
 ## [2.28.1]
 
 ### Fixed

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -15,7 +15,8 @@ import context from 'utils/context';
 import { JOANIE_API_VERSION } from 'settings';
 import { ResourcesQuery } from 'hooks/useResources';
 import { ObjectHelper } from 'utils/ObjectHelper';
-import { Maybe } from 'types/utils';
+import { Maybe, Nullable } from 'types/utils';
+import { PaymentSchedule } from 'types/Joanie';
 import { checkStatus, getFileFromResponse } from './utils';
 
 /*
@@ -142,6 +143,9 @@ export const getRoutes = () => {
       },
       products: {
         get: `${baseUrl}/courses/:course_id/products/:id/`,
+        paymentSchedule: {
+          get: `${baseUrl}/courses/:course_id/products/:id/payment-schedule/`,
+        },
       },
       orders: {
         get: `${baseUrl}/courses/:course_id/orders/:id/`,
@@ -423,6 +427,25 @@ const API = (): Joanie.API => {
           }
 
           return fetchWithJWT(buildApiUrl(ROUTES.courses.products.get, filters)).then(checkStatus);
+        },
+        paymentSchedule: {
+          get: async (
+            filters?: Joanie.CourseProductQueryFilters,
+          ): Promise<Nullable<PaymentSchedule>> => {
+            if (!filters) {
+              throw new Error(
+                'A course code and a product id are required to fetch a course product',
+              );
+            } else if (!filters.course_id) {
+              throw new Error('A course code is required to fetch a course product');
+            } else if (!filters.id) {
+              throw new Error('A product id is required to fetch a course product');
+            }
+
+            return fetchWithJWT(
+              buildApiUrl(ROUTES.courses.products.paymentSchedule.get, filters),
+            ).then(checkStatus);
+          },
         },
       },
       orders: {

--- a/src/frontend/js/components/PaymentScheduleGrid/_styles.scss
+++ b/src/frontend/js/components/PaymentScheduleGrid/_styles.scss
@@ -1,3 +1,16 @@
+.payment-schedule__grid {
+  .payment-schedule__cell {
+    &--wrapped {
+      white-space: normal;
+    }
+
+    &--alignRight {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+}
+
 .status-pill {
   display: inline-flex;
   align-items: center;

--- a/src/frontend/js/components/PaymentScheduleGrid/index.tsx
+++ b/src/frontend/js/components/PaymentScheduleGrid/index.tsx
@@ -1,14 +1,15 @@
 import { DataList } from '@openfun/cunningham-react';
 import { useIntl } from 'react-intl';
 import { StringHelper } from 'utils/StringHelper';
-import { OrderPaymentSchedule, PaymentScheduleState } from 'types/Joanie';
+import { PaymentSchedule, PaymentScheduleState } from 'types/Joanie';
 
-export const PaymentScheduleGrid = ({
-  paymentSchedule,
-}: {
-  paymentSchedule: OrderPaymentSchedule;
-}) => {
+type Props = {
+  schedule: PaymentSchedule;
+};
+
+export const PaymentScheduleGrid = ({ schedule }: Props) => {
   const intl = useIntl();
+
   return (
     <div className="payment-schedule__grid">
       <DataList
@@ -33,12 +34,12 @@ export const PaymentScheduleGrid = ({
               context.row.state ? <StatusPill state={context.row.state} /> : '',
           },
         ]}
-        rows={paymentSchedule.map((installment) => ({
-          id: installment.due_date,
+        rows={schedule.map((installment) => ({
+          id: installment.id,
           date: installment.due_date,
           amount: intl.formatNumber(installment.amount, {
-            style: 'currency',
             currency: installment.currency,
+            style: 'currency',
           }),
           state: installment.state,
         }))}

--- a/src/frontend/js/components/PaymentScheduleGrid/index.tsx
+++ b/src/frontend/js/components/PaymentScheduleGrid/index.tsx
@@ -1,45 +1,59 @@
-import { DataList } from '@openfun/cunningham-react';
-import { useIntl } from 'react-intl';
+import { DataGrid } from '@openfun/cunningham-react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { StringHelper } from 'utils/StringHelper';
 import { PaymentSchedule, PaymentScheduleState } from 'types/Joanie';
+import useDateFormat from 'hooks/useDateFormat';
 
 type Props = {
   schedule: PaymentSchedule;
 };
 
+const messages = defineMessages({
+  withdrawnAt: {
+    id: 'components.PaymentScheduleGrid.withdrawnAt',
+    defaultMessage: 'Withdrawn on {date}',
+    description: 'Label displayed to explain when the installment will be withdrawn.',
+  },
+});
+
 export const PaymentScheduleGrid = ({ schedule }: Props) => {
   const intl = useIntl();
+  const formatDate = useDateFormat();
 
   return (
     <div className="payment-schedule__grid">
-      <DataList
+      <DataGrid
+        displayHeader={false}
         columns={[
+          { field: 'index', size: 10 },
+          { field: 'amount', size: 90 },
           {
-            id: 'date',
-            renderCell: (context) =>
-              context.row.id === 'total' ? <strong>{context.row.date}</strong> : context.row.date,
-          },
-          {
-            id: 'amount',
-            renderCell: (context) =>
-              context.row.id === 'total' ? (
-                <strong>{context.row.amount}</strong>
-              ) : (
-                context.row.amount
-              ),
+            field: 'date',
+            renderCell: ({ row }) => (
+              <span className="payment-schedule__cell--wrapped">
+                <FormattedMessage {...messages.withdrawnAt} values={{ date: row.date }} />
+              </span>
+            ),
           },
           {
             id: 'state',
-            renderCell: (context) =>
-              context.row.state ? <StatusPill state={context.row.state} /> : '',
+            renderCell: ({ row }) =>
+              row.state ? (
+                <div className="payment-schedule__cell--alignRight">
+                  <StatusPill state={row.state} />
+                </div>
+              ) : (
+                ''
+              ),
           },
         ]}
-        rows={schedule.map((installment) => ({
+        rows={schedule.map((installment, index) => ({
           id: installment.id,
-          date: installment.due_date,
+          index: index + 1,
+          date: formatDate(installment.due_date),
           amount: intl.formatNumber(installment.amount, {
-            currency: installment.currency,
             style: 'currency',
+            currency: installment.currency,
           }),
           state: installment.state,
         }))}

--- a/src/frontend/js/components/PurchaseButton/index.spec.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.spec.tsx
@@ -102,10 +102,15 @@ describe('PurchaseButton', () => {
   it('shows cta to open sale tunnel when user is authenticated', async () => {
     const courseCode = '00000';
     const product = ProductFactory().one();
-    fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?course_code=${courseCode}&product_id=${product.id}&state=pending&state=validated&state=submitted`,
-      {},
-    );
+    fetchMock
+      .get(
+        `https://joanie.endpoint/api/v1.0/orders/?course_code=${courseCode}&product_id=${product.id}&state=pending&state=validated&state=submitted`,
+        {},
+      )
+      .get(
+        `https://joanie.endpoint/api/v1.0/courses/${courseCode}/products/${product.id}/payment-schedule/`,
+        [],
+      );
 
     render(
       <Wrapper client={createTestQueryClient({ user: richieUser })}>
@@ -137,10 +142,15 @@ describe('PurchaseButton', () => {
     const product = ProductFactory({ remaining_order_count: null }).one();
     fetchMock.get(`https://demo.endpoint/api/user/v1/accounts/${user.username}`, {});
     fetchMock.get(`https://demo.endpoint/api/user/v1/preferences/${user.username}`, {});
-    fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?course_code=${courseCode}&product_id=${product.id}&state=pending&state=validated&state=submitted`,
-      {},
-    );
+    fetchMock
+      .get(
+        `https://joanie.endpoint/api/v1.0/orders/?course_code=${courseCode}&product_id=${product.id}&state=pending&state=validated&state=submitted`,
+        {},
+      )
+      .get(
+        `https://joanie.endpoint/api/v1.0/courses/${courseCode}/products/${product.id}/payment-schedule/`,
+        [],
+      );
     render(
       <Wrapper client={createTestQueryClient({ user })}>
         <PurchaseButton
@@ -170,10 +180,15 @@ describe('PurchaseButton', () => {
   it('shows cta to open sale tunnel when remaining orders is undefined', async () => {
     const courseCode = '00000';
     const product = ProductFactory().one();
-    fetchMock.get(
-      `https://joanie.endpoint/api/v1.0/orders/?course_code=${courseCode}&product_id=${product.id}&state=pending&state=validated&state=submitted`,
-      {},
-    );
+    fetchMock
+      .get(
+        `https://joanie.endpoint/api/v1.0/orders/?course_code=${courseCode}&product_id=${product.id}&state=pending&state=validated&state=submitted`,
+        {},
+      )
+      .get(
+        `https://joanie.endpoint/api/v1.0/courses/${courseCode}/products/${product.id}/payment-schedule/`,
+        [],
+      );
     delete product.remaining_order_count;
 
     render(

--- a/src/frontend/js/components/SaleTunnel/GenericPaymentButton/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/GenericPaymentButton/index.tsx
@@ -50,14 +50,9 @@ const messages = defineMessages({
     id: 'components.PaymentButton.errorTerms',
   },
   pay: {
-    defaultMessage: 'Pay {price}',
+    defaultMessage: 'Subscribe',
     description: 'CTA label to proceed to the payment of the product',
     id: 'components.PaymentButton.pay',
-  },
-  payInOneClick: {
-    defaultMessage: 'Pay in one click {price}',
-    description: 'CTA label to proceed to the one click payment of the product',
-    id: 'components.PaymentButton.payInOneClick',
   },
   paymentInProgress: {
     defaultMessage: 'Payment in progress',
@@ -305,7 +300,7 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
           </Spinner>
         ) : (
           <FormattedMessage
-            {...(creditCard ? messages.payInOneClick : messages.pay)}
+            {...messages.pay}
             values={{
               price: intl.formatNumber(product.price, {
                 style: 'currency',

--- a/src/frontend/js/components/SaleTunnel/GenericSaleTunnel.tsx
+++ b/src/frontend/js/components/SaleTunnel/GenericSaleTunnel.tsx
@@ -1,5 +1,6 @@
-import { Modal, ModalSize } from '@openfun/cunningham-react';
+import { Alert, Modal, ModalSize, VariantType } from '@openfun/cunningham-react';
 import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+import { FormattedMessage, defineMessages } from 'react-intl';
 import { SaleTunnelSponsors } from 'components/SaleTunnel/Sponsors/SaleTunnelSponsors';
 import { SaleTunnelProps } from 'components/SaleTunnel/index';
 import { Address, CreditCard, Order, Product } from 'types/Joanie';
@@ -11,6 +12,15 @@ import { useOmniscientOrders, useOrders } from 'hooks/useOrders';
 import { SaleTunnelInformation } from 'components/SaleTunnel/SaleTunnelInformation';
 import { useEnrollments } from 'hooks/useEnrollments';
 import SaleTunnelNotValidated from './SaleTunnelNotValidated';
+
+const messages = defineMessages({
+  walkthrough: {
+    id: 'components.SaleTunnel.GenericSaleTunnel.walkthrough',
+    defaultMessage:
+      'To enroll in the training, you will first be invited to sign the training agreement and then to define a payment method. You will not be charged during this step; the first payment will take place on the date mentioned in the payment schedule above.',
+    description: 'Message explaining the credential sale tunnel process',
+  },
+});
 
 export interface SaleTunnelContextType {
   props: SaleTunnelProps;
@@ -188,7 +198,14 @@ export const GenericSaleTunnelPaymentStep = (props: GenericSaleTunnelProps) => {
             <SaleTunnelInformation />
           </div>
         </div>
-        <div className="sale-tunnel__footer">{props.paymentNode}</div>
+        <div className="sale-tunnel__footer">
+          <div style={{ maxWidth: '680px' }} className="mb-s" data-testid="walkthrough-banner">
+            <Alert type={VariantType.INFO}>
+              <FormattedMessage {...messages.walkthrough} />
+            </Alert>
+          </div>
+          {props.paymentNode}
+        </div>
       </div>
     </Modal>
   );

--- a/src/frontend/js/components/SaleTunnel/GenericSaleTunnel.tsx
+++ b/src/frontend/js/components/SaleTunnel/GenericSaleTunnel.tsx
@@ -177,16 +177,18 @@ export const GenericSaleTunnelPaymentStep = (props: GenericSaleTunnelProps) => {
     <Modal {...props} size={ModalSize.EXTRA_LARGE} title={props.product.title} closeOnEsc={false}>
       <div className="sale-tunnel" data-testid="generic-sale-tunnel-payment-step">
         <div className="sale-tunnel__main">
-          <div className="sale-tunnel__main__left">{props.asideNode}</div>
+          <div className="sale-tunnel__main__column sale-tunnel__main__left ">
+            <div>{props.asideNode}</div>
+            <div>
+              <SaleTunnelSponsors />
+            </div>
+          </div>
           <div className="sale-tunnel__main__separator" />
           <div className="sale-tunnel__main__right">
             <SaleTunnelInformation />
           </div>
         </div>
-        <div className="sale-tunnel__footer">
-          {props.paymentNode}
-          <SaleTunnelSponsors />
-        </div>
+        <div className="sale-tunnel__footer">{props.paymentNode}</div>
       </div>
     </Modal>
   );

--- a/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/index.tsx
@@ -60,7 +60,7 @@ const messages = defineMessages({
 
 export const SaleTunnelInformation = () => {
   return (
-    <div className="sale-tunnel__information">
+    <div className="sale-tunnel__main__column sale-tunnel__information">
       <div>
         <h3 className="block-title mb-t">
           <FormattedMessage {...messages.title} />
@@ -78,6 +78,7 @@ export const SaleTunnelInformation = () => {
         <CreditCardSelectorWrapper />
       </div>
       <div>
+        <PaymentScheduleBlock />
         <Total />
       </div>
     </div>

--- a/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/index.tsx
@@ -1,11 +1,13 @@
-import { Alert, VariantType } from '@openfun/cunningham-react';
 import { defineMessages, FormattedMessage, FormattedNumber } from 'react-intl';
 import { AddressSelector } from 'components/SaleTunnel/AddressSelector';
 import { CreditCardSelector } from 'components/CreditCardSelector';
+import { PaymentScheduleGrid } from 'components/PaymentScheduleGrid';
 import { useSaleTunnelContext } from 'components/SaleTunnel/GenericSaleTunnel';
 import OpenEdxFullNameForm from 'components/OpenEdxFullNameForm';
 import { useSession } from 'contexts/SessionContext';
 import useOpenEdxProfile from 'hooks/useOpenEdxProfile';
+import { usePaymentSchedule } from 'hooks/usePaymentSchedule';
+import { Spinner } from 'components/Spinner';
 
 const messages = defineMessages({
   title: {
@@ -122,9 +124,6 @@ const Total = () => {
   const { product } = useSaleTunnelContext();
   return (
     <div className="sale-tunnel__total">
-      <Alert type={VariantType.INFO}>
-        <FormattedMessage {...messages.totalInfo} />
-      </Alert>
       <div className="sale-tunnel__total__amount mt-t" data-testid="sale-tunnel__total__amount">
         <div className="block-title">
           <FormattedMessage {...messages.totalLabel} />
@@ -141,19 +140,23 @@ const Total = () => {
   );
 };
 
-/**
- * Ready for V2.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const PaymentScheduleBlock = () => {
-  return null;
+  const { props } = useSaleTunnelContext();
+  const query = usePaymentSchedule({
+    course_code: props.course?.code || props.enrollment!.course_run.course.code,
+    product_id: props.product.id,
+  });
+
+  if (!query.data || query.isLoading) {
+    return <Spinner size="large" />;
+  }
+
   return (
     <div className="payment-schedule">
-      <h4 className="block-title mb-t">Schedule</h4>
-      <Alert type={VariantType.INFO}>
-        The first payment occurs in 14 days, you will be notified to pay the first 30%.
-      </Alert>
-      <div className="mt-t">{/* <PaymentScheduleGrid /> */}</div>
+      <h4 className="block-title mb-t">Payment schedule</h4>
+      <div className="mt-t">
+        <PaymentScheduleGrid schedule={query.data} />
+      </div>
     </div>
   );
 };

--- a/src/frontend/js/components/SaleTunnel/Sponsors/SaleTunnelSponsors.scss
+++ b/src/frontend/js/components/SaleTunnel/Sponsors/SaleTunnelSponsors.scss
@@ -1,15 +1,14 @@
 .sale-tunnel__sponsors {
   margin-top: 8px;
   display: flex;
-  gap: 8px;
-  justify-content: center;
+  gap: 16px;
+  justify-content: flex-start;
+  align-items: center;
   overflow: hidden;
   flex-wrap: wrap;
 
   img {
-    height: 50px;
-    padding: 8px;
-    width: 130px;
+    width: 90px;
     object-fit: contain;
   }
 }

--- a/src/frontend/js/components/SaleTunnel/Sponsors/SaleTunnelSponsors.tsx
+++ b/src/frontend/js/components/SaleTunnel/Sponsors/SaleTunnelSponsors.tsx
@@ -1,20 +1,43 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { useSaleTunnelContext } from 'components/SaleTunnel/GenericSaleTunnel';
-import { DashboardAvatar } from 'widgets/Dashboard/components/DashboardAvatar';
+import {
+  DashboardAvatar,
+  DashboardAvatarVariantEnum,
+} from 'widgets/Dashboard/components/DashboardAvatar';
+import { Organization } from 'types/Joanie';
+
+const messages = defineMessages({
+  blockTitle: {
+    id: 'components.SaleTunnel.Sponsors.SaleTunnelSponsors.blockTitle',
+    defaultMessage: 'University',
+    description: 'Title for the universities section in the sale tunnel',
+  },
+});
 
 export const SaleTunnelSponsors = () => {
   const {
     props: { organizations },
   } = useSaleTunnelContext();
   return (
-    <div className="sale-tunnel__sponsors">
-      {organizations?.map((organization) => {
-        if (organization.logo) {
-          return (
-            <img key={organization.id} src={organization.logo!.src} alt={organization.title} />
-          );
-        }
-        return <DashboardAvatar key={organization.id} title={organization.title} />;
-      })}
-    </div>
+    <>
+      <h3 className="block-title">
+        <FormattedMessage {...messages.blockTitle} />
+      </h3>
+      <div className="sale-tunnel__sponsors">{organizations?.map(OrganizationLogo)}</div>
+    </>
+  );
+};
+
+const OrganizationLogo = (organization: Organization) => {
+  if (organization.logo) {
+    return <img key={organization.id} src={organization.logo!.src} alt={organization.title} />;
+  }
+
+  return (
+    <DashboardAvatar
+      key={organization.id}
+      title={organization.title}
+      variant={DashboardAvatarVariantEnum.SQUARE}
+    />
   );
 };

--- a/src/frontend/js/components/SaleTunnel/_styles.scss
+++ b/src/frontend/js/components/SaleTunnel/_styles.scss
@@ -33,13 +33,15 @@
       flex: 1;
       overflow: hidden;
     }
+
+    &__column {
+      display: flex;
+      flex-direction: column;
+      gap: var(--c--theme--spacings--b);
+    }
   }
 
   &__information {
-    display: flex;
-    flex-direction: column;
-    gap: var(--c--theme--spacings--b);
-
     &__billing-address {
       display: flex;
       align-items: center;

--- a/src/frontend/js/components/SaleTunnel/index.credential.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.credential.spec.tsx
@@ -98,6 +98,10 @@ describe('SaleTunnel / Credential', () => {
         `https://joanie.endpoint/api/v1.0/orders/?course_code=${course.code}&product_id=${product.id}&state=pending&state=validated&state=submitted`,
         [],
       )
+      .get(
+        `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+        [],
+      )
       .post('https://joanie.endpoint/api/v1.0/orders/', (url, { body }) => {
         createOrderPayload = JSON.parse(body as any);
         return order;

--- a/src/frontend/js/components/SaleTunnel/index.credential.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.credential.spec.tsx
@@ -56,12 +56,6 @@ describe('SaleTunnel / Credential', () => {
     return <SaleTunnel {...props} isOpen={true} onClose={() => {}} />;
   };
 
-  const formatPrice = (price: number, currency: string) =>
-    new Intl.NumberFormat('en', {
-      currency,
-      style: 'currency',
-    }).format(price);
-
   setupJoanieSession();
 
   beforeEach(() => {
@@ -124,7 +118,7 @@ describe('SaleTunnel / Credential', () => {
     await screen.findByText(getAddressLabel(billingAddress));
 
     const $button = screen.getByRole('button', {
-      name: `Pay ${formatPrice(product.price, product.price_currency)}`,
+      name: `Subscribe`,
     }) as HTMLButtonElement;
 
     const $terms = screen.getByLabelText(

--- a/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
@@ -268,7 +268,7 @@ describe('SaleTunnel', () => {
       });
 
     const $button = screen.getByRole('button', {
-      name: `Pay ${priceFormatter(product.price_currency, product.price)}`,
+      name: `Subscribe`,
     }) as HTMLButtonElement;
     await user.click($button);
 

--- a/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
@@ -14,6 +14,7 @@ import {
   AddressFactory,
   CourseProductRelationFactory,
   CredentialOrderWithPaymentFactory,
+  PaymentInstallmentFactory,
 } from 'utils/test/factories/joanie';
 import { ACTIVE_ORDER_STATES, CourseRun } from 'types/Joanie';
 import { Priority } from 'types';
@@ -84,11 +85,16 @@ describe('SaleTunnel', () => {
      * Initialization.
      */
     const relation = CourseProductRelationFactory().one();
+    const paymentSchedule = PaymentInstallmentFactory().many(2);
     const { product, course } = relation;
 
     fetchMock.get(
       `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/`,
       relation,
+    );
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+      paymentSchedule,
     );
     fetchMock.get(`https://joanie.endpoint/api/v1.0/enrollments/`, []);
     const orderQueryParameters = {

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -2,6 +2,8 @@ import { act, cleanup, fireEvent, screen, waitFor } from '@testing-library/react
 import fetchMock from 'fetch-mock';
 import queryString from 'query-string';
 import userEvent from '@testing-library/user-event';
+import { within } from '@testing-library/dom';
+import { createIntl } from 'react-intl';
 import { OrderState, Product, ProductType } from 'types/Joanie';
 import {
   AddressFactory,
@@ -14,6 +16,7 @@ import {
   CredentialProductFactory,
   CreditCardFactory,
   EnrollmentFactory,
+  PaymentInstallmentFactory,
 } from 'utils/test/factories/joanie';
 import {
   RichieContextFactory as mockRichieContextFactory,
@@ -30,6 +33,8 @@ import { User } from 'types/User';
 import { OpenEdxApiProfile } from 'types/openEdx';
 import { OpenEdxApiProfileFactory } from 'utils/test/factories/openEdx';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { StringHelper } from 'utils/StringHelper';
+import { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -72,7 +77,9 @@ describe.each([
 
     const course = CourseFactory().one();
     const enrollment =
-      productType === ProductType.CERTIFICATE ? EnrollmentFactory().one() : undefined;
+      productType === ProductType.CERTIFICATE
+        ? EnrollmentFactory({ course_run: { course } }).one()
+        : undefined;
 
     let richieUser: User;
     let openApiEdxProfile: OpenEdxApiProfile;
@@ -189,6 +196,10 @@ describe.each([
       fetchMock
         .get(
           `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
+          [],
+        )
+        .get(
+          `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
           [],
         )
         .post('https://joanie.endpoint/api/v1.0/orders/', order)
@@ -348,6 +359,10 @@ describe.each([
           `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
           [initialOrder],
         )
+        .get(
+          `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+          [],
+        )
         .post('https://joanie.endpoint/api/v1.0/orders/', order)
         .patch(`https://joanie.endpoint/api/v1.0/orders/${order.id}/submit/`, {
           payment_info: paymentInfo,
@@ -376,6 +391,7 @@ describe.each([
       nbApiCalls += 1; // useProductOrder get order with filters
       nbApiCalls += 1; // get user account call.
       nbApiCalls += 1; // get user preferences call.
+      nbApiCalls += 1; // product payment schedule call.
       await waitFor(() => expect(fetchMock.calls()).toHaveLength(nbApiCalls));
       const $button = screen.getByRole('button', {
         name: `Pay in one click ${formatPrice(product.price, product.price_currency)}`,
@@ -472,6 +488,10 @@ describe.each([
           `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
           [orderSubmitted],
         )
+        .get(
+          `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+          [],
+        )
         .post('https://joanie.endpoint/api/v1.0/orders/', order)
         .patch(`https://joanie.endpoint/api/v1.0/orders/${order.id}/submit/`, {
           payment_info: paymentInfo,
@@ -494,6 +514,7 @@ describe.each([
       nbApiCalls += 1; // fetcher order for userProductOrder
       nbApiCalls += 1; // get user account call.
       nbApiCalls += 1; // get user preferences call.
+      nbApiCalls += 1; // get product payment schedule.
       const apiCalls = fetchMock.calls().map((call) => call[0]);
       expect(apiCalls).toContain(
         `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
@@ -606,6 +627,10 @@ describe.each([
           `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
           [],
         )
+        .get(
+          `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+          [],
+        )
         .post('https://joanie.endpoint/api/v1.0/orders/', order)
         .patch(`https://joanie.endpoint/api/v1.0/orders/${order.id}/submit/`, {
           payment_info: paymentInfo,
@@ -624,6 +649,7 @@ describe.each([
       nbApiCalls += 1; // useProductOrder get order with filters
       nbApiCalls += 1; // get user account call.
       nbApiCalls += 1; // get user preferences call.
+      nbApiCalls += 1; // get product payment schedule.
       await waitFor(() => expect(fetchMock.calls()).toHaveLength(nbApiCalls));
 
       const $terms = screen.getByLabelText(
@@ -691,6 +717,10 @@ describe.each([
           `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
           [],
         )
+        .get(
+          `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+          [],
+        )
         .post('https://joanie.endpoint/api/v1.0/orders/', order)
         .patch(`https://joanie.endpoint/api/v1.0/orders/${order.id}/submit/`, {
           payment_info: paymentInfo,
@@ -709,6 +739,7 @@ describe.each([
       nbApiCalls += 1; // useProductOrder get order with filters
       nbApiCalls += 1; // get user account call.
       nbApiCalls += 1; // get user preferences call.
+      nbApiCalls += 1; // product payment schedule call.
       await waitFor(() => expect(fetchMock.calls()).toHaveLength(nbApiCalls));
 
       const $terms = screen.getByLabelText(
@@ -783,6 +814,10 @@ describe.each([
           `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
           [],
         )
+        .get(
+          `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+          [],
+        )
         .get('https://joanie.endpoint/api/v1.0/addresses/', [billingAddress], {
           overwriteRoutes: true,
         });
@@ -811,23 +846,15 @@ describe.each([
     it('should show a link to the platform terms and conditions', async () => {
       const product = ProductFactory().one();
 
-      const fetchOrderQueryParams =
-        product.type === ProductType.CREDENTIAL
-          ? {
-              course_code: course.code,
-              product_id: product.id,
-              state: ['pending', 'validated', 'submitted'],
-            }
-          : {
-              enrollment_id: enrollment?.id,
-              product_id: product.id,
-              state: ['pending', 'validated', 'submitted'],
-            };
-
-      fetchMock.get(
-        `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(fetchOrderQueryParams)}`,
-        [],
-      );
+      fetchMock
+        .get(
+          `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
+          [],
+        )
+        .get(
+          `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+          [],
+        );
 
       render(<Wrapper product={product} />, {
         queryOptions: { client: createTestQueryClient({ user: richieUser }) },
@@ -835,6 +862,56 @@ describe.each([
 
       const $terms = screen.getByRole('link', { name: 'General Terms of Sale' });
       expect($terms).toHaveAttribute('href', '/en/about/terms-and-conditions/');
+    });
+
+    it('should show the product payment schedule', async () => {
+      const intl = createIntl({ locale: 'en' });
+      const product = ProductFactory().one();
+      const schedule = PaymentInstallmentFactory().many(2);
+      fetchMock
+        .get(
+          `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
+          [],
+        )
+        .get(
+          `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-schedule/`,
+          schedule,
+        );
+
+      render(<Wrapper product={product} />, {
+        queryOptions: { client: createTestQueryClient({ user: richieUser }) },
+      });
+
+      await screen.findByRole('heading', {
+        level: 4,
+        name: 'Payment schedule',
+      });
+
+      const scheduleTable = screen.getByRole('table');
+      const scheduleTableRows = within(scheduleTable).getAllByRole('row');
+      expect(scheduleTableRows).toHaveLength(schedule.length);
+
+      scheduleTableRows.forEach((row, index) => {
+        const installment = schedule[index];
+        // A first column should show the installment index
+        within(row).getByRole('cell', {
+          name: (index + 1).toString(),
+        });
+        // A 2nd column should show the installment amount
+        within(row).getByRole('cell', {
+          name: formatPrice(installment.amount, installment.currency),
+        });
+        // A 3rd column should show the installment withdraw date
+        within(row).getByRole('cell', {
+          name: `Withdrawn on ${intl.formatDate(installment.due_date, {
+            ...DEFAULT_DATE_FORMAT,
+          })}`,
+        });
+        // A 4th column should show the installment state
+        within(row).getByRole('cell', {
+          name: StringHelper.capitalizeFirst(installment.state.replace('_', ' '))!,
+        });
+      });
     });
   },
 );

--- a/src/frontend/js/hooks/useCourseProducts.ts
+++ b/src/frontend/js/hooks/useCourseProducts.ts
@@ -1,20 +1,6 @@
 import { defineMessages } from 'react-intl';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  API,
-  CourseProductQueryFilters,
-  CourseProductRelation,
-  PaymentInstallment,
-  PaymentSchedule,
-  Product,
-} from 'types/Joanie';
-import {
-  QueryOptions,
-  useResource,
-  useResources,
-  useResourcesCustom,
-  UseResourcesProps,
-} from 'hooks/useResources';
+import { API, CourseProductQueryFilters, CourseProductRelation, Product } from 'types/Joanie';
+import { QueryOptions, useResourcesCustom, UseResourcesProps } from 'hooks/useResources';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
 
 export const messages = defineMessages({
@@ -57,14 +43,3 @@ export const useCourseProduct = (
   const { items, ...subRes } = resources;
   return { ...subRes, item: items[0] };
 };
-
-const courseProductPaymentScheduleProps: UseResourcesProps<
-  PaymentSchedule,
-  CourseProductQueryFilters,
-  API['courses']['products']['paymentSchedule']
-> = {
-  queryKey: ['courses-products', 'payment-schedule'],
-  apiInterface: () => useJoanieApi().courses.products.paymentSchedule,
-};
-
-export const useCourseProductPaymentSchedule = useResources(courseProductPaymentScheduleProps);

--- a/src/frontend/js/hooks/useCourseProducts.ts
+++ b/src/frontend/js/hooks/useCourseProducts.ts
@@ -1,6 +1,20 @@
 import { defineMessages } from 'react-intl';
-import { API, CourseProductQueryFilters, CourseProductRelation, Product } from 'types/Joanie';
-import { QueryOptions, useResourcesCustom, UseResourcesProps } from 'hooks/useResources';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  API,
+  CourseProductQueryFilters,
+  CourseProductRelation,
+  PaymentInstallment,
+  PaymentSchedule,
+  Product,
+} from 'types/Joanie';
+import {
+  QueryOptions,
+  useResource,
+  useResources,
+  useResourcesCustom,
+  UseResourcesProps,
+} from 'hooks/useResources';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
 
 export const messages = defineMessages({
@@ -43,3 +57,14 @@ export const useCourseProduct = (
   const { items, ...subRes } = resources;
   return { ...subRes, item: items[0] };
 };
+
+const courseProductPaymentScheduleProps: UseResourcesProps<
+  PaymentSchedule,
+  CourseProductQueryFilters,
+  API['courses']['products']['paymentSchedule']
+> = {
+  queryKey: ['courses-products', 'payment-schedule'],
+  apiInterface: () => useJoanieApi().courses.products.paymentSchedule,
+};
+
+export const useCourseProductPaymentSchedule = useResources(courseProductPaymentScheduleProps);

--- a/src/frontend/js/hooks/usePaymentSchedule.tsx
+++ b/src/frontend/js/hooks/usePaymentSchedule.tsx
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { useJoanieApi } from 'contexts/JoanieApiContext';
+import { PaymentSchedule } from 'types/Joanie';
+import { Nullable } from 'types/utils';
+
+type PaymentScheduleFilters = {
+  course_code: string;
+  product_id: string;
+};
+
+export const usePaymentSchedule = (filters: PaymentScheduleFilters) => {
+  const queryKey = ['courses-products', ...Object.values(filters), 'payment-schedule'];
+
+  const api = useJoanieApi();
+  return useQuery<Nullable<PaymentSchedule>, Error>({
+    queryKey,
+    queryFn: () =>
+      api.courses.products.paymentSchedule.get({
+        id: filters.product_id,
+        course_id: filters.course_code,
+      }),
+  });
+};

--- a/src/frontend/js/hooks/useResources/useResourcesRoot.ts
+++ b/src/frontend/js/hooks/useResources/useResourcesRoot.ts
@@ -136,21 +136,21 @@ export const useResourcesRoot = <
   const mutation = (session ? useSessionMutation : useMutation) as typeof useMutation;
 
   const writeHandlers = {
-    create: api.create
+    create: api?.create
       ? mutation({
           mutationFn: api.create,
           onSuccess,
           onError: () => setError(intl.formatMessage(actualMessages.errorCreate)),
         })
       : undefined,
-    update: api.update
+    update: api?.update
       ? mutation({
           mutationFn: api.update,
           onSuccess,
           onError: () => setError(intl.formatMessage(actualMessages.errorUpdate)),
         })
       : undefined,
-    delete: api.delete
+    delete: api?.delete
       ? mutation({
           mutationFn: api.delete,
           onSuccess,

--- a/src/frontend/js/index.tsx
+++ b/src/frontend/js/index.tsx
@@ -11,6 +11,7 @@ import 'core-js/modules/es.array.iterator';
 import 'core-js/modules/es.promise';
 import { IntlProvider } from 'react-intl';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import countries from 'i18n-iso-countries';
 import { createRoot } from 'react-dom/client';
 import createQueryClient from 'utils/react-query/createQueryClient';
@@ -116,6 +117,7 @@ async function render() {
     const reactRoot = createRoot(rootContainer);
     reactRoot.render(
       <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
         <IntlProvider locale={locale} messages={translatedMessages} defaultLocale="en-US">
           <Root richieReactSpots={richieReactSpots} />
         </IntlProvider>

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -271,20 +271,6 @@ export enum OrderState {
 
 export const ACTIVE_ORDER_STATES = [OrderState.PENDING, OrderState.VALIDATED, OrderState.SUBMITTED];
 
-export enum PaymentScheduleState {
-  PENDING = 'pending',
-  PAID = 'paid',
-  FAILED = 'refused',
-}
-
-export interface OrderInstallment {
-  amount: number;
-  currency: string;
-  due_date: string;
-  state: PaymentScheduleState;
-}
-export type OrderPaymentSchedule = OrderInstallment[];
-
 export interface Order {
   id: string;
   created_on: string;
@@ -303,7 +289,7 @@ export interface Order {
   organization_id: Organization['id'];
   organization: Organization;
   order_group_id?: OrderGroup['id'];
-  payment_schedule?: OrderPaymentSchedule;
+  payment_schedule?: PaymentSchedule;
 }
 
 export interface CredentialOrder extends Order {
@@ -433,6 +419,22 @@ export interface UserWishlistCreationPayload {
 export interface OrderPaymentInfo {
   payment_info: Payment;
 }
+
+export enum PaymentScheduleState {
+  PENDING = 'pending',
+  PAID = 'paid',
+  REFUSED = 'refused',
+}
+
+export interface PaymentInstallment {
+  id: string;
+  amount: number;
+  currency: string;
+  due_date: string;
+  state: PaymentScheduleState;
+}
+
+export type PaymentSchedule = readonly PaymentInstallment[];
 
 // - API
 export interface AddressCreationPayload extends Omit<Address, 'id' | 'is_main'> {
@@ -640,6 +642,11 @@ export interface API {
       : Promise<PaginatedResponse<CourseListItem>>;
     products: {
       get(filters?: CourseProductQueryFilters): Promise<Nullable<CourseProductRelation>>;
+      paymentSchedule: {
+        get(
+          filters?: CourseProductQueryFilters,
+        ): Promise<Nullable<{ payment_schedule: PaymentSchedule }>>;
+      };
     };
     orders: {
       get(

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -643,9 +643,7 @@ export interface API {
     products: {
       get(filters?: CourseProductQueryFilters): Promise<Nullable<CourseProductRelation>>;
       paymentSchedule: {
-        get(
-          filters?: CourseProductQueryFilters,
-        ): Promise<Nullable<{ payment_schedule: PaymentSchedule }>>;
+        get(filters?: CourseProductQueryFilters): Promise<Nullable<PaymentSchedule>>;
       };
     };
     orders: {

--- a/src/frontend/js/utils/OrderHelper/index.ts
+++ b/src/frontend/js/utils/OrderHelper/index.ts
@@ -5,6 +5,7 @@ import {
   OrderState,
   ContractDefinition,
   NestedCourseOrder,
+  PaymentScheduleState,
 } from 'types/Joanie';
 
 export enum OrderStatus {
@@ -95,6 +96,8 @@ export class OrderHelper {
   }
 
   static getFailedInstallment(order: Order) {
-    return order.payment_schedule?.find((installment) => installment.state === 'refused');
+    return order.payment_schedule?.find(
+      (installment) => installment.state === PaymentScheduleState.REFUSED,
+    );
   }
 }

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -31,7 +31,7 @@ import {
   Order,
   OrderEnrollment,
   OrderGroup,
-  OrderInstallment,
+  PaymentInstallment,
   OrderLite,
   OrderState,
   Organization,
@@ -349,8 +349,9 @@ export const CourseListItemFactory = factory((): CourseListItem => {
   };
 });
 
-export const OrderInstallmentFactory = factory((): OrderInstallment => {
+export const PaymentInstallmentFactory = factory((): PaymentInstallment => {
   return {
+    id: faker.string.uuid(),
     currency: faker.finance.currencyCode(),
     amount: faker.number.int(),
     due_date: faker.date.future().toISOString(),
@@ -426,7 +427,7 @@ export const CredentialOrderFactory = factory((): CredentialOrder => {
     ...AbstractOrderFactory().one(),
     course: CourseLightFactory().one(),
     enrollment: null,
-    payment_schedule: OrderInstallmentFactory().many(3),
+    payment_schedule: PaymentInstallmentFactory().many(3),
   };
   return order;
 });

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -886,7 +886,7 @@ describe('<DashboardItemOrder/>', () => {
       .get(`https://joanie.endpoint/api/v1.0/orders/${order.id}/`, validOrder);
 
     order.state = OrderState.FAILED_PAYMENT;
-    order.payment_schedule![1].state = PaymentScheduleState.FAILED;
+    order.payment_schedule![1].state = PaymentScheduleState.REFUSED;
 
     const formatPrice = (price: number, currency: string) =>
       new Intl.NumberFormat('en', {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentDetailsModal/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentDetailsModal/index.tsx
@@ -82,7 +82,7 @@ export const OrderPaymentDetailsModal = ({ order, ...props }: PaymentModalProps)
             <FormattedMessage {...messages.paymentNeededMessage} />
           </Alert>
         )}
-        {order.payment_schedule && <PaymentScheduleGrid paymentSchedule={order.payment_schedule} />}
+        {order.payment_schedule && <PaymentScheduleGrid schedule={order.payment_schedule} />}
       </Modal>
       {failedInstallment && (
         <OrderPaymentRetryModal {...retryModal} installment={failedInstallment} order={order} />

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@openfun/cunningham-react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useRef, useState } from 'react';
-import { CreditCard, Order, OrderInstallment, OrderState } from 'types/Joanie';
+import { CreditCard, Order, PaymentInstallment, OrderState } from 'types/Joanie';
 import { CreditCardSelector } from 'components/CreditCardSelector';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
 import { Payment, PaymentErrorMessageId } from 'components/PaymentInterfaces/types';
@@ -64,7 +64,7 @@ const messages = defineMessages({
 });
 
 interface Props extends Pick<ModalProps, 'isOpen' | 'onClose'> {
-  installment: OrderInstallment;
+  installment: PaymentInstallment;
   order: Order;
 }
 

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -63,6 +63,7 @@
     "@tanstack/query-core": "5.49.1",
     "@tanstack/query-sync-storage-persister": "5.49.1",
     "@tanstack/react-query": "5.49.2",
+    "@tanstack/react-query-devtools": "5.49.2",
     "@tanstack/react-query-persist-client": "5.49.2",
     "@testing-library/dom": "10.2.0",
     "@testing-library/jest-dom": "6.4.6",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -110,7 +110,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.24.7.tgz#d23bbea508c3883ba8251fb4164982c36ea577ed"
   integrity sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==
 
-"@babel/core@7.24.7", "@babel/core@^7.0.0":
+"@babel/core@7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.7.tgz#b676450141e0b52a3d43bc91da86aa608f950ac4"
   integrity sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==
@@ -131,7 +131,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.9.0":
+"@babel/core@^7.0.0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.9.0":
   version "7.21.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.3.tgz#cf1c877284a469da5d1ce1d1e53665253fae712e"
   integrity sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==
@@ -2476,14 +2476,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.7.tgz#f4f0d5530e8dbdf59b3451b9b3e594b6ba082e12"
-  integrity sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -5720,6 +5713,11 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.49.1.tgz#09167842123eddaf47465376f3c835cf59b9f1e9"
   integrity sha512-JnC9ndmD1KKS01Rt/ovRUB1tmwO7zkyXAyIxN9mznuJrcNtOrkmOnQqdJF2ib9oHzc2VxHomnEG7xyfo54Npkw==
 
+"@tanstack/query-devtools@5.49.1":
+  version "5.49.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.49.1.tgz#4b51341cab67cc77f4a606d719cedf4fa2ecc6ea"
+  integrity sha512-9mBtuq76fp+OE780ImoNG109bM7lucZ9MLPLzAkQ2OMx+X6s3BfVATySTxm1Mrtui3qJIFo05ZI4zv9A44+GAg==
+
 "@tanstack/query-persist-client-core@5.49.1":
   version "5.49.1"
   resolved "https://registry.yarnpkg.com/@tanstack/query-persist-client-core/-/query-persist-client-core-5.49.1.tgz#5dc1d596b53399cca040b3c810ced6d31476110f"
@@ -5734,6 +5732,13 @@
   dependencies:
     "@tanstack/query-core" "5.49.1"
     "@tanstack/query-persist-client-core" "5.49.1"
+
+"@tanstack/react-query-devtools@5.49.2":
+  version "5.49.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.49.2.tgz#08073e54c03d1aa5771d8279d88d9773663fe328"
+  integrity sha512-ARQ8GXaTcwXyXIv215sfFqT9s87Jj8vP8jAc9LlC28M+4RbexfBRvm+cra3Cn/xlXJrUEjijf+vUf1Ju9F1XJQ==
+  dependencies:
+    "@tanstack/query-devtools" "5.49.1"
 
 "@tanstack/react-query-persist-client@5.49.2":
   version "5.49.2"
@@ -8054,10 +8059,15 @@ core-js-compat@^3.36.1:
   dependencies:
     browserslist "^4.23.0"
 
-core-js@3.37.1, core-js@^3.0.0:
+core-js@3.37.1:
   version "3.37.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.37.1.tgz#d21751ddb756518ac5a00e4d66499df981a62db9"
   integrity sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==
+
+core-js@^3.0.0:
+  version "3.29.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.29.1.tgz#40ff3b41588b091aaed19ca1aa5cb111803fa9a6"
+  integrity sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==
 
 core-util-is@~1.0.0:
   version "1.0.3"


### PR DESCRIPTION
## Purpose

In further development, we will stop to sell training with one shot payment. Instead we will schedule payments. From frontend, that means, before the user purchase a training, it should be able to know what is the planned schedule. A first step is to retrieve the estimated payment schedule and display it in the sale tunnel.

![CleanShot 2024-06-12 at 16 51 08@2x](https://github.com/openfun/richie/assets/9265241/f6d30802-a4ec-4a44-aff6-952946def3d6)

## Proposal

- [x] Add payment schedule api route to Joanie API module
- [x] Create a hook to retrieve payment schedule through react-query
- [x] Display payment schedule in the sale tunnel
