### PR TITLE
Fix CourseProductItem when no rule in offering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle null offering rules on CourseProduct item
+
 ## [3.2.0] - 2025-08-26
 
 ### Added

--- a/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/index.tsx
@@ -104,7 +104,7 @@ const Total = () => {
   const { product, offering, enrollment } = useSaleTunnelContext();
   const totalPrice =
     enrollment?.offerings?.[0]?.rules?.discounted_price ??
-    offering?.rules.discounted_price ??
+    offering?.rules?.discounted_price ??
     product.price;
   return (
     <div className="sale-tunnel__total">

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -496,7 +496,7 @@ describe.each([
       expect($totalAmount).toHaveTextContent(
         'Total' +
           formatPrice(
-            enrollmentDiscounted.offerings[0].rules.discounted_price!,
+            enrollmentDiscounted.offerings[0].rules?.discounted_price!,
             product.price_currency,
           ).replace(/(\u202F|\u00a0)/g, ' '),
       );
@@ -569,7 +569,7 @@ describe.each([
     const $totalAmount = screen.getByTestId('sale-tunnel__total__amount');
     expect($totalAmount).toHaveTextContent(
       'Total' +
-        formatPrice(offering!.rules.discounted_price!, product.price_currency).replace(
+        formatPrice(offering!.rules!.discounted_price!, product.price_currency).replace(
           /(\u202F|\u00a0)/g,
           ' ',
         ),

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -200,7 +200,7 @@ export interface OfferingRule {
 
 export interface Offering extends OfferingLight {
   is_withdrawable: boolean;
-  rules: OfferingRule;
+  rules?: OfferingRule;
 }
 export function isOffering(
   entity: CourseListItem | OfferingLight | RichieCourse,

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/CourseProductItemFooter/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/CourseProductItemFooter/index.tsx
@@ -33,7 +33,7 @@ const CourseProductItemFooter = ({
   offering,
   canPurchase,
 }: CourseProductItemFooterProps) => {
-  if (!offering.rules.has_seats_left)
+  if (!offering?.rules?.has_seats_left)
     return (
       <p className="product-widget__footer__message">
         <FormattedMessage {...messages.noSeatsAvailable} />
@@ -50,7 +50,7 @@ const CourseProductItemFooter = ({
         disabled={!canPurchase}
         buttonProps={{ fullWidth: true }}
       />
-      {offering.rules.has_seat_limit && (
+      {offering?.rules?.has_seat_limit && (
         <p className="product-widget__footer__message">
           <FormattedMessage
             {...messages.nbSeatsAvailable}

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/CourseProductItem/index.tsx
@@ -103,7 +103,7 @@ const Header = ({ product, order, offering, hasPurchased, canPurchase, compact }
       return null;
     }
 
-    if (offering.rules.discounted_price != null) {
+    if (offering?.rules?.discounted_price != null) {
       return (
         <>
           <span id="original-price" className="offscreen">
@@ -133,7 +133,7 @@ const Header = ({ product, order, offering, hasPurchased, canPurchase, compact }
     return (
       <FormattedNumber currency={product.price_currency} value={product.price} style="currency" />
     );
-  }, [canPurchase, offering.rules.discounted_price, product.price]);
+  }, [canPurchase, offering?.rules?.discounted_price, product.price]);
 
   return (
     <header className="product-widget__header">
@@ -144,10 +144,10 @@ const Header = ({ product, order, offering, hasPurchased, canPurchase, compact }
         {hasPurchased && <FormattedMessage {...messages.purchased} />}
         {displayPrice}
       </strong>
-      {offering?.rules.description && (
+      {offering?.rules?.description && (
         <p className="product-widget__header-description">{offering.rules.description}</p>
       )}
-      {offering?.rules.discounted_price && (
+      {offering?.rules?.discounted_price && (
         <p className="product-widget__header-discount">
           {offering.rules.discount_rate ? (
             <span className="product-widget__header-discount-rate">


### PR DESCRIPTION
The offering may be sometimes null, which created an error. (Detected during the latest MTP).

## Purpose

We want to handle the possibly null offering and rules in the offering.

## Proposal

Description...

- Add `offering?.rules?.` to handle null values
