### PR TITLE
💄(frontend) remove course-glimpse background color

### DIFF
--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -46,7 +46,6 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
   // Apply card styles for elements
   @include m-o-card(
     $border: 0,
-    $background: r-theme-val(course-glimpse, card-background),
     $media-margin: 0,
     $wrapper-padding: 1.7rem $course-glimpse-content-padding-sides 0.5rem,
     $foot-divider: null


### PR DESCRIPTION
## Purpose

We recently revamp the HTML structure of the course glimpse but we forgot to remove the background color applied to the `.course-glimpse` element. This was invisible until the course glimpse was displayed on a background other than white...

| Before | After |
|--------|-------|
|<img width="260" alt="Capture d’écran 2025-03-27 à 16 00 19" src="https://github.com/user-attachments/assets/b5cd78cb-c7d6-41ea-927e-0a72591c3c2f" />|<img width="260" alt="Capture d’écran 2025-03-27 à 16 00 00" src="https://github.com/user-attachments/assets/6eb55c5a-87cf-467e-b3aa-5d1404c2d6c9" />|