### PR TITLE
✨(frontend) allow to manage installments for certificate order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add link to the course syllabus in an enrollment item
+  in the learner dashboard
+- Display Payment Schedule into SaleTunnel
 - Add OrderHelper allowEnrollment
 - Display Payment Schedule into SaleTunnel
 - Add order payment information in the dashboard, including a specific

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Display installment information on certificate product blocks
 - Add `PaymentScheduleHelper` utils
 - Add link to the course syllabus in an enrollment item
   in the learner dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add `PaymentScheduleHelper` utils
 - Add link to the course syllabus in an enrollment item
   in the learner dashboard
 - Display Payment Schedule into SaleTunnel

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -365,7 +365,10 @@ export interface NestedCredentialOrder extends AbstractNestedOrder {
   enrollment: null;
 }
 
-export type OrderEnrollment = Pick<Order, 'id' | 'state' | 'product_id' | 'certificate_id'>;
+export type OrderEnrollment = Pick<
+  Order,
+  'id' | 'state' | 'product_id' | 'certificate_id' | 'payment_schedule'
+>;
 
 export interface NestedCourseOrder {
   id: Order['id'];

--- a/src/frontend/js/utils/OrderHelper/index.ts
+++ b/src/frontend/js/utils/OrderHelper/index.ts
@@ -5,7 +5,6 @@ import {
   Order,
   OrderEnrollment,
   OrderState,
-  PaymentScheduleState,
   PURCHASABLE_ORDER_STATES,
 } from 'types/Joanie';
 
@@ -79,12 +78,6 @@ export class OrderHelper {
       order.contract &&
       order.contract.student_signed_on &&
       !order.contract.organization_signed_on
-    );
-  }
-
-  static getFailedInstallment(order: Order) {
-    return order.payment_schedule?.find(
-      (installment) => installment.state === PaymentScheduleState.REFUSED,
     );
   }
 

--- a/src/frontend/js/utils/PaymentScheduleHelper/index.spec.tsx
+++ b/src/frontend/js/utils/PaymentScheduleHelper/index.spec.tsx
@@ -1,0 +1,78 @@
+/**
+ * Test suite for the helper `PaymentScheduleHelper`.
+ */
+import PaymentScheduleHelper from 'utils/PaymentScheduleHelper/index';
+import { PaymentInstallmentFactory } from 'utils/test/factories/joanie';
+import { PaymentScheduleState } from 'types/Joanie';
+
+describe('PaymentScheduleHelper', () => {
+  describe('getFailedInstallment', () => {
+    it('should return undefined if payment_schedule is undefined', () => {
+      const foundInstallment = PaymentScheduleHelper.getFailedInstallment(undefined);
+
+      expect(foundInstallment).toBeUndefined();
+    });
+
+    it('should return undefined if payment schedule does not have a failed installment', () => {
+      const schedule = PaymentInstallmentFactory({ state: PaymentScheduleState.PENDING }).many(3);
+      const foundInstallment = PaymentScheduleHelper.getFailedInstallment(schedule);
+
+      expect(foundInstallment).toBeUndefined();
+    });
+
+    it('should return the older failed installment', () => {
+      const schedule = [
+        PaymentInstallmentFactory({
+          state: PaymentScheduleState.PAID,
+          due_date: '2024-06-21',
+        }).one(),
+        PaymentInstallmentFactory({
+          state: PaymentScheduleState.REFUSED,
+          due_date: '2024-08-20',
+        }).one(),
+        PaymentInstallmentFactory({
+          state: PaymentScheduleState.REFUSED,
+          due_date: '2024-07-20',
+        }).one(),
+      ];
+      const foundInstallment = PaymentScheduleHelper.getFailedInstallment(schedule);
+
+      expect(foundInstallment?.due_date).toBe(schedule[2].due_date);
+    });
+  });
+
+  describe('getPendingInstallment', () => {
+    it('should return undefined if payment_schedule is undefined', () => {
+      const foundInstallment = PaymentScheduleHelper.getPendingInstallment(undefined);
+
+      expect(foundInstallment).toBeUndefined();
+    });
+
+    it('should return undefined if payment schedule does not have a pending installment', () => {
+      const schedule = PaymentInstallmentFactory({ state: PaymentScheduleState.PAID }).many(3);
+      const foundInstallment = PaymentScheduleHelper.getPendingInstallment(schedule);
+
+      expect(foundInstallment).toBeUndefined();
+    });
+
+    it('should return the older pending installment', () => {
+      const schedule = [
+        PaymentInstallmentFactory({
+          state: PaymentScheduleState.PAID,
+          due_date: '2024-06-21',
+        }).one(),
+        PaymentInstallmentFactory({
+          state: PaymentScheduleState.PENDING,
+          due_date: '2024-08-20',
+        }).one(),
+        PaymentInstallmentFactory({
+          state: PaymentScheduleState.PENDING,
+          due_date: '2024-07-20',
+        }).one(),
+      ];
+
+      const foundInstallment = PaymentScheduleHelper.getPendingInstallment(schedule);
+      expect(foundInstallment?.due_date).toBe(schedule[2].due_date);
+    });
+  });
+});

