### PR TITLE
✨(frontend) add OrderHelper.isPurchasable method

### DIFF
--- a/src/frontend/js/components/SaleTunnel/AddressSelector/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/AddressSelector/index.spec.tsx
@@ -58,7 +58,6 @@ describe('AddressSelector', () => {
           billingAddress,
           setBillingAddress,
           setCreditCard: jest.fn(),
-          onPaymentSuccess: jest.fn(),
           step: SaleTunnelStep.IDLE,
           registerSubmitCallback: jest.fn(),
           unregisterSubmitCallback: jest.fn(),

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -217,7 +217,6 @@ describe.each([
 
     // - Route to create order should have been called
     nbApiCalls += 1; // order create
-    nbApiCalls += 1; // order get (invalidate queries)
     nbApiCalls += 1; // useProductOrder call (invalidate from create)
 
     await waitFor(() => expect(fetchMock.calls()).toHaveLength(nbApiCalls));

--- a/src/frontend/js/utils/OrderHelper/index.ts
+++ b/src/frontend/js/utils/OrderHelper/index.ts
@@ -6,6 +6,7 @@ import {
   OrderEnrollment,
   OrderState,
   PaymentScheduleState,
+  PURCHASABLE_ORDER_STATES,
 } from 'types/Joanie';
 
 export enum OrderStatus {
@@ -95,5 +96,10 @@ export class OrderHelper {
   static isActive(order?: Order | NestedCourseOrder | OrderEnrollment) {
     if (!order) return false;
     return ACTIVE_ORDER_STATES.includes(order.state);
+  }
+
+  static isPurchasable(order?: Order | NestedCourseOrder | OrderEnrollment) {
+    if (!order) return true;
+    return PURCHASABLE_ORDER_STATES.includes(order.state);
   }
 }

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -484,7 +484,6 @@ export const SaleTunnelContextFactory = factory(
     billingAddress: undefined,
     setBillingAddress: noop,
     setCreditCard: noop,
-    onPaymentSuccess: noop,
     step: SaleTunnelStep.IDLE,
     registerSubmitCallback: noop,
     unregisterSubmitCallback: noop,

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
@@ -2,12 +2,7 @@ import { FormattedMessage, defineMessages } from 'react-intl';
 import { useState } from 'react';
 import PurchaseButton from 'components/PurchaseButton';
 import { Icon, IconTypeEnum } from 'components/Icon';
-import {
-  CertificateProduct,
-  Enrollment,
-  ProductType,
-  PURCHASABLE_ORDER_STATES,
-} from 'types/Joanie';
+import { CertificateProduct, Enrollment, ProductType } from 'types/Joanie';
 import DownloadCertificateButton from 'components/DownloadCertificateButton';
 import { useCertificate } from 'hooks/useCertificates';
 import { isOpenedCourseRunCertificate } from 'utils/CourseRuns';
@@ -65,30 +60,27 @@ const ProductCertificateFooter = ({ product, enrollment }: ProductCertificateFoo
           <FormattedMessage {...messages.buyProductCertificateLabel} />
         )}
       </div>
-      {OrderHelper.isActive(order) ? (
-        order!.certificate_id && (
-          <DownloadCertificateButton
-            className="dashboard-item__button"
-            certificateId={order!.certificate_id}
-          />
-        )
-      ) : (
-        <PurchaseButton
+      {OrderHelper.isActive(order) && order!.certificate_id && (
+        <DownloadCertificateButton
           className="dashboard-item__button"
-          product={product}
-          enrollment={enrollment}
-          buttonProps={{ size: 'small' }}
-          disabled={order && !PURCHASABLE_ORDER_STATES.includes(order.state)}
-          onFinish={(o) => {
-            /**
-             * As we do not refetch enrollments in DashboardCourses after SaleTunnel cache invalidation (to avoid
-             * scroll reset - and SaleTunnel modal unmounting too early caused by list reset) we need to manually
-             * update the active order in the enrollment in order to hide the buy button and display the download button.
-             */
-            setOrder(o);
-          }}
+          certificateId={order!.certificate_id}
         />
       )}
+      <PurchaseButton
+        className="dashboard-item__button"
+        product={product}
+        enrollment={enrollment}
+        buttonProps={{ size: 'small' }}
+        disabled={!OrderHelper.isPurchasable(order)}
+        onFinish={(o) => {
+          /**
+           * As we do not refetch enrollments in DashboardCourses after SaleTunnel cache invalidation (to avoid
+           * scroll reset - and SaleTunnel modal unmounting too early caused by list reset) we need to manually
+           * update the active order in the enrollment in order to hide the buy button and display the download button.
+           */
+          setOrder(o);
+        }}
+      />
     </div>
   );
 };

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
@@ -1,7 +1,7 @@
 import { Children, useEffect, useMemo } from 'react';
 import { defineMessages, FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
 import c from 'classnames';
-import { ProductType, Product, CredentialOrder, PURCHASABLE_ORDER_STATES } from 'types/Joanie';
+import { ProductType, Product, CredentialOrder } from 'types/Joanie';
 import { useCourseProduct } from 'hooks/useCourseProducts';
 import { Spinner } from 'components/Spinner';
 import { Icon, IconTypeEnum } from 'components/Icon';
@@ -156,7 +156,7 @@ const CourseProductItem = ({ productId, course, compact = false }: CourseProduct
   });
 
   const order = productOrder as CredentialOrder;
-  const canPurchase = !order || PURCHASABLE_ORDER_STATES.includes(order.state);
+  const canPurchase = OrderHelper.isPurchasable(order);
   const hasPurchased = OrderHelper.isActive(order);
   const canEnroll = OrderHelper.allowEnrollment(order);
 


### PR DESCRIPTION
## Purpose

Currently, when a user purchase a certificate, the enrollment was not refreshed so the purchase button is not hide.