### PR TITLE
🥅(frontend) improve lyra error catching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Improve lyra error catching management
+
 ### Fixed
 
 - Fix course enrollment count shouldn't include the hidden runs.

--- a/src/frontend/js/components/PaymentInterfaces/types.ts
+++ b/src/frontend/js/components/PaymentInterfaces/types.ts
@@ -42,5 +42,5 @@ export type Payment = DummyPayment | PayplugPayment | LyraPayment;
 
 export type PaymentInterfaceProps<P extends Payment = Payment> = P & {
   onSuccess: () => void;
-  onError: (messageId: PaymentErrorMessageId) => void;
+  onError: (messageId: string | PaymentErrorMessageId) => void;
 };

--- a/src/frontend/js/components/SaleTunnel/GenericPaymentButton/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/GenericPaymentButton/index.tsx
@@ -97,7 +97,7 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
   const { methods: orderMethods } = useOrders(undefined, { enabled: false });
   const [payment, setPayment] = useState<PaymentInfo>();
   const [state, setState] = useState<ComponentStates>(ComponentStates.IDLE);
-  const [error, setError] = useState<PaymentErrorMessageId>();
+  const [error, setError] = useState<PaymentErrorMessageId | string>();
   const hasPaymentId = (p: Maybe<Payment>): p is Extract<Payment, PaymentWithId> => {
     return Boolean(p?.hasOwnProperty('payment_id'));
   };
@@ -256,7 +256,9 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
     checkOrderValidity();
   };
 
-  const handleError = (messageId: PaymentErrorMessageId = PaymentErrorMessageId.ERROR_DEFAULT) => {
+  const handleError = (
+    messageId: PaymentErrorMessageId | string = PaymentErrorMessageId.ERROR_DEFAULT,
+  ) => {
     setState(ComponentStates.ERROR);
     setError(messageId);
   };
@@ -274,6 +276,8 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
         .catch(() => {
           handleError();
         });
+    } else if (error && !messages.hasOwnProperty(error)) {
+      orderMethods.invalidate();
     } else if (state === ComponentStates.ERROR) {
       setPayment(undefined);
     }
@@ -320,7 +324,13 @@ export const GenericPaymentButton = ({ buildOrderPayload }: Props) => {
       )}
       {state === ComponentStates.ERROR && (
         <p className="payment-button__error" id="sale-tunnel-payment-error" tabIndex={-1}>
-          <FormattedMessage {...messages[error || PaymentErrorMessageId.ERROR_DEFAULT]} />
+          {!error || messages.hasOwnProperty(error) ? (
+            <FormattedMessage
+              {...messages[(error as PaymentErrorMessageId) || PaymentErrorMessageId.ERROR_DEFAULT]}
+            />
+          ) : (
+            error
+          )}
         </p>
       )}
     </>

--- a/src/frontend/js/components/SaleTunnel/hooks/useTerms.tsx
+++ b/src/frontend/js/components/SaleTunnel/hooks/useTerms.tsx
@@ -29,8 +29,8 @@ export const useTerms = ({
   error,
 }: {
   product: Product;
-  onError: (error: PaymentErrorMessageId) => void;
-  error?: PaymentErrorMessageId;
+  onError: (error: PaymentErrorMessageId | string) => void;
+  error?: PaymentErrorMessageId | string;
 }) => {
   const intl = useIntl();
   const [termsAccepted, setTermsAccepted] = useState(false);


### PR DESCRIPTION
## Purpose

Currently, when an error occurred during a payment using lyra pop-in, a generic error message is displayed. This is weird as the message is not explicit and user does not understand if the problem comes from the application from its bank.

<img width="496" alt="image" src="https://github.com/openfun/richie/assets/9265241/67b87388-4172-45fa-9a49-eab6c7e16a42">


## Proposal

- [x] Improve Lyra error management
