### PR TITLE
🐛(frontend) reset payment state on payment failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Improve Lyra error management to abort payment properly
+
 ### Fixed
 
 - Use CB logo as fallback if credit card is unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Use CB logo as fallback if credit card is unknown
 - Put CunninghamProvider at root level
+- Resubmit order on payment failure
 
 ## [2.26.0]
 

--- a/src/frontend/js/components/PaymentButton/_styles.scss
+++ b/src/frontend/js/components/PaymentButton/_styles.scss
@@ -8,6 +8,7 @@
   &__error {
     color: r-color('firebrick6');
     margin-top: 0.5rem;
+    margin-bottom: 0;
   }
 
   &__terms {

--- a/src/frontend/js/components/PaymentInterfaces/types.ts
+++ b/src/frontend/js/components/PaymentInterfaces/types.ts
@@ -5,6 +5,7 @@ export enum PaymentErrorMessageId {
   ERROR_DEFAULT = 'errorDefault',
   ERROR_FULL_PRODUCT = 'errorFullProduct',
   ERROR_TERMS = 'errorTerms',
+  ERROR_POLLING_LIMIT = 'errorPollingLimit',
 }
 
 export enum PaymentProviders {

--- a/src/frontend/js/components/SaleTunnel/GenericPaymentButton/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/GenericPaymentButton/index.tsx
@@ -135,6 +135,13 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
     );
   }, [product, saleTunnelProps.course, saleTunnelProps.enrollment, billingAddress, termsAccepted]);
 
+  const isBusy = useMemo(() => {
+    return (
+      state === ComponentStates.LOADING ||
+      (state === ComponentStates.ERROR && error === PaymentErrorMessageId.ERROR_ABORTING)
+    );
+  }, [state, error]);
+
   /**
    * Use Joanie API to retrieve an order and check if it's state is validated
    *
@@ -291,9 +298,7 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
     <>
       {renderTermsCheckbox()}
       <Button
-        disabled={
-          state === ComponentStates.LOADING || error === PaymentErrorMessageId.ERROR_POLLING_LIMIT
-        }
+        disabled={isBusy || error === PaymentErrorMessageId.ERROR_POLLING_LIMIT}
         onClick={createOrder}
         data-testid={order && 'payment-button-order-loaded'}
         fullWidth={isMobile}
@@ -301,7 +306,7 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
           'aria-describedby': 'sale-tunnel-payment-error',
         })}
       >
-        {state === ComponentStates.LOADING ? (
+        {isBusy ? (
           <Spinner theme="light" aria-labelledby="payment-in-progress">
             <span id="payment-in-progress">
               <FormattedMessage {...messages.paymentInProgress} />
@@ -323,9 +328,9 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
         <PaymentInterface {...payment} onError={handleError} onSuccess={handleSuccess} />
       )}
       {state === ComponentStates.ERROR && (
-      <p className="payment-button__error" id="sale-tunnel-payment-error" tabIndex={-1}>
+        <p className="payment-button__error" id="sale-tunnel-payment-error" tabIndex={-1}>
           <FormattedMessage {...messages[error || PaymentErrorMessageId.ERROR_DEFAULT]} />
-      </p>
+        </p>
       )}
     </>
   );

--- a/src/frontend/js/components/SaleTunnel/GenericPaymentButton/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/GenericPaymentButton/index.tsx
@@ -266,9 +266,13 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
           payment_id: paymentId,
         })
         .then(() => {
-          setPayment(undefined);
           handleError(PaymentErrorMessageId.ERROR_ABORT);
+        })
+        .catch(() => {
+          handleError();
         });
+    } else if (state === ComponentStates.ERROR) {
+      setPayment(undefined);
     }
   }, [error]);
 


### PR DESCRIPTION
## Purpose

Unlike Payplug, with Lyra, until the user has submit its payment, nothing will
happend on the backend side to notify that a payment has expired or has failed.
So we have to manage all those aspects on the frontend side.

## Proposal

- [x] Improve Lyra error management to prevent to stuck user during payment
- [x] Fix some bugs found on the road (mainly resubmit order after payment failure)
