### PR TITLE
🌐(frontend) rename batch order elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Hide walkthrough message in sale tunnel for B2B process
+- Rename some sentences for B2B process
 
 ### Fixed
 

--- a/src/frontend/js/components/SaleTunnel/SaleTunnelSuccess/index.tsx
+++ b/src/frontend/js/components/SaleTunnel/SaleTunnelSuccess/index.tsx
@@ -20,7 +20,7 @@ const messages = defineMessages({
   },
   successDetailMessage: {
     defaultMessage:
-      'You will be able to start your training once the first installment will be paid.',
+      'You’ll be able to start your training once the first installment has been paid, or once access opens if no payment is required.',
     description: 'Text to explain when the user will be able to start its training.',
     id: 'components.SaleTunnelSuccess.successDetailMessage',
   },

--- a/src/frontend/js/components/SaleTunnel/index.full-process-b2c.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.full-process-b2c.spec.tsx
@@ -404,7 +404,7 @@ describe('SaleTunnel', () => {
     await screen.findByTestId('generic-sale-tunnel-success-step');
     screen.getByText('Subscription confirmed!');
     screen.getByText(
-      /your order has been successfully registered\.you will be able to start your training once the first installment will be paid\./i,
+      /you’ll be able to start your training once the first installment has been paid, or once access opens if no payment is required\./i,
     );
     screen.getByRole('link', { name: 'Close' });
 

--- a/src/frontend/js/widgets/Dashboard/utils/teacherDashboardPaths.tsx
+++ b/src/frontend/js/widgets/Dashboard/utils/teacherDashboardPaths.tsx
@@ -82,7 +82,7 @@ export const TEACHER_DASHBOARD_ROUTE_LABELS = defineMessages<TeacherDashboardPat
   [TeacherDashboardPaths.ORGANIZATION_COURSE_PRODUCT_LEARNER_LIST]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.organization.course.product.learnerList.label',
     description: "Label to display the organization product's learner list view.",
-    defaultMessage: 'Learners',
+    defaultMessage: 'Buyers',
   },
   [TeacherDashboardPaths.COURSE]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.label',
@@ -102,7 +102,7 @@ export const TEACHER_DASHBOARD_ROUTE_LABELS = defineMessages<TeacherDashboardPat
   [TeacherDashboardPaths.COURSE_PRODUCT_LEARNER_LIST]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.product.learnerList.label',
     description: "Label to display the product's learner list view.",
-    defaultMessage: 'Learners',
+    defaultMessage: 'Buyers',
   },
   [TeacherDashboardPaths.COURSE_PRODUCT_CONTRACTS]: {
     id: 'components.TeacherDashboard.TeacherDashboardRoutes.course.product.contracts.label',


### PR DESCRIPTION
We want to modify some elements in english language that are displayed during the batch order process.

Fixes https://github.com/orgs/openfun/projects/15/views/1?pane=issue&itemId=147719114

`You will be able to start your training once the first installment will be paid.` => `You’ll be able to start your training once the first installment has been paid, or once access opens if no payment is required.`

`Learners` => `Buyers`
