### PR TITLE
🔧 (makefile) copy settings.dev.ts at bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ bootstrap: \
   env.d/development/dev \
   env.d/development/dev-ssl \
   env.d/development/crowdin \
+  src/frontend/js/settings/settings.dev.ts \
   data/media/.keep \
   data/smedia/.keep \
   data/static/.keep \
@@ -343,6 +344,9 @@ env.d/development/dev-ssl:
 
 env.d/development/crowdin:
 	cp env.d/development/crowdin.dist env.d/development/crowdin
+
+src/frontend/js/settings/settings.dev.ts:
+	cp src/frontend/js/settings/settings.dev.dist.ts src/frontend/js/settings/settings.dev.ts
 
 data/media/.keep:
 	@echo 'Preparing media volume...'


### PR DESCRIPTION
## Purpose

Add settings.dev.ts to the bootstrap process and create a target to copy its content from settings.dev.dist.ts, ensuring proper setup for development environments.