### PR TITLE
👷(gitlint) fix gitlint warning

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,8 +1,8 @@
 # All these sections are optional, edit this file as you like.
 [general]
+regex-style-search=true
 # Ignore certain rules, you can reference them by their id or by their full name
 # ignore=title-trailing-punctuation, T3
-
 # verbosity should be a value between 1 and 3, the commandline -v flags take precedence over this
 # verbosity = 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix building site from cookicutter
 - Fix lazy load video player mode for programs
+- Fix gitlint warning
 
 ## [3.0.0] - 2025-04-03
 


### PR DESCRIPTION
This commit re-configures the gitlint so it no longer outputs a warning.

```
WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details:
https://jorisroovers.github.io/gitlint/configuration/#regex-style-search
```

To test it run the `gitlint` command.

Before:

```bash
$ gitlint
WARNING: I1 - ignore-by-title: gitlint will be switching from using Python regex 'match' (match beginning) to 'search' (match anywhere) semantics. Please review your ignore-by-title.regex option accordingly. To remove this warning, set general.regex-style-search=True. More details: https://jorisroovers.github.io/gitlint/configuration/#regex-style-search
```

After:

```bash
$ gitlint
```