### PR TITLE
Fix the center of course product item title on small devices and align prices on course glimpse

### DIFF
--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/_styles.scss
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/_styles.scss
@@ -70,6 +70,7 @@
     & .product-widget__header-main {
       display: flex;
       justify-content: center;
+      text-align: center;
     }
 
     & .product-widget__title {

--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -399,6 +399,7 @@ $course-glimpse-content-padding-sides: 0.7rem !default;
     .offer_prices {
       display: flex;
       flex-direction: column;
+      align-items: flex-end;
     }
 
     .offer__price {


### PR DESCRIPTION
## Purpose

The title of course product item was not centered on small devices.


## Proposal

Since it's because a breakpoint add a flex property on small devices, we now center the title with `margin: 0 auto; width: max-content;` to not create a flex issue.
