### PR TITLE
Batch orders v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Handle French and English language in Storybook
 - Upgraded js dependencies, fixed tests and linting errors
+- Display batch order enrollment status in dashboard
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Hide walkthrough message in sale tunnel for B2B process
+- Rename some sentences for B2B process
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Handle aliases in mail regex for b2b sale tunnel
+
 ### Fixed
 
 - Fix storybook configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Handle aliases in mail regex for b2b sale tunnel
 
+### Changed
+
+- Hide walkthrough message in sale tunnel for B2B process
+
 ### Fixed
 
 - Changes the render of download quote button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Changes the render of download quote button
 - Fix storybook configuration
 - Fix course glimpse filters overlap on mobile/tablet
 - Fix slider drag and drop issues

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,11 @@ demo-site: ## create a demo site if app container is running
 	@${MAKE} superuser
 .PHONY: demo-site
 
+ifeq (dev-data,$(firstword $(MAKECMDGOALS)))
+  DEV_DATA_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(DEV_DATA_ARGS):;@:)
+endif
+
 dev-data: ## create dev data if app container is running
 	@echo "Check app container is running..."
 	@if [ $(shell docker container inspect -f '{{.State.Running}}' "$(shell $(COMPOSE) ps -q app)") = "false" ] ; then\
@@ -223,7 +228,7 @@ dev-data: ## create dev data if app container is running
 		exit 1;\
 	fi
 	@$(MANAGE) flush --no-input
-	@$(COMPOSE_EXEC_APP) python sandbox/manage.py create_dev_data ${ARGS}
+	@$(COMPOSE_EXEC_APP) python sandbox/manage.py create_dev_data $(DEV_DATA_ARGS)
 	@${MAKE} search-index
 	@${MAKE} superuser
 .PHONY: dev-data

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -110,6 +110,7 @@ export const getRoutes = () => {
         seats: {
           get: `${baseUrl}/batch-orders/:batch_order_id/seats/`,
         },
+        seats_export: `${baseUrl}/batch-orders/:id/seats-export/`,
       },
       certificates: {
         download: `${baseUrl}/certificates/:id/download/`,
@@ -364,6 +365,10 @@ const API = (): Joanie.API => {
             );
           },
         },
+        seats_export: async (id: string): Promise<File> =>
+          fetchWithJWT(ROUTES.user.batchOrders.seats_export.replace(':id', id))
+            .then(checkStatus)
+            .then(getFileFromResponse),
       },
       enrollments: {
         create: async (payload) =>

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -165,6 +165,7 @@ export const getRoutes = () => {
       },
       agreements: {
         get: `${baseUrl}/organizations/:organization_id/agreements/:id/`,
+        download: `${baseUrl}/organizations/:organization_id/agreements/:id/download/`,
       },
     },
     courses: {
@@ -560,6 +561,10 @@ const API = (): Joanie.API => {
             method: 'GET',
           }).then(checkStatus);
         },
+        download: async (filters: { organization_id: string; id: string }): Promise<File> =>
+          fetchWithJWT(buildApiUrl(ROUTES.organizations.agreements.download, filters))
+            .then(checkStatus)
+            .then(getFileFromResponse),
       },
     },
     courses: {

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -107,6 +107,9 @@ export const getRoutes = () => {
         submit_for_payment: {
           create: `${baseUrl}/batch-orders/:id/submit-for-payment/`,
         },
+        seats: {
+          get: `${baseUrl}/batch-orders/:batch_order_id/seats/`,
+        },
       },
       certificates: {
         download: `${baseUrl}/certificates/:id/download/`,
@@ -352,6 +355,13 @@ const API = (): Joanie.API => {
                 method: 'POST',
               },
             ).then(checkStatus);
+          },
+        },
+        seats: {
+          get: async (filters?: Joanie.BatchOrderSeatsQueryFilters) => {
+            return fetchWithJWT(buildApiUrl(ROUTES.user.batchOrders.seats.get, filters)).then(
+              checkStatus,
+            );
           },
         },
       },

--- a/src/frontend/js/api/utils.ts
+++ b/src/frontend/js/api/utils.ts
@@ -16,11 +16,12 @@ export async function getFileFromResponse(response: Response): Promise<File> {
 }
 
 export function getResponseBody(response: Response) {
-  if (response.headers.get('Content-Type') === 'application/json') {
+  const contentType = (response.headers.get('Content-Type') || '').split(';')[0].trim();
+  if (contentType === 'application/json') {
     return response.json();
   }
-  const fileType = ['application/pdf', 'application/zip'];
-  if (fileType.includes(response.headers.get('Content-Type') || '')) {
+  const fileType = ['application/pdf', 'application/zip', 'text/csv'];
+  if (fileType.includes(contentType)) {
     return new Promise((resolve) => resolve(response));
   }
   return response.text();

--- a/src/frontend/js/components/DownloadAgreementButton/index.tsx
+++ b/src/frontend/js/components/DownloadAgreementButton/index.tsx
@@ -1,0 +1,51 @@
+import { useId } from 'react';
+import { Button } from '@openfun/cunningham-react';
+import { FormattedMessage, defineMessages } from 'react-intl';
+import { Spinner } from 'components/Spinner';
+import { useDownloadAgreement } from 'hooks/useDownloadAgreement';
+
+const messages = defineMessages({
+  download: {
+    defaultMessage: 'Download agreement',
+    description: 'Label for the button to download a signed agreement PDF',
+    id: 'components.DownloadAgreementButton.download',
+  },
+  generating: {
+    defaultMessage: 'Downloading...',
+    description: 'Accessible label displayed while agreement PDF is being downloaded.',
+    id: 'components.DownloadAgreementButton.generating',
+  },
+});
+
+interface DownloadAgreementButtonProps {
+  organizationId: string;
+  agreementId: string;
+}
+
+const DownloadAgreementButton = ({ organizationId, agreementId }: DownloadAgreementButtonProps) => {
+  const { download, loading } = useDownloadAgreement();
+  const labelId = useId();
+
+  return (
+    <Button
+      size="small"
+      color="brand"
+      variant="primary"
+      className="dashboard-item__action-button"
+      disabled={loading}
+      onClick={() => download(organizationId, agreementId)}
+    >
+      {loading ? (
+        <Spinner theme="primary" aria-labelledby={labelId}>
+          <span id={labelId}>
+            <FormattedMessage {...messages.generating} />
+          </span>
+        </Spinner>
+      ) : (
+        <FormattedMessage {...messages.download} />
+      )}
+    </Button>
+  );
+};
+
+export default DownloadAgreementButton;

--- a/src/frontend/js/components/DownloadBatchOrderSeatsButton/index.spec.tsx
+++ b/src/frontend/js/components/DownloadBatchOrderSeatsButton/index.spec.tsx
@@ -1,0 +1,46 @@
+import { buildFilename, sanitizeForFilename } from '.';
+
+describe('sanitizeForFilename', () => {
+  it('replaces spaces with underscores', () => {
+    expect(sanitizeForFilename('Formation React')).toBe('Formation_React');
+  });
+
+  it('removes diacritics', () => {
+    expect(sanitizeForFilename('Développement web')).toBe('Developpement_web');
+  });
+
+  it('removes special characters', () => {
+    expect(sanitizeForFilename('C++ / Python')).toBe('C_Python');
+  });
+
+  it('preserves hyphens', () => {
+    expect(sanitizeForFilename('Formation React - Advanced')).toBe('Formation_React_-_Advanced');
+  });
+
+  it('trims leading and trailing spaces', () => {
+    expect(sanitizeForFilename('  Formation  ')).toBe('Formation');
+  });
+});
+
+describe('buildFilename', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-15T09:30:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('builds the expected filename', () => {
+    expect(buildFilename('seats', 'Formation React')).toBe(
+      'seats_Formation_React_2026-04-15_09-30.csv',
+    );
+  });
+
+  it('sanitizes the product title in the filename', () => {
+    expect(buildFilename('seats', 'Développement web avancé')).toBe(
+      'seats_Developpement_web_avance_2026-04-15_09-30.csv',
+    );
+  });
+});

--- a/src/frontend/js/components/DownloadBatchOrderSeatsButton/index.tsx
+++ b/src/frontend/js/components/DownloadBatchOrderSeatsButton/index.tsx
@@ -1,0 +1,80 @@
+import { useId } from 'react';
+import { Button } from '@openfun/cunningham-react';
+import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
+import { Spinner } from 'components/Spinner';
+import { useDownloadBatchOrderSeats } from 'hooks/useDownloadBatchOrderSeats';
+
+const messages = defineMessages({
+  download: {
+    defaultMessage: 'Export CSV',
+    description: 'Label for the button to export batch order seats as CSV',
+    id: 'components.DownloadBatchOrderSeatsButton.download',
+  },
+  generating: {
+    defaultMessage: 'Generating export...',
+    description: 'Accessible label displayed while CSV export is being generated.',
+    id: 'components.DownloadBatchOrderSeatsButton.generating',
+  },
+  seats: {
+    defaultMessage: 'Seats',
+    description: 'Text displayed for seats value in batch order',
+    id: 'batchOrder.seats',
+  },
+});
+
+export const sanitizeForFilename = (str: string) =>
+  str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '_');
+
+export const buildFilename = (prefix: string, productTitle: string) => {
+  const now = new Date();
+  const date = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+  const time = `${String(now.getUTCHours()).padStart(2, '0')}-${String(now.getUTCMinutes()).padStart(2, '0')}`;
+  return `${prefix}_${sanitizeForFilename(productTitle)}_${date}_${time}.csv`;
+};
+
+interface DownloadBatchOrderSeatsButtonProps {
+  batchOrderId: string;
+  productTitle: string;
+}
+
+const DownloadBatchOrderSeatsButton = ({
+  batchOrderId,
+  productTitle,
+}: DownloadBatchOrderSeatsButtonProps) => {
+  const { download, loading } = useDownloadBatchOrderSeats();
+  const labelId = useId();
+  const intl = useIntl();
+
+  const handleClick = () => {
+    const prefix = intl.formatMessage(messages.seats);
+    download(batchOrderId, buildFilename(prefix, productTitle));
+  };
+
+  return (
+    <Button
+      size="small"
+      color="brand"
+      variant="primary"
+      className="dashboard-item__action-button"
+      disabled={loading}
+      onClick={handleClick}
+    >
+      {loading ? (
+        <Spinner theme="primary" aria-labelledby={labelId}>
+          <span id={labelId}>
+            <FormattedMessage {...messages.generating} />
+          </span>
+        </Spinner>
+      ) : (
+        <FormattedMessage {...messages.download} />
+      )}
+    </Button>
+  );
+};
+
+export default DownloadBatchOrderSeatsButton;

--- a/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/SaleTunnelInformationGroup.tsx
+++ b/src/frontend/js/components/SaleTunnel/SaleTunnelInformation/SaleTunnelInformationGroup.tsx
@@ -96,7 +96,7 @@ export const SaleTunnelInformationGroup = () => {
   );
 };
 
