### PR TITLE
✨(frontend) add faqs to a category and get them from a course

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Added
+
+- Add Additional Information section for a category and
+    use them in a course page
+
 ## [2.33.0] - 2024-12-02
 
 ### Added

--- a/src/frontend/js/components/AddressesManagement/AddressForm/index.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/AddressForm/index.spec.tsx
@@ -153,5 +153,5 @@ describe('AddressForm', () => {
     expect(
       getByText($countryInput.closest('.c__field')!, /This field is required./),
     ).toBeInTheDocument();
-  });
+  }, 15000);
 });

--- a/src/frontend/js/components/AddressesManagement/index.spec.tsx
+++ b/src/frontend/js/components/AddressesManagement/index.spec.tsx
@@ -177,7 +177,7 @@ describe('AddressesManagement', () => {
       ...address,
       is_main: true,
     });
-  }, 10000);
+  }, 15000);
 
   it('renders a form to edit an address when user selects an address to edit', async () => {
     const address = AddressFactory().one();

--- a/src/frontend/js/components/ContractFrame/AbstractContractFrame.spec.tsx
+++ b/src/frontend/js/components/ContractFrame/AbstractContractFrame.spec.tsx
@@ -169,7 +169,7 @@ describe('<AbstractContractFrame />', () => {
     await user.click(button);
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
-  });
+  }, 25000);
 
   it('retrieves invitation link but fails during signature checking', async () => {
     const user = userEvent.setup();
@@ -231,7 +231,7 @@ describe('<AbstractContractFrame />', () => {
     await user.click(button);
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
-  });
+  }, 25000);
 
   it('retrieves invitation link but exceeds polling max attemps', async () => {
     const user = userEvent.setup();

--- a/src/frontend/js/components/SaleTunnel/AddressSelector/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/AddressSelector/index.spec.tsx
@@ -133,7 +133,7 @@ describe('AddressSelector', () => {
         'Billing address' + getAddressLabel(address) + 'closearrow_drop_down',
       );
     });
-  });
+  }, 15000);
   it('has an existing main billing address and choose another', async () => {
     const address = AddressFactory({
       is_main: true,
@@ -268,5 +268,5 @@ describe('AddressSelector', () => {
         'Billing address' + getAddressLabel(newAddress) + 'closearrow_drop_down',
       ),
     );
-  });
+  }, 15000);
 });

--- a/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.full-process.spec.tsx
@@ -381,5 +381,5 @@ describe('SaleTunnel', () => {
     // This way we make sure the cache is updated.
     await screen.findByText('Purchased');
     expect(screen.queryByRole('button', { name: product.call_to_action })).not.toBeInTheDocument();
-  }, 10000);
+  }, 15000);
 });

