### PR TITLE
💄(frontend) fix variable course glimpse height

### DIFF
--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -4,6 +4,7 @@
 
 // Course-glimpse-list related variables
 $r-course-glimpse-gutter: 0.8rem !default;
+$r-course-glimpse-title-line-height: 1.3em;
 
 .course-glimpse-list {
   @include make-container-max-widths();
@@ -174,7 +175,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     font-family: $r-font-family-montserrat;
     font-weight: $font-weight-boldest;
     flex: 1 0 1.3em * 3; // 3 lines;
-    line-height: 1.3em;
+    line-height: $r-course-glimpse-title-line-height;
     margin-bottom: 1rem;
   }
 
@@ -199,11 +200,14 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
   }
 
   &__title-text {
+    --max-lines: 3;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: var(--max-lines);
+    line-clamp: var(--max-lines);
     display: block;
     display: -webkit-box;
     overflow: hidden;
+    min-height: calc($r-course-glimpse-title-line-height * var(--max-lines));
   }
 
   &__link:focus &__title-text {


### PR DESCRIPTION
## Purpose

Currently, if a course glimpse with a long title that goes on 3 lines the glimpse height is higher than other glimpse.

| Before | After |
|--------|-------|
|<img width="800" alt="Capture d’écran 2025-04-02 à 08 37 40" src="https://github.com/user-attachments/assets/24b9a083-4a98-4598-860b-b8d7b96f4b63" />|<img width="800" alt="Capture d’écran 2025-04-02 à 08 37 16" src="https://github.com/user-attachments/assets/d1e6cd07-a11a-4168-8ce3-05180524bec8" />|


