### PR TITLE
🐛(frontend) fix select dropdown clipped in sale tunnel right column

### DIFF
--- a/src/frontend/js/components/SaleTunnel/_styles.scss
+++ b/src/frontend/js/components/SaleTunnel/_styles.scss
@@ -31,8 +31,11 @@
     &__left,
     &__right {
       flex: 1;
-      overflow: hidden;
       position: relative;
+    }
+
+    &__left {
+      overflow: hidden;
     }
 
     &__column {


### PR DESCRIPTION
SaleTunnel was hiding overflowing elements in the right part, so we need to update the overflow style attribute to handle this.

**How to reproduce this case :** remove this fix and add at least 3 organizations to offering organizations to see that they are not displayed (you can mock the API answer with Tanstack Data Explorer). With the fix, it will be displayed.

<img width="1666" height="1982" alt="image" src="https://github.com/user-attachments/assets/0aa81635-666a-48ef-b08d-5138a24a3d2b" />


