### PR TITLE
🐛(backend) fix Category.get_children_categories in public mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - useDateFormat did not return undefined with null values
 - PurchaseButton instantiated a hook conditionnaly
 - Make UserHelper manages OpenEdxProfile object to extract name
+- Do not display unpublished children categories in the public 
+  category detail page
 
 ### Added
 

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -106,10 +106,19 @@ class Category(EsIdMixin, BasePageExtension):
         objects related to this category. A convenient method since
         ``page.get_child_pages`` return every direct child page, no matter
         it's a Category or not.
+
+        In public mode, we only return published categories.
         """
-        return Category.objects.filter(
-            extended_object__in=self.extended_object.get_child_pages()
-        ).select_related("extended_object")
+        filters = {"extended_object__in": self.extended_object.get_child_pages()}
+
+        if not self.extended_object.publisher_is_draft:
+            filters.update(extended_object__title_set__published=True)
+
+        return (
+            Category.objects.filter(**filters)
+            .select_related("extended_object")
+            .distinct()
+        )
 
 
 def get_category_limit_choices_to():


### PR DESCRIPTION
## Purpose

Currently, calling `get_children_categories` for a published category return all category children even draft ones. In order to prevent that, if the category is not in draft, we explicitly exclude unpublished categories.
