### PR TITLE
Unpin/djangocms link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add Slider plugin
 
+### Fixed
+
+- Ugrade to djangocms-link 5
+
 ## [2.32.0] - 2024-11-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "Django<5",
     "djangocms-file",
     "djangocms-googlemap",
-    "djangocms-link<5",
+    "djangocms-link>=5.0.0,<6",
     "djangocms-picture",
     "djangocms-text-ckeditor",
     "djangocms-video",

--- a/renovate.json
+++ b/renovate.json
@@ -31,8 +31,7 @@
       "matchPackageNames": [
         "Django",
         "django-cms",
-        "elasticsearch",
-        "djangocms-link"
+        "elasticsearch"
       ]
     }
   ]

--- a/src/richie/apps/demo/defaults.py
+++ b/src/richie/apps/demo/defaults.py
@@ -373,47 +373,57 @@ SINGLECOLUMN_CONTENT.update(getattr(settings, "RICHIE_DEMO_SINGLECOLUMN_CONTENT"
 
 FOOTER_CONTENT = {
     "en": [
-        {"name": "About", "internal_link": "annex__about"},
-        {"name": "Sitemap", "internal_link": "annex__sitemap"},
-        {"name": "Style guide", "external_link": "/styleguide/"},
+        {"name": "About", "link": {"internal_link": "annex__about"}},
+        {"name": "Sitemap", "link": {"internal_link": "annex__sitemap"}},
+        {"name": "Style guide", "link": {"external_link": "/styleguide/"}},
         {
             "title": "Richie community",
             "items": [
-                {"name": "Website", "external_link": "https://richie.education"},
+                {
+                    "name": "Website",
+                    "link": {"external_link": "https://richie.education"},
+                },
                 {
                     "name": "Github",
-                    "external_link": "https://github.com/openfun/richie",
+                    "link": {"external_link": "https://github.com/openfun/richie"},
                 },
                 {
                     "name": "Site factory",
-                    "external_link": "https://github.com/openfun/richie-site-factory",
+                    "link": {
+                        "external_link": "https://github.com/openfun/richie-site-factory"
+                    },
                 },
                 {
                     "name": "Example site",
-                    "external_link": "https://www.fun-campus.fr",
+                    "link": {"external_link": "https://www.fun-campus.fr"},
                 },
             ],
         },
     ],
     "fr": [
-        {"name": "A propos", "internal_link": "annex__about"},
-        {"name": "Plan du site", "internal_link": "annex__sitemap"},
-        {"name": "Style guide", "external_link": "/styleguide/"},
+        {"name": "A propos", "link": {"internal_link": "annex__about"}},
+        {"name": "Plan du site", "link": {"internal_link": "annex__sitemap"}},
+        {"name": "Style guide", "link": {"external_link": "/styleguide/"}},
         {
             "title": "Communauté Richie",
             "items": [
-                {"name": "Site web", "external_link": "https://richie.education"},
+                {
+                    "name": "Site web",
+                    "link": {"external_link": "https://richie.education"},
+                },
                 {
                     "name": "Github",
-                    "external_link": "https://github.com/openfun/richie",
+                    "link": {"external_link": "https://github.com/openfun/richie"},
                 },
                 {
                     "name": "Usine à sites",
-                    "external_link": "https://github.com/openfun/richie-site-factory",
+                    "link": {
+                        "external_link": "https://github.com/openfun/richie-site-factory"
+                    },
                 },
                 {
                     "name": "Site exemple",
-                    "external_link": "https://www.fun-campus.fr",
+                    "link": {"external_link": "https://www.fun-campus.fr"},
                 },
             ],
         },

--- a/src/richie/apps/demo/management/commands/create_demo_site.py
+++ b/src/richie/apps/demo/management/commands/create_demo_site.py
@@ -81,6 +81,9 @@ def create_demo_site():
     # Create pages as described in PAGES_INFOS
     pages_created = recursive_page_creation(site, defaults.PAGES_INFO)
 
+    def get_internal_link(page):
+        return f"cms.page:{page.id}"
+
     # Create the footer links
     def create_footer_link(**link_info):
         """
@@ -89,9 +92,10 @@ def create_demo_site():
         Links can be nested into a NestedItemPlugin, in this case link_info contains
         a target key.
         """
-        if "internal_link" in link_info:
+        if "internal_link" in link_info["link"]:
             link_info = link_info.copy()
-            link_info["internal_link"] = pages_created[link_info["internal_link"]]
+            link_page = pages_created[link_info["link"]["internal_link"]]
+            link_info["link"] = {"internal_link": get_internal_link(link_page)}
         add_plugin(plugin_type="LinkPlugin", **link_info)
 
     footer_static_ph = StaticPlaceholder.objects.get_or_create(code="footer")[0]
@@ -486,7 +490,7 @@ def create_demo_site():
             target=courses_section,
             name=content["courses_button_title"],
             template=content["button_template_name"],
-            internal_link=pages_created["courses"],
+            link={"internal_link": get_internal_link(pages_created["courses"])},
         )
 
         # Add highlighted blogposts
@@ -512,7 +516,7 @@ def create_demo_site():
             target=blogposts_section,
             name=content["blogposts_button_title"],
             template=content["button_template_name"],
-            internal_link=pages_created["blogposts"],
+            link={"internal_link": get_internal_link(pages_created["blogposts"])},
         )
 
         # Add highlighted programs
@@ -538,7 +542,7 @@ def create_demo_site():
             target=programs_section,
             name=content["programs_button_title"],
             template=content["button_template_name"],
-            internal_link=pages_created["programs"],
+            link={"internal_link": get_internal_link(pages_created["programs"])},
         )
 
         # Add highlighted organizations
@@ -566,7 +570,7 @@ def create_demo_site():
             target=organizations_section,
             name=content["organizations_button_title"],
             template=content["button_template_name"],
-            internal_link=pages_created["organizations"],
+            link={"internal_link": get_internal_link(pages_created["organizations"])},
         )
 
         # Add highlighted subjects
