### PR TITLE
🐛(video_player) fix lazy load video player for programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix building site from cookicutter
+- Fix lazy load video player mode for programs
 
 ## [3.0.0] - 2025-04-03
 

--- a/src/richie/apps/core/templates/djangocms_video/default/video_player.html
+++ b/src/richie/apps/core/templates/djangocms_video/default/video_player.html
@@ -17,7 +17,7 @@ on the browser and external video platform implementations.
     {# show iframe if embed_link is provided #}
     <div class="aspect-ratio">
         {% if RICHIE_VIDEO_PLUGIN_LAZY_LOADING %}
-            <a class="video-player-image" onclick="this.style.display='none'; this.nextSibling.style.display='block'; this.nextSibling.src=this.nextSibling.getAttribute('data-src');" href="javascript:void(0)">
+            <a class="video-player-image" onclick="this.style.display='none'; this.parentNode.getElementsByTagName('iframe')[0].style.display='block'; this.parentNode.getElementsByTagName('iframe')[0].src=this.parentNode.getElementsByTagName('iframe')[0].getAttribute('data-src');" href="javascript:void(0)">
                 {% if instance.poster %}
                     <img
                         src='{% thumbnail instance.poster.url 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.poster.subject_location %}'
@@ -31,6 +31,9 @@ on the browser and external video platform implementations.
                     />
                 {% else %}
                     {% placeholder_as_plugins "course_cover" as cover_plugins %}
+                    {% if cover_plugins|length == 0 %}
+                        {% placeholder_as_plugins "program_cover" as cover_plugins %}
+                    {% endif %}
                     {% blockplugin cover_plugins.0 %}
                         <img
                             src='{% thumbnail instance.picture 300x170 replace_alpha='#FFFFFF' crop upscale subject_location=instance.picture.subject_location %}'

--- a/tests/apps/core/test_videoplayer.py
+++ b/tests/apps/core/test_videoplayer.py
@@ -7,7 +7,7 @@ from django.test.utils import override_settings
 import lxml.html  # nosec
 from cms.test_utils.testcases import CMSTestCase
 
-from richie.apps.courses.factories import CourseFactory, VideoSample
+from richie.apps.courses.factories import CourseFactory, ProgramFactory, VideoSample
 
 
 class CoursesTemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
@@ -33,7 +33,6 @@ class CoursesTemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
         """
         video_sample = self.video_sample_without_image
         course = CourseFactory(fill_teaser=video_sample, should_publish=True)
-
         response = self.client.get(course.extended_object.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         html = lxml.html.fromstring(response.content)
@@ -64,8 +63,60 @@ class CoursesTemplatesCourseDetailRenderingCMSTestCase(CMSTestCase):
             fill_cover={"original_filename": cover_file_name},
             should_publish=True,
         )
-
         response = self.client.get(course.extended_object.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        html = lxml.html.fromstring(response.content)
+        iframe = html.cssselect(".subheader__teaser .aspect-ratio iframe")[0]
+        self.assertEqual(iframe.get("data-src"), video_sample.url + "?&autoplay=1")
+        self.assertEqual(iframe.get("title"), video_sample.label)
+        self.assertEqual(iframe.get("style"), "display: none;")
+        self.assertIn("allowfullscreen", iframe.keys())
+        img = html.cssselect(".subheader__teaser .aspect-ratio a img")[0]
+        self.assertIn(cover_file_name, img.get("src"))
+
+    @override_settings(RICHIE_VIDEO_PLUGIN_LAZY_LOADING=True)
+    def test_templates_program_detail_teaser_video_cover_empty_lazy_play(self):
+        """
+        When the `program_teaser` placeholder is filled with a VideoPlayerPlugin.
+        The program page should return an empty video cover image if:
+        - the video poster image is empty;
+        - the program page hasn't any `program_cover` placeholder.
+        When the `RICHIE_VIDEO_PLUGIN_LAZY_LOADING` is activated, the video iframe should be
+        hidden.
+        """
+        video_sample = self.video_sample_without_image
+        program = ProgramFactory(fill_teaser=video_sample, should_publish=True)
+        response = self.client.get(program.extended_object.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        html = lxml.html.fromstring(response.content)
+        iframe = html.cssselect(".subheader__teaser .aspect-ratio iframe")[0]
+        self.assertEqual(iframe.get("data-src"), video_sample.url + "?&autoplay=1")
+        self.assertEqual(iframe.get("title"), video_sample.label)
+        self.assertEqual(iframe.get("style"), "display: none;")
+        self.assertIn("allowfullscreen", iframe.keys())
+        # no video cover image
+        self.assertEqual(
+            len(html.cssselect(".subheader__teaser .aspect-ratio a img")), 0
+        )
+
+    @override_settings(RICHIE_VIDEO_PLUGIN_LAZY_LOADING=True)
+    def test_templates_program_detail_teaser_video_cover_from_program_cover(self):
+        """
+        When the `program_teaser` placeholder is filled with a VideoPlayerPlugin,
+        the program page should display the program cover image if:
+        - the video poster image is empty;
+        - the program page has a `program_cover` placeholder.
+        When the `RICHIE_VIDEO_PLUGIN_LAZY_LOADING` setting is activated, the video iframe
+        should be hidden, and the cover image should be displayed instead.
+        """
+        cover_file_name = cover_file_name = "cover.jpg"
+        video_sample = self.video_sample_without_image
+        program = ProgramFactory(
+            fill_teaser=video_sample,
+            fill_cover={"original_filename": cover_file_name},
+            should_publish=True,
+        )
+        response = self.client.get(program.extended_object.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         html = lxml.html.fromstring(response.content)
         iframe = html.cssselect(".subheader__teaser .aspect-ratio iframe")[0]


### PR DESCRIPTION
When showing a video player on programs with the
`RICHIE_VIDEO_PLUGIN_LAZY_LOADING` setting enabled it was raising a Javascript error.
This change makes the element swap more resilient for the both cases courses and programs page.
