### PR TITLE
🐛(frontend) fix little issues about dropdown menu

### DIFF
--- a/src/richie/apps/core/templates/menu/header_menu.html
+++ b/src/richie/apps/core/templates/menu/header_menu.html
@@ -4,7 +4,7 @@
     {% with children_slug=child.get_menu_title|slugify menu_options=child.menu_extension %}
         <li class="topbar__item
             {% if menu_options.allow_submenu and child.children %}dropdown{% endif %}
-            {% if menu_options.allow_submenu and menu_options.menu_color %} topbar__item--{{ menu_options.menu_color }}{% endif %}"
+            {% if menu_options.allow_submenu and menu_options.menu_color %} topbar__item--{{ menu_options.menu_color }}{% endif %}
             {% if child.selected or child.attr.redirect_url == current_page.get_absolute_url %} topbar__item--selected{% endif %}
             {% if child.ancestor %} topbar__item--ancestor{% endif %}
             {% if child.sibling %} topbar__item--sibling{% endif %}

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -301,7 +301,7 @@
                     });
                 }
 
-                function _openDropdown($button) {
+                function _openDropdown($button, focus = false) {
                     $button.setAttribute('aria-expanded', 'true');
                     // Set up focus trap and event listeners when opening
                     const $dropdown = document.getElementById($button.getAttribute('aria-controls'));
@@ -311,7 +311,7 @@
                         item.addEventListener('keydown', _handleMenuItemKeydown);
                     });
                     // Focus first menu item
-                    if ($menuItems.length) $menuItems[0].focus();
+                    if (focus && $menuItems.length) $menuItems[0].focus();
                 }
 
                 /**
@@ -369,7 +369,7 @@
                     $button.addEventListener('keydown', (event) => {
                         if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
                             event.preventDefault();
-                            _openDropdown($button);
+                            _openDropdown($button, true);
                         }
                     });
 


### PR DESCRIPTION
## Purpose

The active menu entry selected class was not applied due to a typo
 into the html template. Furthermore, when the dropdown was opened
 the first item was focused. It is relevant when user is using keyboard but not
 when it is using its mouse so we update the code to only focus first item when
 user is using its keyboard.
