### PR TITLE
♻️(backend) adjusted ACTIVATED_DB variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Allow configuration of the `STORAGES` setting via environment variables
 - Rename `CourseProductRelation` to `Offer`
 - Only display payment schedule for credential products
+- Provide postgres as default value for `ACTIVATED_DB` variable.
 
 ### Fixed
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -1,5 +1,5 @@
 include:
-  - docker-compose-${ACTIVATED_DB}.yml
+  - docker-compose-${ACTIVATED_DB:-postgres}.yml
 services:
   elasticsearch:
     image: {{cookiecutter.elasticsearch_image_name}}
@@ -7,7 +7,7 @@ services:
       - discovery.type=single-node
     env_file:
       - "env.d/development"
-      - "env.d/${ACTIVATED_DB}"
+      - "env.d/${ACTIVATED_DB:-postgres}"
     ports:
       - "9220:9200"
     healthcheck:
@@ -30,7 +30,7 @@ services:
     env_file:
       - ".env"
       - "env.d/development"
-      - "env.d/${ACTIVATED_DB}"
+      - "env.d/${ACTIVATED_DB:-postgres}"
     networks:
       - default
       - lms_outside
@@ -40,7 +40,7 @@ services:
       - "./sites/${RICHIE_SITE:?}/src/backend:/app"
       - "./data/media/${RICHIE_SITE:?}:/data/media"
     depends_on:
-      - "${ACTIVATED_DB}"
+      - "${ACTIVATED_DB:-postgres}"
       - "elasticsearch"
       - "redis-sentinel"
     user: ${DOCKER_USER:-1000}
@@ -62,14 +62,14 @@ services:
     env_file:
       - ".env"
       - "env.d/development"
-      - "env.d/${ACTIVATED_DB}"
+      - "env.d/${ACTIVATED_DB:-postgres}"
     networks:
       - default
       - lms_outside
     volumes:
       - ./data/media/${RICHIE_SITE:?}:/data/media
     depends_on:
-      - "${ACTIVATED_DB}"
+      - "${ACTIVATED_DB:-postgres}"
       - "elasticsearch"
       - "redis-sentinel"
     user: ${DOCKER_USER:-1000}


### PR DESCRIPTION
This PR has the only intention to complete [my previous PR](https://github.com/openfun/richie/pull/2564/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) that was missing to provide postgres as default value for `ACTIVATED_DB` environment variable.