### PR TITLE
🐛(frontend) fix edge case with topbar dropdown menu

### DIFF
--- a/src/frontend/scss/components/_header.scss
+++ b/src/frontend/scss/components/_header.scss
@@ -241,12 +241,8 @@
           display: none;
           position: absolute;
           transform: translateX(-8px);
+          width: max-content;
           max-width: 100%;
-
-          &--full-width {
-            left: 0;
-            transform: inherit;
-          }
 
           & > ul[role='menu'] {
             display: flex;
@@ -267,6 +263,15 @@
               background-color: var(--active-background-color);
               color: var(--active-text-color);
             }
+          }
+
+          &--full-width {
+            left: 0;
+            transform: inherit;
+          }
+
+          &--position-right {
+            transform: translateX(calc(-100% + (var(--button-width) + 8px)));
           }
         }
       }

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -275,6 +275,7 @@
                     const $menuButton = $dropdown.previousElementSibling;
                     const topbarWidth = $topbar.getBoundingClientRect().width;
                     const topbarLeft = $topbar.getBoundingClientRect().left;
+                    const menuButtonWidth = $menuButton.getBoundingClientRect().width;
                     const menuButtonLeft = $menuButton.getBoundingClientRect().left;
                     $dropdown.style.display = 'block';
                     $menu.style.flexWrap = 'nowrap';
@@ -282,11 +283,21 @@
                     $dropdown.style = '';
                     $menu.style = '';
                     const menuRelativeOffsetX = menuButtonLeft - topbarLeft;
+                    const rightRemainingSpace = topbarWidth - menuRelativeOffsetX;
 
-                    
-                    if (menuWidth > (topbarWidth - menuRelativeOffsetX)) {
-                        $dropdown.classList.add('topbar__sublist--full-width');
-                    } else {
+                    if (menuWidth > rightRemainingSpace) {
+                        if (menuWidth < (menuRelativeOffsetX + menuButtonWidth)) {
+                            $dropdown.classList.add('topbar__sublist--position-right');
+                            $dropdown.style.setProperty('--button-width', `${menuButtonWidth}px`);
+                            $dropdown.classList.remove('topbar__sublist--full-width');
+                        }
+                        else {
+                            $dropdown.classList.add('topbar__sublist--full-width');
+                            $dropdown.classList.remove('topbar__sublist--position-right');
+                        }
+                    }
+                    else {
+                        $dropdown.classList.remove('topbar__sublist--position-right');
                         $dropdown.classList.remove('topbar__sublist--full-width');
                     }
                 }


### PR DESCRIPTION
## Purpose

In some case, the dropdown menu does not need to be full width
but it has not enough remaining space on its right to be displayed
properly. So we manage this case and align the menu on left in those case.



https://github.com/user-attachments/assets/e6884e15-afab-4c26-8a2b-58a4564da8a8





