### PR TITLE
🔍(backend) fix duplicated h1 in blogpost detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Remove News subheader in blogpost detail page
+
+
 ## [2.29.2]
 
 ### Fixed

--- a/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/blogpost_detail.html
@@ -26,12 +26,6 @@
 
 {% block body_rdfa %} vocab="https://schema.org/" typeof="Article"{% endblock body_rdfa %}
 
-{% block subheader_content %}
-    <div class="subheader__container">
-        <h1 class="subheader__title">{% page_attribute "page_title" request.current_page.parent_page %}</h1>
-    </div>
-{% endblock subheader_content %}
-
 {% block content %}
     {% spaceless %}
     {% block content_header %}{%  endblock %}


### PR DESCRIPTION
## Purpose

On blogpost detail page, there is currently a SEO major issue. Indeed, there are
 two H1 on the same page. The first is the news label on the subheader and the
 second is the blogpost title itself. The post title is the most relevant one
 and the subheader "News" is not really relevant that's why we decide to fix
 this issue to simply remove the subheader on the blogpost detail template.


| Before | After |
|--------|-------|
|<img width="800" alt="image" src="https://github.com/user-attachments/assets/7890d950-4b7b-4951-a4f9-e2300cb3ec4b">|<img width="800" alt="image" src="https://github.com/user-attachments/assets/89b5e78a-95ca-4e0f-8fe4-5eb9f679fd7e">|