### PR TITLE
♻️(course): refactor the self paced course availability presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix Keycloak race condition causing users to appear unauthenticated
 - Hide payment plan block for certificates
 
+### Changed
+
+- Changed self paced course availability presentation
+- Remove the entire run component if other runs list is empty
+
 ## [3.3.0] - 2026-02-25
 
 ### Added

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusAsideList/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusAsideList/index.tsx
@@ -18,17 +18,6 @@ const messages = defineMessages({
       'Message displayed on the top of course runs list on syllabus when there is 0 or multiple course runs opened',
     defaultMessage: 'Course runs',
   },
-  noCourseRuns: {
-    id: 'components.SyllabusAsideList.noCourseRuns',
-    description: 'Message displayed on syllabus when there are no course runs to show',
-    defaultMessage: 'No course runs',
-  },
-  noOtherCourseRuns: {
-    id: 'components.SyllabusAsideList.noOtherCourseRuns',
-    description:
-      'Message displayed on syllabus when there are no other course runs to show than the only one opened',
-    defaultMessage: 'No other course runs',
-  },
   toBeScheduled: {
     id: 'components.SyllabusAsideList.toBeScheduled',
     description: 'Message displayed on syllabus when there are course runs to be scheduled',
@@ -108,28 +97,20 @@ export const SyllabusAsideList = ({
 
   const showLanguages = CourseRunHelper.IsAllCourseRunsWithSameLanguages(courseRuns);
 
+  // If there are no runs to display at all, don't render anything
+  if (openedRuns.length <= 1 && otherRuns.length === 0) {
+    return null;
+  }
+
   return (
     <>
       <h2 className="course-detail__title">
-        {openedRuns.length === 1 ? (
-          <FormattedMessage {...messages.otherCourseRuns} />
-        ) : (
+        {openedRuns.length > 1 ? (
           <FormattedMessage {...messages.courseRunsTitle} />
+        ) : (
+          <FormattedMessage {...messages.otherCourseRuns} />
         )}
       </h2>
-      {openedRuns.length <= 1 && otherRuns.length === 0 && (
-        <div className="course-detail__row course-detail__no-runs">
-          {openedRuns.length === 0 ? (
-            <p>
-              <FormattedMessage {...messages.noCourseRuns} />
-            </p>
-          ) : (
-            <p>
-              <FormattedMessage {...messages.noOtherCourseRuns} />
-            </p>
-          )}
-        </div>
-      )}
       {openedRuns.length > 1 && (
         <div
           id="courseDetailsRunsOpen"

--- a/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted/index.tsx
+++ b/src/frontend/js/widgets/SyllabusCourseRunsList/components/SyllabusCourseRunCompacted/index.tsx
@@ -34,12 +34,17 @@ const messages = defineMessages({
   selfPaceRunPeriod: {
     id: 'components.SyllabusCourseRunCompacted.selfPaceCoursePeriod',
     description: 'Course date of an opened and self paced course run block',
-    defaultMessage: 'Available until {endDate}',
+    defaultMessage: 'Until {endDate, select, undefined {} other {{endDate}}}',
   },
   selfPaceNoEndDate: {
     id: 'components.SyllabusCourseRunCompacted.selfPaceNoEndDate',
     description: 'Self paced course run block with no end date',
     defaultMessage: 'Available',
+  },
+  enrollment: {
+    id: 'components.SyllabusCourseRun.enrollment',
+    description: 'Title of the enrollment dates section of an opened course run block',
+    defaultMessage: 'Enrollment',
   },
   coursePrice: {
     id: 'components.SyllabusCourseRunCompacted.coursePrice',
@@ -105,6 +110,7 @@ const OpenedSelfPacedCourseRun = ({
   let enrollmentDiscountedPrice = '';
   let certificatePrice = '';
   let certificateDiscountedPrice = '';
+  const enrollmentEnd = courseRun.enrollment_end ? formatDate(courseRun.enrollment_end) : '...';
 
   if (courseRun.offer) {
     const offer = courseRun.offer.toUpperCase().replaceAll(' ', '_');
@@ -157,23 +163,41 @@ const OpenedSelfPacedCourseRun = ({
     <>
       {courseRun.title && <h3>{StringHelper.capitalizeFirst(courseRun.title)}</h3>}
       <dl>
-        {!showLanguages && (
-          <dt>
-            <FormattedMessage {...messages.course} />
-          </dt>
+        {hasEndDate ? (
+          <>
+            <dt>
+              <FormattedMessage {...messages.enrollment} />
+            </dt>
+            <dd>
+              <FormattedMessage
+                {...messages.selfPaceRunPeriod}
+                values={{
+                  endDate: enrollmentEnd,
+                }}
+              />
+            </dd>
+            <dt>
+              <FormattedMessage {...messages.course} />
+            </dt>
+            <dd>
+              <FormattedMessage
+                {...messages.selfPaceRunPeriod}
+                values={{
+                  endDate: end,
+                }}
+              />
+            </dd>
+          </>
+        ) : (
+          <>
+            <dt>
+              <FormattedMessage {...messages.enrollment} />
+            </dt>
+            <dd>
+              <FormattedMessage {...messages.selfPaceNoEndDate} />
+            </dd>
+          </>
         )}
-        <dd>
-          {hasEndDate ? (
-            <FormattedMessage
-              {...messages.selfPaceRunPeriod}
-              values={{
-                endDate: end,
-              }}
-            />
-          ) : (
-            <FormattedMessage {...messages.selfPaceNoEndDate} />
-          )}
-        </dd>
         {!showLanguages && (
           <>
             <dt>


### PR DESCRIPTION
In quick words:

- Changed self paced course availability presentation
- Remove the entire course run component if other runs list is empty

Course used as example: https://www.fun-mooc.fr/fr/cours/la-nature-dans-les-vitrines-des-musees/

## Purpose

### Course availability
We are receiving a considerable number of tickets because of this approach showing the course availability. It sounds not clear on what it means in terms of being "Available". Is it the course? Is it the enrollment? 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/c9d3b04e-0a59-466d-8926-827eb585e116" />

### Course run presentation
If no course run available, why to occupy the screen with this information? We have certified that removing this component would not impact in terms of responsiveness, and when not populated it is a irrelevant information in a course page.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7872d65c-ec53-4d7c-be35-bccd76e9589d" />

## Proposal 
Presenting the final dates separated by a title sections, a similar approach of a non self paced course.  

**EN**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8c9b38fe-64a0-4097-bb9a-41496537c6ed" />

**FR**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/55be3485-3efa-465e-9e82-a80f326f6519" />