### PR TITLE
🥅(backend) prevent any error on thumnbail generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Hide courses that are not `is_listed` in public pages
 
+### Fixed
+
+- Prevent indexation failure when any thumbnail generation fails
+
 ## [3.1.2] - 2025-05-22
 
 ### Added

--- a/src/richie/plugins/simple_picture/helpers.py
+++ b/src/richie/plugins/simple_picture/helpers.py
@@ -54,13 +54,14 @@ def get_picture_info(instance, preset_name):
     options.update(location_dict)
     try:
         picture_info["src"] = thumbnailer.get_thumbnail(options).url
-    except ValueError as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.error(
             "Error while generating thumbnail for %s with %s: %s",
             instance.picture,
             options,
             exc,
         )
+        return None
 
     # - srcset
     srcset = []
@@ -70,7 +71,7 @@ def get_picture_info(instance, preset_name):
         try:
             url = thumbnailer.get_thumbnail(options).url
             srcset.append(f"{url:s} {info['descriptor']:s}")
-        except ValueError as exc:
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error(
                 "Error while generating thumbnail for %s with %s: %s",
                 instance.picture,

--- a/tests/plugins/simple_picture/test_helpers.py
+++ b/tests/plugins/simple_picture/test_helpers.py
@@ -1,7 +1,9 @@
 """Testing helpers for Richie's simple picture plugin."""
 
+import io
 from unittest import mock
 
+from django.core.files import File
 from django.test import TestCase
 
 from filer.utils.filer_easy_thumbnails import FilerThumbnailer
@@ -106,5 +108,15 @@ class SimplePictureHelpersTestCase(TestCase):
         a picture without an image.
         """
         simple_picture = PictureFactory(picture=None)
+        info = get_picture_info(simple_picture, "my-preset")
+        self.assertEqual(info, None)
+
+    def test_helpers_simplepicture_get_picture_info_bad_format_picture(self):
+        """
+        The `get_picture_info` method should not fail and raise an error if it encounters
+        a picture badly formatted.
+        """
+        simple_picture = PictureFactory()
+        simple_picture.picture.file = File(io.BytesIO())
         info = get_picture_info(simple_picture, "my-preset")
         self.assertEqual(info, None)


### PR DESCRIPTION
## Purpose

When an indexation is run and a thumbnail generation fails, the whole process
fails. 

## Proposal

Instead of catching a specific error, this change broad-catches any error from the thumbnail generation.
