### PR TITLE
🔧(docker) add `.env` file reference to docker-compose configuration

### DIFF
--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - DJANGO_CONFIGURATION=Development
       - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:?}
     env_file:
+      - ".env"
       - "env.d/development"
       - "env.d/${ACTIVATED_DB:-postgresql}"
     networks:
@@ -59,6 +60,7 @@ services:
       - DJANGO_CONFIGURATION=ContinuousIntegration
       - RICHIE_ES_INDICES_PREFIX=richie_${RICHIE_SITE:?}
     env_file:
+      - ".env"
       - "env.d/development"
       - "env.d/${ACTIVATED_DB:-postgresql}"
     networks:


### PR DESCRIPTION
## Purpose

Include missing `.env` file reference in docker-compose to ensure proper environment variable loading.
