### PR TITLE
Add configurable `next_url` for OpenEdX Hawthorn login/register redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add next_url configuration for OpenEdX Hawthorn login/register redirects
+
 ## [3.4.0] - 2026-03-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Handle aliases in mail regex for b2b sale tunnel
+- Add next_url configuration for OpenEdX Hawthorn login/register redirects
 
 ### Changed
 
@@ -30,7 +31,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Handle French and English language in Storybook
 - Upgraded js dependencies, fixed tests and linting errors
-- Display batch order enrollment status in dashboard
 
 ### Fixed
 

--- a/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
+++ b/cookiecutter/{{cookiecutter.organization}}-richie-site-factory/template/{{cookiecutter.site}}/src/backend/{{cookiecutter.site}}/settings.py
@@ -320,6 +320,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_name="EDX_JS_COURSE_REGEX",
                 environ_prefix=None,
             ),
+            "JS_NEXT_URL": values.Value(
+                "richie",
+                environ_name="EDX_JS_NEXT_URL",
+                environ_prefix=None,
+            ),
             "BASE_URL": values.Value(environ_name="EDX_BASE_URL", environ_prefix=None),
         }
     ]

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -263,6 +263,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_name="EDX_JS_COURSE_REGEX",
                 environ_prefix=None,
             ),
+            "JS_NEXT_URL": values.Value(
+                "richie",
+                environ_name="EDX_JS_NEXT_URL",
+                environ_prefix=None,
+            ),
             # Course runs synchronization
             "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
             "DEFAULT_COURSE_RUN_SYNC_MODE": "sync_to_public",

--- a/src/frontend/js/api/lms/index.spec.ts
+++ b/src/frontend/js/api/lms/index.spec.ts
@@ -1,7 +1,14 @@
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import { handle } from 'utils/errors/handle';
+import { location } from 'utils/indirection/window';
 import LMSHandler from '.';
 
+jest.mock('utils/indirection/window', () => ({
+  location: {
+    pathname: '/courses/a-test-course/',
+    assign: jest.fn(),
+  },
+}));
 jest.mock('utils/context', () => ({
   __esModule: true,
   default: mockRichieContextFactory({
@@ -16,6 +23,12 @@ jest.mock('utils/context', () => ({
         endpoint: 'https://edx.endpoint/api',
         course_regexp: '.*edx.org/.*',
       },
+      {
+        backend: 'openedx-hawthorn',
+        endpoint: 'https://nau.endpoint/api',
+        course_regexp: '.*nau.org/.*',
+        next_url: 'richie-nau',
+      },
     ],
   }).one(),
 }));
@@ -24,6 +37,10 @@ const mockHandle: jest.Mock<typeof handle> = handle as any;
 jest.mock('utils/errors/handle');
 
 describe('API LMS', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns OpenEdX API if url that match edx selector is provided', () => {
     const api = LMSHandler('https://edx.org/courses/a-test-course');
     expect(api).toBeDefined();
@@ -40,6 +57,22 @@ describe('API LMS', () => {
     );
     expect(mockHandle).toHaveBeenCalledWith(
       new Error('No LMS Backend found for https://unknown.org/course/a-test-course.'),
+    );
+  });
+
+  it('uses default "richie" next prefix for openedx-hawthorn without next_url configured', () => {
+    const api = LMSHandler('https://edx.org/courses/a-test-course');
+    api.user.login();
+    expect(location.assign).toHaveBeenCalledWith(
+      `https://edx.endpoint/api/login?next=richie${location.pathname}`,
+    );
+  });
+
+  it('uses configured next_url prefix for openedx-hawthorn with next_url set', () => {
+    const api = LMSHandler('https://nau.org/courses/a-test-course');
+    api.user.login();
+    expect(location.assign).toHaveBeenCalledWith(
+      `https://nau.endpoint/api/login?next=richie-nau${location.pathname}`,
     );
   });
 });

