### PR TITLE
🔧(docker) add compose command

### DIFF
--- a/bin/compose
+++ b/bin/compose
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+_docker_compose "$@"


### PR DESCRIPTION
## Purpose

We recently split our docker-compose configuration in several files to handle properly the use of several database technology in our repository. There is one drawback to this; we cannot use simply docker compose command, we have to target right docker compose files to use according to the active database we want to use.