--- a/src/frontend/js/utils/PaymentScheduleHelper/index.ts
+++ b/src/frontend/js/utils/PaymentScheduleHelper/index.ts
@@ -1,0 +1,30 @@
+import { PaymentInstallment, PaymentSchedule, PaymentScheduleState } from 'types/Joanie';
+import { Maybe } from 'types/utils';
+
+export default class PaymentScheduleHelper {
+  static #sortByDueDateAsc(a: PaymentInstallment, b: PaymentInstallment) {
+    const dateA = new Date(a.due_date).getTime();
+    const dateB = new Date(b.due_date).getTime();
+    return dateA - dateB;
+  }
+
+  static #getInstallmentByState(
+    payment_schedule: Maybe<PaymentSchedule>,
+    state: PaymentScheduleState,
+  ) {
+    if (!payment_schedule) return undefined;
+
+    const installments = [...payment_schedule];
+    return installments
+      ?.sort(this.#sortByDueDateAsc)
+      .find((installment) => installment.state === state);
+  }
+
+  static getFailedInstallment(payment_schedule: Maybe<PaymentSchedule>) {
+    return this.#getInstallmentByState(payment_schedule, PaymentScheduleState.REFUSED);
+  }
+
+  static getPendingInstallment(payment_schedule: Maybe<PaymentSchedule>) {
+    return this.#getInstallmentByState(payment_schedule, PaymentScheduleState.PENDING);
+  }
+}

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -365,6 +365,7 @@ export const OrderEnrollmentFactory = factory((): OrderEnrollment => {
     id: faker.string.uuid(),
     product_id: faker.string.uuid(),
     state: OrderState.COMPLETED,
+    payment_schedule: PaymentInstallmentFactory().many(1),
   };
 });
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.spec.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
+import { userEvent } from '@testing-library/user-event';
 import { Enrollment } from 'types/Joanie';
 import {
   CourseStateFactory,
@@ -80,5 +81,27 @@ describe('<DashboardItemEnrollment/>', () => {
     screen.getByText(enrollment.course_run.course!.title);
     screen.getByText('Ref. ' + enrollment.course_run.course!.code);
     screen.getByText('Not enrolled');
+  });
+
+  it('renders a link to go to the syllabus', async () => {
+    const enrollment: Enrollment = EnrollmentFactory({
+      is_active: false,
+      course_run: CourseRunWithCourseFactory().one(),
+    }).one();
+
+    render(<DashboardItemEnrollment enrollment={enrollment} />);
+    screen.getByRole('heading', { level: 5, name: enrollment.course_run.course!.title });
+
+    const moreButton = screen.getByRole('combobox', {
+      name: 'See additional options',
+    });
+
+    const user = userEvent.setup();
+    await user.click(moreButton);
+
+    const link = screen.getByRole('link', { name: 'Go to syllabus' });
+    expect(link.getAttribute('href')).toBe(
+      '/redirects/courses/' + enrollment.course_run.course.code,
+    );
   });
 });

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/DashboardItemEnrollment.tsx
@@ -1,8 +1,17 @@
 import { useMemo } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { Enrollment, isCertificateProduct } from 'types/Joanie';
 import { Enrolled } from '../CourseEnrolling';
 import { DashboardItem } from '..';
 import ProductCertificateFooter from './ProductCertificateFooter';
