### PR TITLE
🔥(core) remove csrftoken in frontend context processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix course enrollment count shouldn't include the hidden runs.
 - Fix RDFa errors on Google Search Console
 
+### Removed
+
+- csrftoken in richie context
+
 ## [2.28.1]
 
 ### Fixed

--- a/src/frontend/js/types/commonDataProps.ts
+++ b/src/frontend/js/types/commonDataProps.ts
@@ -23,7 +23,6 @@ enum FEATURES {
 
 export interface RichieContext {
   authentication: AuthenticationBackend;
-  csrftoken: string;
   environment: string;
   features: Partial<Record<FEATURES, boolean>>;
   joanie_backend?: JoanieBackend;

--- a/src/frontend/js/utils/test/factories/richie.ts
+++ b/src/frontend/js/utils/test/factories/richie.ts
@@ -152,7 +152,6 @@ export const RichieContextFactory = factory<CommonDataProps['context']>(() => ({
     backend: APIBackend.OPENEDX_HAWTHORN,
     endpoint: 'https://endpoint.test',
   },
-  csrftoken: faker.string.alphanumeric(64),
   environment: 'test',
   features: {},
   lms_backends: [

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.files.storage import get_storage_class
 from django.http.request import HttpRequest
-from django.middleware.csrf import get_token
 from django.utils.translation import get_language_from_request
 
 from cms.models import Page
@@ -250,7 +249,6 @@ class FrontendContextProcessor:
     def context_processor(self, request: HttpRequest) -> dict:
         """Get the frontend context processor."""
         context = {
-            "csrftoken": get_token(request),
             "environment": getattr(settings, "ENVIRONMENT", ""),
             "release": getattr(settings, "RELEASE", ""),
             "sentry_dsn": getattr(settings, "SENTRY_DSN", ""),


### PR DESCRIPTION
## Purpose

The csrftoken present in frontend context processor is not used anymore by the front application. Still using it can lead to increase the django cms cache because lot of csrftoken can be issued and lead to increase significantly the cache.


## Proposal

- [x] remove csrftoken in frontend context processor
