### PR TITLE
✨(backend) exclude non listed courses from list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
+### Changed
+
+- Hide courses that are not `is_listed` in public pages
+
 ## [3.1.2] - 2025-05-22
 
 ### Added

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
@@ -545,7 +545,12 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 "level": "ERROR",
                 "handlers": ["console"],
                 "propagate": False,
-            }
+            },
+            "richie": {
+                "level": values.Value("ERROR", environ_name="RICHIE_LOGGING_LEVEL"),
+                "handlers": ["console"],
+                "propagate": False,
+            },
         },
     }
 

--- a/src/richie/apps/courses/models/category.py
+++ b/src/richie/apps/courses/models/category.py
@@ -71,7 +71,10 @@ class Category(EsIdMixin, BasePageExtension):
         """
         return self.get_reverse_related_page_extensions(
             "course", language=language, include_descendants=include_descendants
-        ).filter(extended_object__node__parent__cms_pages__course__isnull=True)
+        ).filter(
+            extended_object__node__parent__cms_pages__course__isnull=True,
+            is_listed=True,
+        )
 
     def get_blogposts(self, language=None, include_descendants=True):
         """

--- a/src/richie/apps/courses/models/course.py
+++ b/src/richie/apps/courses/models/course.py
@@ -180,7 +180,7 @@ class Course(EsIdMixin, BasePageExtension):
     is_listed = models.BooleanField(
         default=True,
         verbose_name=_("is listed"),
-        help_text=_("Tick if you want the course to be visible on the search page."),
+        help_text=_("Tick if you want the course to be visible."),
     )
 
     is_self_paced = models.BooleanField(

--- a/src/richie/apps/courses/models/organization.py
+++ b/src/richie/apps/courses/models/organization.py
@@ -147,7 +147,10 @@ class Organization(EsIdMixin, BasePageExtension):
         """
         return self.get_reverse_related_page_extensions(
             "course", language=language
-        ).filter(extended_object__node__parent__cms_pages__course__isnull=True)
+        ).filter(
+            extended_object__node__parent__cms_pages__course__isnull=True,
+            is_listed=True,
+        )
 
     def get_persons(self, language=None):
         """

--- a/src/richie/apps/courses/models/person.py
+++ b/src/richie/apps/courses/models/person.py
@@ -50,7 +50,10 @@ class Person(EsIdMixin, BasePageExtension):
         """
         return self.get_reverse_related_page_extensions(
             "course", language=language
-        ).filter(extended_object__node__parent__cms_pages__course__isnull=True)
+        ).filter(
+            extended_object__node__parent__cms_pages__course__isnull=True,
+            is_listed=True,
+        )
 
     def get_blogposts(self, language=None):
         """

--- a/src/richie/apps/courses/models/program.py
+++ b/src/richie/apps/courses/models/program.py
@@ -14,6 +14,7 @@ from ...core.fields.duration import CompositeDurationField
 from ...core.models import BasePageExtension
 from .. import defaults
 from .category import Category, CategoryPluginModel
+from .course import Course, CoursePluginModel
 from .organization import Organization, OrganizationPluginModel
 from .person import Person, PersonPluginModel
 
@@ -113,6 +114,19 @@ class Program(BasePageExtension):
         return self.get_direct_related_page_extensions(
             Person, PersonPluginModel, language=language
         )
+
+    def get_courses(self, language=None):
+        """
+        Return the courses linked to the program via a course plugin in any of the
+        placeholders on the program detail page, ranked by their `path` to respect
+        the order in the courses tree.
+        The courses are filtered to only include those that are listed and published.
+        """
+        courses = self.get_direct_related_page_extensions(
+            Course, CoursePluginModel, language=language
+        ).filter(is_listed=True)
+
+        return [course for course in courses if course.check_publication(language)]
 
     def save(self, *args, **kwargs):
         """

--- a/src/richie/apps/courses/templates/courses/cms/program_detail.html
+++ b/src/richie/apps/courses/templates/courses/cms/program_detail.html
@@ -191,7 +191,7 @@
     </div>
     {% endif %}
 
-    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"program_courses" %}
+    {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"program_courses" or current_page.program.get_courses|length > 0 %}
         <div class="program-detail__courses program-detail__block">
             <div class="program-detail__row">
                 <section class="course-glimpse-list">
@@ -199,7 +199,13 @@
                         <h2 class="program-detail__title">{% trans "Related courses" %}</h2>
                     </div>
                     <div class="course-glimpse-list__content">
-                        {% placeholder "program_courses" %}
+                        {% if request.toolbar.edit_mode_active %}
+                            {% placeholder "program_courses" %}
+                        {% else %}
+                            {% for course in current_page.program.get_courses %}
+                                {% include "courses/cms/fragment_course_glimpse.html" with course=course header_level=3 %}
+                            {% endfor %}
+                        {% endif %}
                     </div>
                 </section>
             </div>

--- a/tests/apps/courses/test_models_category.py
+++ b/tests/apps/courses/test_models_category.py
@@ -167,6 +167,23 @@ class CategoryModelsTestCase(TestCase):
                     course.extended_object.prefetched_titles[0].title, "my title"
                 )
 
+    def test_models_category_get_courses_not_listed(self):
+        """
+        Not listed courses should not be returned by the get_courses method.
+        """
+        category = CategoryFactory(should_publish=True)
+        CourseFactory.create_batch(
+            3,
+            page_title="my title",
+            fill_categories=[category],
+            should_publish=True,
+            is_listed=False,
+        )
+        retrieved_courses = category.get_courses()
+
+        with self.assertNumQueries(1):
+            self.assertEqual(list(retrieved_courses), [])
+
     def test_models_category_get_courses_ordering(self):
         """The related courses should be sorted by their position in the pages tree."""
         category = CategoryFactory(should_publish=True)

--- a/tests/apps/courses/test_models_organization.py
+++ b/tests/apps/courses/test_models_organization.py
@@ -280,6 +280,23 @@ class OrganizationModelsTestCase(TestCase):
                     course.extended_object.prefetched_titles[0].title, "my title"
                 )
 
+    def test_models_organization_get_courses_not_listed(self):
+        """
+        Not listed courses should not be returned by the get_courses method.
+        """
+        organization = OrganizationFactory(should_publish=True)
+        CourseFactory.create_batch(
+            3,
+            page_title="my title",
+            fill_organizations=[organization],
+            should_publish=True,
+            is_listed=False,
+        )
+        retrieved_courses = organization.get_courses()
+
+        with self.assertNumQueries(1):
+            self.assertEqual(list(retrieved_courses), [])
+
     def test_models_organization_get_courses_language_fallback_draft(self):
         """
         Validate that the reverse courses lookup works as expected with language fallback

--- a/tests/apps/courses/test_models_person.py
+++ b/tests/apps/courses/test_models_person.py
@@ -81,6 +81,23 @@ class PersonModelsTestCase(TestCase):
                     course.extended_object.prefetched_titles[0].title, "my title"
                 )
 
+    def test_models_person_get_courses_not_listed(self):
+        """
+        Not listed courses should not be returned by the get_courses method.
+        """
+        person = PersonFactory(should_publish=True)
+        CourseFactory.create_batch(
+            3,
+            page_title="my title",
+            fill_team=[person],
+            should_publish=True,
+            is_listed=False,
+        )
+        retrieved_courses = person.get_courses()
+
+        with self.assertNumQueries(1):
+            self.assertEqual(list(retrieved_courses), [])
+
     def test_models_person_get_courses_language_fallback_draft(self):
         """
         Validate that the reverse courses lookup works as expected with language fallback


### PR DESCRIPTION

## Purpose

When a course is hidden from the search results, it should also be hidden from lists.

Fixes #2630


## Proposal

Add a filter `is_listed=True` to the models get_courses queries.