+
+const messages = defineMessages({
+  syllabusLinkLabel: {
+    id: 'components.DashboardItemEnrollment.syllabusLinkLabel',
+    description: 'Syllabus link label on order details',
+    defaultMessage: 'Go to syllabus',
+  },
+});
 
 interface DashboardItemCourseRunProps {
   enrollment: Enrollment;
@@ -38,5 +47,18 @@ export const DashboardItemEnrollment = ({ enrollment }: DashboardItemCourseRunPr
     return partialFooterList;
   }, [enrollment, course]);
 
-  return <DashboardItem title={course.title} code={'Ref. ' + course.code} footer={footerList} />;
+  return (
+    <DashboardItem
+      title={course.title}
+      code={'Ref. ' + course.code}
+      more={
+        <li>
+          <a className="selector__list__link" href={`/redirects/courses/${course.code}`}>
+            <FormattedMessage {...messages.syllabusLinkLabel} />
+          </a>
+        </li>
+      }
+      footer={footerList}
+    />
+  );
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
@@ -1,12 +1,24 @@
-import { FormattedMessage, defineMessages } from 'react-intl';
-import { useState } from 'react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { useEffect, useState } from 'react';
+import { Button, useModal } from '@openfun/cunningham-react';
 import PurchaseButton from 'components/PurchaseButton';
 import { Icon, IconTypeEnum } from 'components/Icon';
-import { CertificateProduct, Enrollment, ProductType } from 'types/Joanie';
+import {
+  CertificateProduct,
+  Enrollment,
+  Order,
+  OrderEnrollment,
+  OrderState,
+  ProductType,
+} from 'types/Joanie';
 import DownloadCertificateButton from 'components/DownloadCertificateButton';
 import { useCertificate } from 'hooks/useCertificates';
 import { isOpenedCourseRunCertificate } from 'utils/CourseRuns';
 import { OrderHelper } from 'utils/OrderHelper';
