### PR TITLE
💄(frontend) add padding on columns from 'multiple-columns' component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Make user waive its right of withdrawal when purchasing
   a course product relation with `is_withdrawable` set to `false`
 
+### Changed
+
+- Changed `multiple-columns` CSS component so its columns include a padding
+
 ## [2.30.0] - 2024-10-16
 
 ### Added

--- a/src/frontend/scss/components/templates/richie/_multiple-columns.scss
+++ b/src/frontend/scss/components/templates/richie/_multiple-columns.scss
@@ -23,11 +23,6 @@
     padding: 1rem;
   }
 
-  // Impose tiny horizontal padding to every section row
-  .section__row {
-    padding: $cell-gutter;
-  }
-
   // ----------
   // Shared base adjustments for short columns (25+33+50)
   // ----------
@@ -117,6 +112,8 @@
   // ----------
   &__w25 {
     @include sv-flex(1, 0, 100%);
+    padding: $cell-gutter;
+
     @include media-breakpoint-up(lg) {
       @include sv-flex(1, 0, 25%);
     }
@@ -169,6 +166,8 @@
   // ----------
   &__w33 {
     @include sv-flex(1, 0, 100%);
+    padding: $cell-gutter;
+
     @include media-breakpoint-up(lg) {
       @include sv-flex(1, 0, 33.3333%);
     }
@@ -193,6 +192,8 @@
   // ----------
   &__w50 {
     @include sv-flex(1, 0, 100%);
+    padding: $cell-gutter;
+
     @include media-breakpoint-up(lg) {
       @include sv-flex(1, 0, 50%);
     }
@@ -268,6 +269,8 @@
   // ----------
   &__w75 {
     @include sv-flex(1, 0, 100%);
+    padding: $cell-gutter;
+
     @include media-breakpoint-up(lg) {
       @include sv-flex(1, 0, 75%);
     }


### PR DESCRIPTION
## Purpose

Currently only the section content included in multiple columns nicely fit into multiple column templates because they already include their own spacing. But everything else look almost sticked each other because content like plain text or image does not have any spacing.

## Proposal

This adds horizontal and vertical padding on all sizes columns from the `.multiple-columns` CSS component to improve layout with all plugins. The section contents still look nice, especially the section grids because they have been done to properly fit anywhere.

Only the CSS component for `.multiple-columns` has been changed and it don't need any change to work.

## Sample screenshot

![sample](https://github.com/user-attachments/assets/719b74d3-e386-494f-86d4-118bed83a778)

## Topography screenshot

Topography to help to see spacing between element.

![topography](https://github.com/user-attachments/assets/bda14ad1-dec0-4884-bc1f-399b86add7a6)
