### PR TITLE
💄(frontend) display course run link as button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Use CB logo as fallback if credit card is unknown
 - Put CunninghamProvider at root level
 - Resubmit order on payment failure
+- Render course run resource link with button look'n feel when it does not match
+  a LMS Backend
 
 ## [2.26.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Resubmit order on payment failure
 - Render course run resource link with button look'n feel when it does not match
   a LMS Backend
+- Manage display of CourseRun dates when end date and/or enrollment date are
+  undefined
 
 ## [2.26.0]
 

--- a/src/frontend/js/components/EnrollmentDate/index.spec.tsx
+++ b/src/frontend/js/components/EnrollmentDate/index.spec.tsx
@@ -1,0 +1,93 @@
+import { faker } from '@faker-js/faker';
+import { render, screen } from '@testing-library/react';
+import { CourseRunFactory } from 'utils/test/factories/richie';
+import { IntlWrapper } from 'utils/test/wrappers/IntlWrapper';
+import EnrollmentDate from '.';
+
+describe('<EnrollmentDate />', () => {
+  const dateFormatter = Intl.DateTimeFormat('en', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  it('should display when enrollment will open if course run is not yet opened', () => {
+    const courseRun = CourseRunFactory({
+      enrollment_start: faker.date.future().toISOString(),
+      enrollment_end: faker.date.future().toISOString(),
+    }).one();
+
+    render(
+      <IntlWrapper>
+        <EnrollmentDate
+          enrollment_start={courseRun.enrollment_start}
+          enrollment_end={courseRun.enrollment_end}
+        />
+      </IntlWrapper>,
+    );
+
+    screen.getByText(
+      `Enrollment from ${dateFormatter.format(new Date(courseRun.enrollment_start))}`,
+    );
+  });
+
+  it('should display when enrollment will end if course run is opened', () => {
+    const courseRun = CourseRunFactory({
+      enrollment_start: faker.date.past().toISOString(),
+      enrollment_end: faker.date.future().toISOString(),
+    }).one();
+
+    render(
+      <IntlWrapper>
+        <EnrollmentDate
+          enrollment_start={courseRun.enrollment_start}
+          enrollment_end={courseRun.enrollment_end}
+        />
+      </IntlWrapper>,
+    );
+
+    screen.getByText(
+      `Enrollment until ${dateFormatter.format(new Date(courseRun.enrollment_end))}`,
+    );
+  });
+
+  it('should display the date since enrollment is opened if there is no enrollment end', () => {
+    const courseRun = CourseRunFactory({
+      enrollment_start: faker.date.past().toISOString(),
+      enrollment_end: undefined,
+    }).one();
+
+    render(
+      <IntlWrapper>
+        <EnrollmentDate
+          enrollment_start={courseRun.enrollment_start}
+          enrollment_end={courseRun.enrollment_end}
+        />
+      </IntlWrapper>,
+    );
+
+    screen.getByText(
+      `Enrollment open since ${dateFormatter.format(new Date(courseRun.enrollment_start))}`,
+    );
+  });
+
+  it('should display a message to say that enrollment is closed if enrollment dates are passed', () => {
+    const courseRun = CourseRunFactory({
+      enrollment_start: faker.date.past().toISOString(),
+      enrollment_end: faker.date.past().toISOString(),
+    }).one();
+
+    render(
+      <IntlWrapper>
+        <EnrollmentDate
+          enrollment_start={courseRun.enrollment_start}
+          enrollment_end={courseRun.enrollment_end}
+        />
+      </IntlWrapper>,
+    );
+
+    screen.getByText(
+      `Enrollment closed since ${dateFormatter.format(new Date(courseRun.enrollment_end))}`,
+    );
+  });
+});

--- a/src/frontend/js/components/EnrollmentDate/index.tsx
+++ b/src/frontend/js/components/EnrollmentDate/index.tsx
@@ -8,10 +8,20 @@ const messages = defineMessages({
     description: 'Text label for the enrollment dates when enrollment is not yet opened',
     id: 'components.EnrollmentDate.enrollFrom',
   },
+  enrollSince: {
+    defaultMessage: 'Enrollment open since {date}',
+    description: 'Text label for the enrollment dates when enrollment opened and never closed',
+    id: 'components.EnrollmentDate.enrollSince',
+  },
   enrollUntil: {
     defaultMessage: 'Enrollment until {date}',
     description: 'Text label for the enrollment dates when enrollment is opened',
     id: 'components.EnrollmentDate.enrollUntil',
+  },
+  enrollClosed: {
+    defaultMessage: 'Enrollment closed since {date}',
+    description: 'Text label for the enrollment dates when enrollment is passed',
+    id: 'components.EnrollmentDate.enrollClosed',
   },
 });
 