+import { OrderPaymentRetryModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal';
+import PaymentScheduleHelper from 'utils/PaymentScheduleHelper';
+import { useOrder } from 'hooks/useOrders';
+import useDateFormat from 'hooks/useDateFormat';
 import CertificateStatus from '../../CertificateStatus';
 
 const messages = defineMessages({
@@ -25,6 +37,27 @@ const messages = defineMessages({
     description: 'Label on the enrollment when a product of type certificate have been bought',
     defaultMessage: 'Finish this course to obtain your certificate.',
   },
+  failedInstallmentMessage: {
+    id: 'components.ProductCertificateFooter.failedInstallmentMessage',
+    description: 'Message displayed when the last installment has failed',
+    defaultMessage:
+      'Last direct debit has failed. Please resolve your situation as soon as possible.',
+  },
+  examAccessBlocked: {
+    id: 'components.ProductCertificateFooter.examAccessBlocked',
+    description: 'Message displayed when the exam access is blocked',
+    defaultMessage: 'You will be able to pass the exam once the installment has been paid.',
+  },
+  nextInstallmentMessage: {
+    id: 'components.ProductCertificateFooter.nextInstallmentMessage',
+    description: 'Message displayed when an installment is pending',
+    defaultMessage: 'The next installment ({amount}) will be withdrawn on the {due_date}.',
+  },
+  paymentNeededButton: {
+    id: 'components.ProductCertificateFooter.paymentNeededButton',
+    description: 'Button label for the payment needed message',
+    defaultMessage: 'Pay {amount}',
+  },
 });
 
 export interface ProductCertificateFooterProps {
@@ -33,37 +66,37 @@ export interface ProductCertificateFooterProps {
 }
 
 const ProductCertificateFooter = ({ product, enrollment }: ProductCertificateFooterProps) => {
-  if (product.type !== ProductType.CERTIFICATE) {
-    return null;
-  }
   const [order, setOrder] = useState(
     OrderHelper.getActiveEnrollmentOrder(enrollment.orders || [], product.id),
   );
-  const { item: certificate } = useCertificate(order?.certificate_id);
+  const isOrderActive = OrderHelper.isActive(order);
+  const isPurchasable =
+    OrderHelper.isPurchasable(order) && isOpenedCourseRunCertificate(enrollment.course_run.state);
+  const isCertificateIssued = isOrderActive && Boolean(order!.certificate_id);
+  const hasError =
+    isOrderActive && [OrderState.NO_PAYMENT, OrderState.FAILED_PAYMENT].includes(order!.state);
+
+  if (product.type !== ProductType.CERTIFICATE) {
+    return null;
+  }
 
   // The course run is no longer available
   // and no product certificate had been bought therefore there isn't any certificate to download.
-  if (!order && !isOpenedCourseRunCertificate(enrollment.course_run.state)) {
+  if (!isPurchasable && !order) {
     return null;
   }
 
   return (
     <div className="dashboard-item__course-enrolling__infos">
-      <div className="dashboard-item__block__status">
-        <Icon name={IconTypeEnum.CERTIFICATE} />
-        {OrderHelper.isActive(order) ? (
-          <>
-            {product.certificate_definition.title + '. '}
-            <CertificateStatus certificate={certificate} productType={product.type} />
-          </>
-        ) : (
-          <FormattedMessage {...messages.buyProductCertificateLabel} />
-        )}
-      </div>
-      {OrderHelper.isActive(order) && order!.certificate_id && (
+      {!isOrderActive ? (
+        <ProductCertificateStatus />
+      ) : (
+        <OrderCertificateStatus order={order!} product={product} hasError={hasError} />
+      )}
+      {isCertificateIssued && (
         <DownloadCertificateButton
           className="dashboard-item__button"
-          certificateId={order!.certificate_id}
+          certificateId={order!.certificate_id!}
         />
       )}
       <PurchaseButton
@@ -71,7 +104,7 @@ const ProductCertificateFooter = ({ product, enrollment }: ProductCertificateFoo
         product={product}
         enrollment={enrollment}
         buttonProps={{ size: 'small' }}
-        disabled={!OrderHelper.isPurchasable(order)}
+        disabled={!isPurchasable}
         onFinish={(o) => {
           /**
            * As we do not refetch enrollments in DashboardCourses after SaleTunnel cache invalidation (to avoid
@@ -81,7 +114,115 @@ const ProductCertificateFooter = ({ product, enrollment }: ProductCertificateFoo
           setOrder(o);
         }}
       />
+      {hasError && <FailedInstallmentManager order={order!} updateOrder={setOrder} />}
     </div>
+  );
+};
+
+const ProductCertificateStatus = () => (
+  <div className="dashboard-item__block__status">
+    <Icon name={IconTypeEnum.CERTIFICATE} />
+    <FormattedMessage {...messages.buyProductCertificateLabel} />
+  </div>
+);
+
+type OrderCertificateStatusProps = {
+  order: OrderEnrollment;
+  product: CertificateProduct;
+  hasError: boolean;
+};
+const OrderCertificateStatus = ({ order, product, hasError }: OrderCertificateStatusProps) => {
+  const { item: certificate } = useCertificate(order?.certificate_id);
+  const intl = useIntl();
+  const formatDate = useDateFormat();
+  const nextInstallment = PaymentScheduleHelper.getPendingInstallment(order?.payment_schedule);
+  const canAccessToExam = ![OrderState.PENDING, OrderState.NO_PAYMENT].includes(order.state);
+
+  return (
+    <div className="dashboard-item__block__status">
+      <Icon name={hasError ? IconTypeEnum.WARNING : IconTypeEnum.CERTIFICATE} />
+      <p>
+        {hasError && (
+          <>
+            <strong>
+              <FormattedMessage {...messages.failedInstallmentMessage} />
+            </strong>
+            <br />
+          </>
+        )}
+        {canAccessToExam ? (
+          <>
+            {product.certificate_definition.title + '. '}
+            <CertificateStatus certificate={certificate} productType={product.type} />
+          </>
+        ) : (
+          <FormattedMessage {...messages.examAccessBlocked} />
+        )}
+        {!hasError && nextInstallment && (
+          <>
+            <br />
+            <FormattedMessage
+              {...messages.nextInstallmentMessage}
+              values={{
+                amount: intl.formatNumber(nextInstallment.amount, {
+                  style: 'currency',
+                  currency: nextInstallment.currency,
+                }),
+                due_date: formatDate(nextInstallment.due_date),
+              }}
+            />
+          </>
+        )}
+      </p>
+    </div>
+  );
+};
+
+type FailedInstallmentManagerProps = {
+  order: OrderEnrollment;
+  updateOrder: (order: Order) => void;
+};
+const FailedInstallmentManager = ({ order, updateOrder }: FailedInstallmentManagerProps) => {
+  const intl = useIntl();
+  const failedInstallment = PaymentScheduleHelper.getFailedInstallment(order!.payment_schedule);
+  const installmentRetryModal = useModal();
+  const orderQuery = useOrder(order.id);
+
+  useEffect(() => {
+    /**
+     * As we do not refetch enrollments in DashboardCourses after SaleTunnel cache invalidation (to avoid
+     * scroll reset - and SaleTunnel modal unmounting too early caused by list reset) we need to manually
+     * update the active order in the enrollment in order to hide the installment manager.
+     */
+    if (orderQuery.item) {
+      updateOrder(orderQuery.item);
+    }
+  }, [orderQuery.item]);
+
+  if (!failedInstallment) return null;
+
+  return (
+    <>
+      <div className="dashboard-splitted-card__item__actions">
+        <Button size="small" color="primary" onClick={installmentRetryModal.open}>
+          <FormattedMessage
+            {...messages.paymentNeededButton}
+            values={{
+              amount: intl.formatNumber(failedInstallment.amount, {
+                style: 'currency',
+                currency: failedInstallment.currency,
+              }),
+            }}
+          />
+        </Button>
+      </div>
+      <OrderPaymentRetryModal
+        {...installmentRetryModal}
+        installment={failedInstallment}
+        order={order!}
+        onClose={orderQuery.methods.invalidate}
+      />
+    </>
   );
 };
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -50,7 +50,7 @@ import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
 import { render } from 'utils/test/render';
 import { BaseJoanieAppWrapper } from 'utils/test/wrappers/BaseJoanieAppWrapper';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRoutesPaths';
-import { OrderHelper } from 'utils/OrderHelper';
+import PaymentScheduleHelper from 'utils/PaymentScheduleHelper';
 import { DashboardTest } from '../../DashboardTest';
 import { DashboardItemOrder } from './DashboardItemOrder';
 
@@ -1014,7 +1014,7 @@ describe('<DashboardItemOrder/>', () => {
 
     await screen.findByRole('heading', { level: 5, name: product.title });
     screen.getByText(/a payment failed, please update your payment method/i);
-    const failedInstallment = OrderHelper.getFailedInstallment(order)!;
+    const failedInstallment = PaymentScheduleHelper.getFailedInstallment(order.payment_schedule)!;
     const button = screen.getByRole('button', {
       name: 'Pay ' + formatPrice(failedInstallment.amount, failedInstallment.currency),
     });

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/Installment/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/Installment/index.tsx
@@ -8,6 +8,7 @@ import { OrderPaymentDetailsModal } from 'widgets/Dashboard/components/Dashboard
 import { OrderPaymentRetryModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal';
 import { SaleTunnel } from 'components/SaleTunnel';
 import { Spinner } from 'components/Spinner';
+import PaymentScheduleHelper from 'utils/PaymentScheduleHelper';
 
 const messages = defineMessages({
   paymentTitle: {
@@ -60,7 +61,7 @@ type Props = {
 
 const Installment = ({ order }: Props) => {
   const isActive = OrderHelper.isActive(order);
-  const failedInstallment = OrderHelper.getFailedInstallment(order);
+  const failedInstallment = PaymentScheduleHelper.getFailedInstallment(order.payment_schedule);
   const needsPaymentMethod = order.state === OrderState.TO_SAVE_PAYMENT_METHOD;
   const shouldDisplayDot = needsPaymentMethod || !!failedInstallment;
 
@@ -127,7 +128,7 @@ const InstallmentManager = ({ order }: Props) => {
   const intl = useIntl();
   const modal = useModal();
   const retryModal = useModal();
-  const failedInstallment = OrderHelper.getFailedInstallment(order);
+  const failedInstallment = PaymentScheduleHelper.getFailedInstallment(order.payment_schedule);
 
   const pay = async () => {
     retryModal.open();

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentDetailsModal/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentDetailsModal/index.tsx
@@ -13,10 +13,10 @@ import { useState, useEffect } from 'react';
 import { PaymentScheduleGrid } from 'components/PaymentScheduleGrid';
 import { CreditCard, Order } from 'types/Joanie';
 import { CreditCardSelector } from 'components/CreditCardSelector';
-import { OrderHelper } from 'utils/OrderHelper';
 import { OrderPaymentRetryModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal';
 import { Maybe } from 'types/utils';
 import { useCreditCard } from 'hooks/useCreditCards';
+import PaymentScheduleHelper from 'utils/PaymentScheduleHelper';
 
 const messages = defineMessages({
   title: {
@@ -53,7 +53,7 @@ interface PaymentModalProps extends Pick<ModalProps, 'isOpen' | 'onClose'> {
 export const OrderPaymentDetailsModal = ({ order, ...props }: PaymentModalProps) => {
   const intl = useIntl();
   const retryModal = useModal();
-  const failedInstallment = OrderHelper.getFailedInstallment(order);
+  const failedInstallment = PaymentScheduleHelper.getFailedInstallment(order.payment_schedule);
 
   return (
     <>

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal/index.tsx
@@ -9,7 +9,13 @@ import {
 } from '@openfun/cunningham-react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useRef, useState } from 'react';
-import { CreditCard, Order, PaymentInstallment, ACTIVE_ORDER_STATES } from 'types/Joanie';
+import {
+  CreditCard,
+  Order,
+  OrderEnrollment,
+  PaymentInstallment,
+  ACTIVE_ORDER_STATES,
+} from 'types/Joanie';
 import { CreditCardSelector } from 'components/CreditCardSelector';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
 import { Payment, PaymentErrorMessageId } from 'components/PaymentInterfaces/types';
@@ -65,7 +71,7 @@ const messages = defineMessages({
 
 interface Props extends Pick<ModalProps, 'isOpen' | 'onClose'> {
   installment: PaymentInstallment;
-  order: Order;
+  order: Order | OrderEnrollment;
 }
 
 enum ComponentStates {


### PR DESCRIPTION
## Purpose

With the new workflow, the learner must be able to see installment information
for its certificate order. If one installment has failed, it should be able to
pay it manually.

### The order is completed, nothing is displayed
<img width="650" alt="Capture d’écran 2024-08-22 à 16 12 07" src="https://github.com/user-attachments/assets/13524f6c-3074-465a-9fe0-7e1a09a70302">

### The last installment debit has failed, a message to warn learner and a button to pay installment are displayed
<img width="650" alt="Capture d’écran 2024-08-22 à 16 11 43" src="https://github.com/user-attachments/assets/7a464305-30aa-43bb-ad6f-a69a51cd57b0">

### The first installment is pending, a message is displayed to inform the user it has to wait the installment payment to access to the exam and at which date the debit will be processed
<img width="650" alt="Capture d’écran 2024-08-22 à 16 10 44" src="https://github.com/user-attachments/assets/d1cbd44f-3f23-4b81-8cb2-7e1bbb1a0c96">

### An installment (not the first) is pending, a message is displayed to inform the user when the debit will be processed
<img width="650" alt="Capture d’écran 2024-08-22 à 16 09 08" src="https://github.com/user-attachments/assets/dc226118-956f-4e0b-9969-a79ee83c1e2b">


