### PR TITLE
⚡️(cdn) load react JS bundle from CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - PurchaseButton instantiated a hook conditionnaly
 - Make UserHelper manages OpenEdxProfile object to extract name
 
+### Added
+
+- Load React JS bundles from CDN on all pages
+
 ## [2.27.0]
 
 ### Added

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -51,6 +51,12 @@
             {% endblock meta_rdfa_context %}
             {% endblock meta_rdfa %}
 
+            {% block meta_public_path %}
+                {% if CDN_DOMAIN %}
+                    <meta name="public-path" value="{{ CDN_DOMAIN }}" />
+                {% endif %}
+            {% endblock meta_public_path%}
+
         {% endblock meta %}
         {% if MEDIA_URL_IS_EXTERNAL %}
             {% if MEDIA_HOSTNAME_PRECONNECT %}

--- a/src/richie/apps/search/templates/search/search.html
+++ b/src/richie/apps/search/templates/search/search.html
@@ -2,13 +2,6 @@
 {% load cms_tags i18n static %}
 {% get_current_language as LANGUAGE_CODE %}
 
-{% block meta %}
-  {{ block.super }}
-  {% if CDN_DOMAIN %}
-  <meta name="public-path" value="{{ CDN_DOMAIN }}" />
-  {% endif %}
-{% endblock meta %}
-
 {% block head_title %}{% page_attribute "page_title" %}{% endblock head_title %}
 
 {% block topbar_searchbar %}{% endblock topbar_searchbar %}

--- a/tests/apps/core/test_templates_cdn.py
+++ b/tests/apps/core/test_templates_cdn.py
@@ -1,0 +1,45 @@
+"""
+Test for the dns prefetch
+"""
+
+from django.test.utils import override_settings
+
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.core.helpers import create_i18n_page
+
+
+class TemplatesCDNDomainTestCase(CMSTestCase):
+    """Testing the base.html template"""
+
+    def test_templates_cdn_domain_absent(self):
+        """
+        If the `CDN_DOMAIN` isn't defined, then the `public-path` meta should be absent.
+        """
+        homepage = create_i18n_page("my title", is_homepage=True)
+        homepage.publish("en")
+        url = homepage.get_absolute_url(language="en")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            '<meta name="public-path""',
+        )
+
+    @override_settings(CDN_DOMAIN="xyz.acdn.net")
+    def test_templates_cdn_domain(self):
+        """
+        If the `CDN_DOMAIN` setting is defined then the `public-path` meta should contain
+        the value of the CDN, so the React JS bundles can be loaded using that domain.
+        """
+        homepage = create_i18n_page("my title", is_homepage=True)
+        homepage.publish("en")
+        url = homepage.get_absolute_url(language="en")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<meta name="public-path" value="xyz.acdn.net" />',
+        )


### PR DESCRIPTION
If Richie site is configured to use a CDN_DOMAIN then the React JS Bundle should be downloaded from CDN instead of Richie site domain.

resolves #2423
