### PR TITLE
🐛(backend) corrected ACTIVATED_DB default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Allow configuration of the `STORAGES` setting via environment variables
 - Rename `CourseProductRelation` to `Offer`
 - Only display payment schedule for credential products
-- Provide postgres as default value for `ACTIVATED_DB` variable.
+- Provide `postgresql` as default value for `ACTIVATED_DB` variable.
 - Update Offer type with rules property which contains all applicable 
   offer rules
 - Rename again `CourseProductRelation` to `Offering`

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -1,5 +1,5 @@
 include:
-  - docker-compose-${ACTIVATED_DB:-postgres}.yml
+  - docker-compose-${ACTIVATED_DB:-postgresql}.yml
 services:
   elasticsearch:
     image: {{cookiecutter.elasticsearch_image_name}}
@@ -7,7 +7,7 @@ services:
       - discovery.type=single-node
     env_file:
       - "env.d/development"
-      - "env.d/${ACTIVATED_DB:-postgres}"
+      - "env.d/${ACTIVATED_DB:-postgresql}"
     ports:
       - "9220:9200"
     healthcheck:
@@ -30,7 +30,7 @@ services:
     env_file:
       - ".env"
       - "env.d/development"
-      - "env.d/${ACTIVATED_DB:-postgres}"
+      - "env.d/${ACTIVATED_DB:-postgresql}"
     networks:
       - default
       - lms_outside
@@ -40,7 +40,7 @@ services:
       - "./sites/${RICHIE_SITE:?}/src/backend:/app"
       - "./data/media/${RICHIE_SITE:?}:/data/media"
     depends_on:
-      - "${ACTIVATED_DB:-postgres}"
+      - "${ACTIVATED_DB:-postgresql}"
       - "elasticsearch"
       - "redis-sentinel"
     user: ${DOCKER_USER:-1000}
@@ -62,14 +62,14 @@ services:
     env_file:
       - ".env"
       - "env.d/development"
-      - "env.d/${ACTIVATED_DB:-postgres}"
+      - "env.d/${ACTIVATED_DB:-postgresql}"
     networks:
       - default
       - lms_outside
     volumes:
       - ./data/media/${RICHIE_SITE:?}:/data/media
     depends_on:
-      - "${ACTIVATED_DB:-postgres}"
+      - "${ACTIVATED_DB:-postgresql}"
       - "elasticsearch"
       - "redis-sentinel"
     user: ${DOCKER_USER:-1000}


### PR DESCRIPTION
In [this](https://github.com/openfun/richie/pull/2652#event-18276910430) PR was merged a wrong information, which was attributing `postgres` as default value for `ACTIVATED_DB`, while the file is named as `postgresql`.  

- Corrected `postgresql` as default value for `ACTIVATED_DB` instead of only `postgres`.

It must to match the file name, such as `docker-compose-postgresql.yml`

![image](https://github.com/user-attachments/assets/c4218aac-9da6-4d87-98fe-447e956cf69a)

and then, in the `docker-compose.yml` it includes the corresponding service.

```
include:
  - docker-compose-${ACTIVATED_DB:-postgresql}.yml
```

