### PR TITLE
Add above_header block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Topbar dropdown menu layout and accessibility interactions
 - Add two new section grid distributions to better accomodate for 
   course cards
+- Added a new `above_header` block to the base template to allow for better
+  header customization
 
 ### Changed
 

--- a/src/richie/apps/core/templates/richie/base.html
+++ b/src/richie/apps/core/templates/richie/base.html
@@ -88,6 +88,9 @@
         {# First link on a website should always be a skip to content #}
         {# Access key directive allows users to use keyboard shortcuts #}
         <a href="#site-content" class="offscreen-focusable skip-to-content" accesskey="c">{% trans "Skip to main content" %}</a>
+            
+            {# The above_header allows you to place content like notifications or navigation bars on the top of the page #}
+            {% block above_header %}{% endblock above_header %}
         
             {% block body_header %}
 


### PR DESCRIPTION
## Purpose

With the proposed changes to the NAU site, there's a need to create a new, above the header, company wide bar that should contain a link to the brand site.

## Proposal

Add a new `above_header` block for better header customization.
