### PR TITLE
✨(frontend) compact syllabus for self-paced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - csrftoken in richie context
 
+### Added
+
+- On self-paced courses with single run display a simplified
+  version of the syllabus.
+
 ## [2.28.1]
 
 ### Fixed

--- a/src/frontend/js/components/PurchaseButton/index.spec.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.spec.tsx
@@ -6,12 +6,12 @@ import userEvent from '@testing-library/user-event';
 import { CunninghamProvider } from '@openfun/cunningham-react';
 import {
   CourseStateFactory,
+  PacedCourseFactory,
   UserFactory,
   RichieContextFactory as mockRichieContextFactory,
 } from 'utils/test/factories/richie';
 import {
   CertificateProductFactory,
-  CourseLightFactory,
   EnrollmentFactory,
   ProductFactory,
 } from 'utils/test/factories/joanie';
@@ -89,7 +89,7 @@ describe('PurchaseButton', () => {
         <PurchaseButton
           product={product}
           disabled={false}
-          course={CourseLightFactory({ code: '00000' }).one()}
+          course={PacedCourseFactory({ code: '00000' }).one()}
         />
       </Wrapper>,
     );
@@ -112,7 +112,7 @@ describe('PurchaseButton', () => {
         <PurchaseButton
           product={product}
           disabled={false}
-          course={CourseLightFactory({ code: courseCode }).one()}
+          course={PacedCourseFactory({ code: courseCode }).one()}
         />
       </Wrapper>,
     );
@@ -146,7 +146,7 @@ describe('PurchaseButton', () => {
         <PurchaseButton
           product={product}
           disabled={false}
-          course={CourseLightFactory({ code: courseCode }).one()}
+          course={PacedCourseFactory({ code: courseCode }).one()}
         />
       </Wrapper>,
     );
@@ -181,7 +181,7 @@ describe('PurchaseButton', () => {
         <PurchaseButton
           product={product}
           disabled={false}
-          course={CourseLightFactory({ code: courseCode }).one()}
+          course={PacedCourseFactory({ code: courseCode }).one()}
         />
       </Wrapper>,
     );
@@ -214,7 +214,7 @@ describe('PurchaseButton', () => {
         <PurchaseButton
           product={product}
           disabled={false}
-          course={CourseLightFactory({ code: courseCode }).one()}
+          course={PacedCourseFactory({ code: courseCode }).one()}
         />
       </Wrapper>,
     );
@@ -251,7 +251,7 @@ describe('PurchaseButton', () => {
           <PurchaseButton
             product={product}
             disabled={false}
-            course={CourseLightFactory({ code: courseCode }).one()}
+            course={PacedCourseFactory({ code: courseCode }).one()}
           />
         </Wrapper>,
       );
@@ -384,7 +384,7 @@ describe('PurchaseButton', () => {
         <PurchaseButton
           product={product}
           disabled={false}
-          course={CourseLightFactory({ code: courseCode }).one()}
+          course={PacedCourseFactory({ code: courseCode }).one()}
         />
       </Wrapper>,
     );
@@ -414,7 +414,7 @@ describe('PurchaseButton', () => {
         <PurchaseButton
           product={product}
           disabled={true}
-          course={CourseLightFactory({ code: courseCode }).one()}
+          course={PacedCourseFactory({ code: courseCode }).one()}
         />
       </Wrapper>,
     );

--- a/src/frontend/js/components/PurchaseButton/index.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.tsx
@@ -7,6 +7,7 @@ import * as Joanie from 'types/Joanie';
 import { isOpenedCourseRunCertificate, isOpenedCourseRunCredential } from 'utils/CourseRuns';
 import { SaleTunnel, SaleTunnelProps } from 'components/SaleTunnel';
 import { Organization } from 'types/Joanie';
+import { PacedCourse } from 'types';
 
 const messages = defineMessages({
   loginToPurchase: {
@@ -52,7 +53,7 @@ interface PurchaseButtonPropsBase {
 
 interface CredentialPurchaseButtonProps extends PurchaseButtonPropsBase {
   product: Joanie.CredentialProduct;
-  course: Joanie.CourseLight;
+  course: PacedCourse;
   enrollment?: undefined;
 }
 

--- a/src/frontend/js/components/SaleTunnel/index.credential.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.credential.spec.tsx
@@ -2,12 +2,12 @@ import fetchMock from 'fetch-mock';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import {
   RichieContextFactory as mockRichieContextFactory,
+  PacedCourseFactory,
   UserFactory,
 } from 'utils/test/factories/richie';
 import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
 import {
   AddressFactory,
-  CourseFactory,
   CredentialOrderWithPaymentFactory,
   CredentialProductFactory,
   OrderGroupFactory,
@@ -86,7 +86,7 @@ describe('SaleTunnel / Credential', () => {
   });
 
   it('should create an order with an order group', async () => {
-    const course = CourseFactory().one();
+    const course = PacedCourseFactory().one();
     const product = CredentialProductFactory().one();
     const orderGroup = OrderGroupFactory().one();
     const billingAddress: Joanie.Address = AddressFactory({ is_main: true }).one();

--- a/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import countries from 'i18n-iso-countries';
 import {
   RichieContextFactory as mockRichieContextFactory,
+  PacedCourseFactory,
   UserFactory,
 } from 'utils/test/factories/richie';
 import { render } from 'utils/test/render';
@@ -12,8 +13,8 @@ import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
 import CourseProductItem from 'widgets/SyllabusCourseRunsList/components/CourseProductItem';
 import {
   AddressFactory,
-  CourseProductRelationFactory,
   CredentialOrderWithPaymentFactory,
+  CourseProductRelationFactory,
 } from 'utils/test/factories/joanie';
 import { ACTIVE_ORDER_STATES, CourseRun } from 'types/Joanie';
 import { Priority } from 'types';
@@ -101,9 +102,15 @@ describe('SaleTunnel', () => {
       [],
     );
 
-    render(<CourseProductItem productId={product.id} course={course} />, {
-      queryOptions: { client: createTestQueryClient({ user: richieUser }) },
-    });
+    render(
+      <CourseProductItem
+        productId={product.id}
+        course={PacedCourseFactory({ id: course.id, code: course.code }).one()}
+      />,
+      {
+        queryOptions: { client: createTestQueryClient({ user: richieUser }) },
+      },
+    );
 
     // Wait for product information to be fetched
     await screen.findByRole('heading', { level: 3, name: product.title });

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -8,7 +8,6 @@ import {
   CertificateOrderWithOneClickPaymentFactory,
   CertificateOrderWithPaymentFactory,
   CertificateProductFactory,
-  CourseFactory,
   CredentialOrderWithOneClickPaymentFactory,
   CredentialOrderWithPaymentFactory,
   CredentialProductFactory,
@@ -17,6 +16,7 @@ import {
 } from 'utils/test/factories/joanie';
 import {
   RichieContextFactory as mockRichieContextFactory,
+  PacedCourseFactory,
   UserFactory,
 } from 'utils/test/factories/richie';
 import { render } from 'utils/test/render';
@@ -70,7 +70,7 @@ describe.each([
   ({ productType, ProductFactory, OrderWithOneClickPaymentFactory, OrderWithPaymentFactory }) => {
     let nbApiCalls: number;
 
-    const course = CourseFactory().one();
+    const course = PacedCourseFactory().one();
     const enrollment =
       productType === ProductType.CERTIFICATE ? EnrollmentFactory().one() : undefined;
 

--- a/src/frontend/js/components/SaleTunnel/index.stories.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryObj, Meta } from '@storybook/react';
 import { BaseJoanieAppWrapper } from 'utils/test/wrappers/BaseJoanieAppWrapper';
-import { CourseFactory, ProductFactory } from 'utils/test/factories/joanie';
+import { ProductFactory } from 'utils/test/factories/joanie';
+import { PacedCourseFactory } from 'utils/test/factories/richie';
 import { SaleTunnel, SaleTunnelProps } from './index';
 
 export default {
@@ -10,7 +11,7 @@ export default {
       isOpen: true,
       product: ProductFactory().one(),
       onClose: () => {},
-      course: CourseFactory().one(),
+      course: PacedCourseFactory().one(),
       // enrollment?: Enrollment;
       // product: CredentialProduct | CertificateProduct;
       // orderGroup?: OrderGroup;

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -1,7 +1,6 @@
 import { ModalProps } from '@openfun/cunningham-react';
 import {
   CertificateProduct,
-  CourseLight,
   CredentialProduct,
   Enrollment,
   Order,
@@ -12,12 +11,13 @@ import {
 } from 'types/Joanie';
 import { CredentialSaleTunnel } from 'components/SaleTunnel/CredentialSaleTunnel';
 import { CertificateSaleTunnel } from 'components/SaleTunnel/CertificateSaleTunnel';
+import { PacedCourse } from 'types';
 
 export interface SaleTunnelProps extends Pick<ModalProps, 'isOpen' | 'onClose'> {
   product: Product;
   organizations?: Organization[];
 
-  course?: CourseLight;
+  course?: PacedCourse;
   enrollment?: Enrollment;
   orderGroup?: OrderGroup;
   onFinish?: (order: Order) => void;

--- a/src/frontend/js/types/index.ts
+++ b/src/frontend/js/types/index.ts
@@ -16,6 +16,12 @@ export enum CourseRunDisplayMode {
   DETAILED = 'detailed',
 }
 
+export interface PacedCourse {
+  id: string;
+  code: string;
+  is_self_paced: boolean;
+}
+
 export interface CourseRun {
   id: number;
   resource_link: string;

--- a/src/frontend/js/utils/CourseRunHelper/index.spec.ts
+++ b/src/frontend/js/utils/CourseRunHelper/index.spec.ts
@@ -1,0 +1,35 @@
+import { CourseRun, Priority } from 'types';
+import { CourseRunHelper } from 'utils/CourseRunHelper/index';
+import { CourseRunFactoryFromPriority } from 'utils/test/factories/richie';
+
+describe('CourseRunHelper', () => {
+  it('should return true if all course runs have the same languages', () => {
+    const courseRuns: CourseRun[] = [
+      CourseRunFactoryFromPriority(Priority.ONGOING_OPEN)({
+        languages: ['en'],
+      }).one(),
+      CourseRunFactoryFromPriority(Priority.ARCHIVED_OPEN)({
+        languages: ['en'],
+      }).one(),
+      CourseRunFactoryFromPriority(Priority.FUTURE_OPEN)({
+        languages: ['en'],
+      }).one(),
+    ];
+    expect(CourseRunHelper.IsAllCourseRunsWithSameLanguages(courseRuns)).toEqual(true);
+  });
+
+  it('should return false if all course runs have different languages', () => {
+    const courseRuns: CourseRun[] = [
+      CourseRunFactoryFromPriority(Priority.ONGOING_OPEN)({
+        languages: ['en'],
+      }).one(),
+      CourseRunFactoryFromPriority(Priority.ARCHIVED_OPEN)({
+        languages: ['fr'],
+      }).one(),
+      CourseRunFactoryFromPriority(Priority.FUTURE_OPEN)({
+        languages: ['it'],
+      }).one(),
+    ];
+    expect(CourseRunHelper.IsAllCourseRunsWithSameLanguages(courseRuns)).toEqual(false);
+  });
+});

--- a/src/frontend/js/utils/CourseRunHelper/index.ts
+++ b/src/frontend/js/utils/CourseRunHelper/index.ts
@@ -1,0 +1,13 @@
+import { CourseRun } from 'types';
+
+export class CourseRunHelper {
+  /**
+   * Checks if all given runs of a course have the same languages.
+   */
+  static IsAllCourseRunsWithSameLanguages = (courseRuns: CourseRun[]) => {
+    const languages = courseRuns[0].languages.sort().join();
+    return courseRuns
+      .map((courseRun) => courseRun.languages.sort().join())
+      .every((runLanguages) => runLanguages === languages);
+  };
+}

--- a/src/frontend/js/utils/test/factories/richie.ts
+++ b/src/frontend/js/utils/test/factories/richie.ts
@@ -2,7 +2,14 @@ import { faker } from '@faker-js/faker';
 import { User } from 'types/User';
 import { APIBackend } from 'types/api';
 import { CommonDataProps } from 'types/commonDataProps';
-import { CourseRun, CourseRunDisplayMode, CourseState, CourseStateTextEnum, Priority } from 'types';
+import {
+  CourseRun,
+  CourseRunDisplayMode,
+  CourseState,
+  CourseStateTextEnum,
+  PacedCourse,
+  Priority,
+} from 'types';
 import { Course } from 'types/Course';
 import { FactoryHelper } from 'utils/test/factories/helper';
 import { factory } from './factories';
@@ -51,6 +58,14 @@ export const CourseRunFactory = factory<CourseRun>(() => {
     dashboard_link: null,
     title: faker.lorem.sentence(3),
     display_mode: CourseRunDisplayMode.DETAILED,
+  };
+});
+
+export const PacedCourseFactory = factory((): PacedCourse => {
+  return {
+    id: faker.string.uuid(),
+    code: faker.string.alphanumeric(5),
+    is_self_paced: false,
   };
 });
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/CourseProductItemFooter/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/CourseProductItemFooter/index.tsx
@@ -1,6 +1,7 @@
 import { FormattedMessage, defineMessages } from 'react-intl';
 import PurchaseButton from 'components/PurchaseButton';
-import { CourseLight, CourseProductRelation, CredentialProduct, OrderGroup } from 'types/Joanie';
+import { CourseProductRelation, CredentialProduct, OrderGroup } from 'types/Joanie';
+import { PacedCourse } from 'types';
 
 const messages = defineMessages({
   noSeatsAvailable: {
@@ -22,7 +23,7 @@ other {# remaining seats}
 });
 
 interface CourseProductItemFooterProps {
-  course: CourseLight;
+  course: PacedCourse;
   courseProductRelation: CourseProductRelation;
   canPurchase: boolean;
   orderGroups: OrderGroup[];

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.spec.tsx
@@ -1,9 +1,11 @@
 import { getByText, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import queryString from 'query-string';
-import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import {
-  CourseLightFactory,
+  RichieContextFactory as mockRichieContextFactory,
+  PacedCourseFactory,
+} from 'utils/test/factories/richie';
+import {
   CourseProductRelationFactory,
   EnrollmentFactory,
   CredentialOrderFactory,
@@ -81,7 +83,7 @@ describe('CourseProductItem', () => {
 
     render(
       <CourseProductItem
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
         productId={product.id}
       />,
       { queryOptions: { client: createTestQueryClient({ user: null }) } },
@@ -103,7 +105,7 @@ describe('CourseProductItem', () => {
 
     render(
       <CourseProductItem
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
         productId={product.id}
       />,
       { queryOptions: { client: createTestQueryClient({ user: null }) } },
@@ -162,7 +164,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
       { queryOptions: { client: createTestQueryClient({ user: null }) } },
     );
@@ -183,7 +185,7 @@ describe('CourseProductItem', () => {
 
     const { container } = render(
       <CourseProductItem
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
         productId={relation.product.id}
         compact
       />,
@@ -234,7 +236,7 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = CredentialOrderFactory({
       product_id: product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
     }).one();
 
@@ -255,7 +257,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 
@@ -293,7 +295,7 @@ describe('CourseProductItem', () => {
     const relation = CourseProductRelationFactory().one();
     const order: CredentialOrder = CredentialOrderFactory({
       product_id: relation.product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: relation.product.target_courses,
     }).one();
 
@@ -314,7 +316,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={relation.product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
         compact
       />,
     );
@@ -364,7 +366,7 @@ describe('CourseProductItem', () => {
     }).one();
     const order: CredentialOrder = CredentialOrderFactory({
       product_id: product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       target_enrollments: [enrollment],
     }).one();
@@ -386,7 +388,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 
@@ -425,7 +427,7 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = CredentialOrderFactory({
       product_id: product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       state: OrderState.PENDING,
     }).one();
@@ -446,7 +448,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 
@@ -495,7 +497,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 
@@ -529,7 +531,7 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = CredentialOrderFactory({
       product_id: product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       state: OrderState.SUBMITTED,
     }).one();
@@ -550,7 +552,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 
@@ -600,7 +602,7 @@ describe('CourseProductItem', () => {
       const order = CredentialOrderFactory({
         product_id: product.id,
         target_courses: product.target_courses,
-        course: CourseLightFactory({ code: '00000' }).one(),
+        course: PacedCourseFactory({ code: '00000' }).one(),
         state: orderState,
       }).one();
       fetchMock.get(
@@ -621,7 +623,7 @@ describe('CourseProductItem', () => {
       render(
         <CourseProductItem
           productId={product.id}
-          course={CourseLightFactory({ code: '00000' }).one()}
+          course={PacedCourseFactory({ code: '00000' }).one()}
         />,
       );
 
@@ -649,7 +651,7 @@ describe('CourseProductItem', () => {
     const order = CredentialOrderFactory({
       product_id: product.id,
       target_courses: product.target_courses,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       state: OrderState.VALIDATED,
     }).one();
     fetchMock.get(
@@ -670,7 +672,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 
@@ -686,7 +688,7 @@ describe('CourseProductItem', () => {
     const relation = CourseProductRelationFactory().one();
     const order: CredentialOrder = CredentialOrderFactory({
       product_id: relation.product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: relation.product.target_courses,
       state: OrderState.SUBMITTED,
     }).one();
@@ -707,7 +709,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={relation.product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
         compact={true}
       />,
     );
@@ -751,7 +753,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
       { queryOptions: { client: createTestQueryClient({ user: null }) } },
     );
@@ -767,7 +769,7 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = CredentialOrderFactory({
       product_id: product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       state: OrderState.PENDING,
     }).one();
@@ -788,7 +790,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 
@@ -806,7 +808,7 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = CredentialOrderFactory({
       product_id: product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       state: OrderState.PENDING,
     }).one();
@@ -827,7 +829,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 
@@ -846,7 +848,7 @@ describe('CourseProductItem', () => {
     const { product } = relation;
     const order = CredentialOrderFactory({
       product_id: product.id,
-      course: CourseLightFactory({ code: '00000' }).one(),
+      course: PacedCourseFactory({ code: '00000' }).one(),
       target_courses: product.target_courses,
       state: OrderState.PENDING,
     }).one();
@@ -867,7 +869,7 @@ describe('CourseProductItem', () => {
     render(
       <CourseProductItem
         productId={product.id}
-        course={CourseLightFactory({ code: '00000' }).one()}
+        course={PacedCourseFactory({ code: '00000' }).one()}
       />,
     );
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.stories.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.stories.tsx
@@ -3,7 +3,6 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import fetchMock from 'fetch-mock';
 import { StorybookHelper } from 'utils/StorybookHelper';
 import {
-  CourseLightFactory,
   CourseProductRelationFactory,
   CourseRunFactory,
   CredentialOrderFactory,
@@ -12,7 +11,7 @@ import {
   TargetCourseFactory,
 } from 'utils/test/factories/joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
-import { UserFactory } from 'utils/test/factories/richie';
+import { UserFactory, PacedCourseFactory } from 'utils/test/factories/richie';
 import { CredentialOrder, OrderState } from 'types/Joanie';
 import { Maybe } from 'types/utils';
 import CourseProductItem, { CourseProductItemProps } from '.';
@@ -49,7 +48,7 @@ export default {
   },
   args: {
     productId: 'AAA',
-    course: CourseLightFactory({ code: 'BBB' }).one(),
+    course: PacedCourseFactory({ code: 'BBB' }).one(),
   },
   render: (args) => render(args),
 } as Meta<typeof CourseProductItem>;
@@ -61,7 +60,7 @@ export const Default: Story = {};
 export const WithPendingOrder: Story = {
   args: {
     productId: 'AAA',
-    course: CourseLightFactory({ code: 'BBB' }).one(),
+    course: PacedCourseFactory({ code: 'BBB' }).one(),
   },
   render: (args) =>
     render(args, { order: CredentialOrderFactory({ state: OrderState.PENDING }).one() }),
@@ -70,7 +69,7 @@ export const WithPendingOrder: Story = {
 export const WithValidatedOrder: Story = {
   args: {
     productId: 'AAA',
-    course: CourseLightFactory({ code: 'BBB' }).one(),
+    course: PacedCourseFactory({ code: 'BBB' }).one(),
   },
   render: (args) => {
     const courseRunWithEnrollment = CourseRunFactory().one();
@@ -95,7 +94,7 @@ export const WithValidatedOrder: Story = {
 export const WithSubmittedOrder: Story = {
   args: {
     productId: 'AAA',
-    course: CourseLightFactory({ code: 'BBB' }).one(),
+    course: PacedCourseFactory({ code: 'BBB' }).one(),
   },
   render: (args) =>
     render(args, { order: CredentialOrderFactory({ state: OrderState.SUBMITTED }).one() }),

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
@@ -1,7 +1,7 @@
 import { Children, useEffect, useMemo } from 'react';
 import { defineMessages, FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
 import c from 'classnames';
-import { ProductType, OrderState, CourseLight, Product, CredentialOrder } from 'types/Joanie';
+import { ProductType, OrderState, Product, CredentialOrder } from 'types/Joanie';
 import { useCourseProduct } from 'hooks/useCourseProducts';
 import { Spinner } from 'components/Spinner';
 import { Icon, IconTypeEnum } from 'components/Icon';
@@ -12,6 +12,7 @@ import useProductOrder from 'hooks/useProductOrder';
 import { OrderHelper } from 'utils/OrderHelper';
 import { handle } from 'utils/errors/handle';
 import { ProductSignatureHeader } from 'widgets/SyllabusCourseRunsList/components/CourseProductItem/components/ProductSignatureHeader';
+import { PacedCourse } from 'types';
 import CertificateItem from './components/CourseProductCertificateItem';
 import CourseRunItem from './components/CourseRunItem';
 import CourseProductItemFooter from './CourseProductItemFooter';
@@ -48,7 +49,7 @@ const messages = defineMessages({
 
 export interface CourseProductItemProps {
   compact?: boolean;
-  course: CourseLight;
+  course: PacedCourse;
   productId: Product['id'];
 }
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/index.login.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/index.login.spec.tsx
@@ -5,9 +5,11 @@
 import { screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
-import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import {
+  RichieContextFactory as mockRichieContextFactory,
+  PacedCourseFactory,
+} from 'utils/test/factories/richie';
 import { HttpStatusCode } from 'utils/errors/HttpError';
-import { CourseLightFactory } from 'utils/test/factories/joanie';
 import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
 import { render } from 'utils/test/render';
 import { expectNoSpinner } from 'utils/test/expectSpinner';
@@ -29,7 +31,7 @@ jest.mock('utils/context', () => ({
 describe('CourseWishButton', () => {
   const joanieSessionData = setupJoanieSession();
   let nbApiCalls: number;
-  const course = CourseLightFactory().one();
+  const course = PacedCourseFactory().one();
 
   beforeEach(() => {
     nbApiCalls = joanieSessionData.nbSessionApiRequest;

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/index.logout.spec.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/index.logout.spec.tsx
@@ -5,9 +5,11 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
-import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import {
+  RichieContextFactory as mockRichieContextFactory,
+  PacedCourseFactory,
+} from 'utils/test/factories/richie';
 import { location } from 'utils/indirection/window';
-import { CourseLightFactory } from 'utils/test/factories/joanie';
 import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
 import { render } from 'utils/test/render';
 import { HttpStatusCode } from 'utils/errors/HttpError';
@@ -37,7 +39,7 @@ jest.mock('utils/context', () => ({
 
 describe('CourseWishButton', () => {
   setupJoanieSession();
-  const course = CourseLightFactory().one();
+  const course = PacedCourseFactory().one();
 
   it('renders a log me link', async () => {
     fetchMock.get(`https://joanie.endpoint/api/v1.0/courses/${course.code}/wish/`, {

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseWishButton/index.tsx
@@ -3,7 +3,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { Button } from '@openfun/cunningham-react';
 import { Spinner } from 'components/Spinner';
 import { useSession } from 'contexts/SessionContext';
-import { CourseLight } from 'types/Joanie';
+import { PacedCourse } from 'types';
 import { useCourseWish } from './hooks/useCourseWish';
 
 const messages = defineMessages({
@@ -37,7 +37,7 @@ enum ComponentStates {
 }
 
 export interface Props {
-  course: CourseLight;
+  course: PacedCourse;
 }
 
 const CourseWishButton = ({ course }: Props) => {

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusAsideList/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusAsideList/index.tsx
@@ -1,9 +1,9 @@
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import React from 'react';
-import { CourseRun, Priority } from 'types';
+import { PacedCourse, CourseRun, Priority } from 'types';
+import { CourseRunHelper } from 'utils/CourseRunHelper';
 import { SyllabusSimpleCourseRunsList } from 'widgets/SyllabusCourseRunsList/components/SyllabusSimpleCourseRunsList';
 import { SyllabusCourseRun } from 'widgets/SyllabusCourseRunsList/components/SyllabusCourseRun';
-import { CourseLight } from 'types/Joanie';
 
 const messages = defineMessages({
   otherCourseRuns: {
@@ -57,7 +57,7 @@ export const SyllabusAsideList = ({
   maxArchivedCourseRuns,
 }: {
   courseRuns: CourseRun[];
-  course: CourseLight;
+  course: PacedCourse;
   maxArchivedCourseRuns: number;
 }) => {
   const intl = useIntl();
@@ -106,6 +106,8 @@ export const SyllabusAsideList = ({
     [Priority.ARCHIVED_CLOSED].includes(run.state.priority),
   );
 
+  const showLanguages = CourseRunHelper.IsAllCourseRunsWithSameLanguages(courseRuns);
+
   return (
     <>
       <h2 className="course-detail__title">
@@ -134,7 +136,12 @@ export const SyllabusAsideList = ({
           className="course-detail__row course-detail__runs course-detail__runs--open"
         >
           {openedRuns.map((run) => (
-            <SyllabusCourseRun key={run.id} courseRun={run} course={course} />
+            <SyllabusCourseRun
+              key={run.id}
+              courseRun={run}
+              course={course}
+              showLanguages={showLanguages}
+            />
           ))}
         </div>
       )}

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted/index.tsx
@@ -1,5 +1,4 @@
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
-import { Button } from '@openfun/cunningham-react';
 import { CourseRun, CourseRunDisplayMode, PacedCourse } from 'types';
 import useDateFormat from 'hooks/useDateFormat';
 import { extractResourceId, isJoanieResourceLinkProduct } from 'api/lms/joanie';
@@ -11,34 +10,29 @@ import CourseRunEnrollment from '../CourseRunEnrollment';
 import CourseProductItem from '../CourseProductItem';
 
 const messages = defineMessages({
-  enrollment: {
-    id: 'components.SyllabusCourseRun.enrollment',
-    description: 'Title of the enrollment dates section of an opened course run block',
-    defaultMessage: 'Enrollment',
-  },
   course: {
-    id: 'components.SyllabusCourseRun.course',
+    id: 'components.SyllabusCourseRunCompacted.course',
     description: 'Title of the course dates section of an opened course run block',
     defaultMessage: 'Course',
   },
   languages: {
-    id: 'components.SyllabusCourseRun.languages',
+    id: 'components.SyllabusCourseRunCompacted.languages',
     description: 'Title of the languages section of an opened course run block',
     defaultMessage: 'Languages',
   },
-  runPeriod: {
-    id: 'components.SyllabusCourseRun.enrollmentPeriod',
-    description: 'Enrollment date of an opened course run block',
-    defaultMessage: 'From {startDate} {endDate, select, undefined {} other {to {endDate}}}',
+  selfPaceRunPeriod: {
+    id: 'components.SyllabusCourseRunCompacted.selfPaceCoursePeriod',
+    description: 'Course date of an opened and self paced course run block',
+    defaultMessage: 'Available until {endDate}',
   },
-  coursePeriod: {
-    id: 'components.SyllabusCourseRun.coursePeriod',
-    description: 'Course date of an opened course run block',
-    defaultMessage: 'From {startDate} {endDate, select, undefined {} other {to {endDate}}}',
+  selfPaceNoEndDate: {
+    id: 'components.SyllabusCourseRunCompacted.selfPaceNoEndDate',
+    description: 'Self paced course run block with no end date',
+    defaultMessage: 'Available',
   },
 });
 
-const OpenedCourseRun = ({
+const OpenedSelfPacedCourseRun = ({
   courseRun,
   showLanguages,
 }: {
@@ -47,39 +41,28 @@ const OpenedCourseRun = ({
 }) => {
   const formatDate = useDateFormat();
   const intl = useIntl();
-  const enrollmentStart = courseRun.enrollment_start
-    ? formatDate(courseRun.enrollment_start)
-    : '...';
-  const enrollmentEnd = courseRun.enrollment_end ? formatDate(courseRun.enrollment_end) : '...';
-  const start = courseRun.start ? formatDate(courseRun.start) : '...';
   const end = courseRun.end ? formatDate(courseRun.end) : '...';
+  const hasEndDate = end !== '...';
   return (
     <>
       {courseRun.title && <h3>{StringHelper.capitalizeFirst(courseRun.title)}</h3>}
       <dl>
-        <dt>
-          <FormattedMessage {...messages.enrollment} />
-        </dt>
+        {!showLanguages && (
+          <dt>
+            <FormattedMessage {...messages.course} />
+          </dt>
+        )}
         <dd>
-          <FormattedMessage
-            {...messages.runPeriod}
-            values={{
-              startDate: enrollmentStart,
-              endDate: enrollmentEnd,
-            }}
-          />
-        </dd>
-        <dt>
-          <FormattedMessage {...messages.course} />
-        </dt>
-        <dd>
-          <FormattedMessage
-            {...messages.runPeriod}
-            values={{
-              startDate: start,
-              endDate: end,
-            }}
-          />
+          {hasEndDate ? (
+            <FormattedMessage
+              {...messages.selfPaceRunPeriod}
+              values={{
+                endDate: end,
+              }}
+            />
+          ) : (
+            <FormattedMessage {...messages.selfPaceNoEndDate} />
+          )}
         </dd>
         {!showLanguages && (
           <>
@@ -93,15 +76,15 @@ const OpenedCourseRun = ({
       {findLmsBackend(courseRun.resource_link) ? (
         <CourseRunEnrollment courseRun={courseRun} />
       ) : (
-        <Button className="course-run-enrollment__cta" href={courseRun.resource_link} fullWidth>
+        <a className="course-run-enrollment__cta" href={courseRun.resource_link}>
           {StringHelper.capitalizeFirst(courseRun.state.call_to_action)}
-        </Button>
+        </a>
       )}
     </>
   );
 };
 
-export const SyllabusCourseRun = ({
+export const SyllabusCourseRunCompacted = ({
   courseRun,
   course,
   showLanguages,
@@ -120,7 +103,7 @@ export const SyllabusCourseRun = ({
             compact={courseRun.display_mode === CourseRunDisplayMode.COMPACT}
           />
         ) : (
-          <OpenedCourseRun courseRun={courseRun} showLanguages={showLanguages} />
+          <OpenedSelfPacedCourseRun courseRun={courseRun} showLanguages={showLanguages} />
         )}
       </div>
     </DjangoCMSTemplate>

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/index.tsx
@@ -2,14 +2,15 @@ import React, { useEffect, useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { createPortal } from 'react-dom';
 import { Button, CunninghamProvider } from '@openfun/cunningham-react';
-import { CourseRun, Priority } from 'types';
+import { PacedCourse, CourseRun, Priority } from 'types';
 import { computeStates } from 'utils/CourseRuns';
+import { CourseRunHelper } from 'utils/CourseRunHelper';
 import { SyllabusAsideList } from 'widgets/SyllabusCourseRunsList/components/SyllabusAsideList';
+import { SyllabusCourseRunCompacted } from 'widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted';
 import { SyllabusCourseRun } from 'widgets/SyllabusCourseRunsList/components/SyllabusCourseRun';
 import { DjangoCMSPluginsInit } from 'components/DjangoCMSTemplate';
 import { isJoanieEnabled } from 'api/joanie';
 import context from 'utils/context';
-import { CourseLight } from 'types/Joanie';
 import CourseWishButton from './components/CourseWishButton';
 
 const OPENED_COURSES_ELEMENT_ID = 'courseDetailsRunsOpen';
@@ -41,7 +42,7 @@ const SyllabusCourseRunsList = ({
   maxArchivedCourseRuns,
 }: {
   courseRuns: CourseRun[];
-  course: CourseLight;
+  course: PacedCourse;
   maxArchivedCourseRuns: number;
 }) => {
   useEffect(() => {
@@ -59,6 +60,8 @@ const SyllabusCourseRunsList = ({
       ),
     );
   }, [courseRunsComputed]);
+
+  const runsWithSameLanguages = CourseRunHelper.IsAllCourseRunsWithSameLanguages(courseRuns);
 
   const choose = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -81,11 +84,24 @@ const SyllabusCourseRunsList = ({
           </div>
         </div>
       )}
-      {openedRuns.length === 1 && (
-        <div className="course-detail__row course-detail__runs course-detail__runs--open">
-          <SyllabusCourseRun courseRun={openedRuns[0]} course={course} />
-        </div>
-      )}
+      {openedRuns.length === 1 &&
+        (course.is_self_paced && openedRuns[0].state.priority !== Priority.ARCHIVED_OPEN ? (
+          <div className="course-detail__row course-detail__runs course-detail__runs--open">
+            <SyllabusCourseRunCompacted
+              courseRun={openedRuns[0]}
+              course={course}
+              showLanguages={runsWithSameLanguages}
+            />
+          </div>
+        ) : (
+          <div className="course-detail__row course-detail__runs course-detail__runs--open">
+            <SyllabusCourseRun
+              courseRun={openedRuns[0]}
+              course={course}
+              showLanguages={runsWithSameLanguages}
+            />
+          </div>
+        ))}
       {openedRuns.length > 1 && (
         <div className="course-detail__row course-detail__runs course-detail__go-to-open-runs">
           <p>

--- a/src/richie/apps/courses/templatetags/extra_tags.py
+++ b/src/richie/apps/courses/templatetags/extra_tags.py
@@ -298,7 +298,11 @@ def course_runs_list_widget_props(context):
 
     return json.dumps(
         {
-            "course": {"id": course.id, "code": course.code},
+            "course": {
+                "id": course.id,
+                "code": course.code,
+                "is_self_paced": course.is_self_paced,
+            },
             "courseRuns": course_runs,
             "maxArchivedCourseRuns": getattr(
                 settings,

--- a/tests/apps/courses/test_templatetags_extra_tags_course_runs_list_widget_props.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_course_runs_list_widget_props.py
@@ -52,6 +52,7 @@ class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
                     "course": {
                         "id": course.id,
                         "code": course.code,
+                        "is_self_paced": course.is_self_paced,
                     },
                     "courseRuns": [
                         {
@@ -115,6 +116,7 @@ class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
                     "course": {
                         "id": course.id,
                         "code": course.code,
+                        "is_self_paced": course.is_self_paced,
                     },
                     "courseRuns": [
                         {
@@ -195,6 +197,7 @@ class CourseEnrollmentWidgetPropsTagTestCase(CMSTestCase):
                     "course": {
                         "id": course.id,
                         "code": course.code,
+                        "is_self_paced": course.is_self_paced,
                     },
                     "courseRuns": [
                         {


### PR DESCRIPTION
1. If all runs of an opened course have the same languages, we hide the languages on the course run card, because those languages are shown after the course description.
2. On self-paced courses with single opened run, display a simplified version of the syllabus.

fix #1969

Change the message of the enrollment period for a course with single opened run when it is self-paced, and
hide the languages of a course when every run of that course has the same languages as all the others.

## Opened self-paced course:
This PR shows a compacted version of the information.
Before:
<img width="629" alt="1" src="https://github.com/openfun/richie/assets/145666271/91c20532-2de5-458b-bf7c-8e4d4a9ba7e3">

After:
<img width="624" alt="2" src="https://github.com/openfun/richie/assets/145666271/095712ac-6011-43f6-aa5b-1a221de57553">

## Opened course with the same languages as all the other runs of that course
As all runs for the course as the same languages, showing the same exact information multiple times is unnecessary, so this PR removes that languages on each run syllabus.
This behavior is the same for both self-paced and instructor-paced courses.
Before:
<img width="619" alt="3" src="https://github.com/openfun/richie/assets/145666271/26d193a4-bd5b-460f-afab-7344b67afd97">

After:
<img width="618" alt="4" src="https://github.com/openfun/richie/assets/145666271/4da3e409-9f69-4052-aae3-63e1bd1807c9">

## Instructor course with different languages, stays the same
If a course isn't self-paced (instructor pace) and the languages of all runs of that course aren't equal, then the course run card stays the same as it was:
<img width="644" alt="5" src="https://github.com/openfun/richie/assets/145666271/bc9d8ae0-974e-4f49-b6bb-d68b1f11dee6">

## Compacted version for self-paced & same languages for all runs
If an opened course run is self-paced and the languages of all runs of that course are equal, then the course run card will be as displayed bellow.
This is the normal/majority of the courses in [NAU](https://www.nau.edu.pt/).

<img width="628" alt="5" src="https://github.com/openfun/richie/assets/145666271/bb2e5f34-7624-4b4a-8052-4caab9f44922">

## Compacted version for self-paced, same languages for all runs & no course end date
if we have the case described above, but also there is no course end date,  then the course run card will be:

<img width="626" alt="1" src="https://github.com/openfun/richie/assets/145666271/0c008a5f-b390-4c44-9214-576d419b7530">

FYI @igobranco @sandroscosta
