### PR TITLE
🔧(cookiecutter) fix ignore static process regex

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/base/storage.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/base/storage.py
@@ -8,7 +8,9 @@ from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
 from storages.backends.s3boto3 import S3Boto3Storage
 
-STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(r"^richie\/js\/[0-9]*\..*\.index\.js$")
+STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(
+    r"^richie\/js\/build\/[0-9]*\..*\.index\.js(\.map)?$"
+)
 
 
 class CDNManifestStaticFilesStorage(ManifestStaticFilesStorage):


### PR DESCRIPTION
## Purpose

The custom storage class currently ignores js files from its process as those files are already containing a hash during its generation. But the regex was not
 improperly configured so those files were matched and their process recently
 leads to issue.


## Proposal

- [x] Fix `STATIC_POSTPROCESS_IGNORE_REGEX` in storage.py
