### PR TITLE
👽(frontend) update joanie endpoint

### DIFF
--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -98,7 +98,7 @@ export const getRoutes = () => {
           download: `${baseUrl}/orders/:id/invoice/`,
         },
         submit_for_signature: `${baseUrl}/orders/:id/submit_for_signature/`,
-        submit_installment_payment: `${baseUrl}/orders/:id/submit_installment_payment/`,
+        submit_installment_payment: `${baseUrl}/orders/:id/submit-installment-payment/`,
         set_payment_method: `${baseUrl}/orders/:id/payment-method/`,
       },
       certificates: {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -881,7 +881,7 @@ describe('<DashboardItemOrder/>', () => {
     ];
     fetchMock
       .post(
-        `https://joanie.endpoint/api/v1.0/orders/${order.id}/submit_installment_payment/`,
+        `https://joanie.endpoint/api/v1.0/orders/${order.id}/submit-installment-payment/`,
         paymentInfo,
       )
       .get(`https://joanie.endpoint/api/v1.0/orders/${order.id}/`, validOrder);


### PR DESCRIPTION
## Purpose

The endpoint to pay a failed installment has been renamed, so we have to update our joanie api routes to match the new endpoint.
