### PR TITLE
🐛(docker) remove unused .env reference in docker-compose configuration

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - DJANGO_CONFIGURATION=Development
       - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:?}
     env_file:
-      - ".env"
       - "env.d/development"
       - "env.d/${ACTIVATED_DB:-postgresql}"
     networks:
@@ -60,7 +59,6 @@ services:
       - DJANGO_CONFIGURATION=ContinuousIntegration
       - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:?}
     env_file:
-      - ".env"
       - "env.d/development"
       - "env.d/${ACTIVATED_DB:-postgresql}"
     networks:


### PR DESCRIPTION


## Purpose

Unexisting .env file declaration causes ci job to fail.
