### PR TITLE
🐛(frontend) discounted price in sales tunnel for certificate product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Prevent indexation failure when any thumbnail generation fails
+- Display discounted price for the purchase of a certificate product
+  from student dashboard in sale tunnel informations
 
 ## [3.1.2] - 2025-05-22
 

--- a/src/frontend/.storybook/__mocks__/utils/context.ts
+++ b/src/frontend/.storybook/__mocks__/utils/context.ts
@@ -13,3 +13,7 @@ let context = {
 (window as any).__richie_frontend_context__ = {
   context: RichieContextFactory(context).one(),
 };
+
+(window as any).jest = {
+    fn: ((fnc: any) => fnc) as any,
+};

--- a/src/frontend/js/components/SaleTunnel/GenericSaleTunnel.tsx
+++ b/src/frontend/js/components/SaleTunnel/GenericSaleTunnel.tsx
@@ -10,7 +10,15 @@ import {
 } from 'react';
 import { SaleTunnelSponsors } from 'components/SaleTunnel/Sponsors/SaleTunnelSponsors';
 import { SaleTunnelProps } from 'components/SaleTunnel/index';
-import { Address, Offering, CreditCard, Order, OrderState, Product } from 'types/Joanie';
+import {
+  Address,
+  Enrollment,
+  Offering,
+  CreditCard,
+  Order,
+  OrderState,
+  Product,
+} from 'types/Joanie';
 import useProductOrder from 'hooks/useProductOrder';
 import { SaleTunnelSuccess } from 'components/SaleTunnel/SaleTunnelSuccess';
 import WebAnalyticsAPIHandler from 'api/web-analytics';
@@ -27,6 +35,7 @@ export interface SaleTunnelContextType {
   product: Product;
   webAnalyticsEventKey: string;
   offering?: Offering;
+  enrollment?: Enrollment;
 
   // internal
   step: SaleTunnelStep;
@@ -115,6 +124,7 @@ export const GenericSaleTunnel = (props: GenericSaleTunnelProps) => {
       order,
       product: props.product,
       offering: props.offering,
+      enrollment: props.enrollment,
       props,
       billingAddress,
       setBillingAddress,

--- a/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/index.tsx
@@ -101,7 +101,11 @@ const Email = () => {
 };
 
 const Total = () => {
-  const { product, offering } = useSaleTunnelContext();
+  const { product, offering, enrollment } = useSaleTunnelContext();
+  const totalPrice =
+    enrollment?.offerings?.[0]?.rules?.discounted_price ??
+    offering?.rules.discounted_price ??
+    product.price;
   return (
     <div className="sale-tunnel__total">
       <div className="sale-tunnel__total__amount mt-t" data-testid="sale-tunnel__total__amount">
@@ -109,11 +113,7 @@ const Total = () => {
           <FormattedMessage {...messages.totalLabel} />
         </div>
         <div className="block-title">
-          <FormattedNumber
-            value={offering?.rules.discounted_price || product.price}
-            style="currency"
-            currency={product.price_currency}
-          />
+          <FormattedNumber value={totalPrice} style="currency" currency={product.price_currency} />
         </div>
       </div>
     </div>

--- a/src/frontend/js/components/SaleTunnel/index.stories.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.stories.tsx
@@ -1,6 +1,11 @@
 import { StoryObj, Meta } from '@storybook/react';
 import { BaseJoanieAppWrapper } from 'utils/test/wrappers/BaseJoanieAppWrapper';
-import { ProductFactory } from 'utils/test/factories/joanie';
+import {
+  CertificateProductFactory,
+  EnrollmentFactory,
+  OfferingFactory,
+  ProductFactory,
+} from 'utils/test/factories/joanie';
 import { PacedCourseFactory } from 'utils/test/factories/richie';
 import { SaleTunnel, SaleTunnelProps } from './index';
 
@@ -28,6 +33,16 @@ export default {
 
 type Story = StoryObj<typeof SaleTunnel>;
 
-export const Default: Story = {
+export const Credential: Story = {
   args: {},
+};
+
+export const CertificateDiscount: Story = {
+  args: {
+    product: CertificateProductFactory({ price: 100, price_currency: 'EUR' }).one(),
+    course: PacedCourseFactory().one(),
+    enrollment: EnrollmentFactory({
+      offerings: OfferingFactory({ rules: { discounted_price: 80 } }).many(1),
+    }).one(),
+  },
 };


### PR DESCRIPTION
## Purpose

When we open the sales tunnel from the student's dashboard to purchase a certificate in a course that we have enrolled, when a discount is present we would not see the discounted price. Now the sales tunnel information has the data if there is a discounted price on the product certificate. Otherwise, it works has usual.

There is actually two entry points to see the salesTunnel, and we don't use the same endpoints in both.

So my certificate costs normally **600.00.**
Consider that we have applied an OfferRule that takes 10% off the price, we should have **540.00** as last price.

Shot before :
![Capture d’écran du 2025-06-25 19-11-49](https://github.com/user-attachments/assets/e1ce3fd3-2d76-4e93-a595-8da0797cab49)

Shot after : 
![Capture d’écran du 2025-06-25 19-11-27](https://github.com/user-attachments/assets/21397914-21f9-497e-93e9-7ea51ba5886a)

Fixes #2645

## Proposal

- [x] fetch the discounted price for certificate products when opening the sales tunnel information 
