### PR TITLE
🔨(docker) fix first bootstrap can't connect to DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 DOCKER_UID           = $(shell id -u)
 DOCKER_GID           = $(shell id -g)
 DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
-COMPOSE              = DOCKER_USER=$(DOCKER_USER) DB_HOST=$(DB_HOST) DB_PORT=$(DB_PORT) docker compose
+COMPOSE              = DOCKER_USER=$(DOCKER_USER) DB_HOST=$(DB_HOST) DB_PORT=$(DB_PORT) docker compose -f docker-compose.yml -f docker-compose-$(DB_HOST).yml
 COMPOSE_SSL          = NGINX_CONF=ssl DEV_ENV_FILE=dev-ssl $(COMPOSE)
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_RUN_SSL      = $(COMPOSE_SSL) run --rm
@@ -263,7 +263,7 @@ search-index: ## (re)generate the Elasticsearch index
 .PHONY: search-index
 
 superuser: ## Create an admin user with password "admin"
-	@$(COMPOSE) up -d mysql
+	@$(COMPOSE) up -d ${DB_HOST}
 	@echo "Wait for services to be up..."
 	@$(WAIT_DB)
 	@$(MANAGE) shell -c "from django.contrib.auth.models import User; not User.objects.filter(username='admin').exists() and User.objects.create_superuser('admin', 'admin@example.com', 'admin')"
@@ -326,7 +326,7 @@ i18n-generate-front: build-ts
 # -- Database
 
 dbshell: ## connect to database shell
-	docker compose exec app python sandbox/manage.py dbshell
+	@$(COMPOSE) exec app python sandbox/manage.py dbshell
 .PHONY: dbshell
 
 # -- Misc

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -7,12 +7,8 @@ UNSET_USER=0
 COMPOSE_PROJECT="richie"
 
 # By default, all commands are run on Postgresql.
-# They can be run on Mysql by setting an environment variable: `DB_ENGINE=mysql`
-if [[ "${DB_ENGINE}" == "mysql" ]]; then
-    COMPOSE_FILE="${REPO_DIR}/docker/compose/development/mysql/docker-compose.yml"
-else
-    COMPOSE_FILE="${REPO_DIR}/docker-compose.yml"
-fi
+# They can be run on Mysql by setting an environment variable: `DB_HOST=mysql`
+COMPOSE_FILE="-f ${REPO_DIR}/docker-compose.yml -f ${REPO_DIR}/docker-compose-${DB_HOST:-postgresql}.yml"
 
 # _set_user: set (or unset) default user id used to run docker commands
 #
@@ -47,8 +43,9 @@ function _docker_compose() {
     echo "🐳(compose) project: '${COMPOSE_PROJECT}' file: '${COMPOSE_FILE}'"
     docker compose \
         -p "${COMPOSE_PROJECT}" \
-        -f "${COMPOSE_FILE}" \
+        ${COMPOSE_FILE} \
         --project-directory "${REPO_DIR}" \
+        --env-file env.d/development/${DB_HOST:-postgresql}  \
         "$@"
 }
 

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,0 +1,17 @@
+services:
+  mysql:
+    image: mysql:8.0
+    env_file:
+      - env.d/development/mysql
+    command: --default-authentication-plugin=mysql_native_password
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      interval: 1s
+      timeout: 2s
+      retries: 300
+
+  app:
+    depends_on:
+      mysql:
+        condition: service_healthy 
+        restart: true

--- a/docker-compose-postgresql.yml
+++ b/docker-compose-postgresql.yml
@@ -1,0 +1,19 @@
+services:
+  postgresql:
+    image: postgres:12
+    ports:
+      - "5472:5432"
+    env_file:
+      - env.d/development/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 1s
+      timeout: 2s
+      retries: 300
+
+  app:
+    depends_on:
+      postgresql:
+        condition: service_healthy 
+        restart: true
+

--- a/docker-compose-sqlite.yml
+++ b/docker-compose-sqlite.yml
@@ -1,0 +1,1 @@
+# This file is empty on propose!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,4 @@
 services:
-  postgresql:
-    image: postgres:12
-    ports:
-      - "5472:5432"
-    env_file:
-      - env.d/development/postgresql
-
-  mysql:
-    image: mysql:8.0
-    env_file:
-      - env.d/development/mysql
-    command: --default-authentication-plugin=mysql_native_password
 
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch:7.14.0}"
@@ -39,8 +27,8 @@ services:
       - ./data/media:/data/media
       - ./data/smedia:/data/smedia
     depends_on:
-      - "${DB_HOST:-postgresql}"
-      - "elasticsearch"
+      elasticsearch:
+        condition: service_started
     stdin_open: true
     tty: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,11 @@ services:
     environment:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-
+    healthcheck:
+      test: ["CMD", "echo", "''", ">", "/dev/tcp/127.0.0.1/9200", "||", "exit", "1"]
+      interval: 1s
+      timeout: 2s
+      retries: 300
   app:
     build:
       context: .
@@ -29,9 +33,15 @@ services:
     depends_on:
       elasticsearch:
         condition: service_started
+      redis-sentinel:
+        condition: service_started
     stdin_open: true
     tty: true
-
+    healthcheck:
+      test: ["CMD", "echo", "''", ">", "/dev/tcp/127.0.0.1/8000", "||", "exit", "1"]
+      interval: 1s
+      timeout: 2s
+      retries: 3600
   nginx:
     image: nginx
     ports:
@@ -84,12 +94,22 @@ services:
       - redis-replica2
     environment:
       - REDIS_MASTER_HOST=redis-primary
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -p 26379  ping | grep PONG"]
+      interval: 1s
+      timeout: 2s
+      retries: 300
 
   redis-primary:
     image: docker.io/bitnami/redis:6.0-debian-10
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - REDIS_REPLICATION_MODE=master
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -p 6379 ping | grep PONG"]
+      interval: 1s
+      timeout: 2s
+      retries: 300
 
   redis-replica1:
     image: docker.io/bitnami/redis:6.0-debian-10
@@ -99,6 +119,11 @@ services:
       - REDIS_MASTER_HOST=redis-primary
     depends_on:
       - redis-primary
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -p 6379 ping | grep PONG"]
+      interval: 1s
+      timeout: 2s
+      retries: 300
 
   redis-replica2:
     image: docker.io/bitnami/redis:6.0-debian-10
@@ -108,9 +133,11 @@ services:
       - REDIS_MASTER_HOST=redis-primary
     depends_on:
       - redis-primary
-
-  dockerize:
-    image: jwilder/dockerize
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -p 6379 ping | grep PONG"]
+      interval: 1s
+      timeout: 2s
+      retries: 300
 
 networks:
   lms_outside:

--- a/env.d/development/sqlite
+++ b/env.d/development/sqlite
@@ -1,0 +1,5 @@
+# App database configuration
+DB_NAME=db.sqlite3
+
+DB_HOST=sqlite
+DB_ENGINE=django.db.backends.sqlite3


### PR DESCRIPTION
Fix error `dockerflow.health.E001` with the message of `Could not connect to database`.
This only occurs from a fresh installation or on the first boot of the database.
Probably this only occurs when the dev machine has a slower IO.
Split docker compose file, per supported database
and add a dependency of the app to db, if it's healthy, directly on docker compose level.

fixes #2455