--- a/src/frontend/js/hooks/useCourseProductUnion/index.spec.tsx
+++ b/src/frontend/js/hooks/useCourseProductUnion/index.spec.tsx
@@ -82,7 +82,7 @@ describe('useCourseProductUnion', () => {
       `${coursesUrl}?has_listed_course_runs=true&page=1&page_size=${PER_PAGE}`,
     );
     expect(calledUrls).toContain(`${courseProductRelationsUrl}?page=1&page_size=${PER_PAGE}`);
-  });
+  }, 25000);
 
   it('should call organization courses and organization coursesProductRelation endpoints', async () => {
     const organizationId = 'DUMMY_ORGANIZATION_ID';

--- a/src/frontend/js/pages/DashboardAddressesManagement/DashboardCreateAddress.spec.tsx
+++ b/src/frontend/js/pages/DashboardAddressesManagement/DashboardCreateAddress.spec.tsx
@@ -170,7 +170,7 @@ describe('<DashboardCreateAddress/>', () => {
     await waitFor(() => {
       expect(screen.getByText('Billing addresses')).toBeInTheDocument();
     });
-  });
+  }, 15000);
 
   it('shows an error in case of API error', async () => {
     fetchMock.get('https://joanie.endpoint/api/v1.0/addresses/', []);
@@ -210,5 +210,5 @@ describe('<DashboardCreateAddress/>', () => {
     ).toBe(true);
 
     await expectBannerError('An error occurred while creating the address. Please retry later.');
-  });
+  }, 15000);
 });

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -231,7 +231,7 @@ describe('<DashboardCourses/>', () => {
     await waitFor(() => expectList(entities.slice(0, perPage * 3), relations), { timeout: 30000 });
     loadMoreButton = await screen.findByRole('button', { name: 'Load more' });
     expect(loadMoreButton).toBeEnabled();
-  });
+  }, 15000);
 
   it('shows an error', async () => {
     jest.spyOn(console, 'error').mockImplementation(noop);

--- a/src/richie/apps/courses/settings/__init__.py
+++ b/src/richie/apps/courses/settings/__init__.py
@@ -305,6 +305,25 @@ CMS_PLACEHOLDER_CONF = {
         "plugins": ["CKEditorPlugin"],
         "limits": {"CKEditorPlugin": 1},
     },
+    "courses/cms/category_detail.html additional_information": {
+        "name": _("Additional Information"),
+        "plugins": ["SectionPlugin"],
+        "parent_classes": {
+            "CKEditorPlugin": ["SectionPlugin"],
+            "SimplePicturePlugin": ["SectionPlugin"],
+            "GlimpsePlugin": ["SectionPlugin"],
+            "NestedItemPlugin": ["SectionPlugin"],
+        },
+        "child_classes": {
+            "SectionPlugin": [
+                "CKEditorPlugin",
+                "SimplePicturePlugin",
+                "GlimpsePlugin",
+                "NestedItemPlugin",
+            ],
+            "NestedItemPlugin": ["NestedItemPlugin"],
+        },
+    },
     # Person detail
     "courses/cms/person_detail.html categories": {
         "name": _("Categories"),

--- a/src/richie/apps/courses/templates/courses/cms/category_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/category_detail.html
@@ -190,6 +190,19 @@
             {% endif %}
         {% endwith %}
 
+        <div id="page{{ page_suffix }}" class="category-detail__additional-info category-detail__block">
+            <div class="category-detail__row">
+                {% if not current_page|is_empty_placeholder:"additional_information" and not current_page.reverse_id %}
+                    <p class="category-detail__empty">{% trans 'Configure this page id to show this additional information on all related course pages' %}</p>
+                {% endif %}
+                {% placeholder "additional_information" or %}
+                    {% if request.toolbar.edit_mode_active %}
+                        <p class="category-detail__empty">{% trans 'Enter additional information for this category' %}</p>
+                    {% endif %}
+                {% endplaceholder %}
+            </div>
+        </div>
+
         {% with persons=category.get_persons %}
             {% if persons %}
                 {% autopaginate persons GLIMPSE_PAGINATION_PERSONS %}

--- a/src/richie/apps/courses/templates/courses/cms/course_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/course_detail.html
@@ -472,6 +472,23 @@
             {% endif %}
         {% endblock information %}
 
+        {% block category_additional_information %}
+            <!-- Showing all categories additional information of categories pages that have a page id -->
+
+            {% get_categories_pages_additional_information current_page.course as pages %}
+            {% if pages %}
+                <div class="course-detail__additional-info course-detail__block course-detail__row">
+                    {% with is_syllabus_property=True %}   
+                        {% for page in pages %}
+                            {% with reverse_id=page.reverse_id %}
+                                {% show_placeholder "additional_information" reverse_id %}
+                            {% endwith %}
+                        {% endfor %}                           
+                    {% endwith %}
+                </div>
+            {% endif %}    
+        {% endblock category_additional_information %}
+
         {% block licenses %}
             {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_license_content" or not current_page|is_empty_placeholder:"course_license_participation" %}
             <div class="course-detail__license course-detail__block course-detail__block--divider">

--- a/tests/apps/courses/test_templatetags_extra_tags_get_categories_pages_additional_information.py
+++ b/tests/apps/courses/test_templatetags_extra_tags_get_categories_pages_additional_information.py
@@ -1,0 +1,386 @@
+"""Test suite for the get_categories_pages_additional_information template tag."""
+
+from django.db import transaction
+
+from cms.api import add_plugin
+from cms.test_utils.testcases import CMSTestCase
+
+from richie.apps.courses.factories import CategoryFactory, CourseFactory
+from richie.apps.courses.models.course import Course
+from richie.apps.courses.templatetags.extra_tags import (
+    get_categories_pages_additional_information,
+)
+from richie.plugins.nesteditem.defaults import ACCORDION
+
+
+class GetCategoriesPagesAdditionalInformationTestCase(CMSTestCase):
+    """
+    Integration tests to validate the `get_categories_pages_additional_information` template tag.
+
+    To get additional information successfully from a category page, the requirements are:
+
+    - The category page needs to have created additional information
+    - To the category page must be set the `id` in `Advanced Settings`
+    which will be used as `reverse_id`
+    - The category page must be published so the `show_placeholder` tag
+    can find the component
+    """
+
+    def _add_info(self, component: CategoryFactory) -> CategoryFactory:
+        """
+        This method adds additional information to a category
+        """
+
+        placeholder = component.extended_object.placeholders.get(
+            slot="additional_information"
+        )
+
+        section = add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="SectionPlugin",
+            title="Additional Information",
+        )
+
+        container = add_plugin(
+            language="en",
+            placeholder=placeholder,
+            plugin_type="NestedItemPlugin",
+            variant=ACCORDION,
+            target=section,
+        )
+
+        for question in range(1, 3):
+            question_container = add_plugin(
+                language="en",
+                placeholder=placeholder,
+                plugin_type="NestedItemPlugin",
+                target=container,
+                content=f"{question}. question?",
+                variant=ACCORDION,
+            )
+
+            add_plugin(
+                language="en",
+                placeholder=placeholder,
+                plugin_type="NestedItemPlugin",
+                target=question_container,
+                content=f"Answer of question {question}.",
+                variant=ACCORDION,
+            )
+
+        return component
+
+    @transaction.atomic
+    def test_get_categories_pages_additional_information_filled_list_with_lookup(self):
+        """
+        This test validates when a course has categories with additional information and
+        the page_lookup `reverse_id` set the custom tag
+        `get_categories_pages_additional_information` must return a list
+        with the corresponding categories pages
+        """
+
+        category1 = CategoryFactory.create(page_title="Accessible", should_publish=True)
+        category2 = CategoryFactory.create(
+            page_title="Earth and universe sciences", should_publish=True
+        )
+        icon1 = CategoryFactory.create(
+            page_title="Available on edX.org", should_publish=True
+        )
+        icon2 = CategoryFactory.create(
+            page_title="Payment promotion", should_publish=True
+        )
+
+        for component in [category1, category2, icon1, icon2]:
+            reverse_id = component.extended_object.get_title().lower().replace(" ", "-")
+            component.extended_object.reverse_id = reverse_id
+            component.extended_object.save()
+
+        for component in [category1, icon1]:
+            component = self._add_info(component)
+
+        course: Course = CourseFactory.create(
+            fill_categories=[category1, category2],
+            fill_icons=[icon1, icon2],
+        )
+
+        all_categories = course.get_categories()
+        categories_pages_have_info = get_categories_pages_additional_information(course)
+
+        self.assertTrue(len(all_categories) == 4)
+        self.assertTrue(isinstance(categories_pages_have_info, list))
+        self.assertTrue(len(categories_pages_have_info) == 2)
+
+        for page in categories_pages_have_info:
+            self.assertTrue(page.get_title() in ["Accessible", "Available on edX.org"])
+            plugins = (
+                page.get_placeholders().get(slot="additional_information").get_plugins()
+            )
+            self.assertTrue(len(plugins) > 0)
+
+            self.assertTrue(plugins[0].plugin_type == "SectionPlugin")
+
+            for plugin in plugins[1:]:
+                self.assertTrue(plugin.plugin_type == "NestedItemPlugin")
+
+    @transaction.atomic
+    def test_get_categories_pages_additional_information_empty_list_with_lookup(self):
+        """
+        This test validates when a course does not have categories with additional information
+        but with the page_lookup `reverse_id` set the custom tag
+        `get_categories_pages_additional_information` must return an empty
+        """
+
+        category1 = CategoryFactory.create(page_title="Accessible", should_publish=True)
+        category2 = CategoryFactory.create(
+            page_title="Earth and universe sciences", should_publish=True
+        )
+        icon1 = CategoryFactory.create(
+            page_title="Available on edX.org", should_publish=True
+        )
+        icon2 = CategoryFactory.create(
+            page_title="Payment promotion", should_publish=True
+        )
+
+        for component in [category1, category2, icon1, icon2]:
+            reverse_id = component.extended_object.get_title().lower().replace(" ", "-")
+            component.extended_object.reverse_id = reverse_id
+            component.extended_object.save()
+
+        course: Course = CourseFactory.create(
+            fill_categories=[category1, category2],
+            fill_icons=[icon1, icon2],
+        )
+
+        all_categories = course.get_categories()
+        categories_pages_have_info = get_categories_pages_additional_information(course)
+
+        self.assertTrue(len(all_categories) == 4)
+        self.assertTrue(isinstance(categories_pages_have_info, list))
+        self.assertTrue(len(categories_pages_have_info) == 0)
+
+        for category in all_categories:
+            page = category.extended_object
+            plugins = (
+                page.get_placeholders().get(slot="additional_information").get_plugins()
+            )
+            self.assertTrue(len(plugins) == 0)
+
+    @transaction.atomic
+    def test_get_categories_pages_additional_information_filled_list_no_lookup(self):
+        """
+        This test validates when a course has categories with additional information but
+        without page_lookup `reverse_id` the custom tag
+        `get_categories_pages_additional_information` must return an empty list
+        """
+
+        category1 = CategoryFactory.create(page_title="Accessible", should_publish=True)
+        category2 = CategoryFactory.create(
+            page_title="Earth and universe sciences", should_publish=True
+        )
+        icon1 = CategoryFactory.create(
+            page_title="Available on edX.org", should_publish=True
+        )
+        icon2 = CategoryFactory.create(
+            page_title="Payment promotion", should_publish=True
+        )
+
+        for component in [category1, icon1]:
+            component = self._add_info(component)
+
+        course: Course = CourseFactory.create(
+            fill_categories=[category1, category2],
+            fill_icons=[icon1, icon2],
+        )
+
+        all_categories = course.get_categories()
+        categories_pages_have_info = get_categories_pages_additional_information(course)
+
+        self.assertTrue(len(all_categories) == 4)
+
+        for category in all_categories:
+            page = category.extended_object
+            self.assertTrue(page.reverse_id is None)
+
+        categories_have_info = [
+            category
+            for category in all_categories
+            if len(
+                category.extended_object.get_placeholders()
+                .get(slot="additional_information")
+                .get_plugins()
+            )
+            > 0
+        ]
+        self.assertTrue(len(categories_have_info) == 2)
+
+        for category in categories_have_info:
+            page = category.extended_object
+            self.assertTrue(page.get_title() in ["Accessible", "Available on edX.org"])
+            plugins = (
+                page.get_placeholders().get(slot="additional_information").get_plugins()
+            )
+
+            self.assertTrue(plugins[0].plugin_type == "SectionPlugin")
+
+            for plugin in plugins[1:]:
+                self.assertTrue(plugin.plugin_type == "NestedItemPlugin")
+
+        self.assertTrue(isinstance(categories_pages_have_info, list))
+        self.assertTrue(len(categories_pages_have_info) == 0)
+
+    @transaction.atomic
+    def test_get_categories_pages_additional_information_filled_list_content(self):
+        """
+        This test validates when a course has categories with additional information it
+        will insert to the content page their information
+        """
+
+        category1 = CategoryFactory.create(page_title="Accessible", should_publish=True)
+        category2 = CategoryFactory.create(
+            page_title="Earth and universe sciences", should_publish=True
+        )
+        icon1 = CategoryFactory.create(
+            page_title="Available on edX.org", should_publish=True
+        )
+        icon2 = CategoryFactory.create(
+            page_title="Payment promotion", should_publish=True
+        )
+
+        for component in [category1, category2, icon1, icon2]:
+            reverse_id = component.extended_object.get_title().lower().replace(" ", "-")
+            component.extended_object.reverse_id = reverse_id
+            component.extended_object.save()
+
+        for component in [category1, icon1]:
+            component = self._add_info(component)
+            component.get_page().publish("en")
+
+        course: Course = CourseFactory.create(
+            fill_categories=[category1, category2],
+            fill_icons=[icon1, icon2],
+        )
+
+        all_categories = course.get_categories()
+        categories_pages_have_info = get_categories_pages_additional_information(course)
+
+        self.assertTrue(len(all_categories) == 4)
+        self.assertTrue(isinstance(categories_pages_have_info, list))
+        self.assertTrue(len(categories_pages_have_info) == 2)
+
+        page = course.get_page()
+        page.publish("en")
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<div class="course-detail__additional-info course-detail__block course-detail__row">',
+        )
+
+        for question in range(1, 3):
+            self.assertContains(
+                response, f'<meta property="name" content="{question}. question?" />'
+            )
+            self.assertContains(
+                response,
+                f'<meta property="name" content="Answer of question {question}." />',
+            )
+
+    @transaction.atomic
+    def test_get_categories_pages_additional_information_content_no_lookup(self):
+        """
+        This test validates when a course has categories with additional information but
+        without `reverse_id` it will not insert the section title nor the
+        section block
+        """
+
+        category1 = CategoryFactory.create(page_title="Accessible", should_publish=True)
+        category2 = CategoryFactory.create(
+            page_title="Earth and universe sciences", should_publish=True
+        )
+        icon1 = CategoryFactory.create(
+            page_title="Available on edX.org", should_publish=True
+        )
+        icon2 = CategoryFactory.create(
+            page_title="Payment promotion", should_publish=True
+        )
+
+        for component in [category1, icon1]:
+            component = self._add_info(component)
+            component.get_page().publish("en")
+
+        course: Course = CourseFactory.create(
+            fill_categories=[category1, category2],
+            fill_icons=[icon1, icon2],
+        )
+
+        page = course.get_page()
+        page.publish("en")
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            '<div class="course-detail__additional-info course-detail__block course-detail__row">',
+        )
+
+        for question in range(1, 3):
+            self.assertNotContains(
+                response, f'<meta property="name" content="{question}. question?" />'
+            )
+            self.assertNotContains(
+                response,
+                f'<meta property="name" content="Answer of question {question}." />',
+            )
+
+    @transaction.atomic
+    def test_get_categories_pages_additional_information_no_content_with_lookup(self):
+        """
+        This test validates when a course does not have categories with additional information but
+        with `reverse_id` it will not insert the section title nor the section block
+        """
+
+        category1 = CategoryFactory.create(page_title="Accessible", should_publish=True)
+        category2 = CategoryFactory.create(
+            page_title="Earth and universe sciences", should_publish=True
+        )
+        icon1 = CategoryFactory.create(
+            page_title="Available on edX.org", should_publish=True
+        )
+        icon2 = CategoryFactory.create(
+            page_title="Payment promotion", should_publish=True
+        )
+
+        for component in [category1, category2, icon1, icon2]:
+            reverse_id = component.extended_object.get_title().lower().replace(" ", "-")
+            component.extended_object.reverse_id = reverse_id
+            component.extended_object.save()
+            component.get_page().publish("en")
+
+        course: Course = CourseFactory.create(
+            fill_categories=[category1, category2],
+            fill_icons=[icon1, icon2],
+        )
+
+        page = course.get_page()
+        page.publish("en")
+        url = page.get_absolute_url()
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response,
+            '<div class="course-detail__additional-info course-detail__block course-detail__row">',
+        )
+
+        for question in range(1, 3):
+            self.assertNotContains(
+                response, f'<meta property="name" content="{question}. question?" />'
+            )
+            self.assertNotContains(
+                response,
+                f'<meta property="name" content="Answer of question {question}." />',
+            )