@@ -26,6 +36,32 @@ const EnrollmentDate = ({ enrollment_start, enrollment_end, formatOptions = {} }
   const isOpened = useMemo(() => {
     return new Date() >= new Date(enrollment_start);
   }, [enrollment_start]);
+  const isClosed = useMemo(() => {
+    if (!enrollment_end) return false;
+    return new Date() >= new Date(enrollment_end);
+  }, [enrollment_end]);
+
+  if (isClosed) {
+    return (
+      <FormattedMessage
+        {...messages.enrollClosed}
+        values={{
+          date: formatDate(enrollment_end),
+        }}
+      />
+    );
+  }
+
+  if (isOpened && !enrollment_end) {
+    return (
+      <FormattedMessage
+        {...messages.enrollSince}
+        values={{
+          date: formatDate(enrollment_start),
+        }}
+      />
+    );
+  }
 
   if (isOpened) {
     return (

--- a/src/frontend/js/components/SaleTunnel/ProductPath/CourseRunsList.tsx
+++ b/src/frontend/js/components/SaleTunnel/ProductPath/CourseRunsList.tsx
@@ -18,7 +18,7 @@ other {# course runs}
     id: 'components.SaleTunnelStepValidation.availableCourseRuns',
   },
   courseRunDates: {
-    defaultMessage: 'From {start} to {end}',
+    defaultMessage: 'From {start} {end, select, undefined {} other {to {end}}}',
     description: 'Course run date text',
     id: 'components.SaleTunnelStepValidation.courseRunDates',
   },

--- a/src/frontend/js/hooks/useDateFormat/index.spec.tsx
+++ b/src/frontend/js/hooks/useDateFormat/index.spec.tsx
@@ -1,0 +1,37 @@
+import { renderHook } from '@testing-library/react';
+import { IntlWrapper } from 'utils/test/wrappers/IntlWrapper';
+import useDateFormat from '.';
+
+describe('useDateFormat', () => {
+  it('should format date with default options', () => {
+    const date = new Date('2022-03-28T00:00:00.000Z');
+    const { result: dateFormatter } = renderHook(useDateFormat, { wrapper: IntlWrapper });
+
+    expect(dateFormatter.current(date)).toBe('Mar 28, 2022');
+  });
+
+  it('should format date with custom options', () => {
+    const date = new Date('2022-03-28T00:00:00.000Z');
+    const { result: dateFormatter } = renderHook(
+      () =>
+        useDateFormat({
+          month: 'long',
+        }),
+      { wrapper: IntlWrapper },
+    );
+
+    expect(dateFormatter.current(date)).toBe('March 28, 2022');
+  });
+
+  it('date is undefined it should return undefined', () => {
+    const { result: dateFormatter } = renderHook(
+      () =>
+        useDateFormat({
+          month: 'long',
+        }),
+      { wrapper: IntlWrapper },
+    );
+
+    expect(dateFormatter.current(undefined)).toBe(undefined);
+  });
+});

--- a/src/frontend/js/hooks/useDateFormat/index.tsx
+++ b/src/frontend/js/hooks/useDateFormat/index.tsx
@@ -1,4 +1,5 @@
 import { type FormatDateOptions, useIntl } from 'react-intl';
+import { Maybe } from 'types/utils';
 
 export const DEFAULT_DATE_FORMAT: FormatDateOptions = {
   day: '2-digit',
@@ -29,7 +30,11 @@ export const DATETIME_FORMAT: FormatDateOptions = {
 const useDateFormat = (formatOptions: FormatDateOptions = {}) => {
   const intl = useIntl();
 
-  function formatDate(date: string | Date | number, options: FormatDateOptions = {}) {
+  function formatDate(date: Maybe<string | Date | number>, options: FormatDateOptions = {}) {
+    if (date === undefined) {
+      return undefined;
+    }
+
     return intl.formatDate(date, {
       ...DEFAULT_DATE_FORMAT,
       ...formatOptions,

--- a/src/frontend/js/pages/TeacherDashboardCourseLoader/CourseRunList/utils.tsx
+++ b/src/frontend/js/pages/TeacherDashboardCourseLoader/CourseRunList/utils.tsx
@@ -8,7 +8,7 @@ import CourseRunListCell from './CourseRunListCell';
 
 export const messages = defineMessages({
   dataCourseRunPeriod: {
-    defaultMessage: 'From {from} to {to}',
+    defaultMessage: 'From {from} {to, select, undefined {} other {to {to}}}',
     description: 'Message displayed in course run datagrid for course run period',
     id: 'components.CourseRunList.dataCourseRunPeriod',
   },
@@ -42,7 +42,7 @@ export const buildCourseRunData = (intl: IntlShape, courseRuns: CourseRun[]) => 
       <CourseRunListCell
         textContent={intl.formatMessage(messages.dataCourseRunPeriod, {
           from: intl.formatDate(new Date(courseRun.start)),
-          to: intl.formatDate(new Date(courseRun.end)),
+          to: courseRun.end ? intl.formatDate(new Date(courseRun.end)) : undefined,
         })}
         variant={CourseRunListCell.SMALL}
       />

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/CourseEnrolling/hooks/useCourseRunPeriodMessage.ts
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/CourseEnrolling/hooks/useCourseRunPeriodMessage.ts
@@ -8,7 +8,8 @@ const messages = defineMessages({
   onGoingRunPeriod: {
     id: 'components.useCourseRunPeriodMessage.onGoingRunPeriod',
     description: 'Text to display when a course run is on going.',
-    defaultMessage: 'This session started on {startDate} and will end on {endDate}',
+    defaultMessage:
+      'This session started on {startDate} {endDate, select, undefined {} other {and will end on {endDate}}}',
   },
   futureRunPeriod: {
     id: 'components.useCourseRunPeriodMessage.futureRunPeriod',
@@ -18,7 +19,8 @@ const messages = defineMessages({
   onGoingEnrolledRunPeriod: {
     id: 'components.useCourseRunPeriodMessage.onGoingEnrolledRunPeriod',
     description: 'Text to display when a course run is ongoing and the user is enrolled to.',
-    defaultMessage: "You are enrolled for this session. It's open from {startDate} to {endDate}",
+    defaultMessage:
+      "You are enrolled for this session. It's open from {startDate} {endDate, select, undefined {} other {to {endDate}}}",
   },
   futureEnrolledRunPeriod: {
     id: 'components.useCourseRunPeriodMessage.futureEnrolledRunPeriod',

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseProductCourseRuns/EnrollableCourseRunList.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/components/CourseProductCourseRuns/EnrollableCourseRunList.tsx
@@ -18,7 +18,7 @@ import CourseRunSection, { messages as sectionMessages } from './CourseRunSectio
 
 const messages = defineMessages({
   ariaSelectCourseRun: {
-    defaultMessage: 'Select course run from {start} to {end}.',
+    defaultMessage: 'Select course run from {start} {end, select, undefined {} other {to {end}}}.',
     description:
       'Accessible label used by screen reader when user checked a course run radio input.',
     id: 'components.EnrollableCourseRunList.ariaSelectCourseRun',

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
@@ -35,7 +35,7 @@ const messages = defineMessages({
     id: 'components.CourseProductItem.loadingInitial',
   },
   fromTo: {
-    defaultMessage: 'From {from} to {to}',
+    defaultMessage: 'From {from} {to, select, undefined {} other {to {to}}}',
     description: 'Course run date range',
     id: 'components.CourseProductItem.fromTo',
   },
@@ -105,7 +105,7 @@ const Header = ({ product, order, hasPurchased, canPurchase, compact }: HeaderPr
               {...messages.fromTo}
               values={{
                 from: formatDate(minDate!),
-                to: formatDate(maxDate!),
+                to: formatDate(maxDate),
               }}
             />
           </p>

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseRunItem/index.tsx
@@ -8,12 +8,12 @@ const messages = defineMessages({
   courseRunTitleWithDates: {
     id: 'components.CourseRunItem.courseRunTitleWithDates',
     description: 'Course run details displayed on the syllabus',
-    defaultMessage: '{title}, from {start} to {end}',
+    defaultMessage: '{title}, from {start} {end, select, undefined {} other {to {end}}}',
   },
   courseRunWithDates: {
     id: 'components.CourseRunItem.courseRunWithDates',
     description: 'Course run details displayed on the syllabus when it has no title',
-    defaultMessage: 'From {start} to {end}',
+    defaultMessage: 'From {start} {end, select, undefined {} other {to {end}}}',
   },
 });
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRun/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRun/index.tsx
@@ -1,4 +1,5 @@
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { Button } from '@openfun/cunningham-react';
 import { CourseRun, CourseRunDisplayMode } from 'types';
 import useDateFormat from 'hooks/useDateFormat';
 import { extractResourceId, isJoanieResourceLinkProduct } from 'api/lms/joanie';
@@ -83,9 +84,9 @@ const OpenedCourseRun = ({ courseRun }: { courseRun: CourseRun }) => {
       {findLmsBackend(courseRun.resource_link) ? (
         <CourseRunEnrollment courseRun={courseRun} />
       ) : (
-        <a className="course-run-enrollment__cta" href={courseRun.resource_link}>
+        <Button className="course-run-enrollment__cta" href={courseRun.resource_link} fullWidth>
           {StringHelper.capitalizeFirst(courseRun.state.call_to_action)}
-        </a>
+        </Button>
       )}
     </>
   );


### PR DESCRIPTION
## Purpose

When a course run resource link does not match configured LMS Backend, we simply render a link to go follow the resource link. This link is currently a simple anchor tag but it's weird as it does not match the look'n feel of other course run blocks. So we decide to use a Cunningham Button component instead.

### Enrollment link
| Before | After |
|--------|-------|
|<img width="400" alt="image" src="https://github.com/openfun/richie/assets/9265241/83f9fece-0a90-4570-a1ec-9a3ee9a56282">|<img width="400" alt="image" src="https://github.com/openfun/richie/assets/9265241/c992d0ea-16c9-4b6e-b660-d68cfc3f93ec">|

### Date display
| Before | After |
|--------|-------|
|<img width="450" alt="Capture d’écran 2024-05-30 à 16 35 10" src="https://github.com/openfun/richie/assets/9265241/a9979cb9-05f2-4d3d-bccd-4b7f38c1a18b">|<img width="450" alt="image" src="https://github.com/openfun/richie/assets/9265241/96c52d61-6509-4940-9037-d8af68d96532">|

## Proposal

- [x] Display unsupported course run enrollment link as button
- [x] Improvement course run date display
