### PR TITLE
🎨(frontend) style course glimpse icon with scheme colors

### DIFF
--- a/src/frontend/scss/objects/_course_glimpses.scss
+++ b/src/frontend/scss/objects/_course_glimpses.scss
@@ -452,6 +452,11 @@ $offer-schemes: (
 @each $offer, $scheme in $offer-schemes {
   @if $scheme != null {
     .course-glimpse--offer-#{$offer} {
+      .course-glimpse__icon {
+        background: map-get($scheme, 'background');
+        color: map-get($scheme, 'font-color');
+      }
+
       .course-glimpse-footer {
         @include r-button-colors($scheme, $apply-border: true);
         &:after {


### PR DESCRIPTION


## Purpose

Add background and font-color styling to course glimpse icons based on the provided offer scheme.
