### PR TITLE
Make run-state courses optional in dev data and forward make flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,11 @@ demo-site: ## create a demo site if app container is running
 	@${MAKE} superuser
 .PHONY: demo-site
 
+ifeq (dev-data,$(firstword $(MAKECMDGOALS)))
+  DEV_DATA_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(DEV_DATA_ARGS):;@:)
+endif
+
 dev-data: ## create dev data if app container is running
 	@echo "Check app container is running..."
 	@if [ $(shell docker container inspect -f '{{.State.Running}}' "$(shell $(COMPOSE) ps -q app)") = "false" ] ; then\
@@ -223,7 +228,7 @@ dev-data: ## create dev data if app container is running
 		exit 1;\
 	fi
 	@$(MANAGE) flush --no-input
-	@$(COMPOSE_EXEC_APP) python sandbox/manage.py create_dev_data ${ARGS}
+	@$(COMPOSE_EXEC_APP) python sandbox/manage.py create_dev_data $(DEV_DATA_ARGS)
 	@${MAKE} search-index
 	@${MAKE} superuser
 .PHONY: dev-data

--- a/src/richie/apps/demo/management/commands/create_dev_data.py
+++ b/src/richie/apps/demo/management/commands/create_dev_data.py
@@ -1204,6 +1204,7 @@ def create_dev_data(
     create_certificate_discount=False,
     create_credential=False,
     create_credential_discount=False,
+    create_run_state_courses=False,
 ):
     """
     Create a simple site tree structure for developpers to work in realistic environment.
@@ -1345,21 +1346,21 @@ def create_dev_data(
         )
         courses.append(course)
 
-    # Create courses with explicit course run states to test ordering
-    log("Creating courses with varied course run states...")
-    state_courses = create_courses_with_run_states(
-        languages,
-        levels,
-        licences,
-        lms_endpoint,
-        organizations,
-        pages_created,
-        persons_for_organization,
-        subjects,
-        icons,
-        log=log,
-    )
-    courses.extend(state_courses)
+    if create_run_state_courses:
+        log("Creating courses with varied course run states...")
+        state_courses = create_courses_with_run_states(
+            languages,
+            levels,
+            licences,
+            lms_endpoint,
+            organizations,
+            pages_created,
+            persons_for_organization,
+            subjects,
+            icons,
+            log=log,
+        )
+        courses.extend(state_courses)
 
     # Create blog posts under the `News` page
     log(f"Creating {NB_OBJECTS['blogposts']} blog posts...")
@@ -1428,6 +1429,12 @@ class Command(BaseCommand):
             default=False,
             help="Create a credential product with a discount.",
         )
+        parser.add_argument(
+            "--run-state-courses",
+            action="store_true",
+            default=False,
+            help="Create courses with explicit run states to test ordering.",
+        )
 
     def handle(self, *args, **options):
         def log(message):
@@ -1448,6 +1455,7 @@ class Command(BaseCommand):
             create_certificate_discount=options.get("certificate_discount"),
             create_credential=options.get("credential"),
             create_credential_discount=options.get("credential_discount"),
+            create_run_state_courses=options.get("run_state_courses"),
         )
 
         logger.info("done")


### PR DESCRIPTION
## Purpose

Make the creation of courses with explicit run states optional in
`make dev-data` to keep the default dev data generation lightweight.

## Proposal

- Add a `--run-state-courses` flag to `create_dev_data` so that the
  generation of the 24 test courses with explicit run states is opt-in
- Forward trailing flags from `make dev-data` to the underlying command
  using the GNU make `--` convention, allowing
  `make dev-data -- --run-state-courses` instead of the awkward
  `make dev-data ARGS="..."` form