### PR TITLE
Dev - Learner Dashboard - Allow to resume subscription process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Update Learner dashboard to finalize subscription process
 - SaleTunnel has been fully rework to comply with the purchase workflow
 - Replace order abort mutation by order cancel mutation
 

--- a/src/frontend/js/components/ContractStatus/index.spec.tsx
+++ b/src/frontend/js/components/ContractStatus/index.spec.tsx
@@ -23,7 +23,7 @@ describe('<ContractStatus />', () => {
     );
 
     expect(
-      screen.queryByText('You have to sign this training contract to access your training.'),
+      screen.queryByText('You have to sign this training contract to finalize your subscription.'),
     ).toBeInTheDocument();
 
     expect(screen.queryByText(/You signed this training contract/)).not.toBeInTheDocument();

--- a/src/frontend/js/components/ContractStatus/index.tsx
+++ b/src/frontend/js/components/ContractStatus/index.tsx
@@ -15,7 +15,7 @@ const messages = defineMessages({
     id: 'components.ContractStatus.organizationSignedOn',
   },
   waitingLearnerSignature: {
-    defaultMessage: 'You have to sign this training contract to access your training.',
+    defaultMessage: 'You have to sign this training contract to finalize your subscription.',
     description: 'Label displayed when a training contract need to be signed by the learner',
     id: 'components.ContractStatus.waitingSignature',
   },

--- a/src/frontend/js/components/PurchaseButton/index.tsx
+++ b/src/frontend/js/components/PurchaseButton/index.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonProps, useModal } from '@openfun/cunningham-react';
 import { useSession } from 'contexts/SessionContext';
 import * as Joanie from 'types/Joanie';
 import { SaleTunnel, SaleTunnelProps } from 'components/SaleTunnel';
-import { Organization } from 'types/Joanie';
+import { CourseLight, Organization } from 'types/Joanie';
 import { PacedCourse } from 'types';
 import { ProductHelper } from 'utils/ProductHelper';
 
@@ -52,7 +52,7 @@ interface PurchaseButtonPropsBase {
 
 interface CredentialPurchaseButtonProps extends PurchaseButtonPropsBase {
   product: Joanie.CredentialProduct;
-  course: PacedCourse;
+  course: PacedCourse | CourseLight;
   enrollment?: undefined;
 }
 

--- a/src/frontend/js/components/SaleTunnel/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.tsx
@@ -1,6 +1,7 @@
 import { ModalProps } from '@openfun/cunningham-react';
 import {
   CertificateProduct,
+  CourseLight,
   CredentialProduct,
   Enrollment,
   Order,
@@ -17,7 +18,7 @@ export interface SaleTunnelProps extends Pick<ModalProps, 'isOpen' | 'onClose'> 
   product: Product;
   organizations?: Organization[];
 
-  course?: PacedCourse;
+  course?: PacedCourse | CourseLight;
   enrollment?: Enrollment;
   orderGroup?: OrderGroup;
   onFinish?: (order: Order) => void;

--- a/src/frontend/js/pages/DashboardOrderLayout/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardOrderLayout/index.spec.tsx
@@ -1,7 +1,8 @@
 import { findByRole, render, screen, waitFor } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
+import queryString from 'query-string';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
-import { CredentialOrder } from 'types/Joanie';
+import { CredentialOrder, NOT_CANCELED_ORDER_STATES } from 'types/Joanie';
 import { CredentialOrderFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
 import { mockCourseProductWithOrder } from 'utils/test/mockCourseProductWithOrder';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
@@ -54,6 +55,14 @@ describe('<DashboardOrderLayout />', () => {
       { results: [order], next: null, previous: null, count: null },
       { overwriteRoutes: true },
     );
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     render(WrapperWithDashboard(LearnerDashboardPaths.ORDER.replace(':orderId', order.id)));
 

--- a/src/frontend/js/utils/ProductHelper/index.spec.ts
+++ b/src/frontend/js/utils/ProductHelper/index.spec.ts
@@ -1,183 +1,339 @@
 import { createIntl } from 'react-intl';
-import { CourseRunFactory, ProductFactory, TargetCourseFactory } from 'utils/test/factories/joanie';
+import {
+  CertificateProductFactory,
+  CourseRunFactory,
+  CredentialProductFactory,
+  EnrollmentFactory,
+  ProductFactory,
+  TargetCourseFactory,
+} from 'utils/test/factories/joanie';
+import { CourseStateFactory } from 'utils/test/factories/richie';
+import { Priority } from 'types';
 import { ProductHelper } from '.';
 
 describe('ProductHelper', () => {
-  it('should return the product date range processed from course runs dates', () => {
-    const product = ProductFactory({
-      target_courses: [
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              start: new Date('2023-08-13').toISOString(),
-              end: new Date('2024-04-27').toISOString(),
-            }).one(),
-            CourseRunFactory({
-              start: new Date('2023-09-17').toISOString(),
-              end: new Date('2024-05-29').toISOString(),
-            }).one(),
-          ],
-        }).one(),
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              start: new Date('2024-01-19').toISOString(),
-              end: new Date('2025-02-17').toISOString(),
-            }).one(),
-          ],
-        }).one(),
-      ],
-    }).one();
-
-    expect(ProductHelper.getDateRange(product)).toEqual([
-      new Date('2023-08-13'),
-      new Date('2025-02-17'),
-    ]);
+  beforeEach(() => {
+    jest.resetAllMocks();
   });
 
-  it('should return undefined minDate when there is a course run with an undefined start date', () => {
-    const product = ProductFactory({
-      target_courses: [
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              start: undefined,
-              end: new Date('2024-04-27').toISOString(),
-            }).one(),
-            CourseRunFactory({
-              start: new Date('2023-09-17').toISOString(),
-              end: new Date('2024-05-29').toISOString(),
-            }).one(),
-          ],
-        }).one(),
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              start: new Date('2024-01-19').toISOString(),
-              end: new Date('2025-02-17').toISOString(),
-            }).one(),
-          ],
-        }).one(),
-      ],
-    }).one();
+  describe('getDateRange', () => {
+    it('should return the product date range processed from course runs dates', () => {
+      const product = ProductFactory({
+        target_courses: [
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                start: new Date('2023-08-13').toISOString(),
+                end: new Date('2024-04-27').toISOString(),
+              }).one(),
+              CourseRunFactory({
+                start: new Date('2023-09-17').toISOString(),
+                end: new Date('2024-05-29').toISOString(),
+              }).one(),
+            ],
+          }).one(),
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                start: new Date('2024-01-19').toISOString(),
+                end: new Date('2025-02-17').toISOString(),
+              }).one(),
+            ],
+          }).one(),
+        ],
+      }).one();
 
-    expect(ProductHelper.getDateRange(product)).toEqual([undefined, new Date('2025-02-17')]);
+      expect(ProductHelper.getDateRange(product)).toEqual([
+        new Date('2023-08-13'),
+        new Date('2025-02-17'),
+      ]);
+    });
+
+    it('should return undefined minDate when there is a course run with an undefined start date', () => {
+      const product = ProductFactory({
+        target_courses: [
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                start: undefined,
+                end: new Date('2024-04-27').toISOString(),
+              }).one(),
+              CourseRunFactory({
+                start: new Date('2023-09-17').toISOString(),
+                end: new Date('2024-05-29').toISOString(),
+              }).one(),
+            ],
+          }).one(),
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                start: new Date('2024-01-19').toISOString(),
+                end: new Date('2025-02-17').toISOString(),
+              }).one(),
+            ],
+          }).one(),
+        ],
+      }).one();
+
+      expect(ProductHelper.getDateRange(product)).toEqual([undefined, new Date('2025-02-17')]);
+    });
+
+    it('should return undefined maxDate when there is a course run with an undefined end date', () => {
+      const product = ProductFactory({
+        target_courses: [
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                start: new Date('2023-08-13').toISOString(),
+                end: undefined,
+              }).one(),
+              CourseRunFactory({
+                start: new Date('2023-09-17').toISOString(),
+                end: new Date('2024-05-29').toISOString(),
+              }).one(),
+            ],
+          }).one(),
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                start: new Date('2024-01-19').toISOString(),
+                end: new Date('2025-02-17').toISOString(),
+              }).one(),
+            ],
+          }).one(),
+        ],
+      }).one();
+
+      expect(ProductHelper.getDateRange(product)).toEqual([new Date('2023-08-13'), undefined]);
+    });
   });
 
-  it('should return undefined maxDate when there is a course run with an undefined end date', () => {
-    const product = ProductFactory({
-      target_courses: [
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              start: new Date('2023-08-13').toISOString(),
-              end: undefined,
-            }).one(),
-            CourseRunFactory({
-              start: new Date('2023-09-17').toISOString(),
-              end: new Date('2024-05-29').toISOString(),
-            }).one(),
-          ],
-        }).one(),
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              start: new Date('2024-01-19').toISOString(),
-              end: new Date('2025-02-17').toISOString(),
-            }).one(),
-          ],
-        }).one(),
-      ],
-    }).one();
+  describe('getLanguages', () => {
+    it('should return the product languages processed from course runs languages', () => {
+      const product = ProductFactory({
+        target_courses: [
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                languages: ['fr', 'en'],
+              }).one(),
+              CourseRunFactory({
+                languages: ['fr', 'de'],
+              }).one(),
+            ],
+          }).one(),
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                languages: ['fr', 'es'],
+              }).one(),
+            ],
+          }).one(),
+        ],
+      }).one();
 
-    expect(ProductHelper.getDateRange(product)).toEqual([new Date('2023-08-13'), undefined]);
+      expect(ProductHelper.getLanguages(product)).toEqual(['fr', 'en', 'de', 'es']);
+    });
+
+    it('should return an empty array when there is no language', () => {
+      const product = ProductFactory({
+        target_courses: [
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                languages: [],
+              }).one(),
+            ],
+          }).one(),
+        ],
+      }).one();
+
+      expect(ProductHelper.getLanguages(product)).toEqual([]);
+    });
+
+    it('should return sorted human readable languages according to the active language', () => {
+      const product = ProductFactory({
+        target_courses: [
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                languages: ['fr', 'en'],
+              }).one(),
+              CourseRunFactory({
+                languages: ['fr', 'de'],
+              }).one(),
+            ],
+          }).one(),
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                languages: ['fr', 'es'],
+              }).one(),
+            ],
+          }).one(),
+        ],
+      }).one();
+
+      const intl = createIntl({ locale: 'en' });
+      expect(ProductHelper.getLanguages(product, true, intl)).toEqual(
+        'English, French, German and Spanish',
+      );
+    });
+
+    it('should return an empty string when there is no language', () => {
+      const product = ProductFactory({
+        target_courses: [
+          TargetCourseFactory({
+            course_runs: [
+              CourseRunFactory({
+                languages: [],
+              }).one(),
+            ],
+          }).one(),
+        ],
+      }).one();
+
+      const intl = createIntl({ locale: 'en' });
+      expect(ProductHelper.getLanguages(product, true, intl)).toEqual('');
+    });
   });
 
-  it('should return the product languages processed from course runs languages', () => {
-    const product = ProductFactory({
-      target_courses: [
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              languages: ['fr', 'en'],
-            }).one(),
-            CourseRunFactory({
-              languages: ['fr', 'de'],
-            }).one(),
-          ],
-        }).one(),
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              languages: ['fr', 'es'],
-            }).one(),
-          ],
-        }).one(),
-      ],
-    }).one();
+  describe('hasRemainingSeats', () => {
+    it('should return false when the product is undefined', () => {
+      expect(ProductHelper.hasRemainingSeats(undefined)).toBe(false);
+    });
 
-    expect(ProductHelper.getLanguages(product)).toEqual(['fr', 'en', 'de', 'es']);
+    it('should return true when the product has no order group', () => {
+      const product = ProductFactory({
+        remaining_order_count: null,
+      }).one();
+
+      expect(ProductHelper.hasRemainingSeats(product)).toBe(true);
+    });
+
+    it('should return true when the product has remaining seats', () => {
+      const product = ProductFactory({
+        remaining_order_count: 10,
+      }).one();
+
+      expect(ProductHelper.hasRemainingSeats(product)).toBe(true);
+    });
+
+    it('should return false when the product does not have remaining seats', () => {
+      const product = ProductFactory({
+        remaining_order_count: 0,
+      }).one();
+
+      expect(ProductHelper.hasRemainingSeats(product)).toBe(false);
+    });
   });
 
-  it('should return an empty array when there is no language', () => {
-    const product = ProductFactory({
-      target_courses: [
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              languages: [],
-            }).one(),
-          ],
-        }).one(),
-      ],
-    }).one();
+  describe('hasOpenedTargetCourse', () => {
+    const openedCourseRunFactory = CourseRunFactory({
+      state: CourseStateFactory({
+        priority: Priority.ONGOING_OPEN,
+      }).one(),
+    });
 
-    expect(ProductHelper.getLanguages(product)).toEqual([]);
+    const closedCourseRunFactory = CourseRunFactory({
+      state: CourseStateFactory({
+        priority: Priority.ARCHIVED_CLOSED,
+      }).one(),
+    });
+
+    it('should return false when the product is undefined', () => {
+      expect(ProductHelper.hasOpenedTargetCourse(undefined)).toBe(false);
+    });
+
+    it('should throw an error when the product is a certificate and the enrollment is undefined', () => {
+      const product = CertificateProductFactory().one();
+
+      expect(() => ProductHelper.hasOpenedTargetCourse(product, undefined)).toThrowError(
+        'Unable to check if the certificate product relies on an opened course run without enrollment.',
+      );
+    });
+
+    it('should return true when the product is a certificate and the related course run is opened', () => {
+      const product = CertificateProductFactory().one();
+      const courseRun = openedCourseRunFactory.one();
+      const enrollment = EnrollmentFactory({ course_run: courseRun }).one();
+
+      expect(ProductHelper.hasOpenedTargetCourse(product, enrollment)).toBe(true);
+    });
+
+    it('should return false when the product is a certificate and the related course run is not opened', () => {
+      const product = CertificateProductFactory().one();
+      const courseRun = closedCourseRunFactory.one();
+      const enrollment = EnrollmentFactory({ course_run: courseRun }).one();
+
+      expect(ProductHelper.hasOpenedTargetCourse(product, enrollment)).toBe(false);
+    });
+
+    it('should return false when the product is a credential and has not target courses', () => {
+      const product = CredentialProductFactory({ target_courses: [] }).one();
+
+      expect(ProductHelper.hasOpenedTargetCourse(product)).toBe(false);
+    });
+
+    it('should return false when the product is a credential and at least one target course has no opened course run', () => {
+      const targetCourseOpen = TargetCourseFactory({
+        course_runs: [openedCourseRunFactory.one(), closedCourseRunFactory.one()],
+      }).one();
+      const targetCourseClosed = TargetCourseFactory({
+        course_runs: [closedCourseRunFactory.one(), closedCourseRunFactory.one()],
+      }).one();
+      const product = CredentialProductFactory({
+        target_courses: [targetCourseOpen, targetCourseClosed],
+      }).one();
+
+      expect(ProductHelper.hasOpenedTargetCourse(product)).toBe(false);
+    });
+
+    it('should return false when the product is a credential and target courses has one opened course run', () => {
+      const targetCourseOpen = TargetCourseFactory({
+        course_runs: [openedCourseRunFactory.one(), closedCourseRunFactory.one()],
+      }).many(1);
+      const product = CredentialProductFactory({ target_courses: targetCourseOpen }).one();
+
+      expect(ProductHelper.hasOpenedTargetCourse(product)).toBe(true);
+    });
   });
 
-  it('should return sorted human readable languages according to the active language', () => {
-    const product = ProductFactory({
-      target_courses: [
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              languages: ['fr', 'en'],
-            }).one(),
-            CourseRunFactory({
-              languages: ['fr', 'de'],
-            }).one(),
-          ],
-        }).one(),
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              languages: ['fr', 'es'],
-            }).one(),
-          ],
-        }).one(),
-      ],
-    }).one();
+  describe('isPurchasable', () => {
+    it('should return false when the product is undefined', () => {
+      expect(ProductHelper.isPurchasable(undefined)).toBe(false);
+    });
 
-    const intl = createIntl({ locale: 'en' });
-    expect(ProductHelper.getLanguages(product, true, intl)).toEqual(
-      'English, French, German and Spanish',
-    );
-  });
+    it('should return false when the product does not have opened target courses', () => {
+      jest.spyOn(ProductHelper, 'hasOpenedTargetCourse').mockReturnValue(false);
+      jest.spyOn(ProductHelper, 'hasRemainingSeats').mockReturnValue(true);
+      const product = ProductFactory().one();
 
-  it('should return an empty string when there is no language', () => {
-    const product = ProductFactory({
-      target_courses: [
-        TargetCourseFactory({
-          course_runs: [
-            CourseRunFactory({
-              languages: [],
-            }).one(),
-          ],
-        }).one(),
-      ],
-    }).one();
+      expect(ProductHelper.isPurchasable(product)).toBe(false);
+    });
 
-    const intl = createIntl({ locale: 'en' });
-    expect(ProductHelper.getLanguages(product, true, intl)).toEqual('');
+    it('should return false when the product does not remaining seats', () => {
+      jest.spyOn(ProductHelper, 'hasOpenedTargetCourse').mockReturnValue(true);
+      jest.spyOn(ProductHelper, 'hasRemainingSeats').mockReturnValue(false);
+      const product = ProductFactory().one();
+
+      expect(ProductHelper.isPurchasable(product)).toBe(false);
+    });
+
+    it('should return false when the product does not have opened target courses and remaining seats', () => {
+      jest.spyOn(ProductHelper, 'hasOpenedTargetCourse').mockReturnValue(false);
+      jest.spyOn(ProductHelper, 'hasRemainingSeats').mockReturnValue(false);
+      const product = ProductFactory().one();
+
+      expect(ProductHelper.isPurchasable(product)).toBe(false);
+    });
+
+    it('should return true when the product has opened target courses and remaining seats', () => {
+      jest.spyOn(ProductHelper, 'hasOpenedTargetCourse').mockReturnValue(true);
+      jest.spyOn(ProductHelper, 'hasRemainingSeats').mockReturnValue(true);
+      const product = ProductFactory().one();
+
+      expect(ProductHelper.isPurchasable(product)).toBe(true);
+    });
   });
 });

--- a/src/frontend/js/utils/ProductHelper/index.ts
+++ b/src/frontend/js/utils/ProductHelper/index.ts
@@ -2,6 +2,8 @@ import { IntlShape } from 'react-intl';
 import { CourseProductRelation, Product, TargetCourse } from 'types/Joanie';
 import { Maybe } from 'types/utils';
 import { IntlHelper } from 'utils/IntlHelper';
