### PR TITLE
🏷️(frontend) fix OpenEdX level education "other" value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Fixed
+
+- Fix Open EdX Level education enum "other" value
+
 ## [2.29.1]
 
 ### Fixed

--- a/src/frontend/js/types/openEdx.ts
+++ b/src/frontend/js/types/openEdx.ts
@@ -9,7 +9,7 @@ export enum OpenEdxLevelOfEducation {
   JUNIOR_SECONDARY_OR_MIDDLE_SCHOOL = 'jhs',
   ELEMENTARY_PRIMARY_SCHOOL = 'el',
   NONE = 'none',
-  OTHER = 'o',
+  OTHER = 'other',
 }
 
 // * null


### PR DESCRIPTION
## Purpose

The "other" value of the OpenEdxLevelOfEducation was wrong ("o"). It appears the right value is "other".

