### PR TITLE
🐛(rdfa) fix errors on Google Search Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix course enrollment count shouldn't include the hidden runs.
+- Fix RDFa errors on Google Search Console
 
 ## [2.28.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix course enrollment count shouldn't include the hidden runs.
+
 ## [2.28.1]
 
 ### Fixed

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -481,10 +481,14 @@ class Course(EsIdMixin, BasePageExtension):
         node = self.extended_object.node
         current_and_descendant_nodes = node.__class__.get_tree(parent=node)
 
-        return CourseRun.objects.filter(
-            direct_course__extended_object__node__in=current_and_descendant_nodes,
-            direct_course__extended_object__publisher_is_draft=is_draft,
-        ).aggregate(sum=Sum("enrollment_count"))["sum"]
+        return (
+            CourseRun.objects.filter(
+                direct_course__extended_object__node__in=current_and_descendant_nodes,
+                direct_course__extended_object__publisher_is_draft=is_draft,
+            )
+            .exclude(catalog_visibility=CourseRunCatalogVisibility.HIDDEN)
+            .aggregate(sum=Sum("enrollment_count"))["sum"]
+        )
 
     @cached_property
     def languages_display(self):

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -369,18 +369,19 @@
                 <div class="course-detail__aside">
                     {% render_model_add course "" "" "get_admin_url_to_add_run" %}
                     {% with runs_dict=current_page.course.course_runs_dict %}
-                        {% with open_visible_runs=runs_dict.0|add:runs_dict.1|add:runs_dict.2|visible_on_course_page:request.toolbar.edit_mode_active %}
+                        {% with runs_without_to_be_scheduled=runs_dict.0|add:runs_dict.1|add:runs_dict.2|add:runs_dict.3|add:runs_dict.4|add:runs_dict.5|add:runs_dict.6|visible_on_course_page:request.toolbar.edit_mode_active %}
                             <!--
                                 As course runs are rendered through React, we use meta tags to
                                 setup course runs RFDa properties.
-                             -->
-                            {% for run in open_visible_runs %}
+                                -->
+                            {% for run in runs_without_to_be_scheduled %}
                                 <span rel="hasCourseInstance" typeof="CourseInstance">
-                                    <meta property="name" content="{{ run.title }}"  />
-                                    <meta property="inLanguage" content="{{ run.get_languages_display }}"  />
-                                    <meta property="courseMode" content="online"  />
+                                    <meta property="name" content='{{ run.title|default:current_page.get_title }}' />
+                                    <meta property="inLanguage" content="{{ run.get_languages_display }}" />
+                                    <meta property="courseMode" content="online" />
                                     <meta property="startDate" content="{{ run.start|date:'Y-m-d' }}"  />
                                     <meta property="endDate" content="{{ run.end|date:'Y-m-d' }}"  />
+                                    <meta property="courseWorkload" content="{{ current_page.course.pt_effort }}" />
                                 </span>
                             {% endfor %}
                         {% endwith %}

--- a/tests/apps/courses/test_templates_course_detail_rdfa.py
+++ b/tests/apps/courses/test_templates_course_detail_rdfa.py
@@ -25,6 +25,7 @@ from richie.apps.courses.factories import (
     OrganizationFactory,
     PersonFactory,
 )
+from richie.apps.courses.models import CourseRunCatalogVisibility
 from richie.plugins.nesteditem.defaults import ACCORDION
 
 # pylint: disable=too-many-lines,too-many-locals,too-many-statements
@@ -212,6 +213,27 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
             enrollment_end=datetime(2030, 6, 20, tzinfo=timezone.utc),
             languages=["de"],
             enrollment_count=3000,
+        )
+        CourseRunFactory(
+            title="A hidden course run",
+            direct_course=course,
+            start=datetime(2010, 6, 1, tzinfo=timezone.utc),
+            end=datetime(2050, 7, 10, tzinfo=timezone.utc),
+            enrollment_start=datetime(2010, 6, 13, tzinfo=timezone.utc),
+            enrollment_end=datetime(2050, 6, 20, tzinfo=timezone.utc),
+            languages=["pt"],
+            enrollment_count=100,
+            catalog_visibility=CourseRunCatalogVisibility.HIDDEN,
+        )
+        CourseRunFactory(
+            title="A to be scheduled run",
+            direct_course=course,
+            start=None,
+            end=None,
+            enrollment_start=None,
+            enrollment_end=None,
+            languages=["en"],
+            enrollment_count=0,
         )
 
         contributor1.extended_object.publish("en")
@@ -551,6 +573,9 @@ class TemplatesCourseDetailRDFaCMSTestCase(CMSTestCase):
             self.assertTrue((course_run_subject, RDF.type, SDO.CourseInstance) in graph)
             self.assertTrue(
                 (course_run_subject, SDO.courseMode, Literal("online")) in graph
+            )
+            self.assertTrue(
+                (course_run_subject, SDO.courseWorkload, Literal("PT3H")) in graph
             )
 
         for title in ["Run 0", "Run 1"]:


### PR DESCRIPTION
Google Search Console requires more information for the RDFa information.

Fixes 2 of 3 problems identified by #2444:
- [X] Missing field 'hasCourseInstance'
- [X] Either 'courseWorkload' or 'courseSchedule' should be specified (in 'hasCourseInstance')

----

To validate copy paste a course page html code to the Google Search Console validator:
https://search.google.com/test/rich-results/result