### PR TITLE
🐛(frontend) fix enroll action validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Update Learner dashboard to finalize subscription process
 - SaleTunnel has been fully rework to comply with the purchase workflow
 - Replace order abort mutation by order cancel mutation
+- Button instead of link to "Enroll now" CTA in SyllabusCourseRunCompacted
 
 ### Fixed
 
 - Fix logic to know if user is enrolled to a ongoing product
 - Normalize credit card brand on CreditCardBrandLogo component
+- Display SyllabusCourseRunCompacted only for self-paced ongoing opened runs
 
 ## [2.29.2] - 2024-09-23
 

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted/index.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@openfun/cunningham-react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { CourseRun, CourseRunDisplayMode, PacedCourse } from 'types';
 import useDateFormat from 'hooks/useDateFormat';
@@ -76,9 +77,9 @@ const OpenedSelfPacedCourseRun = ({
       {findLmsBackend(courseRun.resource_link) ? (
         <CourseRunEnrollment courseRun={courseRun} />
       ) : (
-        <a className="course-run-enrollment__cta" href={courseRun.resource_link}>
+        <Button className="course-run-enrollment__cta" href={courseRun.resource_link} fullWidth>
           {StringHelper.capitalizeFirst(courseRun.state.call_to_action)}
-        </a>
+        </Button>
       )}
     </>
   );

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/index.tsx
@@ -85,7 +85,7 @@ const SyllabusCourseRunsList = ({
         </div>
       )}
       {openedRuns.length === 1 &&
-        (course.is_self_paced && openedRuns[0].state.priority !== Priority.ARCHIVED_OPEN ? (
+        (course.is_self_paced && openedRuns[0].state.priority === Priority.ONGOING_OPEN ? (
           <div className="course-detail__row course-detail__runs course-detail__runs--open">
             <SyllabusCourseRunCompacted
               courseRun={openedRuns[0]}


### PR DESCRIPTION
Detected the following two bugs on the course detail page:

#### Enrollment validation
To allows the user to enroll a course, the conditions need to validate if the course is opened, and then show it as available. The `Priority` enum value `ARCHIVED_OPEN` does not correspond to this condition.

#### Enroll action component
The enroll action is being treated as link which does not seem correct in terms of accessibility and from the perspective of call to action concept.