### PR TITLE
🐛(frontend) fix Enroll now translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     use them in a course page
 - Added new page extension `MainMenuEntry`
 
+### Fixed
+
+- Fix frontend translation of Enroll now for external LMS backend
+
 ## [2.33.0] - 2024-12-02
 
 ### Added

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRun/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRun/index.tsx
@@ -11,6 +11,16 @@ import CourseRunEnrollment from '../CourseRunEnrollment';
 import CourseProductItem from '../CourseProductItem';
 
 const messages = defineMessages({
+  enrollNow: {
+    id: 'components.SyllabusCourseRun.enrollNow',
+    description: 'CTA for users to enroll on ongoing of future open course.',
+    defaultMessage: 'Enroll now',
+  },
+  studyNow: {
+    id: 'components.SyllabusCourseRun.studyNow',
+    description: 'CTA for users to enroll on archived course.',
+    defaultMessage: 'Study now',
+  },
   enrollment: {
     id: 'components.SyllabusCourseRun.enrollment',
     description: 'Title of the enrollment dates section of an opened course run block',
@@ -94,7 +104,12 @@ const OpenedCourseRun = ({
         <CourseRunEnrollment courseRun={courseRun} />
       ) : (
         <Button className="course-run-enrollment__cta" href={courseRun.resource_link} fullWidth>
-          {StringHelper.capitalizeFirst(courseRun.state.call_to_action)}
+          {courseRun.state.call_to_action === 'enroll now' ? (
+            <FormattedMessage {...messages.enrollNow} />
+          ) : null}
+          {courseRun.state.call_to_action === 'study now' ? (
+            <FormattedMessage {...messages.studyNow} />
+          ) : null}
         </Button>
       )}
     </>

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted/index.tsx
@@ -11,6 +11,16 @@ import CourseRunEnrollment from '../CourseRunEnrollment';
 import CourseProductItem from '../CourseProductItem';
 
 const messages = defineMessages({
+  enrollNow: {
+    id: 'components.SyllabusCourseRunCompacted.enrollNow',
+    description: 'CTA for users to enroll on ongoing of future open course.',
+    defaultMessage: 'Enroll now',
+  },
+  studyNow: {
+    id: 'components.SyllabusCourseRunCompacted.studyNow',
+    description: 'CTA for users to enroll on archived course.',
+    defaultMessage: 'Study now',
+  },
   course: {
     id: 'components.SyllabusCourseRunCompacted.course',
     description: 'Title of the course dates section of an opened course run block',
@@ -78,7 +88,12 @@ const OpenedSelfPacedCourseRun = ({
         <CourseRunEnrollment courseRun={courseRun} />
       ) : (
         <Button className="course-run-enrollment__cta" href={courseRun.resource_link} fullWidth>
-          {StringHelper.capitalizeFirst(courseRun.state.call_to_action)}
+          {courseRun.state.call_to_action === 'enroll now' ? (
+            <FormattedMessage {...messages.enrollNow} />
+          ) : null}
+          {courseRun.state.call_to_action === 'study now' ? (
+            <FormattedMessage {...messages.studyNow} />
+          ) : null}
         </Button>
       )}
     </>


### PR DESCRIPTION
When using an external LMS, the CTA Enroll now on course runs isn't being translated.

Replace https://github.com/openfun/richie/pull/2246

Screenshot on French, is still showing the `Enroll now` on English.
![image](https://github.com/user-attachments/assets/3c7f4570-f4cc-4f35-8ace-37881fd413e3)

Fixed version:
![image](https://github.com/user-attachments/assets/be17d46a-647a-401a-b4bc-54bc741a5d7d)

The course run needs to have something completely different URL that don't match the course regex configured.
Ex: https://lms.nau.edu.pt/course_modes/choose/course-v1:NOVA+FEEF+2023_T2/

To test locally, it requires to add to the file `src/frontend/i18n/locales/fr-FR.json`
```json
  "components.SyllabusCourseRun.enrollNow": {
    "description": "CTA for users to enroll on ongoing of future open course.",
    "message": "S'inscrire maintenant"
  },
  "components.SyllabusCourseRunCompacted.enrollNow": {
    "description": "CTA for users to enroll on ongoing of future open course.",
    "message": "S'inscrire maintenant"
  }
```