### PR TITLE
✨(section) add new section grid distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Topbar dropdown menu layout and accessibility interactions
+- Add two new section grid distributions to better accomodate for 
+  course cards
 
 ### Changed
 

--- a/src/frontend/scss/settings/_variables.scss
+++ b/src/frontend/scss/settings/_variables.scss
@@ -175,6 +175,8 @@ $r-section-grid-sizes: (
   '33x33x33': 1fr 1fr 1fr,
   '25x75': 25% 2fr,
   '75x25': 2fr 25%,
+  '35x65': 35% 2fr,
+  '65x35': 2fr 35%,
 );
 
 // Define gutter size to apply on Section grid

--- a/src/richie/plugins/section/defaults.py
+++ b/src/richie/plugins/section/defaults.py
@@ -31,5 +31,7 @@ SECTION_GRID_COLUMNS = getattr(
         ("50x50", _("Two columns: (50% | 50%)")),
         ("25x75", _("Two columns: (25% | 75%)")),
         ("75x25", _("Two columns: (75% | 25%)")),
+        ("35x65", _("Two columns: (35% | 65%)")),
+        ("65x35", _("Two columns: (65% | 35%)")),
     ],
 )


### PR DESCRIPTION
Introduce two new grid options for better layout distribution when using course cards or program cards. 
- 35x65 
- 65x35 

**Issue**
https://github.com/openfun/richie/issues/2570
