### PR TITLE
👔(frontend) refresh credit cards query on payment method definition

### DIFF
--- a/src/frontend/js/components/CreditCardSelector/index.tsx
+++ b/src/frontend/js/components/CreditCardSelector/index.tsx
@@ -78,7 +78,7 @@ export const CreditCardSelector = ({
   const isMobile = useMatchMediaLg();
 
   const {
-    states: { fetching },
+    states: { fetching, isFetched },
     items: creditCards,
   } = useCreditCardsManagement();
 
@@ -101,7 +101,7 @@ export const CreditCardSelector = ({
 
   return (
     <div className="credit-card-selector">
-      {fetching ? (
+      {!isFetched && fetching ? (
         <Spinner />
       ) : (
         <>

--- a/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
@@ -328,11 +328,9 @@ describe('SaleTunnel', () => {
     fetchMock
       .post('https://joanie.endpoint/api/v1.0/credit-cards/tokenize-card/', PaymentFactory().one())
       .post(`https://joanie.endpoint/api/v1.0/orders/${order.id}/payment-method/`, 200)
-      .get(
-        'https://joanie.endpoint/api/v1.0/credit-cards/',
-        { results: [paymentMethod] },
-        { overwriteRoutes: true },
-      )
+      .get('https://joanie.endpoint/api/v1.0/credit-cards/', [paymentMethod], {
+        overwriteRoutes: true,
+      })
       .get(
         `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(orderQueryParameters)}`,
         [order],

--- a/src/frontend/js/settings/settings.prod.ts
+++ b/src/frontend/js/settings/settings.prod.ts
@@ -31,8 +31,6 @@ export const REACT_QUERY_SETTINGS = {
 export const PAYMENT_SETTINGS = {
   // Interval in ms to poll the related order when a payment has succeeded.
   pollInterval: 1000,
-  // Number of retries
-  pollLimit: 30,
 };
 
 export const CONTRACT_SETTINGS = {

--- a/src/frontend/js/settings/settings.test.ts
+++ b/src/frontend/js/settings/settings.test.ts
@@ -23,3 +23,8 @@ export const CONTRACT_SETTINGS = {
   // Simulated sign request delay
   dummySignatureSignTimeout: 100,
 };
+
+export const PAYMENT_SETTINGS = {
+  // Interval in ms to poll the related order when a payment has succeeded.
+  pollInterval: 150,
+};


### PR DESCRIPTION
## Purpose

Currently, when the user add a new credit card, the related query is not refetched so the new credit card does not appear on the list and credit card information displayed are staled.


## Proposal

- [x] Refresh credit card query on payment method definition