-const EMAIL_REGEX = /^[\w.-]+@([\w-]+\.)+[\w-]{2,4}$/;
+const EMAIL_REGEX = /^[\w.+\-]+@([\w-]+\.)+[\w-]{2,4}$/;
 
 export const validationSchema = Yup.object().shape({
   offering_id: Yup.string().required(),

--- a/src/frontend/js/components/SaleTunnel/SaleTunnelSuccess/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/SaleTunnelSuccess/index.tsx
@@ -20,7 +20,7 @@ const messages = defineMessages({
   },
   successDetailMessage: {
     defaultMessage:
-      'You will be able to start your training once the first installment will be paid.',
+      'You’ll be able to start your training once the first installment has been paid, or once access opens if no payment is required.',
     description: 'Text to explain when the user will be able to start its training.',
     id: 'components.SaleTunnelSuccess.successDetailMessage',
   },

--- a/src/frontend/js/components/SaleTunnel/SubscriptionButton/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/SubscriptionButton/index.tsx
@@ -203,6 +203,7 @@ const SubscriptionButton = ({ buildOrderPayload }: Props) => {
   };
 
   const walkthroughMessages = useMemo(() => {
+    if (batchOrder) return;
     if (product.contract_definition && product.price > 0) {
       return messages.walkthroughToSignAndSavePayment;
     } else if (product.contract_definition && product.price === 0) {
@@ -210,7 +211,7 @@ const SubscriptionButton = ({ buildOrderPayload }: Props) => {
     } else if (!product.contract_definition && product.price > 0 && needsPayment) {
       return messages.walkthroughToSavePayment;
     }
-  }, [product, creditCard, needsPayment]);
+  }, [product, creditCard, needsPayment, batchOrder]);
 
   useEffect(() => {
     if (order) nextStep();

--- a/src/frontend/js/components/SaleTunnel/index.full-process-b2b.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.full-process-b2b.spec.tsx
@@ -210,11 +210,11 @@ describe('SaleTunnel', () => {
     await user.type($lastName, 'Doe');
     await user.type($firstName, 'John');
     await user.type($role, 'HR');
-    await user.type($email, 'john.doe@fun-mooc.com');
+    await user.type($email, 'john.doe+admin@fun-mooc.com');
     await user.type($phone, '+338203920103');
 
     expect($lastName).toHaveValue('Doe');
-    expect($email).toHaveValue('john.doe@fun-mooc.com');
+    expect($email).toHaveValue('john.doe+admin@fun-mooc.com');
 
     // Signatory step
     await user.click(screen.getByRole('button', { name: 'Next' }));
@@ -227,7 +227,7 @@ describe('SaleTunnel', () => {
     await user.type($signatoryLastName, 'Doe');
     await user.type($signatoryFirstName, 'John');
     await user.type($signatoryRole, 'CEO');
-    await user.type($signatoryEmail, 'john.doe@fun-mooc.com');
+    await user.type($signatoryEmail, 'john.doe+ceo@fun-mooc.com');
     await user.type($signatoryPhone, '+338203920103');
 
     // Participants step
@@ -298,12 +298,12 @@ describe('SaleTunnel', () => {
       administrative_lastname: 'Doe',
       administrative_firstname: 'John',
       administrative_profession: 'HR',
-      administrative_email: 'john.doe@fun-mooc.com',
+      administrative_email: 'john.doe+admin@fun-mooc.com',
       administrative_telephone: '+338203920103',
       signatory_lastname: 'Doe',
       signatory_firstname: 'John',
       signatory_profession: 'CEO',
-      signatory_email: 'john.doe@fun-mooc.com',
+      signatory_email: 'john.doe+ceo@fun-mooc.com',
       signatory_telephone: '+338203920103',
       nb_seats: '13',
       payment_method: PaymentMethod.PURCHASE_ORDER,

--- a/src/frontend/js/components/SaleTunnel/index.full-process-b2c.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.full-process-b2c.spec.tsx
@@ -404,7 +404,7 @@ describe('SaleTunnel', () => {
     await screen.findByTestId('generic-sale-tunnel-success-step');
     screen.getByText('Subscription confirmed!');
     screen.getByText(
-      /your order has been successfully registered\.you will be able to start your training once the first installment will be paid\./i,
+      /you’ll be able to start your training once the first installment has been paid, or once access opens if no payment is required\./i,
     );
     screen.getByRole('link', { name: 'Close' });
 

--- a/src/frontend/js/hooks/useBatchOrder/index.tsx
+++ b/src/frontend/js/hooks/useBatchOrder/index.tsx
@@ -1,7 +1,13 @@
 import { defineMessages } from 'react-intl';
 import { useJoanieApi } from 'contexts/JoanieApiContext';
 import { ResourcesQuery, useResource, useResources, UseResourcesProps } from 'hooks/useResources';
-import { API, BatchOrderQueryFilters, BatchOrderRead } from 'types/Joanie';
+import {
+  API,
+  BatchOrderQueryFilters,
+  BatchOrderRead,
+  BatchOrderSeat,
+  BatchOrderSeatsQueryFilters,
+} from 'types/Joanie';
 
 const messages = defineMessages({
   errorCreate: {
@@ -34,3 +40,17 @@ export const useBatchOrdersActions = () => {
     submitForPayment,
   };
 };
+
+const seatsProps: UseResourcesProps<
+  BatchOrderSeat,
+  BatchOrderSeatsQueryFilters,
+  API['user']['batchOrders']['seats']
+> = {
+  queryKey: ['batchOrders', 'seats'],
+  apiInterface: () => useJoanieApi().user.batchOrders.seats,
+  session: true,
+};
+
+export const useBatchOrderSeats = useResources<BatchOrderSeat, BatchOrderSeatsQueryFilters>(
+  seatsProps,
+);

--- a/src/frontend/js/hooks/useDownloadAgreement/index.spec.tsx
+++ b/src/frontend/js/hooks/useDownloadAgreement/index.spec.tsx
@@ -1,0 +1,136 @@
+import { faker } from '@faker-js/faker';
+import fetchMock from 'fetch-mock';
+import { PropsWithChildren } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from 'react-intl';
+import { act, fireEvent, renderHook, waitFor } from '@testing-library/react';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { useDownloadAgreement } from 'hooks/useDownloadAgreement/index';
+import { handle } from 'utils/errors/handle';
+import { SessionProvider } from 'contexts/SessionContext';
+import { Deferred } from 'utils/test/deferred';
+import { OrganizationFactory } from 'utils/test/factories/joanie';
+import { HttpStatusCode } from 'utils/errors/HttpError';
+
+jest.mock('utils/errors/handle');
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+const mockHandle = handle as jest.MockedFn<typeof handle>;
+
+describe('useDownloadAgreement', () => {
+  beforeEach(() => {
+    fetchMock.get('https://joanie.test/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/addresses/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/credit-cards/', []);
+  });
+
+  beforeAll(() => {
+    // eslint-disable-next-line compat/compat
+    URL.createObjectURL = jest.fn();
+    // eslint-disable-next-line compat/compat
+    URL.revokeObjectURL = jest.fn();
+    HTMLAnchorElement.prototype.click = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <QueryClientProvider client={createTestQueryClient({ user: true })}>
+        <IntlProvider locale="en">
+          <SessionProvider>{children}</SessionProvider>
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  it('downloads the agreement PDF', async () => {
+    const organization = OrganizationFactory().one();
+    const agreementId = faker.string.uuid();
+    const DOWNLOAD_URL = `https://joanie.test/api/v1.0/organizations/${organization.id}/agreements/${agreementId}/download/`;
+    const deferred = new Deferred();
+    fetchMock.get(DOWNLOAD_URL, deferred.promise);
+
+    const { result } = renderHook(() => useDownloadAgreement(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(fetchMock.called(DOWNLOAD_URL)).toBe(false);
+    // eslint-disable-next-line compat/compat
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+    expect(result.current.loading).toBe(false);
+
+    act(() => {
+      result.current.download(organization.id, agreementId);
+    });
+    expect(result.current.loading).toBe(true);
+
+    deferred.resolve({
+      status: HttpStatusCode.OK,
+      body: new Blob(['%PDF-1.4']),
+      headers: {
+        'Content-Disposition': 'attachment; filename="Convention_de_formation.pdf";',
+        'Content-Type': 'application/pdf',
+      },
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.called(DOWNLOAD_URL)).toBe(true);
+      // eslint-disable-next-line compat/compat
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line compat/compat
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+      expect(result.current.loading).toBe(false);
+    });
+
+    fireEvent.blur(window);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles an error if agreement download request fails', async () => {
+    const organization = OrganizationFactory().one();
+    const agreementId = faker.string.uuid();
+    const DOWNLOAD_URL = `https://joanie.test/api/v1.0/organizations/${organization.id}/agreements/${agreementId}/download/`;
+    fetchMock.get(DOWNLOAD_URL, HttpStatusCode.UNAUTHORIZED);
+
+    const { result } = renderHook(() => useDownloadAgreement(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(fetchMock.called(DOWNLOAD_URL)).toBe(false);
+    expect(mockHandle).not.toHaveBeenCalled();
+    // eslint-disable-next-line compat/compat
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+
+    act(() => {
+      result.current.download(organization.id, agreementId);
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.called(DOWNLOAD_URL)).toBe(true);
+      expect(mockHandle).toHaveBeenNthCalledWith(1, new Error('Unauthorized'));
+      // eslint-disable-next-line compat/compat
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+      // eslint-disable-next-line compat/compat
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/src/frontend/js/hooks/useDownloadAgreement/index.tsx
+++ b/src/frontend/js/hooks/useDownloadAgreement/index.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { useJoanieApi } from 'contexts/JoanieApiContext';
+import { browserDownloadFromBlob } from 'utils/download';
+
+export const useDownloadAgreement = () => {
+  const [loading, setLoading] = useState(false);
+  const API = useJoanieApi();
+
+  return {
+    download: async (organizationId: string, agreementId: string) => {
+      setLoading(true);
+      try {
+        await browserDownloadFromBlob(() =>
+          API.organizations.agreements.download({
+            organization_id: organizationId,
+            id: agreementId,
+          }),
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    loading,
+  };
+};

--- a/src/frontend/js/hooks/useDownloadBatchOrderSeats/index.spec.tsx
+++ b/src/frontend/js/hooks/useDownloadBatchOrderSeats/index.spec.tsx
@@ -1,0 +1,132 @@
+import fetchMock from 'fetch-mock';
+import { PropsWithChildren } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from 'react-intl';
+import { act, fireEvent, renderHook, waitFor } from '@testing-library/react';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { useDownloadBatchOrderSeats } from 'hooks/useDownloadBatchOrderSeats/index';
+import { handle } from 'utils/errors/handle';
+import { SessionProvider } from 'contexts/SessionContext';
+import { Deferred } from 'utils/test/deferred';
+import { BatchOrderReadFactory } from 'utils/test/factories/joanie';
+import { HttpStatusCode } from 'utils/errors/HttpError';
+
+jest.mock('utils/errors/handle');
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.test' },
+  }).one(),
+}));
+
+const mockHandle = handle as jest.MockedFn<typeof handle>;
+
+describe('useDownloadBatchOrderSeats', () => {
+  beforeEach(() => {
+    fetchMock.get('https://joanie.test/api/v1.0/orders/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/addresses/', []);
+    fetchMock.get('https://joanie.test/api/v1.0/credit-cards/', []);
+  });
+
+  beforeAll(() => {
+    // eslint-disable-next-line compat/compat
+    URL.createObjectURL = jest.fn();
+    // eslint-disable-next-line compat/compat
+    URL.revokeObjectURL = jest.fn();
+    HTMLAnchorElement.prototype.click = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    fetchMock.restore();
+  });
+
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    return (
+      <QueryClientProvider client={createTestQueryClient({ user: true })}>
+        <IntlProvider locale="en">
+          <SessionProvider>{children}</SessionProvider>
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  it('downloads the batch order seats CSV', async () => {
+    const batchOrder = BatchOrderReadFactory().one();
+    const DOWNLOAD_URL = `https://joanie.test/api/v1.0/batch-orders/${batchOrder.id}/seats-export/`;
+    const deferred = new Deferred();
+    fetchMock.get(DOWNLOAD_URL, deferred.promise);
+
+    const { result } = renderHook(() => useDownloadBatchOrderSeats(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(fetchMock.called(DOWNLOAD_URL)).toBe(false);
+    // eslint-disable-next-line compat/compat
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+    expect(result.current.loading).toBe(false);
+
+    act(() => {
+      result.current.download(batchOrder.id);
+    });
+    expect(result.current.loading).toBe(true);
+
+    deferred.resolve({
+      status: HttpStatusCode.OK,
+      body: new Blob(['last_name,first_name,email']),
+      headers: {
+        'Content-Type': 'text/csv',
+      },
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.called(DOWNLOAD_URL)).toBe(true);
+      // eslint-disable-next-line compat/compat
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line compat/compat
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+      expect(result.current.loading).toBe(false);
+    });
+
+    fireEvent.blur(window);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles an error if seats export request fails', async () => {
+    const batchOrder = BatchOrderReadFactory().one();
+    const DOWNLOAD_URL = `https://joanie.test/api/v1.0/batch-orders/${batchOrder.id}/seats-export/`;
+    fetchMock.get(DOWNLOAD_URL, HttpStatusCode.UNAUTHORIZED);
+
+    const { result } = renderHook(() => useDownloadBatchOrderSeats(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current).not.toBeNull());
+
+    expect(fetchMock.called(DOWNLOAD_URL)).toBe(false);
+    expect(mockHandle).not.toHaveBeenCalled();
+    // eslint-disable-next-line compat/compat
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line compat/compat
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+
+    act(() => {
+      result.current.download(batchOrder.id);
+    });
+
+    await waitFor(() => {
+      expect(fetchMock.called(DOWNLOAD_URL)).toBe(true);
+      expect(mockHandle).toHaveBeenNthCalledWith(1, new Error('Unauthorized'));
+      // eslint-disable-next-line compat/compat
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(0);
+      // eslint-disable-next-line compat/compat
+      expect(URL.revokeObjectURL).toHaveBeenCalledTimes(0);
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/src/frontend/js/hooks/useDownloadBatchOrderSeats/index.tsx
+++ b/src/frontend/js/hooks/useDownloadBatchOrderSeats/index.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { useJoanieApi } from 'contexts/JoanieApiContext';
+import { browserDownloadFromBlob } from 'utils/download';
+
+export const useDownloadBatchOrderSeats = () => {
+  const [loading, setLoading] = useState(false);
+  const API = useJoanieApi();
+
+  return {
+    download: async (batchOrderId: string, filename?: string) => {
+      setLoading(true);
+      try {
+        await browserDownloadFromBlob(
+          () => API.user.batchOrders.seats_export(batchOrderId),
+          false,
+          filename,
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    loading,
+  };
+};

--- a/src/frontend/js/pages/DashboardBatchOrderLayout/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardBatchOrderLayout/index.spec.tsx
@@ -2,7 +2,7 @@ import { findByRole, render, screen, waitFor } from '@testing-library/react';
 import { generatePath } from 'react-router';
 import fetchMock from 'fetch-mock';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
-import { BatchOrderReadFactory } from 'utils/test/factories/joanie';
+import { BatchOrderReadFactory, BatchOrderSeatFactory } from 'utils/test/factories/joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
 import { expectUrlMatchLocationDisplayed } from 'utils/test/expectUrlMatchLocationDisplayed';
@@ -49,8 +49,9 @@ describe('<DashboardBatchOrderLayout />', () => {
 
   it('renders sidebar', async () => {
     const batchOrder = BatchOrderReadFactory().one();
-
+    const seats = BatchOrderSeatFactory().many(2);
     fetchMock.get(`https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/`, batchOrder);
+    fetchMock.get(`https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/seats/`, seats);
 
     render(
       WrapperWithDashboard(

--- a/src/frontend/js/pages/DashboardBatchOrderLayout/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardBatchOrderLayout/index.spec.tsx
@@ -2,7 +2,11 @@ import { findByRole, render, screen, waitFor } from '@testing-library/react';
 import { generatePath } from 'react-router';
 import fetchMock from 'fetch-mock';
 import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
-import { BatchOrderReadFactory, BatchOrderSeatFactory } from 'utils/test/factories/joanie';
+import {
+  AgreementFactory,
+  BatchOrderReadFactory,
+  BatchOrderSeatFactory,
+} from 'utils/test/factories/joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
 import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
 import { expectUrlMatchLocationDisplayed } from 'utils/test/expectUrlMatchLocationDisplayed';
@@ -59,6 +63,10 @@ describe('<DashboardBatchOrderLayout />', () => {
         previous: null,
         next: null,
       },
+    );
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/organizations/${batchOrder.organization.id}/agreements/${batchOrder.contract_id}/`,
+      AgreementFactory().one(),
     );
 
     render(

--- a/src/frontend/js/pages/DashboardBatchOrderLayout/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardBatchOrderLayout/index.spec.tsx
@@ -51,7 +51,15 @@ describe('<DashboardBatchOrderLayout />', () => {
     const batchOrder = BatchOrderReadFactory().one();
     const seats = BatchOrderSeatFactory().many(2);
     fetchMock.get(`https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/`, batchOrder);
-    fetchMock.get(`https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/seats/`, seats);
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/seats/?page=1&page_size=10`,
+      {
+        results: seats,
+        count: seats.length,
+        previous: null,
+        next: null,
+      },
+    );
 
     render(
       WrapperWithDashboard(

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/BatchOrderSeatInfoQuote.tsx
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/BatchOrderSeatInfoQuote.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { Button, Input } from '@openfun/cunningham-react';
+import { Icon, IconTypeEnum } from 'components/Icon';
+import Banner, { BannerType } from 'components/Banner';
+import { useBatchOrderSeats } from 'hooks/useBatchOrder';
+import { BatchOrderQuote, BatchOrderSeat } from 'types/Joanie';
+import { batchOrderSeatInfoMessages } from 'widgets/Dashboard/components/DashboardItem/BatchOrder/batchOrderSeatInfoMessages';
+
+const ITEMS_PER_PAGE = 10;
+
+export const BatchOrderSeatInfoQuote = ({ batchOrder }: { batchOrder: BatchOrderQuote }) => {
+  const intl = useIntl();
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [allSeats, setAllSeats] = useState<BatchOrderSeat[]>([]);
+
+  const seatsOwnedCount = batchOrder.seats_owned ?? 0;
+
+  const {
+    items: seats,
+    meta,
+    states,
+  } = useBatchOrderSeats(
+    {
+      batch_order_id: batchOrder.id,
+      query: query || undefined,
+      page,
+      page_size: ITEMS_PER_PAGE,
+    },
+    { enabled: !!batchOrder.id },
+  );
+
+  useEffect(() => {
+    if (page === 1) {
+      setAllSeats(seats);
+    } else if (seats.length > 0) {
+      setAllSeats((prev) => [...prev, ...seats]);
+    }
+  }, [seats]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [query]);
+
+  const totalCount = meta?.pagination?.count ?? 0;
+  const remainingCount = Math.min(ITEMS_PER_PAGE, totalCount - allSeats.length);
+
+  if (
+    !batchOrder.nb_seats ||
+    batchOrder.seats_owned === undefined ||
+    batchOrder.seats_to_own === undefined
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="dashboard__quote__enrollment">
+      <div className="content">
+        <div className="enrollment-progress">
+          <span className="dashboard-item__label">
+            {intl.formatMessage(batchOrderSeatInfoMessages.enrolledParticipants, {
+              seats_owned: seatsOwnedCount,
+              nb_seats: batchOrder.nb_seats,
+            })}
+          </span>
+          <div className="enrollment-progress__bar">
+            <div
+              className="enrollment-progress__bar__fill"
+              style={{ width: `${(seatsOwnedCount / batchOrder.nb_seats) * 100}%` }}
+            />
+          </div>
+        </div>
+        {states.error && <Banner message={states.error} type={BannerType.ERROR} />}
+        <div className="enrollment-nested-section__content">
+          <Input
+            className="enrollment-search"
+            label={intl.formatMessage(batchOrderSeatInfoMessages.searchPlaceholder)}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            rightIcon={<Icon name={IconTypeEnum.MAGNIFYING_GLASS} size="small" />}
+          />
+          {allSeats.length === 0 && query ? (
+            <FormattedMessage {...batchOrderSeatInfoMessages.noResults} />
+          ) : (
+            <>
+              <ul className="enrollment-list">
+                {allSeats.map((seat) => (
+                  <li key={seat.id}>{seat.owner_name ?? seat.voucher}</li>
+                ))}
+              </ul>
+              {remainingCount > 0 && (
+                <Button
+                  className="enrollment-load-more"
+                  color="brand"
+                  variant="secondary"
+                  size="small"
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={states.fetching}
+                >
+                  {intl.formatMessage(batchOrderSeatInfoMessages.loadMore, {
+                    count: remainingCount,
+                  })}
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/_styles.scss
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/_styles.scss
@@ -38,3 +38,20 @@
   display: flex;
   justify-content: center;
 }
+
+.dashboard__quote__enrollment {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid r-theme-val(dashboard-card, base-color);
+
+  &__title {
+    margin: 0 0 0.5rem;
+  }
+
+  .content {
+    font-size: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.full-process.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.full-process.spec.tsx
@@ -50,7 +50,7 @@ describe('full process for the organization quotes dashboard', () => {
       batch_order: {
         state: BatchOrderState.QUOTED,
         payment_method: PaymentMethod.CARD_PAYMENT,
-        available_actions: { next_action: 'confirm_quote' },
+        available_actions: { next_action: 'confirm_quote', download_quote: true },
       },
       organization_signed_on: undefined,
     }).one();

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.full-process.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.full-process.spec.tsx
@@ -214,7 +214,6 @@ describe('full process for the organization quotes dashboard', () => {
       },
     }).one();
     fetchMock.get('https://joanie.endpoint/api/v1.0/organizations/1/', organization);
-
     const quoteQuoted = OrganizationQuoteFactory({
       batch_order: {
         state: BatchOrderState.QUOTED,
@@ -271,6 +270,10 @@ describe('full process for the organization quotes dashboard', () => {
     fetchMock.post(
       `https://joanie.endpoint/api/v1.0/organizations/1/submit-for-signature-batch-order/`,
       200,
+    );
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/batch-orders/${quoteCompleted.batch_order.id}/seats/?page=1&page_size=10`,
+      { results: [], count: 0, previous: null, next: null },
     );
 
     render(<TeacherDashboardOrganizationQuotes />, {

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.spec.tsx
@@ -158,7 +158,7 @@ describe('pages/TeacherDashboardOrganizationQuotes', () => {
     const quoteQuoted = OrganizationQuoteFactory({
       batch_order: {
         state: BatchOrderState.QUOTED,
-        available_actions: { next_action: 'confirm_quote' },
+        available_actions: { next_action: 'confirm_quote', download_quote: true },
       },
     }).one();
     fetchMock.get(`https://joanie.endpoint/api/v1.0/organizations/`, []);

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.spec.tsx
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.spec.tsx
@@ -28,7 +28,9 @@ describe('pages/TeacherDashboardOrganizationQuotes', () => {
   });
 
   it('should render a list of quotes for an organization', async () => {
-    const quoteList = OrganizationQuoteFactory().many(1);
+    const quoteList = OrganizationQuoteFactory({
+      batch_order: { state: BatchOrderState.QUOTED },
+    }).many(1);
     fetchMock.get(`https://joanie.endpoint/api/v1.0/organizations/`, []);
 
     fetchMock.get('https://joanie.endpoint/api/v1.0/organizations/1/', []);
@@ -85,7 +87,9 @@ describe('pages/TeacherDashboardOrganizationQuotes', () => {
   });
 
   it('should paginate', async () => {
-    const quoteList = OrganizationQuoteFactory().many(30);
+    const quoteList = OrganizationQuoteFactory({
+      batch_order: { state: BatchOrderState.QUOTED },
+    }).many(30);
     fetchMock.get(`https://joanie.endpoint/api/v1.0/organizations/`, []);
 
     fetchMock.get('https://joanie.endpoint/api/v1.0/organizations/1/', []);

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.tsx
@@ -360,35 +360,40 @@ const TeacherDashboardOrganizationQuotes = () => {
     );
   };
 
+  const renderDownloadButton = (quote: OrganizationQuote) => {
+    const batchOrder = quote.batch_order;
+
+    return (
+      <Button
+        size="small"
+        color="brand"
+        variant="secondary"
+        className="mr-2"
+        onClick={() => handleDownloadQuote(quote.id)}
+        icon={<span className="material-icons">download</span>}
+        disabled={!abilities?.download_quote || !batchOrder.available_actions.download_quote}
+      >
+        {intl.formatMessage(messages.downloadQuote)}
+      </Button>
+    );
+  };
+
   const renderActionButton = (quote: OrganizationQuote) => {
     const batchOrder = quote.batch_order;
     const state = batchOrder?.state;
     const paymentMethod = batchOrder?.payment_method;
 
-    if (!batchOrder || !state || !paymentMethod || state === BatchOrderState.COMPLETED) return null;
+    if (!batchOrder || !state || !paymentMethod) return null;
 
-    const confirmQuoteButtons = (
-      <div>
-        <Button
-          size="small"
-          color="brand"
-          variant="secondary"
-          className="mr-2"
-          onClick={() => handleDownloadQuote(quote.id)}
-          icon={<span className="material-icons">download</span>}
-          disabled={!abilities?.download_quote}
-        >
-          {intl.formatMessage(messages.downloadQuote)}
-        </Button>
-        <Button
-          size="small"
-          onClick={() => handleOpenConfirm(quote.id)}
-          icon={<span className="material-icons">check_circle</span>}
-          disabled={!abilities?.confirm_quote}
-        >
-          {intl.formatMessage(messages.confirmQuote)}
-        </Button>
-      </div>
+    const confirmQuoteButton = (
+      <Button
+        size="small"
+        onClick={() => handleOpenConfirm(quote.id)}
+        icon={<span className="material-icons">check_circle</span>}
+        disabled={!abilities?.confirm_quote}
+      >
+        {intl.formatMessage(messages.confirmQuote)}
+      </Button>
     );
 
     const confirmPurchaseOrderButton = (
@@ -430,7 +435,7 @@ const TeacherDashboardOrganizationQuotes = () => {
 
     switch (batchOrder.available_actions?.next_action) {
       case 'confirm_quote':
-        return confirmQuoteButtons;
+        return confirmQuoteButton;
       case 'confirm_purchase_order':
         return confirmPurchaseOrderButton;
       case 'confirm_bank_transfer':
@@ -485,7 +490,10 @@ const TeacherDashboardOrganizationQuotes = () => {
                   </Badge>
                 )}
               </div>
-              <div className="dashboard__quote__header__action">{renderActionButton(quote)}</div>
+              <div className="dashboard__quote__header__action">
+                {renderDownloadButton(quote)}
+                {renderActionButton(quote)}
+              </div>
             </div>
           }
           defaultExpanded={false}

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.tsx
@@ -14,6 +14,7 @@ import Badge from 'components/Badge';
 import { Icon, IconTypeEnum } from 'components/Icon';
 import { browserDownloadFromBlob } from 'utils/download';
 import { Spinner } from 'components/Spinner';
+import { BatchOrderSeatInfoQuote } from './BatchOrderSeatInfoQuote';
 
 const messages = defineMessages({
   loading: {
@@ -542,6 +543,9 @@ const TeacherDashboardOrganizationQuotes = () => {
               </div>
             )}
           </div>
+          {quote.batch_order.state === BatchOrderState.COMPLETED && (
+            <BatchOrderSeatInfoQuote batchOrder={quote.batch_order} />
+          )}
         </DashboardCard>
       ))}
       <Pagination {...pagination} />

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -585,7 +585,8 @@ export type BatchOrderAction =
   | 'confirm_quote'
   | 'confirm_purchase_order'
   | 'confirm_bank_transfer'
-  | 'submit_for_signature';
+  | 'submit_for_signature'
+  | 'download_quote';
 
 export type BatchOrderAvailableActions = {
   [K in BatchOrderAction]: boolean;

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -612,6 +612,8 @@ export interface BatchOrderQuote {
   payment_method: PaymentMethod;
   contract_submitted: boolean;
   nb_seats: number;
+  seats_to_own?: number;
+  seats_owned?: number;
   available_actions: BatchOrderAvailableActions;
 }
 

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -852,6 +852,7 @@ interface APIUser {
     seats: {
       get(filters?: BatchOrderSeatsQueryFilters): Promise<PaginatedResponse<BatchOrderSeat>>;
     };
+    seats_export(id: string): Promise<File>;
   };
   certificates: {
     download(id: string): Promise<File>;

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -567,6 +567,14 @@ export interface BatchOrderRead {
   funding_entity?: string;
   funding_amount?: number;
   offering: OfferingBatchOrder;
+  seats_to_own?: number;
+  seats_owned?: number;
+}
+
+export interface BatchOrderSeat {
+  id: string;
+  owner_name: string | null;
+  voucher: string | null;
 }
 
 export interface Relation {
@@ -742,6 +750,10 @@ export interface OfferingQueryFilters extends PaginatedResourceQuery {
 export interface BatchOrderQueryFilters extends PaginatedResourceQuery {
   id?: BatchOrderRead['id'];
 }
+export interface BatchOrderSeatsQueryFilters extends PaginatedResourceQuery {
+  batch_order_id?: string;
+  query?: string;
+}
 export interface OrganizationQuoteQueryFilters extends PaginatedResourceQuery {
   organization_id?: Organization['id'];
   batch_order_id?: BatchOrder['id'];
@@ -834,6 +846,9 @@ interface APIUser {
       : Promise<PaginatedResponse<BatchOrderRead>>;
     submit_for_payment: {
       create(filters: ResourcesQuery): Promise<any>;
+    };
+    seats: {
+      get(filters?: BatchOrderSeatsQueryFilters): Promise<PaginatedResponse<BatchOrderSeat>>;
     };
   };
   certificates: {

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -966,6 +966,7 @@ export interface API {
       ): ContractResourceQuery extends { id: string }
         ? Promise<Nullable<Agreement>>
         : Promise<PaginatedResponse<Agreement>>;
+      download(filters: { organization_id: string; id: string }): Promise<File>;
     };
   };
   courseRuns: {

--- a/src/frontend/js/utils/download.ts
+++ b/src/frontend/js/utils/download.ts
@@ -5,11 +5,13 @@ import { handle } from './errors/handle';
  *
  * @param downloadFunction, an api promise that return a File
  * @param newWindow, does it open in a new window or not
+ * @param filename, optional filename override; if provided, takes precedence over file.name
  * @returns boolean, true for success
  */
 export const browserDownloadFromBlob = async (
   downloadFunction: () => Promise<File>,
   newWindow: boolean = false,
+  filename?: string,
 ) => {
   try {
     const file = await downloadFunction();
@@ -24,7 +26,7 @@ export const browserDownloadFromBlob = async (
 
     const $link = document.createElement('a');
     $link.href = url;
-    $link.download = file.name;
+    $link.download = filename || file.name;
 
     const revokeObject = () => {
       // eslint-disable-next-line compat/compat

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -220,6 +220,7 @@ export const BatchOrderQuoteFactory = factory((): BatchOrderQuote => {
       confirm_purchase_order: false,
       confirm_bank_transfer: false,
       submit_for_signature: false,
+      download_quote: false,
       next_action: null,
     },
   };

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -215,7 +215,9 @@ export const BatchOrderQuoteFactory = factory((): BatchOrderQuote => {
     relation: RelationFactory().one(),
     payment_method: faker.helpers.arrayElement(Object.values(PaymentMethod)),
     contract_submitted: faker.datatype.boolean(),
-    nb_seats: faker.number.int({ min: 1, max: 100 }),
+    nb_seats: faker.number.int({ min: 10, max: 100 }),
+    seats_owned: faker.number.int({ min: 0, max: 10 }),
+    seats_to_own: faker.number.int({ min: 90, max: 100 }),
     available_actions: {
       confirm_quote: false,
       confirm_purchase_order: false,

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -46,6 +46,7 @@ import {
   BatchOrderQuote,
   Relation,
   Agreement,
+  BatchOrderSeat,
 } from 'types/Joanie';
 import { Payment, PaymentMethod, PaymentProviders } from 'components/PaymentInterfaces/types';
 import { CourseStateFactory } from 'utils/test/factories/richie';
@@ -552,6 +553,8 @@ export const BatchOrderReadFactory = factory((): BatchOrderRead => {
     funding_entity: faker.company.name(),
     funding_amount: faker.number.int({ min: 100, max: 10000 }),
     offering: OfferingBatchOrderFactory().one(),
+    seats_owned: faker.number.int({ min: 1, max: 200 }),
+    seats_to_own: faker.number.int({ min: 1, max: 200 }),
   };
 });
 
@@ -679,3 +682,11 @@ export const SaleTunnelContextFactory = factory(
     setPaymentMode: noop,
   }),
 );
+
+export const BatchOrderSeatFactory = factory((): BatchOrderSeat => {
+  return {
+    id: faker.string.uuid(),
+    owner_name: null,
+    voucher: faker.string.alphanumeric(10),
+  };
+});

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderAgreementInfo.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderAgreementInfo.tsx
@@ -1,0 +1,72 @@
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { BatchOrderRead } from 'types/Joanie';
+import DownloadAgreementButton from 'components/DownloadAgreementButton';
+import { DashboardSubItem } from 'widgets/Dashboard/components/DashboardItem/DashboardSubItem';
+import { useOrganizationAgreement } from 'hooks/useOrganizationAgreements.tsx';
+import useDateFormat from 'hooks/useDateFormat';
+
+const messages = defineMessages({
+  title: {
+    id: 'batchOrder.agreement.title',
+    description: 'Step label for the agreement document in the batch order detail',
+    defaultMessage: 'Agreement',
+  },
+  organizationSignedOn: {
+    id: 'batchOrder.agreement.organizationSignedOn',
+    description: 'Label displayed once the organization has counter-signed the agreement',
+    defaultMessage: 'Signed by the organization on {date}.',
+  },
+  waitingOrganization: {
+    id: 'batchOrder.agreement.waitingOrganization',
+    description:
+      'Label displayed when the agreement is waiting for the organization counter-signature',
+    defaultMessage: 'Waiting for the organization to counter-sign the agreement.',
+  },
+});
+
+interface BatchOrderAgreementInfoProps {
+  batchOrder: BatchOrderRead;
+}
+
+export const BatchOrderAgreementInfo = ({ batchOrder }: BatchOrderAgreementInfoProps) => {
+  const intl = useIntl();
+  const formatDate = useDateFormat();
+  const {
+    item: agreement,
+    states: { isFetched, error },
+  } = useOrganizationAgreement(batchOrder.contract_id!, {
+    organization_id: batchOrder.organization.id,
+  });
+
+  if (!isFetched || error || !agreement) {
+    return null;
+  }
+
+  const signedOn = agreement.organization_signed_on;
+
+  return (
+    <DashboardSubItem
+      title={intl.formatMessage(messages.title)}
+      footer={
+        <div className="content">
+          {signedOn ? (
+            <>
+              <p>
+                <FormattedMessage
+                  {...messages.organizationSignedOn}
+                  values={{ date: formatDate(signedOn) }}
+                />
+              </p>
+              <DownloadAgreementButton
+                organizationId={batchOrder.organization.id}
+                agreementId={batchOrder.contract_id!}
+              />
+            </>
+          ) : (
+            <FormattedMessage {...messages.waitingOrganization} />
+          )}
+        </div>
+      }
+    />
+  );
+};

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderSeatInfo.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderSeatInfo.spec.tsx
@@ -1,0 +1,114 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { BatchOrderReadFactory, BatchOrderSeatFactory } from 'utils/test/factories/joanie';
+import { BatchOrderState } from 'types/Joanie';
+import { HttpStatusCode } from 'utils/errors/HttpError';
+import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
+import { render } from 'utils/test/render';
+import { expectBannerError } from 'utils/test/expectBanner';
+import { BatchOrderSeatInfo } from './BatchOrderSeatInfo';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.test' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint' },
+  }).one(),
+}));
+
+describe('<BatchOrderSeatInfo />', () => {
+  setupJoanieSession();
+
+  const paginatedResponse = (results: object[], count?: number) => ({
+    results,
+    count: count ?? results.length,
+    next: null,
+    previous: null,
+  });
+
+  it('renders enrollment progress and seat list, and searches by query param', async () => {
+    const ownedSeat = BatchOrderSeatFactory({ owner_name: 'Alice Martin' }).one();
+    const voucherSeat = BatchOrderSeatFactory().one();
+    const batchOrder = BatchOrderReadFactory({
+      state: BatchOrderState.COMPLETED,
+      nb_seats: 10,
+      seats_owned: 1,
+      seats_to_own: 9,
+    }).one();
+
+    fetchMock.get(
+      `begin:https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/seats/`,
+      paginatedResponse([ownedSeat, voucherSeat], 10),
+    );
+
+    render(<BatchOrderSeatInfo batchOrder={batchOrder} />);
+
+    expect(await screen.findByText('1/10 enrolled participants')).toBeVisible();
+    expect(await screen.findByText('Alice Martin')).toBeVisible();
+    expect(await screen.findByText(voucherSeat.voucher!)).toBeVisible();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByRole('textbox'), 'Alice');
+
+    await waitFor(() => {
+      const urls = fetchMock
+        .calls(`begin:https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/seats/`)
+        .map(([url]) => url);
+      expect(urls.some((url) => url.includes('query=Alice'))).toBe(true);
+    });
+  });
+
+  it('loads more seats when clicking the load more button', async () => {
+    const firstPage = BatchOrderSeatFactory().many(10);
+    const secondPage = BatchOrderSeatFactory().many(5);
+    const batchOrder = BatchOrderReadFactory({
+      state: BatchOrderState.COMPLETED,
+      nb_seats: 15,
+      seats_owned: 15,
+      seats_to_own: 0,
+    }).one();
+
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/seats/?page=1&page_size=10`,
+      { results: firstPage, count: 15, next: 'next-url', previous: null },
+    );
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/seats/?page=2&page_size=10`,
+      { results: secondPage, count: 15, next: null, previous: 'prev-url' },
+    );
+
+    render(<BatchOrderSeatInfo batchOrder={batchOrder} />);
+
+    expect(await screen.findByText(firstPage[0].owner_name ?? firstPage[0].voucher!)).toBeVisible();
+    expect(screen.queryByText(secondPage[0].owner_name ?? secondPage[0].voucher!)).toBeNull();
+    expect(screen.getByRole('button', { name: 'Load 5 more' })).toBeVisible();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Load 5 more' }));
+
+    expect(
+      await screen.findByText(secondPage[0].owner_name ?? secondPage[0].voucher!),
+    ).toBeVisible();
+    expect(screen.queryByText('Load 5 more')).toBeNull();
+    expect(screen.getByText(firstPage[0].owner_name ?? firstPage[0].voucher!)).toBeVisible();
+  });
+
+  it('shows an error banner when the seats API fails', async () => {
+    const batchOrder = BatchOrderReadFactory({
+      state: BatchOrderState.COMPLETED,
+      nb_seats: 10,
+      seats_owned: 1,
+      seats_to_own: 9,
+    }).one();
+
+    fetchMock.get(`begin:https://joanie.endpoint/api/v1.0/batch-orders/${batchOrder.id}/seats/`, {
+      status: HttpStatusCode.INTERNAL_SERVER_ERROR,
+    });
+
+    render(<BatchOrderSeatInfo batchOrder={batchOrder} />);
+
+    await expectBannerError('An error occurred while fetching resources. Please retry later.');
+  });
+});

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderSeatInfo.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderSeatInfo.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { Button, Input } from '@openfun/cunningham-react';
+import { Icon, IconTypeEnum } from 'components/Icon';
+import Banner, { BannerType } from 'components/Banner';
+import { DashboardSubItem } from 'widgets/Dashboard/components/DashboardItem/DashboardSubItem';
+import { useBatchOrderSeats } from 'hooks/useBatchOrder';
+import { BatchOrderRead, BatchOrderSeat } from 'types/Joanie';
+
+const messages = defineMessages({
+  enrollmentManagement: {
+    id: 'batchOrder.enrollmentManagement.title',
+    description: 'Title for enrollment management section',
+    defaultMessage: 'Enrollment',
+  },
+  enrolledParticipants: {
+    id: 'batchOrder.enrollmentManagement.enrolledParticipants',
+    description: 'Progress label showing enrolled participants out of total seats',
+    defaultMessage: '{seats_owned}/{nb_seats} enrolled participants',
+  },
+  searchPlaceholder: {
+    id: 'batchOrder.enrollmentManagement.searchPlaceholder',
+    description: 'Placeholder for the seat search input (student name or voucher)',
+    defaultMessage: 'Student name',
+  },
+  noResults: {
+    id: 'batchOrder.enrollmentManagement.noResults',
+    description: 'Message shown when the student search returns no results',
+    defaultMessage: 'No student matches your search.',
+  },
+  loadMore: {
+    id: 'batchOrder.enrollmentManagement.loadMore',
+    description: 'Button to load more seats',
+    defaultMessage: 'Load {count} more',
+  },
+});
+
+const ITEMS_PER_PAGE = 10;
+
+interface BatchOrderSeatInfoProps {
+  batchOrder: BatchOrderRead;
+}
+
+export const BatchOrderSeatInfo = ({ batchOrder }: BatchOrderSeatInfoProps) => {
+  const intl = useIntl();
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [allSeats, setAllSeats] = useState<BatchOrderSeat[]>([]);
+
+  const seatsOwnedCount = batchOrder.seats_owned ?? 0;
+
+  const {
+    items: seats,
+    meta,
+    states,
+  } = useBatchOrderSeats(
+    {
+      batch_order_id: batchOrder.id,
+      query: query || undefined,
+      page,
+      page_size: ITEMS_PER_PAGE,
+    },
+    { enabled: !!batchOrder.id },
+  );
+
+  useEffect(() => {
+    if (page === 1) {
+      setAllSeats(seats);
+    } else if (seats.length > 0) {
+      setAllSeats((prev) => [...prev, ...seats]);
+    }
+  }, [seats]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [query]);
+
+  const totalCount = meta?.pagination?.count ?? 0;
+  const remainingCount = Math.min(ITEMS_PER_PAGE, totalCount - allSeats.length);
+
+  if (
+    !batchOrder.nb_seats ||
+    batchOrder.seats_owned === undefined ||
+    batchOrder.seats_to_own === undefined
+  ) {
+    return null;
+  }
+
+  return (
+    <DashboardSubItem
+      title={intl.formatMessage(messages.enrollmentManagement)}
+      footer={
+        <div className="content">
+          <div className="enrollment-progress">
+            <span className="dashboard-item__label">
+              {intl.formatMessage(messages.enrolledParticipants, {
+                seats_owned: seatsOwnedCount,
+                nb_seats: batchOrder.nb_seats,
+              })}
+            </span>
+            <div className="enrollment-progress__bar">
+              <div
+                className="enrollment-progress__bar__fill"
+                style={{ width: `${(seatsOwnedCount / batchOrder.nb_seats) * 100}%` }}
+              />
+            </div>
+          </div>
+          {states.error && <Banner message={states.error} type={BannerType.ERROR} />}
+          <div className="enrollment-nested-section__content">
+            <Input
+              className="enrollment-search"
+              label={intl.formatMessage(messages.searchPlaceholder)}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              rightIcon={<Icon name={IconTypeEnum.MAGNIFYING_GLASS} size="small" />}
+            />
+            {allSeats.length === 0 && query ? (
+              <FormattedMessage {...messages.noResults} />
+            ) : (
+              <>
+                <ul className="enrollment-list">
+                  {allSeats.map((seat) => (
+                    <li key={seat.id}>{seat.owner_name ?? seat.voucher}</li>
+                  ))}
+                </ul>
+                {remainingCount > 0 && (
+                  <Button
+                    className="enrollment-load-more"
+                    color="brand"
+                    variant="secondary"
+                    size="small"
+                    onClick={() => setPage((p) => p + 1)}
+                    disabled={states.fetching}
+                  >
+                    {intl.formatMessage(messages.loadMore, { count: remainingCount })}
+                  </Button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      }
+    />
+  );
+};

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderSeatInfo.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderSeatInfo.tsx
@@ -6,32 +6,13 @@ import Banner, { BannerType } from 'components/Banner';
 import { DashboardSubItem } from 'widgets/Dashboard/components/DashboardItem/DashboardSubItem';
 import { useBatchOrderSeats } from 'hooks/useBatchOrder';
 import { BatchOrderRead, BatchOrderSeat } from 'types/Joanie';
+import { batchOrderSeatInfoMessages } from './batchOrderSeatInfoMessages';
 
 const messages = defineMessages({
   enrollmentManagement: {
     id: 'batchOrder.enrollmentManagement.title',
     description: 'Title for enrollment management section',
     defaultMessage: 'Enrollment',
-  },
-  enrolledParticipants: {
-    id: 'batchOrder.enrollmentManagement.enrolledParticipants',
-    description: 'Progress label showing enrolled participants out of total seats',
-    defaultMessage: '{seats_owned}/{nb_seats} enrolled participants',
-  },
-  searchPlaceholder: {
-    id: 'batchOrder.enrollmentManagement.searchPlaceholder',
-    description: 'Placeholder for the seat search input (student name or voucher)',
-    defaultMessage: 'Student name',
-  },
-  noResults: {
-    id: 'batchOrder.enrollmentManagement.noResults',
-    description: 'Message shown when the student search returns no results',
-    defaultMessage: 'No student matches your search.',
-  },
-  loadMore: {
-    id: 'batchOrder.enrollmentManagement.loadMore',
-    description: 'Button to load more seats',
-    defaultMessage: 'Load {count} more',
   },
 });
 
@@ -93,7 +74,7 @@ export const BatchOrderSeatInfo = ({ batchOrder }: BatchOrderSeatInfoProps) => {
         <div className="content">
           <div className="enrollment-progress">
             <span className="dashboard-item__label">
-              {intl.formatMessage(messages.enrolledParticipants, {
+              {intl.formatMessage(batchOrderSeatInfoMessages.enrolledParticipants, {
                 seats_owned: seatsOwnedCount,
                 nb_seats: batchOrder.nb_seats,
               })}
@@ -109,13 +90,13 @@ export const BatchOrderSeatInfo = ({ batchOrder }: BatchOrderSeatInfoProps) => {
           <div className="enrollment-nested-section__content">
             <Input
               className="enrollment-search"
-              label={intl.formatMessage(messages.searchPlaceholder)}
+              label={intl.formatMessage(batchOrderSeatInfoMessages.searchPlaceholder)}
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               rightIcon={<Icon name={IconTypeEnum.MAGNIFYING_GLASS} size="small" />}
             />
             {allSeats.length === 0 && query ? (
-              <FormattedMessage {...messages.noResults} />
+              <FormattedMessage {...batchOrderSeatInfoMessages.noResults} />
             ) : (
               <>
                 <ul className="enrollment-list">
@@ -132,7 +113,9 @@ export const BatchOrderSeatInfo = ({ batchOrder }: BatchOrderSeatInfoProps) => {
                     onClick={() => setPage((p) => p + 1)}
                     disabled={states.fetching}
                   >
-                    {intl.formatMessage(messages.loadMore, { count: remainingCount })}
+                    {intl.formatMessage(batchOrderSeatInfoMessages.loadMore, {
+                      count: remainingCount,
+                    })}
                   </Button>
                 )}
               </>

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderSeatInfo.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/BatchOrderSeatInfo.tsx
@@ -5,6 +5,7 @@ import { Icon, IconTypeEnum } from 'components/Icon';
 import Banner, { BannerType } from 'components/Banner';
 import { DashboardSubItem } from 'widgets/Dashboard/components/DashboardItem/DashboardSubItem';
 import { useBatchOrderSeats } from 'hooks/useBatchOrder';
+import DownloadBatchOrderSeatsButton from 'components/DownloadBatchOrderSeatsButton';
 import { BatchOrderRead, BatchOrderSeat } from 'types/Joanie';
 import { batchOrderSeatInfoMessages } from './batchOrderSeatInfoMessages';
 
@@ -121,6 +122,10 @@ export const BatchOrderSeatInfo = ({ batchOrder }: BatchOrderSeatInfoProps) => {
               </>
             )}
           </div>
+          <DownloadBatchOrderSeatsButton
+            batchOrderId={batchOrder.id}
+            productTitle={batchOrder.offering?.product.title ?? ''}
+          />
         </div>
       }
     />

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/DashboardBatchOrderSubItems.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/DashboardBatchOrderSubItems.tsx
@@ -1,8 +1,9 @@
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { PaymentMethod } from 'components/PaymentInterfaces/types';
-import { BatchOrderRead } from 'types/Joanie';
+import { BatchOrderRead, BatchOrderState } from 'types/Joanie';
 import { DashboardSubItem } from 'widgets/Dashboard/components/DashboardItem/DashboardSubItem';
 import { DashboardSubItemsList } from '../DashboardSubItemsList';
+import { BatchOrderSeatInfo } from './BatchOrderSeatInfo';
 
 const messages = defineMessages({
   stepCompany: {
@@ -143,6 +144,12 @@ const DashboardItemField = ({
 
 export const DashboardBatchOrderSubItems = ({ batchOrder }: { batchOrder: BatchOrderRead }) => {
   const intl = useIntl();
+
+  const displaySeatsInfo =
+    batchOrder.state === BatchOrderState.COMPLETED &&
+    !!batchOrder.nb_seats &&
+    batchOrder.seats_owned !== undefined &&
+    batchOrder.seats_to_own !== undefined;
 
   const items = [
     <DashboardSubItem
@@ -310,6 +317,10 @@ export const DashboardBatchOrderSubItems = ({ batchOrder }: { batchOrder: BatchO
         }
       />,
     );
+  }
+
+  if (displaySeatsInfo) {
+    items.push(<BatchOrderSeatInfo key="enrollment-management" batchOrder={batchOrder} />);
   }
 
   return <DashboardSubItemsList subItems={items} />;

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/DashboardBatchOrderSubItems.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/DashboardBatchOrderSubItems.tsx
@@ -4,6 +4,7 @@ import { BatchOrderRead, BatchOrderState } from 'types/Joanie';
 import { DashboardSubItem } from 'widgets/Dashboard/components/DashboardItem/DashboardSubItem';
 import { DashboardSubItemsList } from '../DashboardSubItemsList';
 import { BatchOrderSeatInfo } from './BatchOrderSeatInfo';
+import { BatchOrderAgreementInfo } from './BatchOrderAgreementInfo';
 
 const messages = defineMessages({
   stepCompany: {
@@ -317,6 +318,10 @@ export const DashboardBatchOrderSubItems = ({ batchOrder }: { batchOrder: BatchO
         }
       />,
     );
+  }
+
+  if (batchOrder.contract_id) {
+    items.push(<BatchOrderAgreementInfo key="agreement" batchOrder={batchOrder} />);
   }
 
   if (displaySeatsInfo) {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/batchOrderSeatInfoMessages.ts
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/batchOrderSeatInfoMessages.ts
@@ -1,0 +1,24 @@
+import { defineMessages } from 'react-intl';
+
+export const batchOrderSeatInfoMessages = defineMessages({
+  enrolledParticipants: {
+    id: 'batchOrder.enrollmentManagement.enrolledParticipants',
+    description: 'Progress label showing enrolled participants out of total seats',
+    defaultMessage: '{seats_owned}/{nb_seats} enrolled participants',
+  },
+  searchPlaceholder: {
+    id: 'batchOrder.enrollmentManagement.searchPlaceholder',
+    description: 'Placeholder for the seat search input (student name or voucher)',
+    defaultMessage: 'Student name',
+  },
+  noResults: {
+    id: 'batchOrder.enrollmentManagement.noResults',
+    description: 'Message shown when the student search returns no results',
+    defaultMessage: 'No student matches your search.',
+  },
+  loadMore: {
+    id: 'batchOrder.enrollmentManagement.loadMore',
+    description: 'Button to load more seats',
+    defaultMessage: 'Load {count} more',
+  },
+});

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/BatchOrder/index.tsx
@@ -14,7 +14,12 @@ const messages = defineMessages({
   seats: {
     id: 'batchOrder.seats',
     description: 'Text displayed for seats value in batch order',
-    defaultMessage: 'Seats',
+    defaultMessage: '{nb_seats} seats',
+  },
+  seatsCount: {
+    id: 'batchOrder.seatsCount',
+    description: 'Text displayed for seats count in batch order (owned / total)',
+    defaultMessage: '{seats_owned}/{nb_seats} seats',
   },
   [BatchOrderState.DRAFT]: {
     id: 'batchOrder.status.draft',
@@ -136,8 +141,16 @@ export const DashboardItemBatchOrder = ({
               {batchOrder.nb_seats && (
                 <div className="dashboard-item__block__information">
                   <Icon name={IconTypeEnum.GROUPS} size="small" />
-                  <span>{batchOrder.nb_seats}</span>
-                  <span>{intl.formatMessage(messages.seats)}</span>
+                  <span>
+                    {batchOrder.seats_owned
+                      ? intl.formatMessage(messages.seatsCount, {
+                          seats_owned: batchOrder.seats_owned,
+                          nb_seats: batchOrder.nb_seats,
+                        })
+                      : intl.formatMessage(messages.seats, {
+                          nb_seats: batchOrder.nb_seats,
+                        })}
+                  </span>
                 </div>
               )}
               {batchOrder.payment_method && (

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -162,8 +162,8 @@
       padding: 0.5rem 1rem;
       font-size: 0.8rem;
       display: flex;
-      gap: 1rem;
-      align-items: center;
+      flex-direction: column;
+      gap: 0.5rem;
     }
   }
 }

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -168,6 +168,10 @@
   }
 }
 
+.dashboard-item__action-button {
+  align-self: flex-end;
+}
+
 .dashboard-item__course-enrolling {
   &__infos {
     align-items: center;

--- a/src/frontend/js/widgets/Dashboard/utils/teacherDashboardPaths.tsx
+++ b/src/frontend/js/widgets/Dashboard/utils/teacherDashboardPaths.tsx
@@ -82,7 +82,7 @@ export const TEACHER_DASHBOARD_ROUTE_LABELS = defineMessages<TeacherDashboardPat
   [TeacherDashboardPaths.ORGANIZATION_COURSE_PRODUCT_LEARNER_LIST]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.organization.course.product.learnerList.label',
     description: "Label to display the organization product's learner list view.",
-    defaultMessage: 'Learners',
+    defaultMessage: 'Buyers',
   },
   [TeacherDashboardPaths.COURSE]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.label',
@@ -102,7 +102,7 @@ export const TEACHER_DASHBOARD_ROUTE_LABELS = defineMessages<TeacherDashboardPat
   [TeacherDashboardPaths.COURSE_PRODUCT_LEARNER_LIST]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.product.learnerList.label',
     description: "Label to display the product's learner list view.",
-    defaultMessage: 'Learners',
+    defaultMessage: 'Buyers',
   },
   [TeacherDashboardPaths.COURSE_PRODUCT_CONTRACTS]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.product.contracts.label',

--- a/src/frontend/scss/objects/_dashboard.scss
+++ b/src/frontend/scss/objects/_dashboard.scss
@@ -101,3 +101,80 @@
     padding: 1rem;
   }
 }
+
+.enrollment-progress {
+  display: flex;
+  align-items: center;
+  gap: rem-calc(8px);
+  margin-bottom: rem-calc(8px);
+
+  &__bar {
+    flex: 1;
+    height: rem-calc(8px);
+    background-color: var(--c--globals--colors--gray-100);
+    border-radius: rem-calc(4px);
+    overflow: hidden;
+
+    &__fill {
+      height: 100%;
+      background-color: var(--c--theme--colors--primary-500);
+      transition: width 0.3s ease;
+      animation: progress-grow 2s ease-out forwards;
+
+      @keyframes progress-grow {
+        from {
+          width: 0;
+        }
+      }
+    }
+  }
+}
+
+.enrollment-nested-section__content {
+  display: flex;
+  flex-direction: column;
+  gap: rem-calc(4px);
+  font-size: rem-calc(13px);
+
+  .enrollment-search {
+    width: 50%;
+    margin-bottom: 0.5rem;
+  }
+
+  .enrollment-list {
+    list-style: disc inside;
+    padding-left: 0;
+    margin: 0;
+
+    li {
+      margin-bottom: rem-calc(4px);
+    }
+  }
+}
+
+.enrollment-load-more {
+  width: fit-content;
+  margin-top: rem-calc(8px);
+  padding: rem-calc(4px) rem-calc(12px);
+}
+
+.enrollment-pagination-wrapper {
+  margin-top: rem-calc(8px);
+
+  .pagination {
+    margin: 0;
+    padding: 0;
+    justify-content: flex-start;
+
+    &__list {
+      margin: 0;
+      padding: 0;
+      gap: rem-calc(4px);
+    }
+
+    &__item {
+      transform: scale(0.9);
+      transform-origin: center;
+    }
+  }
+}

--- a/src/richie/apps/demo/management/commands/create_dev_data.py
+++ b/src/richie/apps/demo/management/commands/create_dev_data.py
@@ -1204,6 +1204,7 @@ def create_dev_data(
     create_certificate_discount=False,
     create_credential=False,
     create_credential_discount=False,
+    create_run_state_courses=False,
 ):
     """
     Create a simple site tree structure for developpers to work in realistic environment.
@@ -1345,21 +1346,21 @@ def create_dev_data(
         )
         courses.append(course)
 
-    # Create courses with explicit course run states to test ordering
-    log("Creating courses with varied course run states...")
-    state_courses = create_courses_with_run_states(
-        languages,
-        levels,
-        licences,
-        lms_endpoint,
-        organizations,
-        pages_created,
-        persons_for_organization,
-        subjects,
-        icons,
-        log=log,
-    )
-    courses.extend(state_courses)
+    if create_run_state_courses:
+        log("Creating courses with varied course run states...")
+        state_courses = create_courses_with_run_states(
+            languages,
+            levels,
+            licences,
+            lms_endpoint,
+            organizations,
+            pages_created,
+            persons_for_organization,
+            subjects,
+            icons,
+            log=log,
+        )
+        courses.extend(state_courses)
 
     # Create blog posts under the `News` page
     log(f"Creating {NB_OBJECTS['blogposts']} blog posts...")
@@ -1428,6 +1429,12 @@ class Command(BaseCommand):
             default=False,
             help="Create a credential product with a discount.",
         )
+        parser.add_argument(
+            "--run-state-courses",
+            action="store_true",
+            default=False,
+            help="Create courses with explicit run states to test ordering.",
+        )
 
     def handle(self, *args, **options):
         def log(message):
@@ -1448,6 +1455,7 @@ class Command(BaseCommand):
             create_certificate_discount=options.get("certificate_discount"),
             create_credential=options.get("credential"),
             create_credential_discount=options.get("credential_discount"),
+            create_run_state_courses=options.get("run_state_courses"),
         )
 
         logger.info("done")


### PR DESCRIPTION
## Purpose

This PR brings several improvements and fixes to the batch orders (B2B) flow in the teacher and learner dashboards.        

## Proposal

### Bug fixes                                                                     
   
  - Handle email aliases in B2B sale tunnel — the email validation regex now accepts plus-sign aliases (e.g. user+tag@domain.com) which were previously
  rejected                                                                      
  - Fix download quote button rendering and corrects how the quote download button is displayed in the teacher dashboard                                        
   
### New features                                                                  
                  
####   Seat management in dashboards                                                 
  - Add seats information (seats_owned / seats_to_own) to the batch order dashboard item, showing enrollment progress as an ownership ratio             
  - Add a searchable, paginated list of enrolled participants (seats) in the batch order detail view, with a load-more pagination                          
                                                                                
 #### CSV seats export
  - Add a "Download seats" button in the teacher dashboard quotes page, allowing export of enrolled participants as a CSV file                                
   
####  Agreement PDF download                                                        
  - Add a "Download agreement" button for batch orders, enabling download of the counter-signed convention PDF                                                
   
  #### Organization enrollment view                                                  
  - Add enrollment information to the organization dashboard for batch orders
                                                                                
 ####  UX / B2B flow cleanup
                                                                                
  - Hide walkthrough messages (B2C-oriented) during B2B batch order processing to avoid confusion
                                                                                
  ### Scripts     

  - Add `--run-state-courses` option to the dev-data management command to make course creation with explicit run states optional
  - Forward flags to dev-data via `make --` for cleaner CLI syntax 