### PR DESCRIPTION
We at [NAU](https://www.nau.edu.pt/pt/) identified the need to provide more information according to the characteriscts of a course.

In quick words this PR includes:

- add `additional_information` placeholder to category detail page
- `additional_information` is a `Section` with `NestedItemPlugin` as children
- get the `additional_information` placeholder from the course detail page using the category **id** page

This PR is related to  [Contextual Course FAQ by Category #2506](https://github.com/openfun/richie/issues/2506).

## Purpose

Dynamically provide information according to a category business logic.

Through additional information content the organizations using the `Richie` can provide more specific information according to a category. For exemple, using the category **Available on edX.org** we can describe how the learner will access this course on the next platform, for exemple edX.org. It would be an advantage as well in terms of payment methods, or promotional periods, as all the courses assigned to certain category will have their additional information.

An additional information can be FAQ's or any complementary information that seems important clarify for a course. The mechanism used to make these information available is a `placeholder` called by `Addiotional Information` on the category page.

## Proposal

Provide a placeholder to be filled with varied information and at the same time be easy to maintain. The way of using is simple, described below.

### Create the content

In a category page, use the placeholder `Additional Information` to create a section with nested items. According to the category needs insert the information that sounds relevant to be shown in a course that has the corresponding category. For exemple, if the course is distribuied by another platform, the `Additional Information` in this case could describre how this process of learning works.

`Additional Information` is a `Section`, which has a title field where can be filled according to the importance of their content, that is, for additional information about frequently asked questions, the `Section` plugin can be named as **Course FAQ's**, but in other cases where this section needs to signal high importance to these information, the `Section` plugin can be name as **Extremely Important Information**, and then reduce the possibilty of learners skipping this section. It is a open field to be used according to the needs.

<img src="https://github.com/user-attachments/assets/605a880d-0f49-454b-95e4-c648d574590a" alt="drawing" width="400"/>

### On the category page it will be shown as

<img src="https://github.com/user-attachments/assets/6c00927c-30a0-4388-b3d9-e3b69ff153bd" alt="drawing" width="800"/>

<br>
<br>

### Set the page id

To dinamically create or edit a category `Additional Information` content and impact all the courses that have it, the tag 
[show_placeholder](https://docs.django-cms.org/en/latest/reference/templatetags.html#show-placeholder) is used. This tag receives as parameter, the placeholder name and the page lookup, which is interpreted as `reverse_id`. For this logic to work, in `Advanced Settings` of the category page, if it not exists, use the field **id** to register the page unique information, so the page can be found by the `show_placeholder` tag.

<br>
<br>
<img src="https://github.com/user-attachments/assets/300c1624-0c0d-469e-9546-57962d0de489" alt="drawing" width="600"/>

### Result

With added information, and **id** defined for this category page, all the courses that have this category, have also their information, as shown following in a course page.

<br>
<br>
<img src="https://github.com/user-attachments/assets/4fb72cbf-501d-4062-9239-c2f1e1c4c2d8" alt="drawing" width="800"/>

<br>
<br>
As all the information come from category page, the maintenence of these contents is excellent, by changing the category page it changes all the courses that have it.