### PR TITLE
Add branding_topbar_logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Change `SearchInput` to have a label, for accessibility purposes
 - Use new credit card promote endpoint
 - Allow user to remove a main credit card
+- Change `branding_topbar` to have and additonal layer in `branding_topbar_logo`
 
 ### Fixed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -56,6 +56,11 @@ $ make migrate
   Other page levels won't be allowed to create a PageIndex extension. Commonly it would
   be `0` for when your main menu list the root pages.
 
+- After the change to the `base.html` template, you will now need to add the
+  `branding_topbar_logo` block to the `branding_topbar` block to have the same functionality.
+  If this remains the same in any site on your site factory, the `Go to homepage` link won't be
+  available.
+
 ## 2.31.0 to 2.33.0
 
 - Add new `slider` plugin theme scheme:

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -98,11 +98,13 @@
                     <div class="topbar__container">
                         <header class="topbar__header">
                             <div class="topbar__brand">
-                                <a href="/" title="{% trans "Go to homepage" %}" rel="home" accesskey="h">
                                 {% block branding_topbar %}
+                                <a href="/" title="{% trans "Go to homepage" %}" rel="home" accesskey="h">
+                                    {% block branding_topbar_logo %}
                                     <img src="{% static "richie/images/logo.png" %}" class="topbar__logo" alt="{{ SITE.name }}">
-                                {% endblock branding_topbar %}
+                                    {% endblock branding_topbar_logo %}
                                 </a>
+                                {% endblock branding_topbar %}
 
                                 <button
                                     class="topbar__hamburger"


### PR DESCRIPTION
## Purpose
The current implementation of `base.html` template doesn't allow us to customize the link on the `branding_topbar`, only the logo.

## Additional context
We received information form our accessibility regulation national agency that our site was not compliant. One of the things they highlighted is that the homepage `h1` does not have enough context and that It would be more relevant to have it associated with the page branding (the top logo).

The suggestion is to only have a "Go back to main page" link if you're not on the main page. Also, if you're on the main page, you should see the `h1` around the image.

```html
<h1>                   
   <img src="your logo" alt="Richie">
</h1>
```

If you want to, you can use a different strategy:

```html
<h1>     
   <img src="your logo" alt="Richie" aria-hidden="true">
   <span class="offscreen">Richie website</span>
</h1>
```

The `<a>` should only be present when you're not on the main page. The `h1` is then replaced with `a`.

## Proposal
Add a new block to host the site image and move the previous one to the outer block. 
This will allow us to override the `branding_topbar` and the outer link behaviour for a11y purposes.