@@ -592,7 +596,7 @@ def create_demo_site():
             target=subjects_section,
             name=content["subjects_button_title"],
             template=content["button_template_name"],
-            internal_link=pages_created["categories"],
+            link={"internal_link": get_internal_link(pages_created["categories"])},
         )
 
         # Add highlighted persons
@@ -618,7 +622,7 @@ def create_demo_site():
             target=persons_section,
             name=content["persons_button_title"],
             template=content["button_template_name"],
-            internal_link=pages_created["persons"],
+            link={"internal_link": get_internal_link(pages_created["persons"])},
         )
 
         # Add Glimpse quotes with empty title
@@ -756,7 +760,7 @@ def create_demo_site():
             target=sample_section,
             name=content["section_sample_button_title"],
             template=content["button_template_name"],
-            internal_link=pages_created["home"],
+            link={"internal_link": get_internal_link(pages_created["home"])},
         )
         # Add a licence
         if licences:

--- a/tests/plugins/section/test_templates_section_default.py
+++ b/tests/plugins/section/test_templates_section_default.py
@@ -27,7 +27,7 @@ class DefaultTemplatesTestCase(CMSPluginTestCase):
             placeholder,
             plugin_type="LinkPlugin",
             language="en",
-            external_link="http://www.example.com/1",
+            link={"external_link": "http://www.example.com/1"},
             name="Example 1",
             target=parent,
         )
@@ -35,7 +35,7 @@ class DefaultTemplatesTestCase(CMSPluginTestCase):
             placeholder,
             plugin_type="LinkPlugin",
             language="en",
-            external_link="http://www.example.com/2",
+            link={"external_link": "http://www.example.com/2"},
             name="Example 2",
             target=parent,
         )
@@ -159,7 +159,7 @@ class DefaultTemplatesTestCase(CMSPluginTestCase):
                 placeholder,
                 plugin_type="LinkPlugin",
                 language="en",
-                external_link="http://www.example.com/1",
+                link={"external_link": "http://www.example.com/1"},
                 name="Example 1",
                 target=parent,
             )
@@ -167,7 +167,7 @@ class DefaultTemplatesTestCase(CMSPluginTestCase):
                 placeholder,
                 plugin_type="LinkPlugin",
                 language="en",
-                external_link="http://www.example.com/2",
+                link={"external_link": "http://www.example.com/2"},
                 name="Example 2",
                 target=parent,
             )


### PR DESCRIPTION
## Purpose

Django CMS Link 5 has been released and introduces some breaking change. We have to update our demo site script to work with this new version. (This version has been already used on our preproduction and production environment and related migrations have been applied so we have no other choice to upgrade...)

~Furthermore currently some packages are not pinned and this may lead to introduce bugs
during deployment that we are not able to detect during development phase
that is really weird.~ -> Will be addressed in a dedicated PR