--- a/src/frontend/js/api/lms/index.ts
+++ b/src/frontend/js/api/lms/index.ts
@@ -15,7 +15,7 @@ const LmsAPIHandler = (url: string): APILms => {
     case APIBackend.OPENEDX_DOGWOOD:
       return OpenEdxDogwoodApiInterface(api);
     case APIBackend.OPENEDX_HAWTHORN:
-      return OpenEdxHawthornApiInterface(api);
+      return OpenEdxHawthornApiInterface(api, { routes: {}, nextURL: api.next_url });
   }
 
   const error = new Error(`No LMS Backend found for ${url}.`);

--- a/src/frontend/js/api/lms/openedx-hawthorn.spec.ts
+++ b/src/frontend/js/api/lms/openedx-hawthorn.spec.ts
@@ -3,10 +3,17 @@ import { faker } from '@faker-js/faker';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
 import { handle } from 'utils/errors/handle';
 import { HttpError, HttpStatusCode } from 'utils/errors/HttpError';
+import { location } from 'utils/indirection/window';
 import context from 'utils/context';
 import API from './openedx-hawthorn';
 
 jest.mock('utils/errors/handle');
+jest.mock('utils/indirection/window', () => ({
+  location: {
+    pathname: '/courses/a-test-course/',
+    assign: jest.fn(),
+  },
+}));
 jest.mock('utils/context', () => ({
   __esModule: true,
   default: mockRichieContextFactory({
@@ -42,6 +49,48 @@ describe('OpenEdX Hawthorn API', () => {
       fetchMock.get(`${EDX_ENDPOINT}/my-custom-api/user/v2.0/whoami`, HttpStatusCode.UNAUTHORIZED);
 
       await expect(CustomApi.user.me()).resolves.toBe(null);
+    });
+  });
+
+  describe('user', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('login', () => {
+      it('redirects to login with default "richie" next prefix when nextURL is not set', () => {
+        const api = API(LMSConf);
+        api.user.login();
+        expect(location.assign).toHaveBeenCalledWith(
+          `${EDX_ENDPOINT}/login?next=richie${location.pathname}`,
+        );
+      });
+
+      it('redirects to login with custom next prefix when nextURL option is provided', () => {
+        const api = API(LMSConf, { routes: {}, nextURL: 'richie-nau' });
+        api.user.login();
+        expect(location.assign).toHaveBeenCalledWith(
+          `${EDX_ENDPOINT}/login?next=richie-nau${location.pathname}`,
+        );
+      });
+    });
+
+    describe('register', () => {
+      it('redirects to register with default "richie" next prefix when nextURL is not set', () => {
+        const api = API(LMSConf);
+        api.user.register();
+        expect(location.assign).toHaveBeenCalledWith(
+          `${EDX_ENDPOINT}/register?next=richie${location.pathname}`,
+        );
+      });
+
+      it('redirects to register with custom next prefix when nextURL option is provided', () => {
+        const api = API(LMSConf, { routes: {}, nextURL: 'richie-ap' });
+        api.user.register();
+        expect(location.assign).toHaveBeenCalledWith(
+          `${EDX_ENDPOINT}/register?next=richie-ap${location.pathname}`,
+        );
+      });
     });
   });
 

--- a/src/frontend/js/api/lms/openedx-hawthorn.ts
+++ b/src/frontend/js/api/lms/openedx-hawthorn.ts
@@ -20,6 +20,8 @@ import { HttpError, HttpStatusCode } from 'utils/errors/HttpError';
  */
 
 const API = (APIConf: AuthenticationBackend | LMSBackend, options?: APIOptions): APILms => {
+  const nextURL = options?.nextURL ?? 'richie';
+
   const extractCourseIdFromUrl = (url: string): Maybe<Nullable<string>> => {
     const matches = url.match((APIConf as LMSBackend).course_regexp);
     return matches && matches[1] ? matches[1] : null;
@@ -61,8 +63,9 @@ const API = (APIConf: AuthenticationBackend | LMSBackend, options?: APIOptions):
         / ! \ Prefix next param with richie.
         In this way, OpenEdX Nginx conf knows that we want to go back to richie app after login/redirect
       */
-      login: () => location.assign(`${ROUTES.user.login}?next=richie${location.pathname}`),
-      register: () => location.assign(`${ROUTES.user.register}?next=richie${location.pathname}`),
+      login: () => location.assign(`${ROUTES.user.login}?next=${nextURL}${location.pathname}`),
+      register: () =>
+        location.assign(`${ROUTES.user.register}?next=${nextURL}${location.pathname}`),
       logout: async () => {
         await fetch(ROUTES.user.logout, {
           mode: 'no-cors',

--- a/src/frontend/js/types/api.ts
+++ b/src/frontend/js/types/api.ts
@@ -63,6 +63,7 @@ export interface APIRoute {
 
 export interface APIOptions {
   routes: APIRoute;
+  nextURL?: string;
 }
 
 export enum APIBackend {

--- a/src/frontend/js/types/commonDataProps.ts
+++ b/src/frontend/js/types/commonDataProps.ts
@@ -9,6 +9,7 @@ export interface LMSBackend {
   backend: string;
   course_regexp: RegExp | string;
   endpoint: string;
+  next_url?: string;
 }
 
 export interface AuthenticationBackend {
@@ -26,6 +27,7 @@ export interface AuthenticationBackend {
     username: string;
     email: string;
   };
+  next_url?: string;
 }
 
 enum FEATURES {

--- a/src/richie/apps/core/context_processors.py
+++ b/src/richie/apps/core/context_processors.py
@@ -251,14 +251,17 @@ class FrontendContextProcessor:
     def get_lms_context(self):
         """Get lms backends context if there are."""
         if getattr(settings, "RICHIE_LMS_BACKENDS", None):
-            return [
-                {
+            result = []
+            for lms in getattr(settings, "RICHIE_LMS_BACKENDS", []):
+                entry = {
                     "endpoint": lms["BASE_URL"],
                     "backend": lms["JS_BACKEND"],
                     "course_regexp": lms["JS_COURSE_REGEX"],
                 }
-                for lms in getattr(settings, "RICHIE_LMS_BACKENDS", [])
-            ]
+                if "JS_NEXT_URL" in lms:
+                    entry["next_url"] = lms["JS_NEXT_URL"]
+                result.append(entry)
+            return result
 
         return None
 

--- a/tests/apps/core/test_context_processors_lms.py
+++ b/tests/apps/core/test_context_processors_lms.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the LMS context processor
+"""
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from richie.apps.core.context_processors import FrontendContextProcessor
+
+
+class ContextProcessorLmsTestCase(TestCase):
+    """Test suite for FrontendContextProcessor.get_lms_context"""
+
+    def setUp(self):
+        self.processor = FrontendContextProcessor()
+
+    @override_settings(RICHIE_LMS_BACKENDS=[])
+    def test_get_lms_context_returns_none_when_no_backends(self):
+        """get_lms_context should return None when RICHIE_LMS_BACKENDS is empty."""
+        result = self.processor.get_lms_context()
+        self.assertIsNone(result)
+
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "https://lms.example.com",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "COURSE_REGEX": r"^https://lms\.example\.com/courses/(?P<course_id>.*)/course/?$",
+                "JS_BACKEND": "openedx-hawthorn",
+                "JS_COURSE_REGEX": r"^https://lms\.example\.com/courses/(.*)/course/?$",
+            }
+        ]
+    )
+    def test_get_lms_context_without_js_next_url(self):
+        """
+        get_lms_context should not include 'next_url' key when JS_NEXT_URL is not configured.
+        """
+        result = self.processor.get_lms_context()
+
+        self.assertEqual(len(result), 1)
+        entry = result[0]
+        self.assertEqual(entry["endpoint"], "https://lms.example.com")
+        self.assertEqual(entry["backend"], "openedx-hawthorn")
+        self.assertNotIn("next_url", entry)
+
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "https://lms.example.com",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "COURSE_REGEX": r"^https://lms\.example\.com/courses/(?P<course_id>.*)/course/?$",
+                "JS_BACKEND": "openedx-hawthorn",
+                "JS_COURSE_REGEX": r"^https://lms\.example\.com/courses/(.*)/course/?$",
+                "JS_NEXT_URL": "richie-nau",
+            }
+        ]
+    )
+    def test_get_lms_context_with_js_next_url(self):
+        """
+        get_lms_context should include 'next_url' when JS_NEXT_URL is configured.
+        """
+        result = self.processor.get_lms_context()
+
+        self.assertEqual(len(result), 1)
+        entry = result[0]
+        self.assertEqual(entry["endpoint"], "https://lms.example.com")
+        self.assertEqual(entry["backend"], "openedx-hawthorn")
+        self.assertEqual(entry["next_url"], "richie-nau")
+
+    @override_settings(
+        RICHIE_LMS_BACKENDS=[
+            {
+                "BASE_URL": "https://lms1.example.com",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "COURSE_REGEX": r"^https://lms1\.example\.com/courses/(?P<course_id>.*)/course/?$",
+                "JS_BACKEND": "openedx-hawthorn",
+                "JS_COURSE_REGEX": r"^https://lms1\.example\.com/courses/(.*)/course/?$",
+                "JS_NEXT_URL": "richie-site-a",
+            },
+            {
+                "BASE_URL": "https://lms2.example.com",
+                "BACKEND": "richie.apps.courses.lms.edx.EdXLMSBackend",
+                "COURSE_REGEX": r"^https://lms2\.example\.com/courses/(?P<course_id>.*)/course/?$",
+                "JS_BACKEND": "openedx-hawthorn",
+                "JS_COURSE_REGEX": r"^https://lms2\.example\.com/courses/(.*)/course/?$",
+            },
+        ]
+    )
+    def test_get_lms_context_multiple_backends_mixed_next_url(self):
+        """
+        With multiple backends, next_url should only appear for entries that define JS_NEXT_URL.
+        """
+        result = self.processor.get_lms_context()
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["next_url"], "richie-site-a")
+        self.assertNotIn("next_url", result[1])


### PR DESCRIPTION

### Summary

The OpenEdX Hawthorn API previously hardcoded the `richie` prefix in the
`?next=` query parameter used during login and register redirects
(e.g. `?next=richie/courses/...`). This prefix is used by OpenEdX's Nginx
configuration to identify that the redirect target belongs to the Richie
application.

This PR makes that prefix configurable per LMS backend, allowing sites with
custom Nginx routing rules to set their own prefix.

This allows to have multiple Richie sites connected to the same Open edX LMS.
And the Open edX redirects to the right Richie site during login/register redirects.

### Changes

**Backend**
- Added `JS_NEXT_URL` optional setting to `RICHIE_LMS_BACKENDS` configuration
  (defaulting to `"richie"` if not set)
- Updated `FrontendContextProcessor.get_lms_context()` to include `next_url`
  in the frontend context when `JS_NEXT_URL` is configured
- Added tests for the LMS context processor covering: no backends, missing
  `JS_NEXT_URL`, present `JS_NEXT_URL`, and mixed multi-backend scenarios

**Frontend**
- Added optional `nextURL` option to `APIOptions` type
- Added optional `next_url` field to `LMSBackend` and `AuthenticationBackend`
  types
- Updated `OpenEdxHawthornApiInterface` to use `options?.nextURL`
  (falling back to `"richie"`) for login/register redirects
- Updated `LMSHandler` to pass `next_url` from the backend config through to
  `OpenEdxHawthornApiInterface`
- Added tests for default and custom `next_url` behavior in both the Hawthorn
  API and the LMS handler

### How to configure

```python
RICHIE_LMS_BACKENDS = [
    {
        "BASE_URL": "https://lms.example.com",
        "JS_BACKEND": "openedx-hawthorn",
        "JS_COURSE_REGEX": r"...",
        "JS_NEXT_URL": "richie-mysite",  # optional, defaults to "richie"
    }
]