+import * as Joanie from 'types/Joanie';
+import { isOpenedCourseRunCertificate, isOpenedCourseRunCredential } from 'utils/CourseRuns';
 
 /**
  * Helper class for products
@@ -44,5 +46,35 @@ export class ProductHelper {
 
   static getActiveOrderGroups(courseProductRelation: CourseProductRelation) {
     return courseProductRelation.order_groups?.filter((orderGroup) => orderGroup.is_active);
+  }
+
+  static hasRemainingSeats(product: Maybe<Product>) {
+    if (!product) return false;
+    return typeof product?.remaining_order_count !== 'number' || product.remaining_order_count > 0;
+  }
+
+  static hasOpenedTargetCourse(product: Maybe<Product>, enrollment?: Maybe<Joanie.Enrollment>) {
+    if (!product) return false;
+
+    if (product.type === Joanie.ProductType.CERTIFICATE) {
+      if (!enrollment?.course_run) {
+        throw new Error(
+          'Unable to check if the certificate product relies on an opened course run without enrollment.',
+        );
+      }
+
+      return isOpenedCourseRunCertificate(enrollment.course_run.state);
+    }
+
+    return (
+      product.target_courses.length > 0 &&
+      product.target_courses.every(({ course_runs }) =>
+        course_runs.some((targetCourseRun) => isOpenedCourseRunCredential(targetCourseRun.state)),
+      )
+    );
+  }
+
+  static isPurchasable(product: Maybe<Product>, enrollment?: Maybe<Joanie.Enrollment>) {
+    return this.hasOpenedTargetCourse(product, enrollment) && this.hasRemainingSeats(product);
   }
 }

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Contract/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Contract/index.spec.tsx
@@ -122,7 +122,7 @@ describe.each([
     expect(await screen.findByText(contract.definition.title)).toBeInTheDocument();
     expect(screen.getByText(contract.order.product_title)).toBeInTheDocument();
     expect(
-      screen.getByText('You have to sign this training contract to access your training.'),
+      screen.getByText('You have to sign this training contract to finalize your subscription.'),
     ).toBeInTheDocument();
 
     expect(screen.queryByRole('button', { name: 'Sign' })).toBeInTheDocument();
@@ -149,7 +149,7 @@ describe.each([
     expect(await screen.findByText(contract.definition.title)).toBeInTheDocument();
     expect(screen.getByText(contract.order.product_title)).toBeInTheDocument();
     expect(
-      screen.getByText('You have to sign this training contract to access your training.'),
+      screen.getByText('You have to sign this training contract to finalize your subscription.'),
     ).toBeInTheDocument();
 
     expect(screen.queryByRole('link', { name: 'Sign' })).toBeInTheDocument();

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/CertificateItem/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/CertificateItem/index.tsx
@@ -1,0 +1,51 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { CredentialOrder, Product } from 'types/Joanie';
+import { DashboardItemCertificate } from 'widgets/Dashboard/components/DashboardItem/Certificate';
+import { useCertificate } from 'hooks/useCertificates';
+import { Spinner } from 'components/Spinner';
+
+const messages = defineMessages({
+  loadingCertificate: {
+    id: 'components.DashboardItemOrder.CertificateItem.loadingCertificate',
+    description: 'Accessible label displayed while certificate is being fetched on the dashboard.',
+    defaultMessage: 'Loading certificate...',
+  },
+});
+
+interface DashboardItemOrderCertificateProps {
+  order: CredentialOrder;
+  product: Product;
+}
+
+const CertificateItem = ({ order, product }: DashboardItemOrderCertificateProps) => {
+  if (!order.certificate_id) {
+    return (
+      <DashboardItemCertificate
+        certificateDefinition={product.certificate_definition}
+        productType={product.type}
+        mode="compact"
+      />
+    );
+  }
+  const certificate = useCertificate(order.certificate_id);
+  return (
+    <>
+      {certificate.states.fetching && (
+        <Spinner aria-labelledby="loading-certificate">
+          <span id="loading-certificate">
+            <FormattedMessage {...messages.loadingCertificate} />
+          </span>
+        </Spinner>
+      )}
+      {certificate.item && (
+        <DashboardItemCertificate
+          certificate={certificate.item}
+          productType={product.type}
+          mode="compact"
+        />
+      )}
+    </>
+  );
+};
+
+export default CertificateItem;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/ContractItem/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/ContractItem/index.tsx
@@ -1,0 +1,52 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+import classNames from 'classnames';
+import { CredentialOrder, Product } from 'types/Joanie';
+import { OrderHelper } from 'utils/OrderHelper';
+import ContractStatus from 'components/ContractStatus';
+import SignContractButton from 'components/SignContractButton';
+
+const messages = defineMessages({
+  trainingContractTitle: {
+    id: 'components.DashboardItemOrder.ContractItem.trainingContractTitle',
+    description: 'Title of the training contract section',
+    defaultMessage: 'Training contract',
+  },
+});
+
+const ContractItem = ({ order, product }: { order: CredentialOrder; product: Product }) => {
+  if (!product?.contract_definition) {
+    return;
+  }
+
+  const needsSignature = OrderHelper.orderNeedsSignature(order);
+  return (
+    <div
+      id="dashboard-item-contract"
+      className="dashboard-splitted-card__item"
+      data-testid={`dashboard-item-contract-${order.id}`}
+    >
+      <div
+        className={classNames('dashboard-splitted-card__item__title', {
+          'dashboard-splitted-card__item__title--dot': needsSignature,
+        })}
+      >
+        <span>
+          <FormattedMessage {...messages.trainingContractTitle} />
+        </span>
+      </div>
+      <div className="dashboard-splitted-card__item__description">
+        <ContractStatus contract={order.contract} />
+      </div>
+      <div className="dashboard-splitted-card__item__actions">
+        <SignContractButton
+          order={order}
+          contract={order.contract}
+          writable={true}
+          className="dashboard-item__button"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ContractItem;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -12,6 +12,7 @@ import {
 import { faker } from '@faker-js/faker';
 import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
+import queryString from 'query-string';
 import { DEFAULT_DATE_FORMAT } from 'hooks/useDateFormat';
 import {
   CourseStateFactory,
@@ -31,6 +32,7 @@ import {
   CourseLight,
   CourseRun,
   CredentialOrder,
+  NOT_CANCELED_ORDER_STATES,
   OrderState,
   PaymentScheduleState,
 } from 'types/Joanie';
@@ -257,6 +259,15 @@ describe('<DashboardItemOrder/>', () => {
     order.target_courses = [];
     const { product } = mockCourseProductWithOrder(order);
 
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
+
     render(<DashboardItemOrder order={order} writable={true} showDetailsButton={false} />);
 
     await screen.findByRole('heading', { level: 5, name: product.title });
@@ -283,6 +294,15 @@ describe('<DashboardItemOrder/>', () => {
     ];
 
     const { product } = mockCourseProductWithOrder(order);
+
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     render(<DashboardItemOrder order={order} writable={true} showDetailsButton={false} />);
 
@@ -349,6 +369,14 @@ describe('<DashboardItemOrder/>', () => {
       { results: [order], next: null, previous: null, count: null },
       { overwriteRoutes: true },
     );
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     // The order with an enrollment that will be returned from the API when the orders will be
     // invalided after the click on the Enroll button.
@@ -432,6 +460,15 @@ describe('<DashboardItemOrder/>', () => {
       { overwriteRoutes: true },
     );
 
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
+
     fetchMock.post('https://joanie.endpoint/api/v1.0/enrollments/', {
       status: HttpStatusCode.INTERNAL_SERVER_ERROR,
       body: 'Internal Server Error',
@@ -502,6 +539,14 @@ describe('<DashboardItemOrder/>', () => {
       { results: [order], next: null, previous: null, count: null },
       { overwriteRoutes: true },
     );
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     // The order with new enrollment that will be returned from the API when the orders will be
     // invalided after the click on the Enroll button.
@@ -608,6 +653,14 @@ describe('<DashboardItemOrder/>', () => {
       { results: [order], next: null, previous: null, count: null },
       { overwriteRoutes: true },
     );
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     const courseRun = order.target_courses[0].course_runs[0];
     const newEnrolledCourseRun = order.target_courses[0].course_runs[1];
@@ -693,6 +746,14 @@ describe('<DashboardItemOrder/>', () => {
       { results: [order], next: null, previous: null, count: null },
       { overwriteRoutes: true },
     );
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     // The order with new enrollment that will be returned from the API when the orders will be
     // invalided after the click on the Enroll button.
@@ -772,6 +833,14 @@ describe('<DashboardItemOrder/>', () => {
       }).many(1),
     }).one();
     const { product } = mockCourseProductWithOrder(order);
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     render(<DashboardItemOrder order={order} writable={true} showDetailsButton={false} />);
 
@@ -808,6 +877,15 @@ describe('<DashboardItemOrder/>', () => {
 
     const { product } = mockCourseProductWithOrder(order);
 
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
+
     render(<DashboardItemOrder order={order} writable={true} showDetailsButton={false} />);
 
     await screen.findByRole('heading', { level: 5, name: product.title });
@@ -836,6 +914,15 @@ describe('<DashboardItemOrder/>', () => {
 
     const { product } = mockCourseProductWithOrder(order);
 
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
+
     render(<DashboardItemOrder order={order} writable={true} showDetailsButton={false} />);
 
     await screen.findByRole('heading', { level: 5, name: product.title });
@@ -851,6 +938,15 @@ describe('<DashboardItemOrder/>', () => {
   it('renders a writable order with organization details', async () => {
     const order: CredentialOrder = CredentialOrderFactory().one();
     const { product } = mockCourseProductWithOrder(order);
+
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     render(<DashboardItemOrder order={order} writable={true} showDetailsButton={false} />);
 
@@ -885,6 +981,15 @@ describe('<DashboardItemOrder/>', () => {
         paymentInfo,
       )
       .get(`https://joanie.endpoint/api/v1.0/orders/${order.id}/`, validOrder);
+
+    const orderQueryParameters = {
+      course_code: order.course.code,
+      product_id: order.product_id,
+      state: NOT_CANCELED_ORDER_STATES,
+    };
+    const queryParams = queryString.stringify(orderQueryParameters);
+    const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+    fetchMock.get(url, [order]);
 
     order.state = OrderState.FAILED_PAYMENT;
     order.payment_schedule![1].state = PaymentScheduleState.REFUSED;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -1,23 +1,15 @@
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
-import { Alert, Button, useModal, VariantType } from '@openfun/cunningham-react';
-import classNames from 'classnames';
 import { generatePath } from 'react-router-dom';
-import { CourseLight, CredentialOrder, Product } from 'types/Joanie';
+import { CredentialOrder, OrderState } from 'types/Joanie';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { CoursesHelper } from 'utils/CoursesHelper';
-import { useCertificate } from 'hooks/useCertificates';
-import { Spinner } from 'components/Spinner';
 import { DashboardSubItem } from 'widgets/Dashboard/components/DashboardItem/DashboardSubItem';
-import { DashboardItemCertificate } from 'widgets/Dashboard/components/DashboardItem/Certificate';
 import { RouterButton } from 'widgets/Dashboard/components/RouterButton';
 import { useCourseProduct } from 'hooks/useCourseProducts';
 import { OrderHelper } from 'utils/OrderHelper';
-import ContractStatus from 'components/ContractStatus';
-import SignContractButton from 'components/SignContractButton';
-import { AddressView } from 'components/Address';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRoutesPaths';
-import { OrderPaymentDetailsModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderPaymentDetailsModal';
-import { OrderPaymentRetryModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal';
+import OrganizationBlock from 'widgets/Dashboard/components/DashboardItem/Order/OrganizationBlock';
+import CertificateItem from 'widgets/Dashboard/components/DashboardItem/Order/CertificateItem';
 import { DashboardSubItemsList } from '../DashboardSubItemsList';
 import { DashboardItemCourseEnrolling } from '../CourseEnrolling';
 import { DashboardItem } from '../index';
@@ -30,80 +22,25 @@ const messages = defineMessages({
     description: 'Button that redirects to the order details',
     defaultMessage: 'View details',
   },
-  loadingCertificate: {
-    id: 'components.DashboardItemOrder.loadingCertificate',
-    description: 'Accessible label displayed while certificate is being fetched on the dashboard.',
-    defaultMessage: 'Loading certificate...',
-  },
   syllabusLinkLabel: {
     id: 'components.DashboardItemOrder.syllabusLinkLabel',
     description: 'Syllabus link label on order details',
     defaultMessage: 'Go to syllabus',
   },
-  contactDescription: {
-    id: 'components.DashboardItemOrder.contactDescription',
-    description: 'Description of the contact information for the organization',
-    defaultMessage: 'Your training reference is {name} - {email}.',
+  missingPaymentMethodTitle: {
+    id: 'components.DashboardItemOrder.missingPaymentMethodTitle',
+    description: 'Main message displayed when the order is missing a payment method',
+    defaultMessage: 'A payment method is missing',
   },
-  contactButton: {
-    id: 'components.DashboardItemOrder.contactButton',
-    description: 'Button to contact the organization',
-    defaultMessage: 'Contact',
+  missingPaymentMethodDescription: {
+    id: 'components.DashboardItemOrder.missingPaymentMethodDescription',
+    description: 'Description message displayed when the order is missing a payment method',
+    defaultMessage: 'You must define a payment method to finalize your subscription.',
   },
-  organizationHeader: {
-    id: 'components.DashboardItemOrder.organizationHeader',
-    description: 'Header of the organization section',
-    defaultMessage: 'This training is provided by',
-  },
-  organizationLogoAlt: {
-    id: 'components.DashboardItemOrder.organizationLogoAlt',
-    description: 'Alt text for the organization logo',
-    defaultMessage: 'Logo of the organization',
-  },
-  trainingContractTitle: {
-    id: 'components.DashboardItemOrder.trainingContractTitle',
-    description: 'Title of the training contract section',
-    defaultMessage: 'Training contract',
-  },
-  organizationMailContactLabel: {
-    id: 'components.DashboardItemOrder.organizationMailContactLabel',
-    description: 'Label for the organization mail contact',
-    defaultMessage: 'Email',
-  },
-  organizationPhoneContactLabel: {
-    id: 'components.DashboardItemOrder.organizationPhoneContactLabel',
-    description: 'Label for the organization phone contact',
-    defaultMessage: 'Phone',
-  },
-  organizationDpoContactLabel: {
-    id: 'components.DashboardItemOrder.organizationDpoContactLabel',
-    description: 'Label for the organization DPO contact',
-    defaultMessage: 'Data protection email',
-  },
-  paymentTitle: {
-    id: 'components.DashboardItemOrder.paymentTitle',
-    description: 'Label for the payment block',
-    defaultMessage: 'Payment',
-  },
-  paymentLabel: {
-    id: 'components.DashboardItemOrder.paymentLabel',
-    description: 'Label for the payment block',
-    defaultMessage: 'You can see and manage all installments.',
-  },
-  paymentButton: {
-    id: 'components.DashboardItemOrder.paymentButton',
-    description: 'Button label for the payment block',
-    defaultMessage: 'Manage payment',
-  },
-  paymentNeededMessage: {
-    id: 'components.DashboardItemOrder.paymentNeededMessage',
-    description: 'Message displayed when payment is needed',
-    defaultMessage: 'A payment failed, please update your payment method',
-  },
-  paymentNeededButton: {
-    id: 'components.DashboardItemOrder.paymentNeededButton',
-    description: 'Button label for the payment needed message',
-    defaultMessage: 'Pay {amount}',
+  missingPaymentMethodCTA: {
+    id: 'components.DashboardItemOrder.missingPaymentMethodCTA',
+    description: 'CTA label displayed when the order is missing a payment method',
+    defaultMessage: 'Define',
   },
 });
 
@@ -114,50 +51,13 @@ interface DashboardItemOrderProps {
   writable?: boolean;
 }
 
-interface DashboardItemOrderCertificateProps {
-  order: CredentialOrder;
-  product: Product;
-}
-
-const DashboardItemOrderCertificate = ({ order, product }: DashboardItemOrderCertificateProps) => {
-  if (!order.certificate_id) {
-    return (
-      <DashboardItemCertificate
-        certificateDefinition={product.certificate_definition}
-        productType={product.type}
-        mode="compact"
-      />
-    );
-  }
-  const certificate = useCertificate(order.certificate_id);
-  return (
-    <>
-      {certificate.states.fetching && (
-        <Spinner aria-labelledby="loading-certificate">
-          <span id="loading-certificate">
-            <FormattedMessage {...messages.loadingCertificate} />
-          </span>
-        </Spinner>
-      )}
-      {certificate.item && (
-        <DashboardItemCertificate
-          certificate={certificate.item}
-          productType={product.type}
-          mode="compact"
-        />
-      )}
-    </>
-  );
-};
-
 export const DashboardItemOrder = ({
   order,
   showDetailsButton = true,
   showCertificate,
   writable = false,
 }: DashboardItemOrderProps) => {
-  const course = order.course as CourseLight;
-
+  const { course } = order;
   const intl = useIntl();
   const { item: courseProductRelation } = useCourseProduct({
     product_id: order.product_id,
@@ -165,6 +65,8 @@ export const DashboardItemOrder = ({
   });
   const { product } = courseProductRelation || {};
   const needsSignature = OrderHelper.orderNeedsSignature(order);
+  const needsPaymentMethod = order.state === OrderState.TO_SAVE_PAYMENT_METHOD;
+  const isActive = OrderHelper.isActive(order);
   const canEnroll = OrderHelper.allowEnrollment(order);
 
   if (!product) return null;
@@ -212,6 +114,39 @@ export const DashboardItemOrder = ({
                 mode="compact"
               />
             )}
+            {!writable && needsPaymentMethod && (
+              <DashboardItem
+                title=""
+                data-testid={`dashboard-item-payment-method-${order.id}`}
+                mode="compact"
+                footer={
+                  <>
+                    <div className="dashboard-contract__body">
+                      <Icon name={IconTypeEnum.CREDIT_CARD} />
+                      <span>
+                        <FormattedMessage {...messages.missingPaymentMethodTitle} />
+                      </span>
+                    </div>
+                    <div className="dashboard-contract__footer">
+                      <span className="dashboard-contract__footer__status">
+                        <FormattedMessage {...messages.missingPaymentMethodDescription} />
+                      </span>
+                      <div>
+                        <RouterButton
+                          size="small"
+                          href={generatePath(LearnerDashboardPaths.ORDER, {
+                            orderId: order.id,
+                          })}
+                          className="dashboard-item__button"
+                        >
+                          <FormattedMessage {...messages.missingPaymentMethodCTA} />
+                        </RouterButton>
+                      </div>
+                    </div>
+                  </>
+                }
+              />
+            )}
           </>
         }
       >
@@ -239,190 +174,9 @@ export const DashboardItemOrder = ({
         />
       </DashboardItem>
       {showCertificate && !!product?.certificate_definition && (
-        <DashboardItemOrderCertificate order={order} product={product} />
+        <CertificateItem order={order} product={product} />
       )}
       {writable && <OrganizationBlock order={order} product={product} />}
-    </div>
-  );
-};
-
-const OrganizationBlock = ({ order, product }: { order: CredentialOrder; product: Product }) => {
-  const { organization } = order;
-  if (!organization) {
-    return null;
-  }
-
-  const showContactsBlock =
-    organization.contact_email || organization.contact_phone || organization.dpo_email;
-
-  return (
-    <div className="dashboard-splitted-card mt-s" data-testid="organization-block">
-      <div className="dashboard-splitted-card__column order-organization__caption">
-        <div className="dashboard-item-order__organization">
-          <div className="dashboard-item-order__organization__header">
-            <FormattedMessage {...messages.organizationHeader} />
-          </div>
-          <div
-            className="dashboard-item-order__organization__logo"
-            style={{
-              backgroundImage: `url(${organization.logo?.src})`,
-            }}
-          />
-          <div className="dashboard-item-order__organization__name">{organization.title}</div>
-        </div>
-      </div>
-      <div className="dashboard-splitted-card__separator order-organization__separator" />
-      <div className="dashboard-splitted-card__column order-organization__items">
-        <ContractItem order={order} product={product} />
-        {showContactsBlock && (
-          <div className="dashboard-splitted-card__item">
-            <div className="dashboard-splitted-card__item__title">Contacts</div>
-            <div className="dashboard-splitted-card__item__description">
-              {organization.contact_email && (
-                <div className="organization-block__contact__item">
-                  <FormattedMessage {...messages.organizationMailContactLabel} />
-                  <Button
-                    size="small"
-                    color="tertiary"
-                    href={'mailto:' + (organization.contact_email ?? '')}
-                  >
-                    {organization.contact_email}
-                  </Button>
-                </div>
-              )}
-              {organization.contact_phone && (
-                <div className="organization-block__contact__item">
-                  <FormattedMessage {...messages.organizationPhoneContactLabel} />
-                  <Button
-                    size="small"
-                    color="tertiary"
-                    href={'tel:' + (organization.contact_phone ?? '')}
-                  >
-                    {organization.contact_phone}
-                  </Button>
-                </div>
-              )}
-              {organization.dpo_email && (
-                <div className="organization-block__contact__item">
-                  <FormattedMessage {...messages.organizationDpoContactLabel} />
-                  <Button
-                    size="small"
-                    color="tertiary"
-                    href={'mailto:' + (organization.dpo_email ?? '')}
-                  >
-                    {organization.dpo_email}
-                  </Button>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-        {organization.address && (
-          <div className="dashboard-splitted-card__item dashboard-splitted-card__item__address">
-            <div className="dashboard-splitted-card__item__title">Address</div>
-            <div className="dashboard-splitted-card__item__description">
-              <AddressView address={organization.address} />
-            </div>
-          </div>
-        )}
-        <Installment order={order} />
-      </div>
-    </div>
-  );
-};
-
-const Installment = ({ order }: { order: CredentialOrder }) => {
-  const modal = useModal();
-  const retryModal = useModal();
-  const failedInstallment = OrderHelper.getFailedInstallment(order);
-  const intl = useIntl();
-
-  const pay = async () => {
-    retryModal.open();
-  };
-
-  return (
-    <>
-      <div className="dashboard-splitted-card__item">
-        <div
-          className={classNames('dashboard-splitted-card__item__title', {
-            'dashboard-splitted-card__item__title--dot': !!failedInstallment,
-          })}
-        >
-          <span>
-            <FormattedMessage {...messages.paymentTitle} />
-          </span>
-        </div>
-        {failedInstallment && (
-          <Alert
-            className="mb-t"
-            type={VariantType.ERROR}
-            buttons={
-              <Button size="small" onClick={pay}>
-                <FormattedMessage
-                  {...messages.paymentNeededButton}
-                  values={{
-                    amount: intl.formatNumber(failedInstallment.amount, {
-                      style: 'currency',
-                      currency: failedInstallment.currency,
-                    }),
-                  }}
-                />
-              </Button>
-            }
-          >
-            <FormattedMessage {...messages.paymentNeededMessage} />
-          </Alert>
-        )}
-        <div className="dashboard-splitted-card__item__description">
-          <FormattedMessage {...messages.paymentLabel} />
-        </div>
-        <div className="dashboard-splitted-card__item__actions">
-          <Button size="small" color="secondary" onClick={modal.open}>
-            <FormattedMessage {...messages.paymentButton} />
-          </Button>
-        </div>
-      </div>
-      <OrderPaymentDetailsModal {...modal} order={order} />
-      {failedInstallment && (
-        <OrderPaymentRetryModal {...retryModal} installment={failedInstallment} order={order} />
-      )}
-    </>
-  );
-};
-
-const ContractItem = ({ product, order }: { order: CredentialOrder; product: Product }) => {
-  if (!product?.contract_definition) {
-    return;
-  }
-
-  const needsSignature = OrderHelper.orderNeedsSignature(order);
-  return (
-    <div
-      id={`dashboard-item-contract-${order.id}`}
-      className="dashboard-splitted-card__item"
-      data-testid={`dashboard-item-contract-${order.id}`}
-    >
-      <div
-        className={classNames('dashboard-splitted-card__item__title', {
-          'dashboard-splitted-card__item__title--dot': needsSignature,
-        })}
-      >
-        <span>
-          <FormattedMessage {...messages.trainingContractTitle} />
-        </span>
-      </div>
-      <div className="dashboard-splitted-card__item__description">
-        <ContractStatus contract={order.contract} />
-      </div>
-      <div className="dashboard-splitted-card__item__actions">
-        <SignContractButton
-          order={order}
-          contract={order.contract}
-          writable={true}
-          className="dashboard-item__button"
-        />
-      </div>
     </div>
   );
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.spec.tsx
@@ -77,7 +77,9 @@ describe('<DashboardItemOrder/> Contract', () => {
       await screen.findByRole('heading', { level: 5, name: product.title });
 
       expect(
-        screen.queryByText('You have to sign this training contract to access your training.'),
+        screen.queryByText(
+          'You have to sign this training contract to finalize your subscription.',
+        ),
       ).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
       expect(screen.getByText('On going')).toBeInTheDocument();
@@ -111,7 +113,9 @@ describe('<DashboardItemOrder/> Contract', () => {
       await screen.findByRole('heading', { level: 5, name: product.title });
 
       expect(
-        screen.queryByText('You have to sign this training contract to access your training.'),
+        screen.queryByText(
+          'You have to sign this training contract to finalize your subscription.',
+        ),
       ).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
       expect(screen.getByText('On going')).toBeInTheDocument();
@@ -147,7 +151,7 @@ describe('<DashboardItemOrder/> Contract', () => {
 
       expect(screen.getByText('Ref. ' + (order.course as CourseLight).code)).toBeInTheDocument();
       expect(
-        screen.getByText('You have to sign this training contract to access your training.'),
+        screen.getByText('You have to sign this training contract to finalize your subscription.'),
       ).toBeInTheDocument();
       expect(screen.getByText('Signature required')).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'Sign' })).toBeInTheDocument();
@@ -212,7 +216,7 @@ describe('<DashboardItemOrder/> Contract', () => {
       expect(screen.getByText('Signature required')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Sign' })).toBeInTheDocument();
       expect(
-        screen.getByText('You have to sign this training contract to access your training.'),
+        screen.getByText('You have to sign this training contract to finalize your subscription.'),
       ).toBeInTheDocument();
 
       expect(screen.queryByRole('button', { name: 'Download' })).not.toBeInTheDocument();
@@ -254,7 +258,9 @@ describe('<DashboardItemOrder/> Contract', () => {
       expect(screen.getByText('On going')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Sign' })).not.toBeInTheDocument();
       expect(
-        screen.queryByText('You have to sign this training contract to access your training.'),
+        screen.queryByText(
+          'You have to sign this training contract to finalize your subscription.',
+        ),
       ).not.toBeInTheDocument();
 
       expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.spec.tsx
@@ -1,9 +1,10 @@
 import fetchMock from 'fetch-mock';
 import { faker } from '@faker-js/faker';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
+import queryString from 'query-string';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
-import { CourseLight, OrderState } from 'types/Joanie';
+import { CourseLight, NOT_CANCELED_ORDER_STATES, OrderState } from 'types/Joanie';
 import {
   ContractDefinitionFactory,
   ContractFactory,
@@ -178,6 +179,15 @@ describe('<DashboardItemOrder/> Contract', () => {
         { overwriteRoutes: true },
       );
 
+      const orderQueryParameters = {
+        course_code: order.course.code,
+        product_id: order.product_id,
+        state: NOT_CANCELED_ORDER_STATES,
+      };
+      const queryParams = queryString.stringify(orderQueryParameters);
+      const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+      fetchMock.get(url, [order]);
+
       render(
         <DashboardTest initialRoute={LearnerDashboardPaths.ORDER.replace(':orderId', order.id)} />,
         { wrapper: BaseJoanieAppWrapper },
@@ -205,6 +215,15 @@ describe('<DashboardItemOrder/> Contract', () => {
         { overwriteRoutes: true },
       );
 
+      const orderQueryParameters = {
+        course_code: order.course.code,
+        product_id: order.product_id,
+        state: NOT_CANCELED_ORDER_STATES,
+      };
+      const queryParams = queryString.stringify(orderQueryParameters);
+      const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+      fetchMock.get(url, [order]);
+
       render(
         <DashboardTest initialRoute={LearnerDashboardPaths.ORDER.replace(':orderId', order.id)} />,
         { wrapper: BaseJoanieAppWrapper },
@@ -226,7 +245,15 @@ describe('<DashboardItemOrder/> Contract', () => {
       expect($enrollButtons).toHaveLength(order.target_courses[0].course_runs.length);
       $enrollButtons.forEach(($button) => expect($button).toBeDisabled());
 
-      await expectBannerError('You need to sign your contract before enrolling in a course run');
+      await expectBannerError(
+        'You have to sign your training contract to finalize your subscription.',
+      );
+
+      // The payment block should not display information about the payment schedule
+      const paymentBlock = screen.getByTestId('dashboard-item-payment-method');
+      within(paymentBlock).getByText(
+        'You will able to manage your payment installment here once your subscription is finalized.',
+      );
     });
 
     it('renders a writable order with a signed contract', async () => {
@@ -245,6 +272,15 @@ describe('<DashboardItemOrder/> Contract', () => {
         { results: [order], next: null, previous: null, count: null },
         { overwriteRoutes: true },
       );
+
+      const orderQueryParameters = {
+        course_code: order.course.code,
+        product_id: order.product_id,
+        state: NOT_CANCELED_ORDER_STATES,
+      };
+      const queryParams = queryString.stringify(orderQueryParameters);
+      const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+      fetchMock.get(url, [order]);
 
       render(
         <DashboardTest initialRoute={LearnerDashboardPaths.ORDER.replace(':orderId', order.id)} />,
@@ -291,6 +327,15 @@ describe('<DashboardItemOrder/> Contract', () => {
         { results: [order], next: null, previous: null, count: null },
         { overwriteRoutes: true },
       );
+
+      const orderQueryParameters = {
+        course_code: order.course.code,
+        product_id: order.product_id,
+        state: NOT_CANCELED_ORDER_STATES,
+      };
+      const queryParams = queryString.stringify(orderQueryParameters);
+      const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+      fetchMock.get(url, [order]);
 
       const DOWNLOAD_URL = `https://joanie.endpoint/api/v1.0/contracts/${
         order.contract!.id

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.useUnionResource.cache.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.useUnionResource.cache.spec.tsx
@@ -3,6 +3,7 @@
 import fetchMock from 'fetch-mock';
 import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import queryString from 'query-string';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
 import {
@@ -19,7 +20,7 @@ import { render } from 'utils/test/render';
 import { BaseJoanieAppWrapper } from 'utils/test/wrappers/BaseJoanieAppWrapper';
 
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRoutesPaths';
-import { OrderState } from 'types/Joanie';
+import { NOT_CANCELED_ORDER_STATES, OrderState } from 'types/Joanie';
 
 jest.mock('utils/context', () => ({
   __esModule: true,
@@ -65,6 +66,16 @@ describe('<DashboardItemOrder/> Contract', () => {
         { results: [order], next: null, previous: null, count: 1 },
         { overwriteRoutes: true },
       );
+
+      // overwrite useProductOrder call
+      const orderQueryParameters = {
+        course_code: order.course.code,
+        product_id: order.product_id,
+        state: NOT_CANCELED_ORDER_STATES,
+      };
+      const queryParams = queryString.stringify(orderQueryParameters);
+      const url = `https://joanie.endpoint/api/v1.0/orders/?${queryParams}`;
+      fetchMock.get(url, [order]);
 
       // mock useUnionResources calls
       fetchMock.get('begin:https://joanie.endpoint/api/v1.0/enrollments/', {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemSavePaymentMethod.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemSavePaymentMethod.spec.tsx
@@ -1,0 +1,113 @@
+/**
+ * Test suite for DashboardItem component with an order in the state TO_SAVE_PAYMENT_METHOD.
+ */
+import fetchMock from 'fetch-mock';
+import { screen } from '@testing-library/react';
+import { within } from '@testing-library/dom';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { CredentialOrderFactory } from 'utils/test/factories/joanie';
+import { OrderState } from 'types/Joanie';
+import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
+import { render } from 'utils/test/render';
+import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
+import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRoutesPaths';
+import { BaseJoanieAppWrapper } from 'utils/test/wrappers/BaseJoanieAppWrapper';
+import { mockCourseProductWithOrder } from 'utils/test/mockCourseProductWithOrder';
+import { expectBannerError, expectNoBannerError } from 'utils/test/expectBanner';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://demo.endpoint' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint' },
+  }).one(),
+}));
+
+describe('DashboardItem / (Save Payment Methode State)', () => {
+  setupJoanieSession();
+  beforeEach(() => {
+    fetchMock.get(
+      'begin:https://joanie.endpoint/api/v1.0/enrollments/',
+      { results: [], next: null, previous: null, count: null },
+      { overwriteRoutes: true },
+    );
+  });
+
+  describe('non-writable', () => {
+    it('renders elements to explain that a payment method is missing', async () => {
+      const order = CredentialOrderFactory({
+        state: OrderState.TO_SAVE_PAYMENT_METHOD,
+      }).one();
+
+      fetchMock.get('begin:https://joanie.endpoint/api/v1.0/orders/', {
+        results: [order],
+        next: null,
+        previous: null,
+        count: null,
+      });
+
+      const { product } = mockCourseProductWithOrder(order);
+
+      render(<DashboardTest initialRoute={LearnerDashboardPaths.COURSES} />, {
+        wrapper: BaseJoanieAppWrapper,
+      });
+
+      const dashboardItem = await screen.findByTestId(`dashboard-item-order-${order.id}`);
+      within(dashboardItem).getByRole('heading', { level: 5, name: product.title });
+      within(dashboardItem).getByText('A payment method is missing');
+      within(dashboardItem).getByText(
+        'You must define a payment method to finalize your subscription.',
+      );
+      const link = within(dashboardItem).getByRole('link', { name: 'Define' });
+      expect(link).toHaveAttribute('href', `/courses/orders/${order.id}`);
+      await expectNoBannerError(
+        'You have to define a payment method to finalize your subscription.',
+      );
+    });
+  });
+
+  describe('writable', () => {
+    it('renders elements to explain that a payment method is missing', async () => {
+      const order = CredentialOrderFactory({
+        state: OrderState.TO_SAVE_PAYMENT_METHOD,
+      }).one();
+
+      fetchMock.get(
+        'https://joanie.endpoint/api/v1.0/orders/',
+        { results: [order], next: null, previous: null, count: null },
+        { overwriteRoutes: true },
+      );
+
+      const url = `begin:https://joanie.endpoint/api/v1.0/orders/?`;
+      fetchMock.get(url, [order]);
+
+      const { product } = mockCourseProductWithOrder(order);
+
+      render(
+        <DashboardTest initialRoute={LearnerDashboardPaths.ORDER.replace(':orderId', order.id)} />,
+        {
+          wrapper: BaseJoanieAppWrapper,
+        },
+      );
+
+      const dashboardItem = await screen.findByTestId(`dashboard-item-order-${order.id}`);
+      within(dashboardItem).getByRole('heading', { level: 5, name: product.title });
+      expect(
+        within(dashboardItem).queryByText('A payment method is missing'),
+      ).not.toBeInTheDocument();
+      expect(within(dashboardItem).queryByRole('link', { name: 'Define' })).not.toBeInTheDocument();
+      await expectBannerError('You have to define a payment method to finalize your subscription.');
+      const link = screen.getByRole('link', { name: 'define a payment method' });
+      expect(link).toHaveAttribute('href', '#dashboard-item-payment-method');
+
+      // The payment block should display information about the missing payment method
+      const paymentBlock = screen.getByTestId('dashboard-item-payment-method');
+      const title = within(paymentBlock).getByText('Payment');
+      expect(title.parentElement).toHaveClass('dashboard-splitted-card__item__title--dot');
+      within(paymentBlock).getByText(
+        'To finalize your subscription, you must define a payment method.',
+      );
+      within(paymentBlock).getByRole('button', { name: 'Define' });
+    });
+  });
+});

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/Installment/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/Installment/index.tsx
@@ -1,0 +1,174 @@
+import { Alert, Button, useModal, VariantType } from '@openfun/cunningham-react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import classNames from 'classnames';
+import { CredentialOrder, CredentialProduct, OrderState } from 'types/Joanie';
+import { OrderHelper } from 'utils/OrderHelper';
+import { useCourseProduct } from 'hooks/useCourseProducts';
+import { OrderPaymentDetailsModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderPaymentDetailsModal';
+import { OrderPaymentRetryModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal';
+import { SaleTunnel } from 'components/SaleTunnel';
+import { Spinner } from 'components/Spinner';
+
+const messages = defineMessages({
+  paymentTitle: {
+    id: 'components.DashboardItemOrder.Installment.paymentTitle',
+    description: 'Label for the payment block',
+    defaultMessage: 'Payment',
+  },
+  paymentMethodMissingMessage: {
+    id: 'components.DashboardItemOrder.Installment.paymentMethodMissingMessage',
+    description: 'Message displayed when payment method is missing',
+    defaultMessage: 'To finalize your subscription, you must define a payment method.',
+  },
+  paymentInactiveDescription: {
+    id: 'components.DashboardItemOrder.Installment.paymentInactiveDescription',
+    description:
+      'Explanation displayed when the order is not yet active and do not miss payment method',
+    defaultMessage:
+      'You will able to manage your payment installment here once your subscription is finalized.',
+  },
+  paymentNeededMessage: {
+    id: 'components.DashboardItemOrder.Installment.paymentNeededMessage',
+    description: 'Message displayed when payment is needed',
+    defaultMessage: 'A payment failed, please update your payment method',
+  },
+  paymentNeededButton: {
+    id: 'components.DashboardItemOrder.Installment.paymentNeededButton',
+    description: 'Button label for the payment needed message',
+    defaultMessage: 'Pay {amount}',
+  },
+  paymentLabel: {
+    id: 'components.DashboardItemOrder.Installment.paymentLabel',
+    description: 'Label for the payment block',
+    defaultMessage: 'You can see and manage all installments.',
+  },
+  paymentButton: {
+    id: 'components.DashboardItemOrder.Installment.paymentButton',
+    description: 'Button label for the payment block',
+    defaultMessage: 'Manage payment',
+  },
+  defineButton: {
+    id: 'components.DashboardItemOrder.Installment.defineButton',
+    description: 'Button label to define payment method',
+    defaultMessage: 'Define',
+  },
+});
+
+type Props = {
+  order: CredentialOrder;
+};
+
+const Installment = ({ order }: Props) => {
+  const isActive = OrderHelper.isActive(order);
+  const failedInstallment = OrderHelper.getFailedInstallment(order);
+  const needsPaymentMethod = order.state === OrderState.TO_SAVE_PAYMENT_METHOD;
+  const shouldDisplayDot = needsPaymentMethod || !!failedInstallment;
+
+  return (
+    <div
+      id="dashboard-item-payment-method"
+      data-testid="dashboard-item-payment-method"
+      className="dashboard-splitted-card__item"
+    >
+      <div
+        className={classNames('dashboard-splitted-card__item__title', {
+          'dashboard-splitted-card__item__title--dot': shouldDisplayDot,
+        })}
+      >
+        <span>
+          <FormattedMessage {...messages.paymentTitle} />
+        </span>
+      </div>
+      {!isActive && !needsPaymentMethod && (
+        <p className="dashboard-splitted-card__item__description">
+          <FormattedMessage {...messages.paymentInactiveDescription} />
+        </p>
+      )}
+      <PaymentMethodManager order={order} />
+      {isActive && <InstallmentManager order={order} />}
+    </div>
+  );
+};
+
+const PaymentMethodManager = ({ order }: Props) => {
+  const needsPaymentMethod = order.state === OrderState.TO_SAVE_PAYMENT_METHOD;
+  const { item: relation, states } = useCourseProduct({
+    course_id: order.course.code,
+    product_id: order.product_id,
+  });
+  const modal = useModal({ isOpenDefault: false });
+
+  if (!order || states.fetching) {
+    return <Spinner size="small" />;
+  }
+
+  return (
+    <>
+      {needsPaymentMethod && (
+        <div>
+          <p>
+            <FormattedMessage {...messages.paymentMethodMissingMessage} />
+          </p>
+          <Button size="small" onClick={modal.open}>
+            <FormattedMessage {...messages.defineButton} />
+          </Button>
+        </div>
+      )}
+      <SaleTunnel
+        {...modal}
+        product={relation.product as CredentialProduct}
+        course={relation.course}
+      />
+    </>
+  );
+};
+
+const InstallmentManager = ({ order }: Props) => {
+  const intl = useIntl();
+  const modal = useModal();
+  const retryModal = useModal();
+  const failedInstallment = OrderHelper.getFailedInstallment(order);
+
+  const pay = async () => {
+    retryModal.open();
+  };
+  return (
+    <>
+      {failedInstallment && (
+        <Alert
+          className="mb-t"
+          type={VariantType.ERROR}
+          buttons={
+            <Button size="small" onClick={pay}>
+              <FormattedMessage
+                {...messages.paymentNeededButton}
+                values={{
+                  amount: intl.formatNumber(failedInstallment.amount, {
+                    style: 'currency',
+                    currency: failedInstallment.currency,
+                  }),
+                }}
+              />
+            </Button>
+          }
+        >
+          <FormattedMessage {...messages.paymentNeededMessage} />
+        </Alert>
+      )}
+      <div className="dashboard-splitted-card__item__description">
+        <FormattedMessage {...messages.paymentLabel} />
+      </div>
+      <div className="dashboard-splitted-card__item__actions">
+        <Button size="small" color="secondary" onClick={modal.open}>
+          <FormattedMessage {...messages.paymentButton} />
+        </Button>
+      </div>
+      <OrderPaymentDetailsModal {...modal} order={order} />
+      {failedInstallment && (
+        <OrderPaymentRetryModal {...retryModal} installment={failedInstallment} order={order} />
+      )}
+    </>
+  );
+};
+
+export default Installment;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentDetailsModal/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentDetailsModal/index.tsx
@@ -26,7 +26,7 @@ const messages = defineMessages({
   },
   scheduleTitle: {
     id: 'components.DashboardItemOrder.PaymentModal.scheduleTitle',
-    defaultMessage: 'Repayment schedule',
+    defaultMessage: 'Payment schedule',
     description: 'Title of the payment schedule',
   },
   paymentMethodTitle: {
@@ -54,6 +54,7 @@ export const OrderPaymentDetailsModal = ({ order, ...props }: PaymentModalProps)
   const intl = useIntl();
   const retryModal = useModal();
   const failedInstallment = OrderHelper.getFailedInstallment(order);
+
   return (
     <>
       <Modal {...props} size={ModalSize.MEDIUM} title={intl.formatMessage(messages.title)}>

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrganizationBlock/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrganizationBlock/index.tsx
@@ -1,0 +1,150 @@
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Button } from '@openfun/cunningham-react';
+import { CredentialOrder, Product } from 'types/Joanie';
+import { AddressView } from 'components/Address';
+import ContractItem from '../ContractItem';
+import Installment from '../Installment';
+
+const messages = defineMessages({
+  contactDescription: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.contactDescription',
+    description: 'Description of the contact information for the organization',
+    defaultMessage: 'Your training reference is {name} - {email}.',
+  },
+  contactButton: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.contactButton',
+    description: 'Button to contact the organization',
+    defaultMessage: 'Contact',
+  },
+  organizationHeader: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.organizationHeader',
+    description: 'Header of the organization section',
+    defaultMessage: 'This training is provided by',
+  },
+  organizationLogoAlt: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.organizationLogoAlt',
+    description: 'Alt text for the organization logo',
+    defaultMessage: 'Logo of the organization',
+  },
+  organizationMailContactLabel: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.organizationMailContactLabel',
+    description: 'Label for the organization mail contact',
+    defaultMessage: 'Email',
+  },
+  organizationPhoneContactLabel: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.organizationPhoneContactLabel',
+    description: 'Label for the organization phone contact',
+    defaultMessage: 'Phone',
+  },
+  organizationDpoContactLabel: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.organizationDpoContactLabel',
+    description: 'Label for the organization DPO contact',
+    defaultMessage: 'Data protection email',
+  },
+  organizationSubtitleAddress: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.organizationSubtitleAddress',
+    description: 'Subtitle for the organization address section',
+    defaultMessage: 'Address',
+  },
+  organizationSubtitleContacts: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.organizationSubtitleContacts',
+    description: 'Subtitle for the organization contacts section',
+    defaultMessage: 'Contacts',
+  },
+});
+
+type Props = {
+  product: Product;
+  order: CredentialOrder;
+};
+
+const OrganizationBlock = ({ order, product }: Props) => {
+  const { organization } = order;
+  if (!organization) {
+    return null;
+  }
+
+  const showContactsBlock =
+    organization.contact_email || organization.contact_phone || organization.dpo_email;
+
+  return (
+    <div className="dashboard-splitted-card mt-s" data-testid="organization-block">
+      <div className="dashboard-splitted-card__column order-organization__caption">
+        <div className="dashboard-item-order__organization">
+          <div className="dashboard-item-order__organization__header">
+            <FormattedMessage {...messages.organizationHeader} />
+          </div>
+          <div
+            className="dashboard-item-order__organization__logo"
+            style={{
+              backgroundImage: `url(${organization.logo?.src})`,
+            }}
+          />
+          <div className="dashboard-item-order__organization__name">{organization.title}</div>
+        </div>
+      </div>
+      <div className="dashboard-splitted-card__separator order-organization__separator" />
+      <div className="dashboard-splitted-card__column order-organization__items">
+        <ContractItem order={order} product={product} />
+        {showContactsBlock && (
+          <div className="dashboard-splitted-card__item">
+            <div className="dashboard-splitted-card__item__title">
+              <FormattedMessage {...messages.organizationSubtitleContacts} />
+            </div>
+            <div className="dashboard-splitted-card__item__description">
+              {organization.contact_email && (
+                <div className="organization-block__contact__item">
+                  <FormattedMessage {...messages.organizationMailContactLabel} />
+                  <Button
+                    size="small"
+                    color="tertiary"
+                    href={'mailto:' + (organization.contact_email ?? '')}
+                  >
+                    {organization.contact_email}
+                  </Button>
+                </div>
+              )}
+              {organization.contact_phone && (
+                <div className="organization-block__contact__item">
+                  <FormattedMessage {...messages.organizationPhoneContactLabel} />
+                  <Button
+                    size="small"
+                    color="tertiary"
+                    href={'tel:' + (organization.contact_phone ?? '')}
+                  >
+                    {organization.contact_phone}
+                  </Button>
+                </div>
+              )}
+              {organization.dpo_email && (
+                <div className="organization-block__contact__item">
+                  <FormattedMessage {...messages.organizationDpoContactLabel} />
+                  <Button
+                    size="small"
+                    color="tertiary"
+                    href={'mailto:' + (organization.dpo_email ?? '')}
+                  >
+                    {organization.dpo_email}
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+        {organization.address && (
+          <div className="dashboard-splitted-card__item dashboard-splitted-card__item__address">
+            <div className="dashboard-splitted-card__item__title">
+              <FormattedMessage {...messages.organizationSubtitleAddress} />
+            </div>
+            <div className="dashboard-splitted-card__item__description">
+              <AddressView address={organization.address} />
+            </div>
+          </div>
+        )}
+        <Installment order={order} />
+      </div>
+    </div>
+  );
+};
+
+export default OrganizationBlock;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardOrderLoader/index.tsx
@@ -7,6 +7,7 @@ import Banner, { BannerType } from 'components/Banner';
 import { isCredentialOrder } from 'pages/DashboardCourses/useOrdersEnrollments';
 import { handle } from 'utils/errors/handle';
 import { OrderHelper } from 'utils/OrderHelper';
+import { OrderState } from 'types/Joanie';
 import { DashboardItemOrder } from '../DashboardItem/Order/DashboardItemOrder';
 
 const messages = defineMessages({
@@ -16,12 +17,12 @@ const messages = defineMessages({
     id: 'components.DashboardOrderLoader.loading',
   },
   signatureNeeded: {
-    defaultMessage: 'You need to {signLink} before enrolling in a course run',
+    defaultMessage: 'You have to {signLink} to finalize your subscription.',
     description: 'Banner displayed when the contract is not signed',
     id: 'components.DashboardOrderLoader.signatureNeeded',
   },
   signLink: {
-    defaultMessage: 'sign your contract',
+    defaultMessage: 'sign your training contract',
     description: 'Link to sign the contract',
     id: 'components.DashboardOrderLoader.signLink',
   },
@@ -29,6 +30,16 @@ const messages = defineMessages({
     defaultMessage: 'This page is not available for this order.',
     description: "Error message displayed when order's linked product type is not handle.",
     id: 'components.DashboardOrderLoader.wrongLinkedProductError',
+  },
+  paymentMethodMissing: {
+    defaultMessage: 'You have to {definePaymentMethodLink} to finalize your subscription.',
+    description: 'Error message displayed when no payment method is defined.',
+    id: 'components.DashboardOrderLoader.paymentMethodMissing',
+  },
+  definePaymentMethodLink: {
+    defaultMessage: 'define a payment method',
+    description: 'Link to define a payment method',
+    id: 'components.DashboardOrderLoader.definePaymentMethodLink',
   },
 });
 
@@ -50,6 +61,7 @@ export const DashboardOrderLoader = () => {
   const error = errorOrder || wrongLinkedProductError;
   const fetching = fetchingOrder;
   const needsSignature = order ? OrderHelper.orderNeedsSignature(order) : false;
+  const needsPaymentMethod = order?.state === OrderState.TO_SAVE_PAYMENT_METHOD;
 
   return (
     <>
@@ -67,8 +79,22 @@ export const DashboardOrderLoader = () => {
             message={
               intl.formatMessage(messages.signatureNeeded, {
                 signLink: (
-                  <a href={'#dashboard-item-contract-' + order.id}>
+                  <a href="#dashboard-item-contract">
                     <FormattedMessage {...messages.signLink} />
+                  </a>
+                ),
+              }) as any
+            }
+            type={BannerType.ERROR}
+          />
+        )}
+        {order && needsPaymentMethod && (
+          <Banner
+            message={
+              intl.formatMessage(messages.paymentMethodMissing, {
+                definePaymentMethodLink: (
+                  <a href="#dashboard-item-payment-method">
+                    <FormattedMessage {...messages.definePaymentMethodLink} />
                   </a>
                 ),
               }) as any

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -49,7 +49,7 @@
     "@formatjs/intl-relativetimeformat": "11.2.14",
     "@hookform/resolvers": "3.9.0",
     "@lyracom/embedded-form-glue": "1.4.2",
-    "@openfun/cunningham-react": "2.9.3",
+    "@openfun/cunningham-react": "2.9.4",
     "@openfun/cunningham-tokens": "2.1.1",
     "@sentry/browser": "8.26.0",
     "@sentry/types": "8.26.0",

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -1441,15 +1441,15 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
   integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
 
-"@fontsource-variable/roboto-flex@5.0.15":
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/@fontsource-variable/roboto-flex/-/roboto-flex-5.0.15.tgz#c507e8c7c647ddf973da4fc520549b83471d1f70"
-  integrity sha512-CTBG6EceGcuj49sYZVPx533laiGxKboq0H4GLTJ+/2FkqTsSYIYoF8RzeyySTiCSmY7+EfWckfwYW7L9Wlh3bw==
+"@fontsource-variable/roboto-flex@5.0.16":
+  version "5.0.16"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/roboto-flex/-/roboto-flex-5.0.16.tgz#277bcd53e7548d21db2b091eb58fd9c4c9792853"
+  integrity sha512-aMJw0ac9M2fu78YUx5BRtdSqNqGV4cJPF6lbFpow8e0hXVH7wPwk5d0mpox1MTwvHFHRStmkYVB/SSUytmlaSw==
 
-"@fontsource/material-icons-outlined@5.0.12":
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/@fontsource/material-icons-outlined/-/material-icons-outlined-5.0.12.tgz#4fa80f5ec52892e9cd2e56e88445cf962faa75cd"
-  integrity sha512-Zi8qYVOCtSS6CFGZzjUY+ENYmVtSgH1GDQBeGllwXJ2Ny/TmCTsO+tjHpr74nV4u63JSAAl72QnX0eOhOcldJw==
+"@fontsource/material-icons-outlined@5.0.13":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@fontsource/material-icons-outlined/-/material-icons-outlined-5.0.13.tgz#f8f2a669cb5bdc45fb3ca41f057bc149e3484695"
+  integrity sha512-mQxKJcFiwclTJd0G5fUg0gJ/ZszdaZRSIMFkvbPvMUteA9aSFzFswHr9Yuacw+x4wlBl7GlsVCujAPaBeLv/dw==
 
 "@formatjs/cli@6.2.12":
   version "6.2.12"
@@ -1627,14 +1627,7 @@
   dependencies:
     mute-stream "^1.0.0"
 
-"@internationalized/date@3.5.4":
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.5.4.tgz#49ba11634fd4350b7a9308e297032267b4063c44"
-  integrity sha512-qoVJVro+O0rBaw+8HPjUB1iH8Ihf8oziEnqMnvhJUSuVIrHOuZ6eNLHNvzXJKUvAtaDiqMnRlg8Z2mgh09BlUw==
-  dependencies:
-    "@swc/helpers" "^0.5.0"
-
-"@internationalized/date@^3.5.4", "@internationalized/date@^3.5.5":
+"@internationalized/date@3.5.5", "@internationalized/date@^3.5.5":
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.5.5.tgz#7d34cb9da35127f98dd669fc926bb37e771e177f"
   integrity sha512-H+CfYvOZ0LTJeeLOqm19E3uj/4YjrmOFtBufDHPfvtI80hFAMqtrp7oCACpe4Cil5l8S0Qu/9dYfZc/5lY8WQQ==
@@ -1999,31 +1992,31 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-2.1.0.tgz#0acf32f470af2ceaf47f095cdecd40d68666efda"
   integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
 
-"@openfun/cunningham-react@2.9.3":
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/@openfun/cunningham-react/-/cunningham-react-2.9.3.tgz#cea4aca62c207047f4156287c8c255924031a6ed"
-  integrity sha512-+FNh63ocHeWweKBoahSJiWWbu992A+FDJXAjzcYoWz1jCIdQs8fLaeCzTl9t5x7cCCgo2DElBnwZQ2GBAA2hSw==
+"@openfun/cunningham-react@2.9.4":
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/@openfun/cunningham-react/-/cunningham-react-2.9.4.tgz#f8dba15033597d8d5cbd96601c3a624e1e273df9"
+  integrity sha512-jz91L48LoSwL1cH3pfuMRdlGdVEeAkRhR6iseRtNQTcoUi5DIDsZemdtf0ltoxJOYjitZdcOC1U6/J8TV3H+Xg==
   dependencies:
-    "@fontsource-variable/roboto-flex" "5.0.15"
-    "@fontsource/material-icons-outlined" "5.0.12"
-    "@internationalized/date" "3.5.4"
+    "@fontsource-variable/roboto-flex" "5.0.16"
+    "@fontsource/material-icons-outlined" "5.0.13"
+    "@internationalized/date" "3.5.5"
     "@openfun/cunningham-tokens" "*"
-    "@react-aria/calendar" "3.5.8"
-    "@react-aria/datepicker" "3.10.1"
-    "@react-aria/i18n" "3.11.1"
-    "@react-stately/calendar" "3.5.1"
-    "@react-stately/datepicker" "3.9.4"
-    "@tanstack/react-table" "8.17.3"
+    "@react-aria/calendar" "3.5.11"
+    "@react-aria/datepicker" "3.11.2"
+    "@react-aria/i18n" "3.12.2"
+    "@react-stately/calendar" "3.5.4"
+    "@react-stately/datepicker" "3.10.2"
+    "@tanstack/react-table" "8.20.1"
     "@types/react-modal" "3.16.3"
-    chromatic "11.4.0"
+    chromatic "11.7.1"
     classnames "2.5.1"
-    downshift "9.0.6"
+    downshift "9.0.8"
     react "18.3.1"
-    react-aria "3.33.1"
-    react-aria-components "1.2.1"
+    react-aria "3.34.2"
+    react-aria-components "1.3.2"
     react-dom "18.3.1"
     react-modal "3.16.1"
-    react-stately "3.31.1"
+    react-stately "3.32.2"
 
 "@openfun/cunningham-tokens@*", "@openfun/cunningham-tokens@2.1.1":
   version "2.1.1"
@@ -2046,324 +2039,281 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
-"@react-aria/breadcrumbs@^3.5.13", "@react-aria/breadcrumbs@^3.5.15":
-  version "3.5.15"
-  resolved "https://registry.yarnpkg.com/@react-aria/breadcrumbs/-/breadcrumbs-3.5.15.tgz#c8ba91b36ec07b4c81bc6124461054a91d258217"
-  integrity sha512-KJ7678hwKbacz6dyY4aOJlgtV91PtuSnlWGR+AsK88WwHhpjjTjLLTSRepjbQ35GuQuoYokM4mmfaS/I0nblhw==
+"@react-aria/breadcrumbs@^3.5.16":
+  version "3.5.16"
+  resolved "https://registry.yarnpkg.com/@react-aria/breadcrumbs/-/breadcrumbs-3.5.16.tgz#bea4b38e2ac218d113be56294fc556f790db8581"
+  integrity sha512-OXLKKu4SmjnSaSHkk4kow5/aH/SzlHWPJt+Uq3xec9TwDOr/Ob8aeFVGFoY0HxfGozuQlUz+4e+d29vfA0jNWg==
   dependencies:
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/link" "^3.7.3"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/link" "^3.7.4"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/breadcrumbs" "^3.7.7"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/button@^3.9.5", "@react-aria/button@^3.9.7":
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/@react-aria/button/-/button-3.9.7.tgz#f839cb54d318d03cc3ec8bdcd31cca9a4046cd21"
-  integrity sha512-xwE6uatbbn3KbNSc0dyDnOo539HJM2cqCPfjiQGt8O9cFbpQSmx76Fj4WotU3BwT7ZVbcAC8D206CgF1C2cDcQ==
+"@react-aria/button@^3.9.8":
+  version "3.9.8"
+  resolved "https://registry.yarnpkg.com/@react-aria/button/-/button-3.9.8.tgz#bf0a54268e9b88b0aa18494e8453f2c4f70e129c"
+  integrity sha512-MdbMQ3t5KSCkvKtwYd/Z6sgw0v+r1VQFRYOZ4L53xOkn+u140z8vBpNeWKZh/45gxGv7SJn9s2KstLPdCWmIxw==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/toggle" "^3.7.6"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/toggle" "^3.7.7"
     "@react-types/button" "^3.9.6"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/calendar@3.5.8":
-  version "3.5.8"
-  resolved "https://registry.yarnpkg.com/@react-aria/calendar/-/calendar-3.5.8.tgz#fd0858b34c8961b76957e9ac13b514f485c329a3"
-  integrity sha512-Whlp4CeAA5/ZkzrAHUv73kgIRYjw088eYGSc+cvSOCxfrc/2XkBm9rNrnSBv0DvhJ8AG0Fjz3vYakTmF3BgZBw==
-  dependencies:
-    "@internationalized/date" "^3.5.4"
-    "@react-aria/i18n" "^3.11.1"
-    "@react-aria/interactions" "^3.21.3"
-    "@react-aria/live-announcer" "^3.3.4"
-    "@react-aria/utils" "^3.24.1"
-    "@react-stately/calendar" "^3.5.1"
-    "@react-types/button" "^3.9.4"
-    "@react-types/calendar" "^3.4.6"
-    "@react-types/shared" "^3.23.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-aria/calendar@^3.5.10", "@react-aria/calendar@^3.5.8":
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/@react-aria/calendar/-/calendar-3.5.10.tgz#749ac8baf44f7b4639b898dc9f4e80b5e905f4e4"
-  integrity sha512-5PokdIHAH+CAd6vMHFW9mg77I5tC0FQglYsCEI9ikhCnL5xlt3FmJjLtOs3UJQaWgrd4cdVd0oINpPafJ9ydhA==
+"@react-aria/calendar@3.5.11", "@react-aria/calendar@^3.5.11":
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/@react-aria/calendar/-/calendar-3.5.11.tgz#da75da0eaf40a48d33a766b67fc342dc21deb21d"
+  integrity sha512-VLhBovLVu3uJXBkHbgEippmo/K58QLcc/tSJQ0aJUNyHsrvPgHEcj484cb+Uj/yOirXEIzaoW6WEvhcdKrb49Q==
   dependencies:
     "@internationalized/date" "^3.5.5"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
     "@react-aria/live-announcer" "^3.3.4"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/calendar" "^3.5.3"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/calendar" "^3.5.4"
     "@react-types/button" "^3.9.6"
-    "@react-types/calendar" "^3.4.8"
+    "@react-types/calendar" "^3.4.9"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/checkbox@^3.14.3", "@react-aria/checkbox@^3.14.5":
-  version "3.14.5"
-  resolved "https://registry.yarnpkg.com/@react-aria/checkbox/-/checkbox-3.14.5.tgz#8e25a19a2cf6c28de603aebd77ec14f0f504333b"
-  integrity sha512-On8m66CNi1LvbDeDo355au0K66ayIjo0nDe4oe85aNsR/owyzz8hXNPAFuh98owQVMsKt4596FZICAVSMzzhJg==
+"@react-aria/checkbox@^3.14.6":
+  version "3.14.6"
+  resolved "https://registry.yarnpkg.com/@react-aria/checkbox/-/checkbox-3.14.6.tgz#79050d5c491a8e16be42bc80188f72b6891c610f"
+  integrity sha512-LICY1PR3WsW/VbuLMjZbxo75+poeo3XCXGcUnk6hxMlWfp/Iy/XHVsHlGu9stRPKRF8BSuOGteaHWVn6IXfwtA==
   dependencies:
-    "@react-aria/form" "^3.0.7"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/toggle" "^3.10.6"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/checkbox" "^3.6.7"
+    "@react-aria/form" "^3.0.8"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/toggle" "^3.10.7"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/checkbox" "^3.6.8"
     "@react-stately/form" "^3.0.5"
-    "@react-stately/toggle" "^3.7.6"
+    "@react-stately/toggle" "^3.7.7"
     "@react-types/checkbox" "^3.8.3"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/color@3.0.0-beta.33":
-  version "3.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@react-aria/color/-/color-3.0.0-beta.33.tgz#6773627e788f339154dca58450dd50d9f3721051"
-  integrity sha512-nhqnIHYm5p6MbuF3cC6lnqzG7MjwBsBd0DtpO+ByFYO+zxpMMbeC5R+1SFxvapR4uqmAzTotbtiUCGsG+SUaIg==
+"@react-aria/collections@3.0.0-alpha.4":
+  version "3.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@react-aria/collections/-/collections-3.0.0-alpha.4.tgz#ad1e8eea9d3c784d17a4de43b3e52d888f45efdd"
+  integrity sha512-chMNAlsubnpErBWN7sLhmAMOnE7o17hSfq3s0VDHlvRN9K/mPOPlYokmyWkkPqi7fYiR50EPVHDtwTWLJoqfnw==
   dependencies:
-    "@react-aria/i18n" "^3.11.1"
-    "@react-aria/interactions" "^3.21.3"
-    "@react-aria/numberfield" "^3.11.3"
-    "@react-aria/slider" "^3.7.8"
-    "@react-aria/spinbutton" "^3.6.5"
-    "@react-aria/textfield" "^3.14.5"
-    "@react-aria/utils" "^3.24.1"
-    "@react-aria/visually-hidden" "^3.8.12"
-    "@react-stately/color" "^3.6.1"
-    "@react-stately/form" "^3.0.3"
-    "@react-types/color" "3.0.0-beta.25"
-    "@react-types/shared" "^3.23.1"
+    "@react-aria/ssr" "^3.9.5"
+    "@react-aria/utils" "^3.25.2"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+    use-sync-external-store "^1.2.0"
+
+"@react-aria/color@3.0.0-rc.2":
+  version "3.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/color/-/color-3.0.0-rc.2.tgz#b16f363fd61ff11875f3ec49d1f8ad7804919c65"
+  integrity sha512-h4P7LocDEHPOEWgHYb8VPJLRGkyMhcsXemmvGao6G23zGTpTX8Nr6pEuJhcXQlGWt8hXvj/ASnC750my+zb1yA==
+  dependencies:
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/numberfield" "^3.11.6"
+    "@react-aria/slider" "^3.7.11"
+    "@react-aria/spinbutton" "^3.6.8"
+    "@react-aria/textfield" "^3.14.8"
+    "@react-aria/utils" "^3.25.2"
+    "@react-aria/visually-hidden" "^3.8.15"
+    "@react-stately/color" "^3.7.2"
+    "@react-stately/form" "^3.0.5"
+    "@react-types/color" "3.0.0-rc.1"
+    "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/combobox@^3.10.1", "@react-aria/combobox@^3.9.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/combobox/-/combobox-3.10.1.tgz#8e964815471e09f794d314945b7f8fabf250858a"
-  integrity sha512-B0zjX66HEqjPFnunYR0quAqwVJ6U0ez1eqBp25/611Dtzh3JHUovQmTE0xGGTjRe6N6qJg0VHVr2eRO/D0A+Lw==
+"@react-aria/combobox@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/combobox/-/combobox-3.10.2.tgz#501f5373ab9211d48a6b117f7be88a118b1edca8"
+  integrity sha512-2srEtgf4mJNniSISvgYB7nZDQldMRoqSNjAFX7ftr1TBRTeiEdo27WFAA9G8UHwDGtE8+8llEePxG4FkTVYPIw==
   dependencies:
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/listbox" "^3.13.1"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/listbox" "^3.13.2"
     "@react-aria/live-announcer" "^3.3.4"
-    "@react-aria/menu" "^3.15.1"
-    "@react-aria/overlays" "^3.23.1"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/textfield" "^3.14.7"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/menu" "^3.15.2"
+    "@react-aria/overlays" "^3.23.2"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/textfield" "^3.14.8"
+    "@react-aria/utils" "^3.25.2"
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/combobox" "^3.9.1"
+    "@react-stately/combobox" "^3.9.2"
     "@react-stately/form" "^3.0.5"
     "@react-types/button" "^3.9.6"
     "@react-types/combobox" "^3.12.1"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/datepicker@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/datepicker/-/datepicker-3.10.1.tgz#513a9d18e118d4c3d078fdbfc45dca76b7eeb37f"
-  integrity sha512-4HZL593nrNMa1GjBmWEN/OTvNS6d3/16G1YJWlqiUlv11ADulSbqBIjMmkgwrJVFcjrgqtXFy+yyrTA/oq94Zw==
-  dependencies:
-    "@internationalized/date" "^3.5.4"
-    "@internationalized/number" "^3.5.3"
-    "@internationalized/string" "^3.2.3"
-    "@react-aria/focus" "^3.17.1"
-    "@react-aria/form" "^3.0.5"
-    "@react-aria/i18n" "^3.11.1"
-    "@react-aria/interactions" "^3.21.3"
-    "@react-aria/label" "^3.7.8"
-    "@react-aria/spinbutton" "^3.6.5"
-    "@react-aria/utils" "^3.24.1"
-    "@react-stately/datepicker" "^3.9.4"
-    "@react-stately/form" "^3.0.3"
-    "@react-types/button" "^3.9.4"
-    "@react-types/calendar" "^3.4.6"
-    "@react-types/datepicker" "^3.7.4"
-    "@react-types/dialog" "^3.5.10"
-    "@react-types/shared" "^3.23.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-aria/datepicker@^3.10.1", "@react-aria/datepicker@^3.11.1":
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/datepicker/-/datepicker-3.11.1.tgz#0162ac24f5e46c798422e5cdbb23a1c2d41f1de3"
-  integrity sha512-yEEuDt/ynt7bTfd/9RD1EiLPysWhbgSYSpn5PHVz7I2XORvNPpyamyAgz3+oFiLFLC/zy0qrG7e6V1rvI1NBzw==
+"@react-aria/datepicker@3.11.2", "@react-aria/datepicker@^3.11.2":
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/datepicker/-/datepicker-3.11.2.tgz#628f70ea532480421e7ebe1f0020856baee60639"
+  integrity sha512-6sbLln3VXSBcBRDgSACBzIzF/5KV5NlNOhZvXPFE6KqFw6GbevjZQTv5BNDXiwA3CQoawIRF7zgRvTANw8HkNA==
   dependencies:
     "@internationalized/date" "^3.5.5"
     "@internationalized/number" "^3.5.3"
     "@internationalized/string" "^3.2.3"
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/form" "^3.0.7"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/spinbutton" "^3.6.7"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/datepicker" "^3.10.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/form" "^3.0.8"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/spinbutton" "^3.6.8"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/datepicker" "^3.10.2"
     "@react-stately/form" "^3.0.5"
     "@react-types/button" "^3.9.6"
-    "@react-types/calendar" "^3.4.8"
-    "@react-types/datepicker" "^3.8.1"
+    "@react-types/calendar" "^3.4.9"
+    "@react-types/datepicker" "^3.8.2"
     "@react-types/dialog" "^3.5.12"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/dialog@^3.5.14", "@react-aria/dialog@^3.5.16":
-  version "3.5.16"
-  resolved "https://registry.yarnpkg.com/@react-aria/dialog/-/dialog-3.5.16.tgz#f21d69886ce9d87c07903cc51551888445dadb8e"
-  integrity sha512-2clBSQQaoqCjAUkHnMA/noZ1ZnFbEVU67fL9M1QfokezAyLAlyCyD9XSed6+Td/Ncj80N3/Lax65XAlvWCyOlg==
+"@react-aria/dialog@^3.5.17":
+  version "3.5.17"
+  resolved "https://registry.yarnpkg.com/@react-aria/dialog/-/dialog-3.5.17.tgz#156c62be73ee5c1fb68d8cd59effa350f9d69970"
+  integrity sha512-lvfEgaqg922J1hurscqCS600OZQVitGtdpo81kAefJaUzMnCxzrYviyT96aaW0simHOlimbYF5js8lxBLZJRaw==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/overlays" "^3.23.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/overlays" "^3.23.2"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/dialog" "^3.5.12"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/dnd@^3.6.1", "@react-aria/dnd@^3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/dnd/-/dnd-3.7.1.tgz#091d42094fc8f47816075704b5b16a34da8b3a57"
-  integrity sha512-p3/pc8p2fGd4s+Qj4SfRPJjZFStuuXqRNyDQxd9AAFYUWcCQxwDOqtiTZmfvs7Hvl0PUuysHW6Q5v7ABRjVr7w==
+"@react-aria/dnd@^3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/dnd/-/dnd-3.7.2.tgz#d42b83729f21902fe1614a1efd4d62f7918e57a8"
+  integrity sha512-NuE3EGqoBbe9aXAO9mDfbu4kMO7S4MCgkjkCqYi16TWfRUf38ajQbIlqodCx91b3LVN3SYvNbE3D4Tj5ebkljw==
   dependencies:
     "@internationalized/string" "^3.2.3"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
     "@react-aria/live-announcer" "^3.3.4"
-    "@react-aria/overlays" "^3.23.1"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/dnd" "^3.4.1"
+    "@react-aria/overlays" "^3.23.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/dnd" "^3.4.2"
     "@react-types/button" "^3.9.6"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/focus@^3.17.1", "@react-aria/focus@^3.18.1":
-  version "3.18.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.18.1.tgz#b54b88e78662549ddae917e3143723c8dd7a4e90"
-  integrity sha512-N0Cy61WCIv+57mbqC7hiZAsB+3rF5n4JKabxUmg/2RTJL6lq7hJ5N4gx75ymKxkN8GnVDwt4pKZah48Wopa5jw==
+"@react-aria/focus@^3.18.2":
+  version "3.18.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.18.2.tgz#93accfce59c8abbbb95589e65816a240cd16068a"
+  integrity sha512-Jc/IY+StjA3uqN73o6txKQ527RFU7gnG5crEl5Xy3V+gbYp2O5L3ezAo/E0Ipi2cyMbG6T5Iit1IDs7hcGu8aw==
   dependencies:
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
     clsx "^2.0.0"
 
-"@react-aria/form@^3.0.5", "@react-aria/form@^3.0.7":
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/@react-aria/form/-/form-3.0.7.tgz#767a6474a20d4206dca0fd5f5946656452ff59a9"
-  integrity sha512-VIsKP/KytJPOLRQl0NxWWS1bQELPBuW3vRjmmhBrtgPFmp0uCLhjPBkP6A4uIVj1E/JtAocyHN3DNq4+IJGQCg==
+"@react-aria/form@^3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@react-aria/form/-/form-3.0.8.tgz#9d98040b44795052bddffd47741ed64b739dd070"
+  integrity sha512-8S2QiyUdAgK43M3flohI0R+2rTyzH088EmgeRArA8euvJTL16cj/oSOKMEgWVihjotJ9n6awPb43ZhKboyNsMg==
   dependencies:
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
     "@react-stately/form" "^3.0.5"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/grid@^3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/grid/-/grid-3.10.1.tgz#5eb81575c9f8d872b00e2c43e5167f5d9451f131"
-  integrity sha512-7dSgiYVQapBtPV4SIit+9fJ1qoEjtp+PXffJkWAPtGbg/jJ4b0jcVzykH7ARD4w/6jAJN/oVSfrKZqFPoLAd9w==
+"@react-aria/grid@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/grid/-/grid-3.10.2.tgz#3605fbf16523558a454a89b69d237454741e5e19"
+  integrity sha512-Uj/+m8924fdu3TDR/LMoGEs+Fo+UcMsu02sQix1RgVWialvc0JUpt85rjC79+7ZzwPDGOHsyWLeQcDqv930yqA==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
     "@react-aria/live-announcer" "^3.3.4"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/utils" "^3.25.2"
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/grid" "^3.9.1"
-    "@react-stately/selection" "^3.16.1"
+    "@react-stately/grid" "^3.9.2"
+    "@react-stately/selection" "^3.16.2"
     "@react-types/checkbox" "^3.8.3"
     "@react-types/grid" "^3.2.8"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/gridlist@^3.8.1", "@react-aria/gridlist@^3.9.1":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/gridlist/-/gridlist-3.9.1.tgz#02672b42f8b1c8df26521ef24b5722aee252da09"
-  integrity sha512-cue2KCI4WyVmL3j9tZx7xG7gUJ7UyRbawzRTcocJukOmpeoyRaw/robrIYK2Pd//GhRbIMAoo4iOyZk5j7vEww==
+"@react-aria/gridlist@^3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/gridlist/-/gridlist-3.9.2.tgz#32ba8175d5ae89ce59ffa114689b0bc694d1d24a"
+  integrity sha512-PED9DaOL51o/1dtgsjl7WM52TAR6hmekOaHBD2085OmppnmnwRUBGWJb7lG939+fNKO26NJPSVqnI36Oq8wwtA==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/grid" "^3.10.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/grid" "^3.10.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/utils" "^3.25.2"
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/list" "^3.10.7"
-    "@react-stately/tree" "^3.8.3"
+    "@react-stately/list" "^3.10.8"
+    "@react-stately/tree" "^3.8.4"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/i18n@3.11.1":
-  version "3.11.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.11.1.tgz#2d238d2be30d8c691b5fa3161f5fb48066fc8e4b"
-  integrity sha512-vuiBHw1kZruNMYeKkTGGnmPyMnM5T+gT8bz97H1FqIq1hQ6OPzmtBZ6W6l6OIMjeHI5oJo4utTwfZl495GALFQ==
-  dependencies:
-    "@internationalized/date" "^3.5.4"
-    "@internationalized/message" "^3.1.4"
-    "@internationalized/number" "^3.5.3"
-    "@internationalized/string" "^3.2.3"
-    "@react-aria/ssr" "^3.9.4"
-    "@react-aria/utils" "^3.24.1"
-    "@react-types/shared" "^3.23.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-aria/i18n@^3.11.1", "@react-aria/i18n@^3.12.1":
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.12.1.tgz#2b170953867f14688c4dd17b2ab55a8ca8eba07d"
-  integrity sha512-0q3gyogF9Ekah+9LOo6tcfshxsk2Ope+KdbtFHJVhznedMxn6RpHGcVur5ImbQ1dYafA5CmjBUGJW70b56+BGA==
+"@react-aria/i18n@3.12.2", "@react-aria/i18n@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/i18n/-/i18n-3.12.2.tgz#f1e63ddb5227bc1c8a17cd3475235851e428dd0b"
+  integrity sha512-PvEyC6JWylTpe8dQEWqQwV6GiA+pbTxHQd//BxtMSapRW3JT9obObAnb/nFhj3HthkUvqHyj0oO1bfeN+mtD8A==
   dependencies:
     "@internationalized/date" "^3.5.5"
     "@internationalized/message" "^3.1.4"
     "@internationalized/number" "^3.5.3"
     "@internationalized/string" "^3.2.3"
     "@react-aria/ssr" "^3.9.5"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/interactions@^3.21.3", "@react-aria/interactions@^3.22.1":
-  version "3.22.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.22.1.tgz#f2219a100c886cee383da7be9ae05e9dd940d39a"
-  integrity sha512-5TLzQaDAQQ5C70yG8GInbO4wIylKY67RfTIIwQPGR/4n5OIjbUD8BOj3NuSsuZ/frUPaBXo1VEBBmSO23fxkjw==
+"@react-aria/interactions@^3.22.2":
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.22.2.tgz#88ab021326459513fb16cf752974471932ffb5d1"
+  integrity sha512-xE/77fRVSlqHp2sfkrMeNLrqf2amF/RyuAS6T5oDJemRSgYM3UoxTbWjucPhfnoW7r32pFPHHgz4lbdX8xqD/g==
   dependencies:
     "@react-aria/ssr" "^3.9.5"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/label@^3.7.10", "@react-aria/label@^3.7.8":
-  version "3.7.10"
-  resolved "https://registry.yarnpkg.com/@react-aria/label/-/label-3.7.10.tgz#5343c95da514bc448ad779b2fbec9f8dd550e0d1"
-  integrity sha512-e5XVHA+OUK0aIwr4nHcnIj0z1kUryGaJWYYD2OGkkIltyUCKmwpRqdx8LQYbO4HGsJhvC3hJgidFdGcQwHHPYw==
+"@react-aria/label@^3.7.11":
+  version "3.7.11"
+  resolved "https://registry.yarnpkg.com/@react-aria/label/-/label-3.7.11.tgz#79cb5234dce68eb6eb011fa74de435e394cac2a8"
+  integrity sha512-REgejE5Qr8cXG/b8H2GhzQmjQlII/0xQW/4eDzydskaTLvA7lF5HoJUE6biYTquH5va38d8XlH465RPk+bvHzA==
   dependencies:
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/link@^3.7.1", "@react-aria/link@^3.7.3":
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/@react-aria/link/-/link-3.7.3.tgz#a6170ed04c67e55dedf0eec1b699cfa168e9eb28"
-  integrity sha512-dOwzxzo7LF4djBfRC8GcIhuTpDkNUIMT6ykQRV1a3749kgrr10YLascsO/l66k60i2k0T2oClkzfefYEK6WZeA==
+"@react-aria/link@^3.7.4":
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/@react-aria/link/-/link-3.7.4.tgz#3ea250b2f81f4af518118eaf183553cc8f296e49"
+  integrity sha512-E8SLDuS9ssm/d42+3sDFNthfMcNXMUrT2Tq1DIZt22EsMcuEzmJ9B0P7bDP5RgvIw05xVGqZ20nOpU4mKTxQtA==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/link" "^3.5.7"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/listbox@^3.12.1", "@react-aria/listbox@^3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/listbox/-/listbox-3.13.1.tgz#3a59b2973baebb96f10e784f14c6ddf1312c2196"
-  integrity sha512-b5Nu+5d5shJbxpy4s6OXvMlMzm+PVbs3L6CtoHlsKe8cAlSWD340vPHCOGYLwZApIBewepOBvRWgeAF8IDI04w==
+"@react-aria/listbox@^3.13.2":
+  version "3.13.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/listbox/-/listbox-3.13.2.tgz#db8a9e2b0f2fbc76d47592ae2619bd4abe726c95"
+  integrity sha512-8heK/6c1ooO2vT9bXtrSniOCOoNEMREsI/GE/lUfw4slo4obbzIx34B5rX2uEXvPUAuF+8NvESNv4APmRNo89g==
   dependencies:
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/utils" "^3.25.2"
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/list" "^3.10.7"
+    "@react-stately/list" "^3.10.8"
     "@react-types/listbox" "^3.5.1"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
@@ -2375,370 +2325,371 @@
   dependencies:
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/menu@^3.14.1", "@react-aria/menu@^3.15.1":
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/menu/-/menu-3.15.1.tgz#d44196d268f731c7a1b6b4fb907419a7c3632060"
-  integrity sha512-ZBTMZiJ17j6t7epcsjd0joAzsMKO31KLJHPtWAEfk1JkBxrMoirISPN8O1CeK/uBX++VaWSrDZfFe1EjrOwKuA==
+"@react-aria/menu@^3.15.2":
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/menu/-/menu-3.15.2.tgz#0b1b2784350896480c2d00e72c547e94f85d298c"
+  integrity sha512-r4Rl+0yuSI+MAnDvqZTiTzJH6B6QDHaQEqUpzRdYPUqd7QY+DcziVz+CcId85V9hrZSuxWMCpQIy9QzxTPWAgQ==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/overlays" "^3.23.1"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/overlays" "^3.23.2"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/utils" "^3.25.2"
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/menu" "^3.8.1"
-    "@react-stately/tree" "^3.8.3"
+    "@react-stately/menu" "^3.8.2"
+    "@react-stately/tree" "^3.8.4"
     "@react-types/button" "^3.9.6"
     "@react-types/menu" "^3.9.11"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/meter@^3.4.13", "@react-aria/meter@^3.4.15":
-  version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@react-aria/meter/-/meter-3.4.15.tgz#7a277636f8f03660134296dc067b614b59d52b98"
-  integrity sha512-OUAzgmfiyEvBF+h9NlG7s8jvrGNTqj/zAWyUWEh5FMEjKFrDfni6awwFoRs164QqmUvRBNC0/eKv3Ghd2GIkRA==
+"@react-aria/meter@^3.4.16":
+  version "3.4.16"
+  resolved "https://registry.yarnpkg.com/@react-aria/meter/-/meter-3.4.16.tgz#fea02ce06ccef4042702de585bf5b71bf805824d"
+  integrity sha512-hJqKnEE6mmK2Psx5kcI7NZ44OfTg0Bp7DatQSQ4zZE4yhnykRRwxqSKjze37tPR63cCqgRXtQ5LISfBfG54c0Q==
   dependencies:
-    "@react-aria/progress" "^3.4.15"
+    "@react-aria/progress" "^3.4.16"
     "@react-types/meter" "^3.4.3"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/numberfield@^3.11.3", "@react-aria/numberfield@^3.11.5":
-  version "3.11.5"
-  resolved "https://registry.yarnpkg.com/@react-aria/numberfield/-/numberfield-3.11.5.tgz#09582fadda67a908c83175949c0f5ebabbbdc1df"
-  integrity sha512-cfJzU7SWsksKiLjfubSj5lR18ebQ7IbYaMQZbxdpZSPOANHIiktaxjPK4Nz7cqZ+HZ/6tQEirpY0iqpLx35CSw==
+"@react-aria/numberfield@^3.11.6":
+  version "3.11.6"
+  resolved "https://registry.yarnpkg.com/@react-aria/numberfield/-/numberfield-3.11.6.tgz#f96d927adc8c35b6c36965f7adaf7abb3c81284e"
+  integrity sha512-nvEWiQcWRwj6O2JXmkXEeWoBX/GVZT9zumFJcew3XknGTWJUr3h2AOymIQFt9g4mpag8IgOFEpSIlwhtZHdp1A==
   dependencies:
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/spinbutton" "^3.6.7"
-    "@react-aria/textfield" "^3.14.7"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/spinbutton" "^3.6.8"
+    "@react-aria/textfield" "^3.14.8"
+    "@react-aria/utils" "^3.25.2"
     "@react-stately/form" "^3.0.5"
-    "@react-stately/numberfield" "^3.9.5"
+    "@react-stately/numberfield" "^3.9.6"
     "@react-types/button" "^3.9.6"
     "@react-types/numberfield" "^3.8.5"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/overlays@^3.22.1", "@react-aria/overlays@^3.23.1":
-  version "3.23.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/overlays/-/overlays-3.23.1.tgz#64214e91251a0c005f93d3c769547cf8f3c8c5dd"
-  integrity sha512-qNV3pGThvRXjhdHCfqN9Eg4uD+nFm2DoK6d5e9LFd1+xCkKbT88afDBIcLmeG7fgfmukb1sNmzCJQJt8Svk54g==
+"@react-aria/overlays@^3.23.2":
+  version "3.23.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/overlays/-/overlays-3.23.2.tgz#1413b4f7cb9e0d0f7c5b483da9115539fcf5ad5c"
+  integrity sha512-vjlplr953YAuJfHiP4O+CyrTlr6OaFgXAGrzWq4MVMjnpV/PT5VRJWYFHR0sUGlHTPqeKS4NZbi/xCSgl/3pGQ==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
     "@react-aria/ssr" "^3.9.5"
-    "@react-aria/utils" "^3.25.1"
-    "@react-aria/visually-hidden" "^3.8.14"
-    "@react-stately/overlays" "^3.6.9"
+    "@react-aria/utils" "^3.25.2"
+    "@react-aria/visually-hidden" "^3.8.15"
+    "@react-stately/overlays" "^3.6.10"
     "@react-types/button" "^3.9.6"
     "@react-types/overlays" "^3.8.9"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/progress@^3.4.13", "@react-aria/progress@^3.4.15":
-  version "3.4.15"
-  resolved "https://registry.yarnpkg.com/@react-aria/progress/-/progress-3.4.15.tgz#20a1d339a34cfc408c40ad74738a4fa978c8e9f5"
-  integrity sha512-wlx8pgEet3mlq5Skjy7yV1DfQiEg79tZtojpb5YGN2dIAH8sxClrKOSJRVce0fy9IXVCKrQxjQNXPNUIojK5Rg==
+"@react-aria/progress@^3.4.16":
+  version "3.4.16"
+  resolved "https://registry.yarnpkg.com/@react-aria/progress/-/progress-3.4.16.tgz#78296ead8268867a0a7a4077ae94dc2440a010a8"
+  integrity sha512-RbDIFQg4+/LG+KYZeLAijt2zH7K2Gp0CY9RKWdho3nU5l3/w57Fa7NrfDGWtpImrt7bR2nRmXMA6ESfr7THfrg==
   dependencies:
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/progress" "^3.5.6"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/radio@^3.10.4", "@react-aria/radio@^3.10.6":
-  version "3.10.6"
-  resolved "https://registry.yarnpkg.com/@react-aria/radio/-/radio-3.10.6.tgz#e5ded29e604866bde49b536c1e146b2812b3cc38"
-  integrity sha512-Cr7kiTUWw+HOEdFHztqrFlSXvwuzOCTMbwNkziTyc9fualIX6UDilykND2ctfBgkM4qH7SgQt+SxAIwTdevsKg==
+"@react-aria/radio@^3.10.7":
+  version "3.10.7"
+  resolved "https://registry.yarnpkg.com/@react-aria/radio/-/radio-3.10.7.tgz#7c76548b6f08bfce7c48eba910799eb71b4b98c4"
+  integrity sha512-o2tqIe7xd1y4HeCBQfz/sXIwLJuI6LQbVoCQ1hgk/5dGhQ0LiuXohRYitGRl9zvxW8jYdgLULmOEDt24IflE8A==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/form" "^3.0.7"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/radio" "^3.10.6"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/form" "^3.0.8"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/radio" "^3.10.7"
     "@react-types/radio" "^3.8.3"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/searchfield@^3.7.5", "@react-aria/searchfield@^3.7.7":
-  version "3.7.7"
-  resolved "https://registry.yarnpkg.com/@react-aria/searchfield/-/searchfield-3.7.7.tgz#4cfb5497f3192ea4a84653466dd862e1a23e40a7"
-  integrity sha512-2f087PCR8X5LYyLnvjCIOV27xjjTCkDFPnQaC7XSPCfzDYGM8utCR56JfZMqHnjcMnVNoiEg7EjSBBrh7I2bnQ==
+"@react-aria/searchfield@^3.7.8":
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/@react-aria/searchfield/-/searchfield-3.7.8.tgz#da263ba56a2a8d41f015ece7933b14e413630bd9"
+  integrity sha512-SsF5xwH8Us548QgzivvbM7nhFbw7pu23xnRRIuhlP3MwOR3jRUFh17NKxf3Z0jvrDv/u0xfm3JKHIgaUN0KJ2A==
   dependencies:
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/textfield" "^3.14.7"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/searchfield" "^3.5.5"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/textfield" "^3.14.8"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/searchfield" "^3.5.6"
     "@react-types/button" "^3.9.6"
-    "@react-types/searchfield" "^3.5.7"
+    "@react-types/searchfield" "^3.5.8"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/select@^3.14.5", "@react-aria/select@^3.14.7":
-  version "3.14.7"
-  resolved "https://registry.yarnpkg.com/@react-aria/select/-/select-3.14.7.tgz#8019c2b0b81360b17001798cf7db6d8b2c0001e7"
-  integrity sha512-qZy5oX6P8SGrdv4bHb8iVMIVv+vLuo7UwOJtsQ1FUORIsZmBEz0RyfgYdzlueMcZNoQ9JgLYtrK2e0h6AmJOlg==
+"@react-aria/select@^3.14.8":
+  version "3.14.8"
+  resolved "https://registry.yarnpkg.com/@react-aria/select/-/select-3.14.8.tgz#edc6a6ef40ed0b3fd922dc2547836546dc41b8c5"
+  integrity sha512-8piIhc/kT11+joBde845WHd2c82M2rm0yi3QSU/OR6YAgmTM+kz4nW0Lsns/9Jcz9I0DUvYYjzlhi1zSDbu+Ig==
   dependencies:
-    "@react-aria/form" "^3.0.7"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/listbox" "^3.13.1"
-    "@react-aria/menu" "^3.15.1"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/utils" "^3.25.1"
-    "@react-aria/visually-hidden" "^3.8.14"
-    "@react-stately/select" "^3.6.6"
+    "@react-aria/form" "^3.0.8"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/listbox" "^3.13.2"
+    "@react-aria/menu" "^3.15.2"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-aria/visually-hidden" "^3.8.15"
+    "@react-stately/select" "^3.6.7"
     "@react-types/button" "^3.9.6"
     "@react-types/select" "^3.9.6"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/selection@^3.18.1", "@react-aria/selection@^3.19.1":
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/selection/-/selection-3.19.1.tgz#3fbbac4d3f8dc1711cb6523bef0d9e0c47a514cb"
-  integrity sha512-mbExvq2Omi60sTWFGjwcNz1ja2P8VDsxWAqSypHRTyqXhtgqbv8V/v8Gp+7BmVPH1YHcbhztl6rvUZTDOSszzw==
+"@react-aria/selection@^3.19.2":
+  version "3.19.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/selection/-/selection-3.19.2.tgz#8c4e7dd232f7c9da4d0e3b0cf25cbc3d4ee12869"
+  integrity sha512-twQ/mOIfdtcq6edh13Fc9G8AqNShGwnDkRV1m0xo++5Ru/uUytWDBGbUa7iTGR3yOPvijMyQPNqIjbCL+Q1ApA==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/selection" "^3.16.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/selection" "^3.16.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/separator@^3.3.13", "@react-aria/separator@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/separator/-/separator-3.4.1.tgz#c8c643f9506b569ba2af7185761588a87ca73949"
-  integrity sha512-bZ+GQ936Y+WXAtsQjJdEMgYeqmqjhU90+wOlRGjmGdwf+/ht2yzBpeRuHEYUbE6F0iis/YoVc+b8ppAtPna/kA==
+"@react-aria/separator@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/separator/-/separator-3.4.2.tgz#4f9a40bd423bac4f3f4371d6eb050b6d1a944548"
+  integrity sha512-Xql9Kg3VlGesEUC7QheE+L5b3KgBv0yxiUU+/4JP8V2vfU/XSz4xmprHEeq7KVQVOetn38iiXU8gA5g26SEsUA==
   dependencies:
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/slider@^3.7.10", "@react-aria/slider@^3.7.8":
-  version "3.7.10"
-  resolved "https://registry.yarnpkg.com/@react-aria/slider/-/slider-3.7.10.tgz#09474eb9f6d041bf1651dc663695843b34652061"
-  integrity sha512-QmBn87sDkncS/uhcrH0MxUN7bcEo8cHYcWk+gk7mibdIpyxyVDPKh7v7ZsosmAJLzjS0yb2ec1/Q5Oldfg1k/A==
+"@react-aria/slider@^3.7.11":
+  version "3.7.11"
+  resolved "https://registry.yarnpkg.com/@react-aria/slider/-/slider-3.7.11.tgz#43bb0dd1e19218238ee72696514243de000315c1"
+  integrity sha512-2WAwjANXPsA2LHJ5nxxV4c7ihFAzz2spaBz8+FJ7MDYE7WroYnE8uAXElea1aGo+Lk0DTiAdepLpBkggqPNanw==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/slider" "^3.5.6"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/slider" "^3.5.7"
     "@react-types/shared" "^3.24.1"
     "@react-types/slider" "^3.7.5"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/spinbutton@^3.6.5", "@react-aria/spinbutton@^3.6.7":
-  version "3.6.7"
-  resolved "https://registry.yarnpkg.com/@react-aria/spinbutton/-/spinbutton-3.6.7.tgz#4c549039542e1215f68c791d5bb2d8be61b10979"
-  integrity sha512-OCimp4yXoFIgh6WAMOls5DDDRDRO75ZFic3YA6wLWTRNHxo1Lj8S90i1A6pakY6bi4hdBCKmj4DnFSNKAw1iWg==
+"@react-aria/spinbutton@^3.6.8":
+  version "3.6.8"
+  resolved "https://registry.yarnpkg.com/@react-aria/spinbutton/-/spinbutton-3.6.8.tgz#5e44c02543b6669a8aa0b86f932183b7c3d573c5"
+  integrity sha512-OJMAYRIZ0WrWE+5tZsywrSg4t+aOwl6vl/e1+J64YcGMM+p+AKd61KGG5T0OgNSORXjoVIZOmj6wZ6Od4xfPMw==
   dependencies:
-    "@react-aria/i18n" "^3.12.1"
+    "@react-aria/i18n" "^3.12.2"
     "@react-aria/live-announcer" "^3.3.4"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/utils" "^3.25.2"
     "@react-types/button" "^3.9.6"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/ssr@^3.9.4", "@react-aria/ssr@^3.9.5":
+"@react-aria/ssr@^3.9.5":
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.9.5.tgz#775d84f51f90934ff51ae74eeba3728daac1a381"
   integrity sha512-xEwGKoysu+oXulibNUSkXf8itW0npHHTa6c4AyYeZIJyRoegeteYuFpZUBPtIDE8RfHdNsSmE1ssOkxRnwbkuQ==
   dependencies:
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/switch@^3.6.4", "@react-aria/switch@^3.6.6":
-  version "3.6.6"
-  resolved "https://registry.yarnpkg.com/@react-aria/switch/-/switch-3.6.6.tgz#da1ec971ad877ea9551f15a7d23d990075c62e34"
-  integrity sha512-+dZOX1utODlx5dC90DtwnXd9nvln9HxMffBj/gmMT1/cD/RmXfjvymfjTsTMwvHhqCew9yfpvod0ZWwj3BkLGw==
+"@react-aria/switch@^3.6.7":
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/@react-aria/switch/-/switch-3.6.7.tgz#47937f18935f8411fb2d19d7d3cde0a69ecfb05a"
+  integrity sha512-yBNvKylhc3ZRQ0+7mD0mIenRRe+1yb8YaqMMZr8r3Bf87LaiFtQyhRFziq6ZitcwTJz5LEWjBihxbSVvUrf49w==
   dependencies:
-    "@react-aria/toggle" "^3.10.6"
-    "@react-stately/toggle" "^3.7.6"
+    "@react-aria/toggle" "^3.10.7"
+    "@react-stately/toggle" "^3.7.7"
     "@react-types/shared" "^3.24.1"
     "@react-types/switch" "^3.5.5"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/table@^3.14.1", "@react-aria/table@^3.15.1":
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/table/-/table-3.15.1.tgz#908175bf2ad064fd0c7862ff49297b3c036dc920"
-  integrity sha512-jVDLxp6Y/9M6y45c1I6u6msJ9dBg2I7Cu/FlSaK6HthTpN23UXuGw1oWuAjbfqi31nVXHWBwjCZkGKTdMjLf5A==
+"@react-aria/table@^3.15.2":
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/table/-/table-3.15.2.tgz#34f0435602fa8fec3e5ca03c1ddc811e6cb87be0"
+  integrity sha512-Vsfk5xwvY+bjyiusvr497A/cKnF9PyC8idGdnEI01FSSRYEXy+gtm7AhXe7REyAAqm7e7zAoGyVEXEpXnJJajg==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/grid" "^3.10.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/grid" "^3.10.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
     "@react-aria/live-announcer" "^3.3.4"
-    "@react-aria/utils" "^3.25.1"
-    "@react-aria/visually-hidden" "^3.8.14"
+    "@react-aria/utils" "^3.25.2"
+    "@react-aria/visually-hidden" "^3.8.15"
     "@react-stately/collections" "^3.10.9"
     "@react-stately/flags" "^3.0.3"
-    "@react-stately/table" "^3.12.1"
+    "@react-stately/table" "^3.12.2"
     "@react-types/checkbox" "^3.8.3"
     "@react-types/grid" "^3.2.8"
     "@react-types/shared" "^3.24.1"
     "@react-types/table" "^3.10.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/tabs@^3.9.1", "@react-aria/tabs@^3.9.3":
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/@react-aria/tabs/-/tabs-3.9.3.tgz#77e9216ba93dbd5f1af17dca00a2229de0285766"
-  integrity sha512-J1KOCdx4eSyMMeNCvO8BIz8E8xez12B+cYbM4BbJzWlcfMboGYUnM0lvI8QSpFPa/H9LkAhp7BJnl9IZeIBzoA==
+"@react-aria/tabs@^3.9.4":
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/@react-aria/tabs/-/tabs-3.9.4.tgz#43ebefde15382cb8f4577455f37c065a62a458a3"
+  integrity sha512-2RhkYvQhvd72MyADIxxp4jzDWzOLelLB1TwcZIJGO7znn2OGDJNgvuxYeWGqe8r4ComK/Z8wnFeqxQ+Ed1UNQw==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/tabs" "^3.6.8"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/tabs" "^3.6.9"
     "@react-types/shared" "^3.24.1"
     "@react-types/tabs" "^3.3.9"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/tag@^3.4.1", "@react-aria/tag@^3.4.3":
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/@react-aria/tag/-/tag-3.4.3.tgz#7d59f4a863ca7fe75bd6f3e21bb328f4c684627d"
-  integrity sha512-BqXKazX9YHvt6+qzGTu770V0FqGVefzz03hmnV2IVb+zYchXBv3WYbWVy46s/D5zTePOAXdpitQHxqy5rh+hgw==
+"@react-aria/tag@^3.4.4":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@react-aria/tag/-/tag-3.4.4.tgz#fa9fc6618df4a8e7504c78874265889489887025"
+  integrity sha512-yYu34xk7zBUhV17xzH/LF6JplWN0l9CtaFsGIroEznrLELMCymBkglcIPyWR5OOVTWkn1aW+smN0q7pdkAjCaA==
   dependencies:
-    "@react-aria/gridlist" "^3.9.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/list" "^3.10.7"
+    "@react-aria/gridlist" "^3.9.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/list" "^3.10.8"
     "@react-types/button" "^3.9.6"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/textfield@^3.14.5", "@react-aria/textfield@^3.14.7":
-  version "3.14.7"
-  resolved "https://registry.yarnpkg.com/@react-aria/textfield/-/textfield-3.14.7.tgz#368c2da2e0596a1ebadc6d21df5da41f2c619feb"
-  integrity sha512-1cWCG6vkjlwJuRTXKbKl9P0Q/0Li5pnMafZqDDWfDOlkS5dFGxYG6QFfoaYp7N6XMoNkXiculnCssfrQ+8hWgA==
+"@react-aria/textfield@^3.14.8":
+  version "3.14.8"
+  resolved "https://registry.yarnpkg.com/@react-aria/textfield/-/textfield-3.14.8.tgz#76b8d01f2892022048e42f239e1c43c4b8d6cacc"
+  integrity sha512-FHEvsHdE1cMR2B7rlf+HIneITrC40r201oLYbHAp3q26jH/HUujzFBB9I20qhXjyBohMWfQLqJhSwhs1VW1RJQ==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/form" "^3.0.7"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/form" "^3.0.8"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/utils" "^3.25.2"
     "@react-stately/form" "^3.0.5"
-    "@react-stately/utils" "^3.10.2"
+    "@react-stately/utils" "^3.10.3"
     "@react-types/shared" "^3.24.1"
-    "@react-types/textfield" "^3.9.5"
+    "@react-types/textfield" "^3.9.6"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/toggle@^3.10.6":
-  version "3.10.6"
-  resolved "https://registry.yarnpkg.com/@react-aria/toggle/-/toggle-3.10.6.tgz#c0afba7bdf5263869b7169d97651b1ba746f84f9"
-  integrity sha512-AGlbtB1b8grrtjbiW5Au0LKYzxR83RHbHhaUkFwajyYRGyuEzr3Y03OiveoPB+DayA8Gz3H1ZVmW++8JZQOWHw==
+"@react-aria/toggle@^3.10.7":
+  version "3.10.7"
+  resolved "https://registry.yarnpkg.com/@react-aria/toggle/-/toggle-3.10.7.tgz#50f7af45e6b875e3ff42e9871db9f065d9910cb7"
+  integrity sha512-/RJQU8QlPZXRElZ3Tt10F5K5STgUBUGPpfuFUGuwF3Kw3GpPxYsA1YAVjxXz2MMGwS0+y6+U/J1xIs1AF0Jwzg==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/toggle" "^3.7.6"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/toggle" "^3.7.7"
     "@react-types/checkbox" "^3.8.3"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/toolbar@3.0.0-beta.5":
-  version "3.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@react-aria/toolbar/-/toolbar-3.0.0-beta.5.tgz#09d79bc758c10d602ed3ed9b6e9c62f3e69e1533"
-  integrity sha512-c8spY7aeLI6L+ygdXvEbAzaT41vExsxZ1Ld0t7BB+6iEF3nyBNJHshjkgdR7nv8FLgNk0no4tj0GTq4Jj4UqHQ==
+"@react-aria/toolbar@3.0.0-beta.8":
+  version "3.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@react-aria/toolbar/-/toolbar-3.0.0-beta.8.tgz#2846f22c9c524ec75d577f9edddc4d534cc48fcd"
+  integrity sha512-nMlA1KK54/Kohb3HlHAzobg69PVIEr8Q1j5P3tLd9apY8FgGvnz7yLpcj6kO1GA872gseEzgiO0Rzk+yRHQRCA==
   dependencies:
-    "@react-aria/focus" "^3.17.1"
-    "@react-aria/i18n" "^3.11.1"
-    "@react-aria/utils" "^3.24.1"
-    "@react-types/shared" "^3.23.1"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/tooltip@^3.7.4", "@react-aria/tooltip@^3.7.6":
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/@react-aria/tooltip/-/tooltip-3.7.6.tgz#1e3a715a2d0a977bd4481d4ae6cc69de16e4f5a3"
-  integrity sha512-JvRAMTcMju/KBOtISjVKKtIDzG3J1r6xK+mZTvu6ArM7DdeMBM5A8Lwk0bJ8dhr+YybiM9rR3hoZv3/E7IIYVw==
+"@react-aria/tooltip@^3.7.7":
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/@react-aria/tooltip/-/tooltip-3.7.7.tgz#5372c086af55d549461e3cd736beb136fffb5be5"
+  integrity sha512-UOTTDbbUz7OaE48VjNSWl+XQbYCUs5Gss4I3Tv1pfRLXzVtGYXv3ur/vRayvZR0xd12ANY26fZPNkSmCFpmiXw==
   dependencies:
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/utils" "^3.25.1"
-    "@react-stately/tooltip" "^3.4.11"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/tooltip" "^3.4.12"
     "@react-types/shared" "^3.24.1"
     "@react-types/tooltip" "^3.4.11"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/tree@3.0.0-alpha.1":
-  version "3.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/tree/-/tree-3.0.0-alpha.1.tgz#00855ef1d3b54f9c3f5d728085e3d1561b153a53"
-  integrity sha512-CucyeJ4VeAvWO5UJHt/l9JO65CVtsOVUctMOVNCQS77Isqp3olX9pvfD3LXt8fD5Ph2g0Q/b7siVpX5ieVB32g==
+"@react-aria/tree@3.0.0-alpha.4":
+  version "3.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@react-aria/tree/-/tree-3.0.0-alpha.4.tgz#b98c170f09d2b5039eba5ddfd6cacad2929076ff"
+  integrity sha512-a35/clOnkMIF6vLJQWRHJfUzZLAld+XYRZ/vbs+FihZZYgVxgfGT6QKxf4yMPKVx5JKrtkFJ/UCxV+pUPcSyyg==
   dependencies:
-    "@react-aria/gridlist" "^3.8.1"
-    "@react-aria/i18n" "^3.11.1"
-    "@react-aria/selection" "^3.18.1"
-    "@react-aria/utils" "^3.24.1"
-    "@react-stately/tree" "^3.8.1"
-    "@react-types/button" "^3.9.4"
-    "@react-types/shared" "^3.23.1"
+    "@react-aria/gridlist" "^3.9.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/tree" "^3.8.4"
+    "@react-types/button" "^3.9.6"
+    "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-aria/utils@^3.24.1", "@react-aria/utils@^3.25.1":
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.25.1.tgz#f6530ce47aa28617924cc6868b4cf1c113a909c5"
-  integrity sha512-5Uj864e7T5+yj78ZfLnfHqmypLiqW2mN+nsdslog2z5ssunTqjolVeM15ootXskjISlZ7MojLpq97kIC4nlnAw==
+"@react-aria/utils@^3.25.2":
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.25.2.tgz#2cce329849617b2df6a34f0931abe431f60aaedc"
+  integrity sha512-GdIvG8GBJJZygB4L2QJP1Gabyn2mjFsha73I2wSe+o4DYeGWoJiMZRM06PyTIxLH4S7Sn7eVDtsSBfkc2VY/NA==
   dependencies:
     "@react-aria/ssr" "^3.9.5"
-    "@react-stately/utils" "^3.10.2"
+    "@react-stately/utils" "^3.10.3"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
     clsx "^2.0.0"
 
-"@react-aria/visually-hidden@^3.8.12", "@react-aria/visually-hidden@^3.8.14":
-  version "3.8.14"
-  resolved "https://registry.yarnpkg.com/@react-aria/visually-hidden/-/visually-hidden-3.8.14.tgz#ccfff3c5220b833ef811574b70751bac303b29c5"
-  integrity sha512-DV3yagbAgO4ywQTq6D/AxcIaTC8c77r/SxlIMhQBMQ6vScJWTCh6zFG55wmLe3NKqvRrowv1OstlmYfZQ4v/XA==
+"@react-aria/virtualizer@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/virtualizer/-/virtualizer-4.0.2.tgz#88efb92813619a273ef754133dc50ac957480313"
+  integrity sha512-HNhpZl53UM2Z8g0DNvjAW7aZRwOReYgKRxdTF/IlYHNMLpdqWZinKwLbxZCsbgX3SCjdIGns90YhkMSKVpfrpw==
   dependencies:
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/utils" "^3.25.1"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-stately/virtualizer" "^4.0.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/calendar@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/calendar/-/calendar-3.5.1.tgz#3e865d69675ba78f56e7abfadff0ef667f438a69"
-  integrity sha512-7l7QhqGUJ5AzWHfvZzbTe3J4t72Ht5BmhW4hlVI7flQXtfrmYkVtl3ZdytEZkkHmWGYZRW9b4IQTQGZxhtlElA==
+"@react-aria/visually-hidden@^3.8.15":
+  version "3.8.15"
+  resolved "https://registry.yarnpkg.com/@react-aria/visually-hidden/-/visually-hidden-3.8.15.tgz#8b0317621e1eab3e4188df1a0206f483b95cd8f2"
+  integrity sha512-l+sJ7xTdD5Sd6+rDNDaeJCSPnHOsI+BaJyApvb/YcVgHa7rB47lp6TXCWUCDItcPY4JqRGyeByRJVrtzBFTWCw==
   dependencies:
-    "@internationalized/date" "^3.5.4"
-    "@react-stately/utils" "^3.10.1"
-    "@react-types/calendar" "^3.4.6"
-    "@react-types/shared" "^3.23.1"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/utils" "^3.25.2"
+    "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/calendar@^3.5.1", "@react-stately/calendar@^3.5.3":
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/@react-stately/calendar/-/calendar-3.5.3.tgz#7bfbeceac85a273ee71f80312c6c98939623148f"
-  integrity sha512-SRwsgszyc9FNcvkjqBe81e/tnjKpRqH+yTYpG0uI9NR1HfyddmhR3Y7QilWPcqQkq4SQb7pL68SkTPH2dX2dng==
+"@react-stately/calendar@3.5.4", "@react-stately/calendar@^3.5.4":
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/@react-stately/calendar/-/calendar-3.5.4.tgz#847b2a2e5cf13a81b3344f1ef4e9a0d10138191e"
+  integrity sha512-R2011mtFSXIjzMXaA+CZ1sflPm9XkTBMqVk77Bnxso2ZsG7FUX8nqFmaDavxwTuHFC6OUexAGSMs8bP9KycTNg==
   dependencies:
     "@internationalized/date" "^3.5.5"
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/calendar" "^3.4.8"
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/calendar" "^3.4.9"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/checkbox@^3.6.5", "@react-stately/checkbox@^3.6.7":
-  version "3.6.7"
-  resolved "https://registry.yarnpkg.com/@react-stately/checkbox/-/checkbox-3.6.7.tgz#d622c3cac9c1ad5e09746d354fe82fc37259659f"
-  integrity sha512-ZOaBNXXazpwkuKj5hk6FtGbXO7HoKEGXvf3p7FcHcIHyiEJ65GBvC7e7HwMc3jYxlBwtbebSpEcf3oFqI5dl3A==
+"@react-stately/checkbox@^3.6.8":
+  version "3.6.8"
+  resolved "https://registry.yarnpkg.com/@react-stately/checkbox/-/checkbox-3.6.8.tgz#87e43cbf762fce8569e9b0fecd7e6213952e0aac"
+  integrity sha512-c8TWjU67XHHBCpqj6+FXXhQUWGr2Pil1IKggX81pkedhWiJl3/7+WHJuZI0ivGnRjp3aISNOG8UNVlBEjS9E8A==
   dependencies:
     "@react-stately/form" "^3.0.5"
-    "@react-stately/utils" "^3.10.2"
+    "@react-stately/utils" "^3.10.3"
     "@react-types/checkbox" "^3.8.3"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/collections@^3.10.7", "@react-stately/collections@^3.10.9":
+"@react-stately/collections@^3.10.9":
   version "3.10.9"
   resolved "https://registry.yarnpkg.com/@react-stately/collections/-/collections-3.10.9.tgz#cdf23d46de30741e2f836b96d439cf095acf4d84"
   integrity sha512-plyrng6hOQMG8LrjArMA6ts/DgWyXln3g90/hFNbqe/hdVYF53sDVsj8Jb+5LtoYTpiAlV6eOvy1XR0vPZUf8w==
@@ -2746,38 +2697,38 @@
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/color@^3.6.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/color/-/color-3.7.1.tgz#a43cab02b8655e9b495f62cc885c1ae7dc15d1c8"
-  integrity sha512-pJqM7fZ7+zy8wnzCUkBMkTgmjMs+lBLjQm1k+dFbmXK2SuELiDOQLirrl6j15NVBOKn8avvRHXpAQhGX43GOCQ==
+"@react-stately/color@^3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/color/-/color-3.7.2.tgz#13548d05caf4f0876f3a32e54e20fc3b6a83c9a6"
+  integrity sha512-tNJ7pQjBqXtfASdLRjIYzeI8q0b3JtxqkJbusyEEdLAumpcWkbOvl3Vp9un0Bu/XXWihDa4v2dEdpKxjM+pPxg==
   dependencies:
     "@internationalized/number" "^3.5.3"
     "@internationalized/string" "^3.2.3"
-    "@react-aria/i18n" "^3.12.1"
+    "@react-aria/i18n" "^3.12.2"
     "@react-stately/form" "^3.0.5"
-    "@react-stately/numberfield" "^3.9.5"
-    "@react-stately/slider" "^3.5.6"
-    "@react-stately/utils" "^3.10.2"
+    "@react-stately/numberfield" "^3.9.6"
+    "@react-stately/slider" "^3.5.7"
+    "@react-stately/utils" "^3.10.3"
     "@react-types/color" "3.0.0-rc.1"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/combobox@^3.8.4", "@react-stately/combobox@^3.9.1":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/combobox/-/combobox-3.9.1.tgz#2593c050b65c6c90b806fe17d5526b54a21f53bc"
-  integrity sha512-jmeKUKs0jK18NwDAlpu79ATufgxrc6Sn3ZMmI8KPVQ5sdPTjNlnDx6gTFyOOIa87axf/c6WYU7v3jxmcp+RDdg==
+"@react-stately/combobox@^3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/combobox/-/combobox-3.9.2.tgz#18b39ea430ef520959a586053071e9d8146f73d0"
+  integrity sha512-ZsbAcD58IvxZqwYxg9d2gOf8R/k5RUB2TPUiGKD6wgWfEKH6SDzY3bgRByHGOyMCyJB62cHjih/ZShizNTguqA==
   dependencies:
     "@react-stately/collections" "^3.10.9"
     "@react-stately/form" "^3.0.5"
-    "@react-stately/list" "^3.10.7"
-    "@react-stately/overlays" "^3.6.9"
-    "@react-stately/select" "^3.6.6"
-    "@react-stately/utils" "^3.10.2"
+    "@react-stately/list" "^3.10.8"
+    "@react-stately/overlays" "^3.6.10"
+    "@react-stately/select" "^3.6.7"
+    "@react-stately/utils" "^3.10.3"
     "@react-types/combobox" "^3.12.1"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/data@^3.11.4", "@react-stately/data@^3.11.6":
+"@react-stately/data@^3.11.6":
   version "3.11.6"
   resolved "https://registry.yarnpkg.com/@react-stately/data/-/data-3.11.6.tgz#bf4e5216cac3f1e302924b1e5369519a27b76146"
   integrity sha512-S8q1Ejuhijl8SnyVOdDNFrMrWWnLk/Oh1ZT3KHSbTdpfMRtvhi5HukoiP06jlzz75phnpSPQL40npDtUB/kk3Q==
@@ -2785,40 +2736,26 @@
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/datepicker@3.9.4":
-  version "3.9.4"
-  resolved "https://registry.yarnpkg.com/@react-stately/datepicker/-/datepicker-3.9.4.tgz#c9862cdc09da72760ed3005169223c7743b44b2d"
-  integrity sha512-yBdX01jn6gq4NIVvHIqdjBUPo+WN8Bujc4OnPw+ZnfA4jI0eIgq04pfZ84cp1LVXW0IB0VaCu1AlQ/kvtZjfGA==
-  dependencies:
-    "@internationalized/date" "^3.5.4"
-    "@internationalized/string" "^3.2.3"
-    "@react-stately/form" "^3.0.3"
-    "@react-stately/overlays" "^3.6.7"
-    "@react-stately/utils" "^3.10.1"
-    "@react-types/datepicker" "^3.7.4"
-    "@react-types/shared" "^3.23.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/datepicker@^3.10.1", "@react-stately/datepicker@^3.9.4":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/datepicker/-/datepicker-3.10.1.tgz#f4926f9b881fdb925220b9d78f6a64646f8aa4b5"
-  integrity sha512-KXr5cxLOLUYBf3wlDSKhvshsKOWpdV2flhS075V6dgC/EPBh7igBZGUXJ9AZzndT7Hx1w8v/ul6CIffxEJz1Nw==
+"@react-stately/datepicker@3.10.2", "@react-stately/datepicker@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/datepicker/-/datepicker-3.10.2.tgz#2023e5cfc71240e8557720f1c3dfbe03207083bf"
+  integrity sha512-pa5IZUw+49AyOnddwu4XwU2kI5eo/1thbiIVNHP8uDpbbBrBkquSk3zVFDAGX1cu/I1U2VUkt64U/dxgkwaMQw==
   dependencies:
     "@internationalized/date" "^3.5.5"
     "@internationalized/string" "^3.2.3"
     "@react-stately/form" "^3.0.5"
-    "@react-stately/overlays" "^3.6.9"
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/datepicker" "^3.8.1"
+    "@react-stately/overlays" "^3.6.10"
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/datepicker" "^3.8.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/dnd@^3.3.1", "@react-stately/dnd@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/dnd/-/dnd-3.4.1.tgz#a91be9a01d8788970d4be1313a2a556bbb12c96e"
-  integrity sha512-EXPW1vKx3vNpMaXOpPKTOU1T4S+jqjllGFDyWD659Ql0lL9SQ5Y4IU/KmIK3T3yKkjps9xrMmCjLAkb75PH5zg==
+"@react-stately/dnd@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/dnd/-/dnd-3.4.2.tgz#5fa177a9de019ea6d07cba283a8a7dd76cd2512c"
+  integrity sha512-VrHmNoNdVGrx5JHdz/zewmN+N8rlZe+vL/iAOLmvQ74RRLEz8KDFnHdlhgKg1AZqaSg3JJ18BlHEkS7oL1n+tA==
   dependencies:
-    "@react-stately/selection" "^3.16.1"
+    "@react-stately/selection" "^3.16.2"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
@@ -2829,7 +2766,7 @@
   dependencies:
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/form@^3.0.3", "@react-stately/form@^3.0.5":
+"@react-stately/form@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@react-stately/form/-/form-3.0.5.tgz#653f603ddd8b74a8a126b426ebc17abd112b672b"
   integrity sha512-J3plwJ63HQz109OdmaTqTA8Qhvl3gcYYK7DtgKyNP6mc/Me2Q4tl2avkWoA+22NRuv5m+J8TpBk4AVHUEOwqeQ==
@@ -2837,169 +2774,191 @@
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/grid@^3.9.1":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/grid/-/grid-3.9.1.tgz#27b4a35e344891e3cf69ef7a3d7dc56979f117ec"
-  integrity sha512-LSVIcXO/cqwG0IgDSk2juDbpARBS1IzGnsTp/8vSOejMxq5MXrwxL5hUcqNczL8Ss6aLpELm42tCS0kPm3cMKw==
+"@react-stately/grid@^3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/grid/-/grid-3.9.2.tgz#b880ea037a9d8c7cd4302456acaf294700d41883"
+  integrity sha512-2gK//sqAqg2Xaq6UITTFQwFUJnBRgcW+cKBVbFt+F8d152xB6UwwTS/K79E5PUkOotwqZgTEpkrSFs/aVxCLpw==
   dependencies:
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/selection" "^3.16.1"
+    "@react-stately/selection" "^3.16.2"
     "@react-types/grid" "^3.2.8"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/list@^3.10.5", "@react-stately/list@^3.10.7":
-  version "3.10.7"
-  resolved "https://registry.yarnpkg.com/@react-stately/list/-/list-3.10.7.tgz#cff58ca38103cdb770d3d9809273a77e6606759c"
-  integrity sha512-W5PG7uG5GQV2Q59vXJE7QLKHZIoUNEx+JmHrBUCMKUgyngSpKIIEDR/R/C1b6ZJ9jMqqZA68Zlnd5iK1/mBi1A==
+"@react-stately/layout@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/layout/-/layout-4.0.2.tgz#9b711ae2b4bf7591da71eee2fa618a8c17163bb3"
+  integrity sha512-g3IOrYQcaWxWKW44fYCOLoLMYKEmoOAcT9vQIbgK8MLTQV9Zgt9sGREwn4WJPm85N58Ij6yP72aQ7og/PSymvg==
   dependencies:
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/selection" "^3.16.1"
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/shared" "^3.24.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/menu@^3.7.1", "@react-stately/menu@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/menu/-/menu-3.8.1.tgz#f7c91aae721eb2678673ecb5161e5803fb55ce3a"
-  integrity sha512-HzAANHg+QUpyRok0CBIL/5qb+4TARteP0q9av2tKnQWPG91iJw84phJDJrmmY55uFFax4fxBgDM9dy1t12iKgQ==
-  dependencies:
-    "@react-stately/overlays" "^3.6.9"
-    "@react-types/menu" "^3.9.11"
-    "@react-types/shared" "^3.24.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/numberfield@^3.9.3", "@react-stately/numberfield@^3.9.5":
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/@react-stately/numberfield/-/numberfield-3.9.5.tgz#0a6869ead08c387cc6becefa06fc68353c5dc9b7"
-  integrity sha512-aWilyzrZOvkgntcXd6Kl+t1QiCbnajUCN8yll6/saByKpfuOf1k6AGYNQBJ0CO/5HyffPPdbFs+45sj4e3cdjA==
-  dependencies:
-    "@internationalized/number" "^3.5.3"
-    "@react-stately/form" "^3.0.5"
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/numberfield" "^3.8.5"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/overlays@^3.6.7", "@react-stately/overlays@^3.6.9":
-  version "3.6.9"
-  resolved "https://registry.yarnpkg.com/@react-stately/overlays/-/overlays-3.6.9.tgz#3eaea249e35f424c4354fbee75c7c6767776a877"
-  integrity sha512-4chfyzKw7P2UEainm0yzjUgYwG1ovBejN88eTrn+O62x5huuMCwe0cbMxmYh4y7IhRFSee3jIJd0SP0u/+i39w==
-  dependencies:
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/overlays" "^3.8.9"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/radio@^3.10.4", "@react-stately/radio@^3.10.6":
-  version "3.10.6"
-  resolved "https://registry.yarnpkg.com/@react-stately/radio/-/radio-3.10.6.tgz#2513757b5aa49aed5f0b95d3e3a4460dde2635c5"
-  integrity sha512-wiJuUUQ6LuEv0J1DQtkC0+Sed7tO6y3sIPeB+5uIxIIsUpxvNlDcqr+JOkrQm7gZmkmvcfotb5Gv5PqaIl1zKA==
-  dependencies:
-    "@react-stately/form" "^3.0.5"
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/radio" "^3.8.3"
-    "@react-types/shared" "^3.24.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/searchfield@^3.5.3", "@react-stately/searchfield@^3.5.5":
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/@react-stately/searchfield/-/searchfield-3.5.5.tgz#bcd6da5fd077baaa8ba35b5257f370f4ba9168fa"
-  integrity sha512-rKWIVNbxft5eGGxQ4CtcTKGXm2B1AuYSg6kLRQLq+VYspPNq3wfeMtVBeIdy4LNjWXsTmzs2b3o+zkFYdPqPPw==
-  dependencies:
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/searchfield" "^3.5.7"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/select@^3.6.4", "@react-stately/select@^3.6.6":
-  version "3.6.6"
-  resolved "https://registry.yarnpkg.com/@react-stately/select/-/select-3.6.6.tgz#fd01bc8cd47aebcddf07488b52d8250437ebbe1f"
-  integrity sha512-JEpBosWNSXRexE/iReATei1EiVdTIwOWlLcCGw6K7oC/5/f+OHMsh2Kkt/c/RzM/to3vgR+Wbbqwrb712AWgYQ==
-  dependencies:
-    "@react-stately/form" "^3.0.5"
-    "@react-stately/list" "^3.10.7"
-    "@react-stately/overlays" "^3.6.9"
-    "@react-types/select" "^3.9.6"
-    "@react-types/shared" "^3.24.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/selection@^3.15.1", "@react-stately/selection@^3.16.1":
-  version "3.16.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/selection/-/selection-3.16.1.tgz#00fd65d2abef48067cbb67ad1a7aee8e89bf25c2"
-  integrity sha512-qmnmYaXY7IhhzmIiInec1a/yPxlPSBHka6vrWddvt0S6zN7FU5cv6sm69ONUwYwLKSoaNHgOGvZhmsTzyV0O2A==
-  dependencies:
-    "@react-stately/collections" "^3.10.9"
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/shared" "^3.24.1"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/slider@^3.5.4", "@react-stately/slider@^3.5.6":
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/@react-stately/slider/-/slider-3.5.6.tgz#691a14e5aace3208c3de14d3ad6e54d32f26519d"
-  integrity sha512-a7DZgpOVjQyGzMLPiVRCVHISPJX8E3bT+qbZpcRQN+F7T7wReOwUt2I8gQMosnnCGWgU6kdYk8snn0obXe70Fg==
-  dependencies:
-    "@react-stately/utils" "^3.10.2"
-    "@react-types/shared" "^3.24.1"
-    "@react-types/slider" "^3.7.5"
-    "@swc/helpers" "^0.5.0"
-
-"@react-stately/table@^3.11.8", "@react-stately/table@^3.12.1":
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/table/-/table-3.12.1.tgz#fd12c2c43cf9225e0afd8f57583c3a7ff60d79b4"
-  integrity sha512-Cg3lXrWJNrYkD1gqRclMxq0GGiR+ygxdeAqk2jbbsmHU8RSQuzoO/RtUCw6WAKfQjAq4gE0E60TlAsGgCUdJGA==
-  dependencies:
-    "@react-stately/collections" "^3.10.9"
-    "@react-stately/flags" "^3.0.3"
-    "@react-stately/grid" "^3.9.1"
-    "@react-stately/selection" "^3.16.1"
-    "@react-stately/utils" "^3.10.2"
+    "@react-stately/table" "^3.12.2"
+    "@react-stately/virtualizer" "^4.0.2"
     "@react-types/grid" "^3.2.8"
     "@react-types/shared" "^3.24.1"
     "@react-types/table" "^3.10.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/tabs@^3.6.6", "@react-stately/tabs@^3.6.8":
-  version "3.6.8"
-  resolved "https://registry.yarnpkg.com/@react-stately/tabs/-/tabs-3.6.8.tgz#c02d8f730d0a9fac9d80075636d62ca37bf3f7b2"
-  integrity sha512-pLRwnMmXk/IWvbIJYSO5hm3/PiJ/VzrQlwKr6dlOcrDOSVIZpTjnGWHd6mJSDoPiDyBThlN/k3+2pUFMEOAcfw==
+"@react-stately/list@^3.10.8":
+  version "3.10.8"
+  resolved "https://registry.yarnpkg.com/@react-stately/list/-/list-3.10.8.tgz#2192708df0ff53345356ba116d8676d4b36ff120"
+  integrity sha512-rHCiPLXd+Ry3ztR9DkLA5FPQeH4Zd4/oJAEDWJ77W3oBBOdiMp3ZdHDLP7KBRh17XGNLO/QruYoHWAQTPiMF4g==
   dependencies:
-    "@react-stately/list" "^3.10.7"
+    "@react-stately/collections" "^3.10.9"
+    "@react-stately/selection" "^3.16.2"
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/menu@^3.8.2":
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/menu/-/menu-3.8.2.tgz#e7ecd5ea179d38a5d543b8e1fb58e1cde24257a4"
+  integrity sha512-lt6hIHmSixMzkKx1rKJf3lbAf01EmEvvIlENL20GLiU9cRbpPnPJ1aJMZ5Ad5ygglA7wAemAx+daPhlTQfF2rg==
+  dependencies:
+    "@react-stately/overlays" "^3.6.10"
+    "@react-types/menu" "^3.9.11"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/numberfield@^3.9.6":
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/@react-stately/numberfield/-/numberfield-3.9.6.tgz#4c3a08c34844b44c9b2a8bcb52b8d23ac8846ef3"
+  integrity sha512-p2R9admGLI439qZzB39dyANhkruprJJtZwuoGVtxW/VD0ficw6BrPVqAaKG25iwKPkmveleh9p8o+yRqjGedcQ==
+  dependencies:
+    "@internationalized/number" "^3.5.3"
+    "@react-stately/form" "^3.0.5"
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/numberfield" "^3.8.5"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/overlays@^3.6.10":
+  version "3.6.10"
+  resolved "https://registry.yarnpkg.com/@react-stately/overlays/-/overlays-3.6.10.tgz#949a0cde397b16e2bc7ad9908a181d94f6b72533"
+  integrity sha512-XxZ2qScT5JPwGk9qiVJE4dtVh3AXTcYwGRA5RsHzC26oyVVsegPqY2PmNJGblAh6Q57VyodoVUyebE0Eo5CzRw==
+  dependencies:
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/overlays" "^3.8.9"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/radio@^3.10.7":
+  version "3.10.7"
+  resolved "https://registry.yarnpkg.com/@react-stately/radio/-/radio-3.10.7.tgz#7933619a6c14eaab8fba4834286fb2cfeb8a55d6"
+  integrity sha512-ZwGzFR+sGd42DxRlDTp3G2vLZyhMVtgHkwv2BxazPHxPMvLO9yYl7+3PPNxAmhMB4tg2u9CrzffpGX2rmEJEXA==
+  dependencies:
+    "@react-stately/form" "^3.0.5"
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/radio" "^3.8.3"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/searchfield@^3.5.6":
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/@react-stately/searchfield/-/searchfield-3.5.6.tgz#d6f0bcad74eb1ca444505b9a265c83ea145355ea"
+  integrity sha512-gVzU0FeWiLYD8VOYRgWlk79Qn7b2eirqOnWhtI5VNuGN8WyNaCIuBp6SkXTW2dY8hs2Hzn8HlMbgy1MIc7130Q==
+  dependencies:
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/searchfield" "^3.5.8"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/select@^3.6.7":
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/@react-stately/select/-/select-3.6.7.tgz#83a6a63d9d11dcbdab32e6b354a5c65743550fd8"
+  integrity sha512-hCUIddw0mPxVy1OH6jhyaDwgNea9wESjf+MYdnnTG/abRB+OZv/dWScd87OjzVsHTHWcw7CN4ZzlJoXm0FJbKQ==
+  dependencies:
+    "@react-stately/form" "^3.0.5"
+    "@react-stately/list" "^3.10.8"
+    "@react-stately/overlays" "^3.6.10"
+    "@react-types/select" "^3.9.6"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/selection@^3.16.2":
+  version "3.16.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/selection/-/selection-3.16.2.tgz#9eeb5038ca2f0f1bc688363b3b75a2185d5af060"
+  integrity sha512-C4eSKw7BIZHJLPzwqGqCnsyFHiUIEyryVQZTJDt6d0wYBOHU6k1pW+Q4VhrZuzSv+IMiI2RkiXeJKc55f0ZXrg==
+  dependencies:
+    "@react-stately/collections" "^3.10.9"
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/shared" "^3.24.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/slider@^3.5.7":
+  version "3.5.7"
+  resolved "https://registry.yarnpkg.com/@react-stately/slider/-/slider-3.5.7.tgz#115b9a28fbe260492aaa233bbc4ff0d7bb824766"
+  integrity sha512-gEIGTcpBLcXixd8LYiLc8HKrBiGQJltrrEGoOvvTP8KVItXQxmeL+JiSsh8qgOoUdRRpzmAoFNUKGEg2/gtN8A==
+  dependencies:
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/shared" "^3.24.1"
+    "@react-types/slider" "^3.7.5"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/table@^3.12.2":
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/table/-/table-3.12.2.tgz#dee76a176d9842f0d250d337a3755a35c37c97d9"
+  integrity sha512-dUcsrdALylhWz6exqIoqtR/dnrzjIAptMyAUPT378Y/mCYs4PxKkHSvtPEQrZhdQS1ALIIgfeg9KUVIempoXPw==
+  dependencies:
+    "@react-stately/collections" "^3.10.9"
+    "@react-stately/flags" "^3.0.3"
+    "@react-stately/grid" "^3.9.2"
+    "@react-stately/selection" "^3.16.2"
+    "@react-stately/utils" "^3.10.3"
+    "@react-types/grid" "^3.2.8"
+    "@react-types/shared" "^3.24.1"
+    "@react-types/table" "^3.10.1"
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/tabs@^3.6.9":
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/@react-stately/tabs/-/tabs-3.6.9.tgz#54169ec17baa882aed1b28a018b3b9bfb9b9cef6"
+  integrity sha512-YZDqZng3HrRX+uXmg6u78x73Oi24G5ICpiXVqDKKDkO333XCA5H8MWItiuPZkYB2h3SbaCaLqSobLkvCoWYpNQ==
+  dependencies:
+    "@react-stately/list" "^3.10.8"
     "@react-types/shared" "^3.24.1"
     "@react-types/tabs" "^3.3.9"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/toggle@^3.7.4", "@react-stately/toggle@^3.7.6":
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/@react-stately/toggle/-/toggle-3.7.6.tgz#de31d74b9f9bd73350cf99ba582bc3cd79fa8c74"
-  integrity sha512-xRZyrjNVu1VCd1xpg5RwmNYs9fXb+JHChoUaRcBmGCCjsPD0R5uR3iNuE17RXJtWS3/8o9IJVn90+/7NW7boOg==
+"@react-stately/toggle@^3.7.7":
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/@react-stately/toggle/-/toggle-3.7.7.tgz#5ff135b8e8a3d2f85a09d599af6fcfc9ccea22c3"
+  integrity sha512-AS+xB4+hHWa3wzYkbS6pwBkovPfIE02B9SnuYTe0stKcuejpWKo5L3QMptW0ftFYsW3ZPCXuneImfObEw2T01A==
   dependencies:
-    "@react-stately/utils" "^3.10.2"
+    "@react-stately/utils" "^3.10.3"
     "@react-types/checkbox" "^3.8.3"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/tooltip@^3.4.11", "@react-stately/tooltip@^3.4.9":
-  version "3.4.11"
-  resolved "https://registry.yarnpkg.com/@react-stately/tooltip/-/tooltip-3.4.11.tgz#9fac5c5cd891893b7ea9d7cf2f6f1ee148d0e570"
-  integrity sha512-r1ScIXau2LZ/lUUBQ5PI01S2TB2urF2zrPzNM2xgngFLlG2uTyfIgMga6/035quQQKd3Bd0qGigMvTgZ3GRGEg==
+"@react-stately/tooltip@^3.4.12":
+  version "3.4.12"
+  resolved "https://registry.yarnpkg.com/@react-stately/tooltip/-/tooltip-3.4.12.tgz#a4020fb235ce63d09793299c892cbd8430ebc2ff"
+  integrity sha512-QKYT/cze7n9qaBsk7o5ais3jRfhYCzcVRfps+iys/W+/9FFbbhjfQG995Lwi6b+vGOHWfXxXpwmyIO2tzM1Iog==
   dependencies:
-    "@react-stately/overlays" "^3.6.9"
+    "@react-stately/overlays" "^3.6.10"
     "@react-types/tooltip" "^3.4.11"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/tree@^3.8.1", "@react-stately/tree@^3.8.3":
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/@react-stately/tree/-/tree-3.8.3.tgz#c92854f6b10b146f983759243b64cdcba0a1fb28"
-  integrity sha512-9sRQOxkK7ZMdtSTGHx0sMabHC39PEM4tMl+IdJKkmcp60bfsm3p6LHXhha3E58jwnZaemBfUrlQmTP/E26BbGw==
+"@react-stately/tree@^3.8.4":
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/@react-stately/tree/-/tree-3.8.4.tgz#8fb6dcfeadd39183d7e776e4001fa2037d579a78"
+  integrity sha512-HFNclIXJ/3QdGQWxXbj+tdlmIX/XwCfzAMB5m26xpJ6HtJhia6dtx3GLfcdyHNjmuRbAsTBsAAnnVKBmNRUdIQ==
   dependencies:
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/selection" "^3.16.1"
-    "@react-stately/utils" "^3.10.2"
+    "@react-stately/selection" "^3.16.2"
+    "@react-stately/utils" "^3.10.3"
     "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
-"@react-stately/utils@^3.10.1", "@react-stately/utils@^3.10.2":
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.10.2.tgz#09377f771592ff537c901aa64178cb3a004a916f"
-  integrity sha512-fh6OTQtbeQC0ywp6LJuuKs6tKIgFvt/DlIZEcIpGho6/oZG229UnIk6TUekwxnDbumuYyan6D9EgUtEMmT8UIg==
+"@react-stately/utils@^3.10.3":
+  version "3.10.3"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.10.3.tgz#ed1bf00a8419750fc11ccba73350b97e30f3f707"
+  integrity sha512-moClv7MlVSHpbYtQIkm0Cx+on8Pgt1XqtPx6fy9rQFb2DNc9u1G3AUVnqA17buOkH1vLxAtX4MedlxMWyRCYYA==
   dependencies:
+    "@swc/helpers" "^0.5.0"
+
+"@react-stately/virtualizer@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-stately/virtualizer/-/virtualizer-4.0.2.tgz#5697bf05d84f1c1c29ce7a7cad6b47518f8de3ee"
+  integrity sha512-LiSr6E6OoL/cKVFO088zEzkNGj41g02nlOAgLluYONncNEjoYiHmb8Yw0otPgViVLKiFjO6Kk4W+dbt8EZ51Ag==
+  dependencies:
+    "@react-aria/utils" "^3.25.2"
+    "@react-types/shared" "^3.24.1"
     "@swc/helpers" "^0.5.0"
 
 "@react-types/breadcrumbs@^3.7.7":
@@ -3010,17 +2969,17 @@
     "@react-types/link" "^3.5.7"
     "@react-types/shared" "^3.24.1"
 
-"@react-types/button@^3.9.4", "@react-types/button@^3.9.6":
+"@react-types/button@^3.9.6":
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/@react-types/button/-/button-3.9.6.tgz#135fc465a3026f2c5005725b63cf7c3525be2306"
   integrity sha512-8lA+D5JLbNyQikf8M/cPP2cji91aVTcqjrGpDqI7sQnaLFikM8eFR6l1ZWGtZS5MCcbfooko77ha35SYplSQvw==
   dependencies:
     "@react-types/shared" "^3.24.1"
 
-"@react-types/calendar@^3.4.6", "@react-types/calendar@^3.4.8":
-  version "3.4.8"
-  resolved "https://registry.yarnpkg.com/@react-types/calendar/-/calendar-3.4.8.tgz#e9cc625d286b6a2df17e3d17a2c825b700f01f6c"
-  integrity sha512-KVampt/X4uJvWU0TsxIdgPdXIAUClGtxcDWHzuFRJ7YUYkA4rH8Lad0kQ1mVehnwOLpuba8j9GCYKorkbln0gw==
+"@react-types/calendar@^3.4.9":
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/@react-types/calendar/-/calendar-3.4.9.tgz#7f2372624996be4c78a431d4ed942acf9eb1da5b"
+  integrity sha512-O/PS9c21HgO9qzxOyZ7/dTccxabFZdF6tj3UED4DrBw7AN3KZ7JMzwzYbwHinOcO7nUcklGgNoAIHk45UAKR9g==
   dependencies:
     "@internationalized/date" "^3.5.5"
     "@react-types/shared" "^3.24.1"
@@ -3031,14 +2990,6 @@
   integrity sha512-f4c1mnLEt0iS1NMkyZXgT3q3AgcxzDk7w6MSONOKydcnh0xG5L2oefY14DhVDLkAuQS7jThlUFwiAs+MxiO3MA==
   dependencies:
     "@react-types/shared" "^3.24.1"
-
-"@react-types/color@3.0.0-beta.25":
-  version "3.0.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@react-types/color/-/color-3.0.0-beta.25.tgz#0ed945459c4812b4c0bead02e2fc5a7d011f340f"
-  integrity sha512-D24ASvLeSWouBwOBi4ftUe4/BhrZj5AiHV7tXwrVeMGOy9Z9jyeK65Xysq+R3ecaSONLXsgai5CQMvj13cOacA==
-  dependencies:
-    "@react-types/shared" "^3.23.1"
-    "@react-types/slider" "^3.7.3"
 
 "@react-types/color@3.0.0-rc.1":
   version "3.0.0-rc.1"
@@ -3055,17 +3006,17 @@
   dependencies:
     "@react-types/shared" "^3.24.1"
 
-"@react-types/datepicker@^3.7.4", "@react-types/datepicker@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@react-types/datepicker/-/datepicker-3.8.1.tgz#2998a40f19cd5dbfd57ead6b45c748639a276990"
-  integrity sha512-ZpxHHVT3rmZ4YsYP4TWCZSMSfOUm+067mZyyGLmvHxg55eYmctiB4uMgrRCqDoeiSiOjtxad0VtpPjf6ftK1GQ==
+"@react-types/datepicker@^3.8.2":
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/@react-types/datepicker/-/datepicker-3.8.2.tgz#49883bd6885f7d3b32493e957087918d76d85d39"
+  integrity sha512-Ih4F0bNVGrEuwCD8XmmBAspuuOBsj/Svn/pDFtC2RyAZjXfWh+sI+n4XLz/sYKjvARh5TUI8GNy9smYS4vYXug==
   dependencies:
     "@internationalized/date" "^3.5.5"
-    "@react-types/calendar" "^3.4.8"
+    "@react-types/calendar" "^3.4.9"
     "@react-types/overlays" "^3.8.9"
     "@react-types/shared" "^3.24.1"
 
-"@react-types/dialog@^3.5.10", "@react-types/dialog@^3.5.12":
+"@react-types/dialog@^3.5.12":
   version "3.5.12"
   resolved "https://registry.yarnpkg.com/@react-types/dialog/-/dialog-3.5.12.tgz#cba173e3a1ca7efd8859bd995389eaa90070e5ea"
   integrity sha512-JmpQbSpXltqEyYfEwoqDolABIiojeExkqolHNdQlayIsfFuSxZxNwXZPOpz58Ri/iwv21JP7K3QF0Gb2Ohxl9w==
@@ -3073,14 +3024,14 @@
     "@react-types/overlays" "^3.8.9"
     "@react-types/shared" "^3.24.1"
 
-"@react-types/form@^3.7.4":
+"@react-types/form@^3.7.6":
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/@react-types/form/-/form-3.7.6.tgz#4a7b529bd9eccf2252d113edbbbea0fcb0e06c3c"
   integrity sha512-lhS2y1bVtRnyYjkM+ylJUp2g663ZNbeZxu2o+mFfD5c2wYmVLA58IWR90c7DL8IVUitoANnZ1JPhhXvutiFpQQ==
   dependencies:
     "@react-types/shared" "^3.24.1"
 
-"@react-types/grid@^3.2.6", "@react-types/grid@^3.2.8":
+"@react-types/grid@^3.2.8":
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/@react-types/grid/-/grid-3.2.8.tgz#1855586e309387edcc6a77bb675a624039e9831a"
   integrity sha512-6PJrpukwMqlv3IhJSDkJuVbhHM8Oe6hd2supWqd9adMXrlSP7QHt9a8SgFcFblCCTx8JzUaA0PvY5sTudcEtOQ==
@@ -3144,13 +3095,13 @@
   dependencies:
     "@react-types/shared" "^3.24.1"
 
-"@react-types/searchfield@^3.5.7":
-  version "3.5.7"
-  resolved "https://registry.yarnpkg.com/@react-types/searchfield/-/searchfield-3.5.7.tgz#f95b5693f09ebb2b4b267a4bc149de2fdc2a1fbd"
-  integrity sha512-dyuPwNWGswRZfb4i50Q1Q3tCwTBxRLkrAxcMs+Rf2Rl4t93bawBdSdIQuvxu1KEhgd0EXA9ZUW53ZplqfVmtiw==
+"@react-types/searchfield@^3.5.8":
+  version "3.5.8"
+  resolved "https://registry.yarnpkg.com/@react-types/searchfield/-/searchfield-3.5.8.tgz#88b7b0492b7d272fc8a98e8e322c410a48dc7556"
+  integrity sha512-EcdqalHNIC6BJoRfmqUhAvXRd3aHkWlV1cFCz57JJKgUEFYyXPNrXd1b73TKLzTXEk+X/D6LKV15ILYpEaxu8w==
   dependencies:
     "@react-types/shared" "^3.24.1"
-    "@react-types/textfield" "^3.9.5"
+    "@react-types/textfield" "^3.9.6"
 
 "@react-types/select@^3.9.6":
   version "3.9.6"
@@ -3159,12 +3110,12 @@
   dependencies:
     "@react-types/shared" "^3.24.1"
 
-"@react-types/shared@^3.23.1", "@react-types/shared@^3.24.1":
+"@react-types/shared@^3.24.1":
   version "3.24.1"
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.24.1.tgz#fa06cb681d144fce9c515d8bd296d81440a45d25"
   integrity sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==
 
-"@react-types/slider@^3.7.3", "@react-types/slider@^3.7.5":
+"@react-types/slider@^3.7.5":
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/@react-types/slider/-/slider-3.7.5.tgz#62f71c5e51a013fe14ad84d3496a0fa281b5b3a7"
   integrity sha512-bRitwQRQjQoOcKEdPMljnvm474dwrmsc6pdsVQDh/qynzr+KO9IHuYc3qPW53WVE2hMQJDohlqtCAWQXWQ5Vcg==
@@ -3178,7 +3129,7 @@
   dependencies:
     "@react-types/shared" "^3.24.1"
 
-"@react-types/table@^3.10.1", "@react-types/table@^3.9.5":
+"@react-types/table@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@react-types/table/-/table-3.10.1.tgz#a44e871cd163d6838668ffd6821c604cf5fd307a"
   integrity sha512-xsNh0Gm4GtNeSknZqkMsfGvc94fycmfhspGO+FzQKim2hB5k4yILwd+lHYQ2UKW6New9GVH/zN2Pd3v67IeZ2g==
@@ -3193,10 +3144,10 @@
   dependencies:
     "@react-types/shared" "^3.24.1"
 
-"@react-types/textfield@^3.9.5":
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/@react-types/textfield/-/textfield-3.9.5.tgz#a9d906ccbe6e5d42f3158320c036e112ae8c61d0"
-  integrity sha512-0hwZI4WXSEStPzdltKwbNUZWlgHtwbxMWE0LfqIzEW8RB7DyBflYSKzLyTBFqwUZ8j3C1gWy9c9OPSeCOq792Q==
+"@react-types/textfield@^3.9.6":
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/@react-types/textfield/-/textfield-3.9.6.tgz#11f5112a85d6a0f1f07470e470810045c5847591"
+  integrity sha512-0uPqjJh4lYp1aL1HL9IlV8Cgp8eT0PcsNfdoCktfkLytvvBPmox2Pfm57W/d0xTtzZu2CjxhYNTob+JtGAOeXA==
   dependencies:
     "@react-types/shared" "^3.24.1"
 
@@ -3741,17 +3692,17 @@
   dependencies:
     "@tanstack/query-core" "5.51.24"
 
-"@tanstack/react-table@8.17.3":
-  version "8.17.3"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.17.3.tgz#4e10b4cf5355a40d6d72a83d3f4b3ecd32f56bf4"
-  integrity sha512-5gwg5SvPD3lNAXPuJJz1fOCEZYk9/GeBFH3w/hCgnfyszOIzwkwgp5I7Q4MJtn0WECp84b5STQUDdmvGi8m3nA==
+"@tanstack/react-table@8.20.1":
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.20.1.tgz#bd2d549d8a18458fb8284025ce66a9b86176fa6b"
+  integrity sha512-PJK+07qbengObe5l7c8vCdtefXm8cyR4i078acWrHbdm8JKw1ES7YpmOtVt9ALUVEEFAHscdVpGRhRgikgFMbQ==
   dependencies:
-    "@tanstack/table-core" "8.17.3"
+    "@tanstack/table-core" "8.20.1"
 
-"@tanstack/table-core@8.17.3":
-  version "8.17.3"
-  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.17.3.tgz#d7a9830abb29cd369b52b2a7159dc0360af646fd"
-  integrity sha512-mPBodDGVL+fl6d90wUREepHa/7lhsghg2A3vFpakEhrhtbIlgNAZiMr7ccTgak5qbHqF14Fwy+W1yFWQt+WmYQ==
+"@tanstack/table-core@8.20.1":
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.20.1.tgz#74bfab10fa35bed51fa0bd2f3539a331d7e78f1b"
+  integrity sha512-5Ly5TIRHnWH7vSDell9B/OVyV380qqIJVg7H7R7jU4fPEmOD4smqAX7VRflpYI09srWR8aj5OLD2Ccs1pI5mTg==
 
 "@testing-library/dom@10.1.0", "@testing-library/dom@10.4.0":
   version "10.4.0"
@@ -5360,10 +5311,10 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@11.4.0:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.4.0.tgz#411a51e82599472b2131a08895faf000e0f9a0fa"
-  integrity sha512-/O6OwEUckqKTBGbm9KvYsR/eKCXy4s2eelO38yyfimBIJiL8+TS/pVnBqdtzUqO2hVK4GjrFiea9CnZUG9Akzw==
+chromatic@11.7.1:
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-11.7.1.tgz#9de59dd9d0e2a847627bccd959f05881335b524e"
+  integrity sha512-LvgPimdQdnQB07ZDxLEC2KtxgYeqTw0X71GA7fi3zhgtKLxZcE+BSZ/5I9rrQp1V8ydmfElfw0ZwnUH4fVgUAQ==
 
 chrome-trace-event@^1.0.2:
   version "1.0.4"
@@ -6020,17 +5971,6 @@ dot-case@^3.0.4:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
-
-downshift@9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-9.0.6.tgz#a842e59741ac5e789e80be852609a2738b85e85f"
-  integrity sha512-lkqWh0eb34XuH+3z3/BH/LGVRV7ur0rielSlxtlQKsjAFF/wc/c0wsM9phUGXyzK2g1QWHoNHQyc+vVAheI17Q==
-  dependencies:
-    "@babel/runtime" "^7.24.5"
-    compute-scroll-into-view "^3.1.0"
-    prop-types "^15.8.1"
-    react-is "18.2.0"
-    tslib "^2.6.2"
 
 downshift@9.0.8:
   version "9.0.8"
@@ -10048,119 +9988,81 @@ raw-body@2.5.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-aria-components@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-aria-components/-/react-aria-components-1.2.1.tgz#7bed3be5b495fcc8def5d3c082804764db80851b"
-  integrity sha512-iGIdDjbTyLLn0/tGUyBQxxu+E1bw4/H4AU89d0cRcu8yIdw6MXG29YElmRHn0ugiyrERrk/YQALihstnns5kRQ==
+react-aria-components@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-aria-components/-/react-aria-components-1.3.2.tgz#dee58665210330ec12843e6393ef5cc28ff9a9da"
+  integrity sha512-jAHR18ubLi4R6mUgSVpPfPGNNfwrveJ7IZ9ns8prUkXpY/A8IkR5x8y1SbXJKq9uwlGC2cEiWjG6OMAsmAAXdQ==
   dependencies:
-    "@internationalized/date" "^3.5.4"
+    "@internationalized/date" "^3.5.5"
     "@internationalized/string" "^3.2.3"
-    "@react-aria/color" "3.0.0-beta.33"
-    "@react-aria/focus" "^3.17.1"
-    "@react-aria/interactions" "^3.21.3"
-    "@react-aria/menu" "^3.14.1"
-    "@react-aria/toolbar" "3.0.0-beta.5"
-    "@react-aria/tree" "3.0.0-alpha.1"
-    "@react-aria/utils" "^3.24.1"
-    "@react-stately/color" "^3.6.1"
-    "@react-stately/menu" "^3.7.1"
-    "@react-stately/table" "^3.11.8"
-    "@react-stately/utils" "^3.10.1"
-    "@react-types/color" "3.0.0-beta.25"
-    "@react-types/form" "^3.7.4"
-    "@react-types/grid" "^3.2.6"
-    "@react-types/shared" "^3.23.1"
-    "@react-types/table" "^3.9.5"
+    "@react-aria/collections" "3.0.0-alpha.4"
+    "@react-aria/color" "3.0.0-rc.2"
+    "@react-aria/dnd" "^3.7.2"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/menu" "^3.15.2"
+    "@react-aria/toolbar" "3.0.0-beta.8"
+    "@react-aria/tree" "3.0.0-alpha.4"
+    "@react-aria/utils" "^3.25.2"
+    "@react-aria/virtualizer" "^4.0.2"
+    "@react-stately/color" "^3.7.2"
+    "@react-stately/layout" "^4.0.2"
+    "@react-stately/menu" "^3.8.2"
+    "@react-stately/table" "^3.12.2"
+    "@react-stately/utils" "^3.10.3"
+    "@react-stately/virtualizer" "^4.0.2"
+    "@react-types/color" "3.0.0-rc.1"
+    "@react-types/form" "^3.7.6"
+    "@react-types/grid" "^3.2.8"
+    "@react-types/shared" "^3.24.1"
+    "@react-types/table" "^3.10.1"
     "@swc/helpers" "^0.5.0"
     client-only "^0.0.1"
-    react-aria "^3.33.1"
-    react-stately "^3.31.1"
+    react-aria "^3.34.2"
+    react-stately "^3.32.2"
     use-sync-external-store "^1.2.0"
 
-react-aria@3.33.1:
-  version "3.33.1"
-  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-3.33.1.tgz#91b80b756187999c6c9f6f3d10c6e5e4eac576c5"
-  integrity sha512-hFC3K/UA+90Krlx2IgRTgzFbC6FSPi4pUwHT+STperPLK+cTEHkI+3Lu0YYwQSBatkgxnIv9+GtFuVbps2kROw==
+react-aria@3.34.2, react-aria@^3.34.2:
+  version "3.34.2"
+  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-3.34.2.tgz#7d00dd445d2bedcc4d68aea9aa5ecffe04066aa3"
+  integrity sha512-V5xvIw/nW6ED8mEdNIao7+z8gKMSff0HAiU7mshh1ZDI0LGyOM6JR/qQmux0mUOxbBARtNiBbBV6pwmQGkfQDw==
   dependencies:
     "@internationalized/string" "^3.2.3"
-    "@react-aria/breadcrumbs" "^3.5.13"
-    "@react-aria/button" "^3.9.5"
-    "@react-aria/calendar" "^3.5.8"
-    "@react-aria/checkbox" "^3.14.3"
-    "@react-aria/combobox" "^3.9.1"
-    "@react-aria/datepicker" "^3.10.1"
-    "@react-aria/dialog" "^3.5.14"
-    "@react-aria/dnd" "^3.6.1"
-    "@react-aria/focus" "^3.17.1"
-    "@react-aria/gridlist" "^3.8.1"
-    "@react-aria/i18n" "^3.11.1"
-    "@react-aria/interactions" "^3.21.3"
-    "@react-aria/label" "^3.7.8"
-    "@react-aria/link" "^3.7.1"
-    "@react-aria/listbox" "^3.12.1"
-    "@react-aria/menu" "^3.14.1"
-    "@react-aria/meter" "^3.4.13"
-    "@react-aria/numberfield" "^3.11.3"
-    "@react-aria/overlays" "^3.22.1"
-    "@react-aria/progress" "^3.4.13"
-    "@react-aria/radio" "^3.10.4"
-    "@react-aria/searchfield" "^3.7.5"
-    "@react-aria/select" "^3.14.5"
-    "@react-aria/selection" "^3.18.1"
-    "@react-aria/separator" "^3.3.13"
-    "@react-aria/slider" "^3.7.8"
-    "@react-aria/ssr" "^3.9.4"
-    "@react-aria/switch" "^3.6.4"
-    "@react-aria/table" "^3.14.1"
-    "@react-aria/tabs" "^3.9.1"
-    "@react-aria/tag" "^3.4.1"
-    "@react-aria/textfield" "^3.14.5"
-    "@react-aria/tooltip" "^3.7.4"
-    "@react-aria/utils" "^3.24.1"
-    "@react-aria/visually-hidden" "^3.8.12"
-    "@react-types/shared" "^3.23.1"
-
-react-aria@^3.33.1:
-  version "3.34.1"
-  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-3.34.1.tgz#a4cfa4abdd2882196fbadbded6ef87b02a1790f7"
-  integrity sha512-vA4BP+SWjFFRfOTQcNJtIp9gKlxuC7kPUXQK9fuNA+2K4mJdIc9mBnmwXQiLl/eAthMf43fD4fETfY9SiCm1Zg==
-  dependencies:
-    "@internationalized/string" "^3.2.3"
-    "@react-aria/breadcrumbs" "^3.5.15"
-    "@react-aria/button" "^3.9.7"
-    "@react-aria/calendar" "^3.5.10"
-    "@react-aria/checkbox" "^3.14.5"
-    "@react-aria/combobox" "^3.10.1"
-    "@react-aria/datepicker" "^3.11.1"
-    "@react-aria/dialog" "^3.5.16"
-    "@react-aria/dnd" "^3.7.1"
-    "@react-aria/focus" "^3.18.1"
-    "@react-aria/gridlist" "^3.9.1"
-    "@react-aria/i18n" "^3.12.1"
-    "@react-aria/interactions" "^3.22.1"
-    "@react-aria/label" "^3.7.10"
-    "@react-aria/link" "^3.7.3"
-    "@react-aria/listbox" "^3.13.1"
-    "@react-aria/menu" "^3.15.1"
-    "@react-aria/meter" "^3.4.15"
-    "@react-aria/numberfield" "^3.11.5"
-    "@react-aria/overlays" "^3.23.1"
-    "@react-aria/progress" "^3.4.15"
-    "@react-aria/radio" "^3.10.6"
-    "@react-aria/searchfield" "^3.7.7"
-    "@react-aria/select" "^3.14.7"
-    "@react-aria/selection" "^3.19.1"
-    "@react-aria/separator" "^3.4.1"
-    "@react-aria/slider" "^3.7.10"
+    "@react-aria/breadcrumbs" "^3.5.16"
+    "@react-aria/button" "^3.9.8"
+    "@react-aria/calendar" "^3.5.11"
+    "@react-aria/checkbox" "^3.14.6"
+    "@react-aria/combobox" "^3.10.2"
+    "@react-aria/datepicker" "^3.11.2"
+    "@react-aria/dialog" "^3.5.17"
+    "@react-aria/dnd" "^3.7.2"
+    "@react-aria/focus" "^3.18.2"
+    "@react-aria/gridlist" "^3.9.2"
+    "@react-aria/i18n" "^3.12.2"
+    "@react-aria/interactions" "^3.22.2"
+    "@react-aria/label" "^3.7.11"
+    "@react-aria/link" "^3.7.4"
+    "@react-aria/listbox" "^3.13.2"
+    "@react-aria/menu" "^3.15.2"
+    "@react-aria/meter" "^3.4.16"
+    "@react-aria/numberfield" "^3.11.6"
+    "@react-aria/overlays" "^3.23.2"
+    "@react-aria/progress" "^3.4.16"
+    "@react-aria/radio" "^3.10.7"
+    "@react-aria/searchfield" "^3.7.8"
+    "@react-aria/select" "^3.14.8"
+    "@react-aria/selection" "^3.19.2"
+    "@react-aria/separator" "^3.4.2"
+    "@react-aria/slider" "^3.7.11"
     "@react-aria/ssr" "^3.9.5"
-    "@react-aria/switch" "^3.6.6"
-    "@react-aria/table" "^3.15.1"
-    "@react-aria/tabs" "^3.9.3"
-    "@react-aria/tag" "^3.4.3"
-    "@react-aria/textfield" "^3.14.7"
-    "@react-aria/tooltip" "^3.7.6"
-    "@react-aria/utils" "^3.25.1"
-    "@react-aria/visually-hidden" "^3.8.14"
+    "@react-aria/switch" "^3.6.7"
+    "@react-aria/table" "^3.15.2"
+    "@react-aria/tabs" "^3.9.4"
+    "@react-aria/tag" "^3.4.4"
+    "@react-aria/textfield" "^3.14.8"
+    "@react-aria/tooltip" "^3.7.7"
+    "@react-aria/utils" "^3.25.2"
+    "@react-aria/visually-hidden" "^3.8.15"
     "@react-types/shared" "^3.24.1"
 
 react-autosuggest@10.1.0:
@@ -10293,62 +10195,33 @@ react-router@6.26.1:
   dependencies:
     "@remix-run/router" "1.19.1"
 
-react-stately@3.31.1:
-  version "3.31.1"
-  resolved "https://registry.yarnpkg.com/react-stately/-/react-stately-3.31.1.tgz#8cc160adfe6e15034be0a68cd5ab8281b53dcfb9"
-  integrity sha512-wuq673NHkYSdoceGryjtMJJvB9iQgyDkQDsnTN0t2v91pXjGDsN/EcOvnUrxXSBtY9eLdIw74R54z9GX5cJNEg==
+react-stately@3.32.2, react-stately@^3.32.2:
+  version "3.32.2"
+  resolved "https://registry.yarnpkg.com/react-stately/-/react-stately-3.32.2.tgz#72f2cdb890327f62738388a7d311ed356bfde41d"
+  integrity sha512-pDSrbCIJtir4HeSa//PTqLSR7Tl7pFC9usmkkBObNKktObQq3Vdgkf46cxeTD1ov7J7GDdR3meIyjXGnZoEzUg==
   dependencies:
-    "@react-stately/calendar" "^3.5.1"
-    "@react-stately/checkbox" "^3.6.5"
-    "@react-stately/collections" "^3.10.7"
-    "@react-stately/combobox" "^3.8.4"
-    "@react-stately/data" "^3.11.4"
-    "@react-stately/datepicker" "^3.9.4"
-    "@react-stately/dnd" "^3.3.1"
-    "@react-stately/form" "^3.0.3"
-    "@react-stately/list" "^3.10.5"
-    "@react-stately/menu" "^3.7.1"
-    "@react-stately/numberfield" "^3.9.3"
-    "@react-stately/overlays" "^3.6.7"
-    "@react-stately/radio" "^3.10.4"
-    "@react-stately/searchfield" "^3.5.3"
-    "@react-stately/select" "^3.6.4"
-    "@react-stately/selection" "^3.15.1"
-    "@react-stately/slider" "^3.5.4"
-    "@react-stately/table" "^3.11.8"
-    "@react-stately/tabs" "^3.6.6"
-    "@react-stately/toggle" "^3.7.4"
-    "@react-stately/tooltip" "^3.4.9"
-    "@react-stately/tree" "^3.8.1"
-    "@react-types/shared" "^3.23.1"
-
-react-stately@^3.31.1:
-  version "3.32.1"
-  resolved "https://registry.yarnpkg.com/react-stately/-/react-stately-3.32.1.tgz#423bc816fd11b15867ec58a3cbc15ed16ac7b3ff"
-  integrity sha512-znw+bqHJk1fvv34O3HoVH61otyYJomRu1gI7A4B3UHCnSFS6E6nMI6D3nRv9RrAWhf4ekLLg35FwDTHDcG1zdg==
-  dependencies:
-    "@react-stately/calendar" "^3.5.3"
-    "@react-stately/checkbox" "^3.6.7"
+    "@react-stately/calendar" "^3.5.4"
+    "@react-stately/checkbox" "^3.6.8"
     "@react-stately/collections" "^3.10.9"
-    "@react-stately/combobox" "^3.9.1"
+    "@react-stately/combobox" "^3.9.2"
     "@react-stately/data" "^3.11.6"
-    "@react-stately/datepicker" "^3.10.1"
-    "@react-stately/dnd" "^3.4.1"
+    "@react-stately/datepicker" "^3.10.2"
+    "@react-stately/dnd" "^3.4.2"
     "@react-stately/form" "^3.0.5"
-    "@react-stately/list" "^3.10.7"
-    "@react-stately/menu" "^3.8.1"
-    "@react-stately/numberfield" "^3.9.5"
-    "@react-stately/overlays" "^3.6.9"
-    "@react-stately/radio" "^3.10.6"
-    "@react-stately/searchfield" "^3.5.5"
-    "@react-stately/select" "^3.6.6"
-    "@react-stately/selection" "^3.16.1"
-    "@react-stately/slider" "^3.5.6"
-    "@react-stately/table" "^3.12.1"
-    "@react-stately/tabs" "^3.6.8"
-    "@react-stately/toggle" "^3.7.6"
-    "@react-stately/tooltip" "^3.4.11"
-    "@react-stately/tree" "^3.8.3"
+    "@react-stately/list" "^3.10.8"
+    "@react-stately/menu" "^3.8.2"
+    "@react-stately/numberfield" "^3.9.6"
+    "@react-stately/overlays" "^3.6.10"
+    "@react-stately/radio" "^3.10.7"
+    "@react-stately/searchfield" "^3.5.6"
+    "@react-stately/select" "^3.6.7"
+    "@react-stately/selection" "^3.16.2"
+    "@react-stately/slider" "^3.5.7"
+    "@react-stately/table" "^3.12.2"
+    "@react-stately/tabs" "^3.6.9"
+    "@react-stately/toggle" "^3.7.7"
+    "@react-stately/tooltip" "^3.4.12"
+    "@react-stately/tree" "^3.8.4"
     "@react-types/shared" "^3.24.1"
 
 react-themeable@^1.1.0:


### PR DESCRIPTION
## Purpose

With the new workflow, a learner can quit the subscription process then it should be able to resume it later. Currently this is only possible on the course syllabus that is weird. In its dashboard, it is able to sign its training contract but not to define a payment method. So the UI should be updated to allow that.

https://github.com/user-attachments/assets/bb987914-159c-4e0f-bd43-5f24fe469734

Furthermore if a user has not finalized a subscription process, it should not be able to resume it if the related product is no more purchasable (no remaining seats, some target courses don't have opened course runs).

<img width="680" alt="Capture d’écran 2024-08-21 à 13 12 59" src="https://github.com/user-attachments/assets/7721789c-9965-4215-b3db-90df1c0e847b">



