### PR TITLE
✨(frontend) implement withdrawal right for credential and certificate…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Withdrawing feature for certificate and credential orders
+
 ## [3.5.1] - 2026-08-18
 
 ### Fixed

--- a/src/frontend/js/api/joanie.ts
+++ b/src/frontend/js/api/joanie.ts
@@ -101,6 +101,7 @@ export const getRoutes = () => {
         submit_for_signature: `${baseUrl}/orders/:id/submit_for_signature/`,
         submit_installment_payment: `${baseUrl}/orders/:id/submit-installment-payment/`,
         set_payment_method: `${baseUrl}/orders/:id/payment-method/`,
+        withdraw: `${baseUrl}/orders/:id/withdraw/`,
       },
       batchOrders: {
         get: `${baseUrl}/batch-orders/:id/`,
@@ -339,6 +340,10 @@ const API = (): Joanie.API => {
           fetchWithJWT(ROUTES.user.orders.set_payment_method.replace(':id', id), {
             method: 'POST',
             body: JSON.stringify(payload),
+          }).then(checkStatus),
+        withdraw: async (id) =>
+          fetchWithJWT(ROUTES.user.orders.withdraw.replace(':id', id), {
+            method: 'POST',
           }).then(checkStatus),
       },
       batchOrders: {

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -552,7 +552,7 @@ describe.each([
       enrollmentDiscounted.offerings[0].product = product;
       fetchMock
         .get(
-          `https://joanie.endpoint/api/v1.0/orders/?enrollment_id=${enrollmentDiscounted.id}&product_id=${product.id}&state=pending&state=pending_payment&state=no_payment&state=failed_payment&state=completed&state=draft&state=assigned&state=to_sign&state=signing&state=to_save_payment_method`,
+          `https://joanie.endpoint/api/v1.0/orders/?enrollment_id=${enrollmentDiscounted.id}&product_id=${product.id}&state=pending&state=pending_payment&state=no_payment&state=failed_payment&state=completed&state=pending_withdraw&state=draft&state=assigned&state=to_sign&state=signing&state=to_save_payment_method`,
           {
             results: [],
             next: null,

--- a/src/frontend/js/hooks/useLearnerCoursesSearch/index.tsx
+++ b/src/frontend/js/hooks/useLearnerCoursesSearch/index.tsx
@@ -1,8 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
-import { Enrollment, CredentialOrder, ProductType, CANCELED_ORDER_STATES } from 'types/Joanie';
+import { Enrollment, CredentialOrder, ProductType, OrderState } from 'types/Joanie';
 import { Maybe, Nullable } from 'types/utils';
-import { useOrdersEnrollments } from 'pages/DashboardCourses/useOrdersEnrollments';
+import { OrderHelper } from 'utils/OrderHelper';
+import { isOrder, useOrdersEnrollments } from 'pages/DashboardCourses/useOrdersEnrollments';
+
+/**
+ * Orders canceled following the buyer's withdrawal must stay visible in the dashboard
+ * (the learner needs to keep a trace of that legal action), unlike other cancellation
+ * causes. The API can't filter on that distinction yet, so we only exclude REFUNDING/
+ * REFUNDED server-side and drop the remaining non-withdrawn CANCELED orders here.
+ */
+const isHiddenCanceledOrder = (item: CredentialOrder | Enrollment) =>
+  isOrder(item) && OrderHelper.isCanceled(item) && !OrderHelper.isWithdrawn(item);
 
 const useLearnerCoursesSearch = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -23,7 +33,7 @@ const useLearnerCoursesSearch = () => {
     query,
     orderFilters: {
       product_type: [ProductType.CREDENTIAL],
-      state_exclude: CANCELED_ORDER_STATES,
+      state_exclude: [OrderState.REFUNDING, OrderState.REFUNDED],
     },
   });
 
@@ -41,7 +51,10 @@ const useLearnerCoursesSearch = () => {
     }
 
     if (isNewSearchLoading || data.length > orderAndEnrollmentList?.length) {
-      setOrderAndEnrollmentList(data as (CredentialOrder | Enrollment)[]);
+      const visibleData = (data as (CredentialOrder | Enrollment)[]).filter(
+        (item) => !isHiddenCanceledOrder(item),
+      );
+      setOrderAndEnrollmentList(visibleData);
       setCount(currentCount);
     }
   }, [data.length, isLoading, isNewSearchLoading, query]);

--- a/src/frontend/js/hooks/useProductOrder/index.spec.tsx
+++ b/src/frontend/js/hooks/useProductOrder/index.spec.tsx
@@ -84,6 +84,7 @@ describe('useProductOrder', () => {
       `&state=${OrderState.NO_PAYMENT}` +
       `&state=${OrderState.FAILED_PAYMENT}` +
       `&state=${OrderState.COMPLETED}` +
+      `&state=${OrderState.PENDING_WITHDRAW}` +
       `&state=${OrderState.DRAFT}` +
       `&state=${OrderState.ASSIGNED}` +
       `&state=${OrderState.TO_SIGN}` +

--- a/src/frontend/js/pages/DashboardCourses/index.spec.tsx
+++ b/src/frontend/js/pages/DashboardCourses/index.spec.tsx
@@ -10,7 +10,7 @@ import {
   CredentialOrderFactory,
 } from 'utils/test/factories/joanie';
 import { createTestQueryClient } from 'utils/test/createTestQueryClient';
-import { CourseLight, Offering, Enrollment, CredentialOrder } from 'types/Joanie';
+import { CourseLight, Offering, Enrollment, CredentialOrder, OrderState } from 'types/Joanie';
 import { expectNoSpinner, expectSpinner } from 'utils/test/expectSpinner';
 import { expectBannerError, expectBannerInfo, expectNoBannerInfo } from 'utils/test/expectBanner';
 import { Deferred } from 'utils/test/deferred';
@@ -105,7 +105,6 @@ describe('<DashboardCourses/>', () => {
     fetchMock.get(
       'https://joanie.endpoint/api/v1.0/orders/' +
         '?product_type=credential' +
-        '&state_exclude=canceled' +
         '&state_exclude=refunding' +
         '&state_exclude=refunded' +
         '&page=1' +
@@ -153,7 +152,6 @@ describe('<DashboardCourses/>', () => {
     fetchMock.get(
       'https://joanie.endpoint/api/v1.0/orders/' +
         '?product_type=credential' +
-        '&state_exclude=canceled' +
         '&state_exclude=refunding' +
         '&state_exclude=refunded' +
         '&page=1' +
@@ -163,7 +161,6 @@ describe('<DashboardCourses/>', () => {
         next:
           'https://joanie.endpoint/api/v1.0/orders/' +
           '?product_type=credential' +
-          '&state_exclude=canceled' +
           '&state_exclude=refunding' +
           '&state_exclude=refunded' +
           '&page=2' +
@@ -175,7 +172,6 @@ describe('<DashboardCourses/>', () => {
     fetchMock.get(
       'https://joanie.endpoint/api/v1.0/orders/' +
         '?product_type=credential' +
-        '&state_exclude=canceled' +
         '&state_exclude=refunding' +
         '&state_exclude=refunded' +
         '&page=2' +
@@ -185,7 +181,6 @@ describe('<DashboardCourses/>', () => {
         next:
           'https://joanie.endpoint/api/v1.0/orders/' +
           '?product_type=credential' +
-          '&state_exclude=canceled' +
           '&state_exclude=refunding' +
           '&state_exclude=refunded' +
           '&page=3' +
@@ -197,7 +192,6 @@ describe('<DashboardCourses/>', () => {
     fetchMock.get(
       'https://joanie.endpoint/api/v1.0/orders/' +
         '?product_type=credential' +
-        '&state_exclude=canceled' +
         '&state_exclude=refunding' +
         '&state_exclude=refunded' +
         '&page=3' +
@@ -271,13 +265,51 @@ describe('<DashboardCourses/>', () => {
     expect(loadMoreButton).toBeEnabled();
   }, 15000);
 
+  it('keeps a withdrawn order visible while filtering out other canceled orders', async () => {
+    const activeOrder = CredentialOrderFactory({
+      state: OrderState.COMPLETED,
+      created_on: '2026-01-03T00:00:00.000Z',
+    }).one();
+    const withdrawnOrder = CredentialOrderFactory({
+      state: OrderState.CANCELED,
+      created_on: '2026-01-02T00:00:00.000Z',
+      withdrawn_confirmation_at: '2026-01-02T00:00:00.000Z',
+    }).one();
+    const canceledOrder = CredentialOrderFactory({
+      state: OrderState.CANCELED,
+      created_on: '2026-01-01T00:00:00.000Z',
+      withdrawn_confirmation_at: null,
+    }).one();
+    const { orders, offerings } = mockOrders([activeOrder, withdrawnOrder, canceledOrder]);
+
+    fetchMock.get(
+      'https://joanie.endpoint/api/v1.0/orders/' +
+        '?product_type=credential' +
+        '&state_exclude=refunding' +
+        '&state_exclude=refunded' +
+        '&page=1' +
+        `&page_size=${perPage}`,
+      { results: orders, next: null, previous: null, count: orders.length },
+    );
+    fetchMock.get(
+      `https://joanie.endpoint/api/v1.0/enrollments/?was_created_by_order=false&is_active=true&page=1&page_size=${perPage}`,
+      { results: [], next: null, previous: null, count: 0 },
+    );
+
+    render(<DashboardTest initialRoute={LearnerDashboardPaths.COURSES} />, {
+      wrapper: BaseJoanieAppWrapper,
+    });
+
+    await expectNoSpinner('Loading orders and enrollments...');
+    await waitFor(() => expectList([activeOrder, withdrawnOrder], offerings));
+  });
+
   it('shows an error', async () => {
     jest.spyOn(console, 'error').mockImplementation(noop);
     const ordersDeferred = new Deferred();
     fetchMock.get(
       'https://joanie.endpoint/api/v1.0/orders/' +
         '?product_type=credential' +
-        '&state_exclude=canceled' +
         '&state_exclude=refunding' +
         '&state_exclude=refunded' +
         '&page=1' +

--- a/src/frontend/js/types/Joanie.ts
+++ b/src/frontend/js/types/Joanie.ts
@@ -312,6 +312,7 @@ export enum OrderState {
   NO_PAYMENT = 'no_payment',
   PENDING = 'pending',
   PENDING_PAYMENT = 'pending_payment',
+  PENDING_WITHDRAW = 'pending_withdraw',
   SIGNING = 'signing',
   TO_SAVE_PAYMENT_METHOD = 'to_save_payment_method',
   TO_SIGN = 'to_sign',
@@ -331,6 +332,7 @@ export const ACTIVE_ORDER_STATES = [
   OrderState.NO_PAYMENT,
   OrderState.FAILED_PAYMENT,
   OrderState.COMPLETED,
+  OrderState.PENDING_WITHDRAW,
 ];
 
 export const NOT_CANCELED_ORDER_STATES = [...ACTIVE_ORDER_STATES, ...PURCHASABLE_ORDER_STATES];
@@ -367,6 +369,11 @@ export interface Order {
   payment_schedule?: PaymentSchedule;
   credit_card_id?: CreditCard['id'];
   from_batch_order?: boolean;
+  has_waived_withdrawal_right: boolean;
+  eligible_to_withdraw: boolean;
+  withdrawal_date_limit: Nullable<string>;
+  withdrawn_requested_at: Nullable<string>;
+  withdrawn_confirmation_at: Nullable<string>;
 }
 
 export interface CredentialOrder extends Order {
@@ -418,7 +425,16 @@ export interface NestedCredentialOrder extends AbstractNestedOrder {
 
 export type OrderEnrollment = Pick<
   Order,
-  'id' | 'state' | 'product_id' | 'certificate_id' | 'payment_schedule'
+  | 'id'
+  | 'state'
+  | 'product_id'
+  | 'certificate_id'
+  | 'payment_schedule'
+  | 'has_waived_withdrawal_right'
+  | 'eligible_to_withdraw'
+  | 'withdrawal_date_limit'
+  | 'withdrawn_requested_at'
+  | 'withdrawn_confirmation_at'
 >;
 
 export interface NestedCourseOrder {
@@ -838,6 +854,7 @@ interface APIUser {
       payload?: OrderSubmitInstallmentPayment,
     ): Promise<Payment>;
     set_payment_method(payload: OrderSetPaymentMethodPayload): Promise<void>;
+    withdraw(id: Order['id']): Promise<CredentialOrder | CertificateOrder>;
   };
   batchOrders: {
     create(payload: BatchOrder): Promise<BatchOrderRead>;

--- a/src/frontend/js/utils/OrderHelper/index.spec.ts
+++ b/src/frontend/js/utils/OrderHelper/index.spec.ts
@@ -1,0 +1,75 @@
+import { OrderState } from 'types/Joanie';
+import { CredentialOrderFactory, OrderEnrollmentFactory } from 'utils/test/factories/joanie';
+import { OrderHelper, OrderStatus } from '.';
+
+describe('OrderHelper', () => {
+  describe('isWithdrawn', () => {
+    it('should return false when the order is undefined', () => {
+      expect(OrderHelper.isWithdrawn(undefined)).toBe(false);
+    });
+
+    it('should return false when withdrawn_confirmation_at is not set', () => {
+      const order = CredentialOrderFactory({ withdrawn_confirmation_at: null }).one();
+      expect(OrderHelper.isWithdrawn(order)).toBe(false);
+    });
+
+    it('should return true when withdrawn_confirmation_at is set', () => {
+      const order = CredentialOrderFactory({
+        withdrawn_confirmation_at: new Date().toISOString(),
+      }).one();
+      expect(OrderHelper.isWithdrawn(order)).toBe(true);
+    });
+  });
+
+  describe('getState', () => {
+    it('should return WITHDRAWN when the order has been withdrawn, regardless of its state', () => {
+      const order = CredentialOrderFactory({
+        state: OrderState.CANCELED,
+        withdrawn_confirmation_at: new Date().toISOString(),
+      }).one();
+      expect(OrderHelper.getState(order)).toBe(OrderStatus.WITHDRAWN);
+    });
+
+    it('should return PENDING_WITHDRAWAL for a pending_withdraw order', () => {
+      const order = CredentialOrderFactory({
+        state: OrderState.PENDING_WITHDRAW,
+        withdrawn_confirmation_at: null,
+      }).one();
+      expect(OrderHelper.getState(order)).toBe(OrderStatus.PENDING_WITHDRAWAL);
+    });
+  });
+
+  describe('getActiveEnrollmentOrder', () => {
+    it('should return a withdrawn order matching the product id even though it is not active', () => {
+      const withdrawnOrder = OrderEnrollmentFactory({
+        state: OrderState.CANCELED,
+        product_id: 'PRODUCT_ID',
+        withdrawn_confirmation_at: new Date().toISOString(),
+      }).one();
+
+      expect(OrderHelper.getActiveEnrollmentOrder([withdrawnOrder], 'PRODUCT_ID')).toBe(
+        withdrawnOrder,
+      );
+    });
+
+    it('should not return a canceled order that has not been withdrawn', () => {
+      const canceledOrder = OrderEnrollmentFactory({
+        state: OrderState.CANCELED,
+        product_id: 'PRODUCT_ID',
+        withdrawn_confirmation_at: null,
+      }).one();
+
+      expect(OrderHelper.getActiveEnrollmentOrder([canceledOrder], 'PRODUCT_ID')).toBeUndefined();
+    });
+  });
+
+  describe('isPurchasable', () => {
+    it('should return true when the order has been withdrawn, regardless of its state', () => {
+      const order = CredentialOrderFactory({
+        state: OrderState.CANCELED,
+        withdrawn_confirmation_at: new Date().toISOString(),
+      }).one();
+      expect(OrderHelper.isPurchasable(order)).toBe(true);
+    });
+  });
+});

--- a/src/frontend/js/utils/OrderHelper/index.ts
+++ b/src/frontend/js/utils/OrderHelper/index.ts
@@ -20,9 +20,11 @@ export enum OrderStatus {
   PASSED = 'passed',
   PENDING = 'pending',
   PENDING_PAYMENT = 'pending_payment',
+  PENDING_WITHDRAWAL = 'pending_withdrawal',
   WAITING_COUNTER_SIGNATURE = 'waiting_counter_signature',
   WAITING_PAYMENT_METHOD = 'waiting_payment_method',
   WAITING_SIGNATURE = 'waiting_signature',
+  WITHDRAWN = 'withdrawn',
 }
 
 /**
@@ -36,6 +38,9 @@ export class OrderHelper {
     if (order.state === OrderState.COMPLETED && order.certificate_id) {
       return OrderStatus.PASSED;
     }
+    if (OrderHelper.isWithdrawn(order)) {
+      return OrderStatus.WITHDRAWN;
+    }
 
     const orderStatusMap = {
       [OrderState.ASSIGNED]: OrderStatus.ASSIGNED,
@@ -48,6 +53,7 @@ export class OrderHelper {
       [OrderState.NO_PAYMENT]: OrderStatus.NO_PAYMENT,
       [OrderState.PENDING]: OrderStatus.PENDING,
       [OrderState.PENDING_PAYMENT]: OrderStatus.PENDING_PAYMENT,
+      [OrderState.PENDING_WITHDRAW]: OrderStatus.PENDING_WITHDRAWAL,
       [OrderState.SIGNING]: OrderStatus.WAITING_SIGNATURE,
       [OrderState.TO_SAVE_PAYMENT_METHOD]: OrderStatus.WAITING_PAYMENT_METHOD,
       [OrderState.TO_SIGN]: OrderStatus.WAITING_SIGNATURE,
@@ -65,7 +71,8 @@ export class OrderHelper {
    */
   static getActiveEnrollmentOrder(orders: OrderEnrollment[], productId: string) {
     const filter = (order: OrderEnrollment) =>
-      ACTIVE_ORDER_STATES.includes(order.state) && order.product_id === productId;
+      (ACTIVE_ORDER_STATES.includes(order.state) || OrderHelper.isWithdrawn(order)) &&
+      order.product_id === productId;
     return orders.find(filter);
   }
 
@@ -100,8 +107,13 @@ export class OrderHelper {
     return CANCELED_ORDER_STATES.includes(order.state);
   }
 
+  static isWithdrawn(order?: Order | NestedCourseOrder | OrderEnrollment) {
+    if (!order) return false;
+    return Boolean('withdrawn_confirmation_at' in order && order.withdrawn_confirmation_at);
+  }
+
   static isPurchasable(order?: Order | NestedCourseOrder | OrderEnrollment) {
-    if (!order) return true;
+    if (!order || OrderHelper.isWithdrawn(order)) return true;
     return PURCHASABLE_ORDER_STATES.includes(order.state);
   }
 

--- a/src/frontend/js/utils/test/factories/joanie.ts
+++ b/src/frontend/js/utils/test/factories/joanie.ts
@@ -471,6 +471,11 @@ export const OrderEnrollmentFactory = factory((): OrderEnrollment => {
     product_id: faker.string.uuid(),
     state: OrderState.COMPLETED,
     payment_schedule: PaymentInstallmentFactory().many(1),
+    has_waived_withdrawal_right: false,
+    eligible_to_withdraw: false,
+    withdrawal_date_limit: null,
+    withdrawn_requested_at: null,
+    withdrawn_confirmation_at: null,
   };
 });
 
@@ -600,6 +605,11 @@ const AbstractOrderFactory = factory((): Order => {
     course: null,
     organization_id: faker.string.uuid(),
     organization: OrganizationFactory().one(),
+    has_waived_withdrawal_right: false,
+    eligible_to_withdraw: false,
+    withdrawal_date_limit: null,
+    withdrawn_requested_at: null,
+    withdrawn_confirmation_at: null,
   };
 });
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.spec.tsx
@@ -23,6 +23,7 @@ import {
   PaymentInstallmentFactory,
 } from 'utils/test/factories/joanie';
 import { Priority } from 'types';
+import { DATETIME_FORMAT } from 'hooks/useDateFormat';
 import { DashboardTest } from 'widgets/Dashboard/components/DashboardTest';
 import { expectNoSpinner } from 'utils/test/expectSpinner';
 import { PER_PAGE } from 'settings';
@@ -66,6 +67,33 @@ jest.mock('widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryMod
     return (
       <div data-testid="OrderPaymentRetryModalMock">
         <button onClick={onClose}>Trigger Close</button>
+      </div>
+    );
+  },
+}));
+jest.mock('widgets/Dashboard/components/DashboardItem/Order/OrderWithdrawalModal', () => ({
+  __esModule: true,
+  OrderWithdrawalModal: ({
+    isOpen,
+    order,
+    productTitle,
+    reference,
+    onSuccess,
+  }: {
+    isOpen: boolean;
+    order: { id: string; state: string };
+    productTitle: string;
+    reference: string;
+    onSuccess?: (order: any) => void;
+  }) => {
+    if (!isOpen) return null;
+
+    return (
+      <div data-testid="OrderWithdrawalModalMock">
+        {order.id} - {productTitle} - {reference}
+        <button onClick={() => onSuccess?.({ ...order, state: 'canceled' })}>
+          Trigger Success
+        </button>
       </div>
     );
   },
@@ -230,7 +258,6 @@ describe('<ProductCertificateFooter/>', () => {
     fetchMock.get(
       'https://joanie.endpoint/api/v1.0/orders/' +
         '?product_type=credential' +
-        '&state_exclude=canceled' +
         '&state_exclude=refunding' +
         '&state_exclude=refunded' +
         '&page=1' +
@@ -384,4 +411,189 @@ describe('<ProductCertificateFooter/>', () => {
       expect(fetchMock.lastUrl()).toBe(`https://joanie.endpoint/api/v1.0/orders/${order.id}/`);
     },
   );
+
+  it('should display the withdrawal manager and open the withdrawal modal when the order is eligible', async () => {
+    const order = OrderEnrollmentFactory({
+      state: OrderState.COMPLETED,
+      certificate_id: undefined,
+      product_id: product.id,
+      eligible_to_withdraw: true,
+      withdrawal_date_limit: '2026-08-30T10:00:00.000Z',
+    }).one();
+    const enrollment = EnrollmentFactory({
+      orders: [order],
+      course_run: CourseRunFactory({ course }).one(),
+    }).one();
+
+    render(
+      <ProductCertificateFooter product={product} enrollment={enrollment} isWithdrawable={true} />,
+    );
+
+    const datetimeFormatter = new Intl.DateTimeFormat('en', DATETIME_FORMAT);
+    screen.getByText(`until ${datetimeFormatter.format(new Date(order.withdrawal_date_limit!))}.`, {
+      exact: false,
+    });
+    expect(screen.queryByTestId('OrderWithdrawalModalMock')).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'I wish to withdraw' }));
+
+    const modal = screen.getByTestId('OrderWithdrawalModalMock');
+    within(modal).getByText(`${order.id} - ${product.title} - ${course.code}`);
+
+    // A successful withdrawal request updates the order held by the footer, hiding the
+    // withdrawal manager since the order is no longer active.
+    await user.click(within(modal).getByRole('button', { name: 'Trigger Success' }));
+    expect(screen.queryByRole('button', { name: 'I wish to withdraw' })).not.toBeInTheDocument();
+  });
+
+  it('should not display the withdrawal manager when the order is not eligible', () => {
+    const order = OrderEnrollmentFactory({
+      state: OrderState.COMPLETED,
+      certificate_id: undefined,
+      product_id: product.id,
+      eligible_to_withdraw: false,
+    }).one();
+    const enrollment = EnrollmentFactory({ orders: [order] }).one();
+
+    render(
+      <ProductCertificateFooter product={product} enrollment={enrollment} isWithdrawable={true} />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'I wish to withdraw' })).not.toBeInTheDocument();
+  });
+
+  it('should display a pending withdrawal message while the withdrawal request is being processed', () => {
+    const requestedAt = '2026-08-20T09:30:00.000Z';
+    const order = OrderEnrollmentFactory({
+      state: OrderState.PENDING_WITHDRAW,
+      certificate_id: undefined,
+      product_id: product.id,
+      eligible_to_withdraw: false,
+      withdrawn_requested_at: requestedAt,
+    }).one();
+    const enrollment = EnrollmentFactory({ orders: [order] }).one();
+
+    render(
+      <ProductCertificateFooter product={product} enrollment={enrollment} isWithdrawable={true} />,
+    );
+
+    screen.getByText(
+      `Your withdrawal request has been recorded on ${dateFormatter.format(
+        new Date(requestedAt),
+      )} and is being processed.`,
+    );
+    expect(
+      screen.queryByText(product.certificate_definition.title, { exact: false }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display a withdrawn message and hide the exam access status once the order has been withdrawn', () => {
+    const confirmedAt = '2026-08-25T14:00:00.000Z';
+    const order = OrderEnrollmentFactory({
+      state: OrderState.CANCELED,
+      certificate_id: undefined,
+      product_id: product.id,
+      eligible_to_withdraw: false,
+      withdrawn_confirmation_at: confirmedAt,
+    }).one();
+    const enrollment = EnrollmentFactory({ orders: [order] }).one();
+
+    render(
+      <ProductCertificateFooter product={product} enrollment={enrollment} isWithdrawable={true} />,
+    );
+
+    screen.getByText(
+      `You withdrew from this order on ${dateFormatter.format(new Date(confirmedAt))}.`,
+    );
+    expect(
+      screen.queryByText(product.certificate_definition.title, { exact: false }),
+    ).not.toBeInTheDocument();
+  });
+
+  /**
+   * The footer holds the active order in local state, initialized once from the
+   * `enrollment` prop: it isn't kept in sync with prop changes, so the only way the
+   * learner sees an admin's decision on a pending withdrawal request is by reloading
+   * the dashboard, which remounts the footer with fresh data. These two tests simulate
+   * that reload via unmount + render, rather than rerender.
+   */
+  it('reflects a confirmed withdrawal after the page is refreshed', () => {
+    const pendingOrder = OrderEnrollmentFactory({
+      state: OrderState.PENDING_WITHDRAW,
+      certificate_id: undefined,
+      product_id: product.id,
+      eligible_to_withdraw: false,
+      withdrawn_requested_at: '2026-08-20T09:30:00.000Z',
+    }).one();
+    const { unmount } = render(
+      <ProductCertificateFooter
+        product={product}
+        enrollment={EnrollmentFactory({ orders: [pendingOrder] }).one()}
+        isWithdrawable={true}
+      />,
+    );
+    screen.getByText('and is being processed.', { exact: false });
+    unmount();
+
+    const confirmedOrder = {
+      ...pendingOrder,
+      state: OrderState.CANCELED,
+      withdrawn_confirmation_at: '2026-08-21T10:00:00.000Z',
+    };
+    render(
+      <ProductCertificateFooter
+        product={product}
+        enrollment={EnrollmentFactory({ orders: [confirmedOrder] }).one()}
+        isWithdrawable={true}
+      />,
+    );
+
+    screen.getByText(
+      `You withdrew from this order on ${dateFormatter.format(
+        new Date(confirmedOrder.withdrawn_confirmation_at),
+      )}.`,
+    );
+    expect(screen.queryByText('and is being processed.', { exact: false })).not.toBeInTheDocument();
+  });
+
+  it('reflects a rejected withdrawal after the page is refreshed', () => {
+    const pendingOrder = OrderEnrollmentFactory({
+      state: OrderState.PENDING_WITHDRAW,
+      certificate_id: undefined,
+      product_id: product.id,
+      eligible_to_withdraw: false,
+      withdrawn_requested_at: '2026-08-20T09:30:00.000Z',
+    }).one();
+    const { unmount } = render(
+      <ProductCertificateFooter
+        product={product}
+        enrollment={EnrollmentFactory({ orders: [pendingOrder] }).one()}
+        isWithdrawable={true}
+      />,
+    );
+    screen.getByText('and is being processed.', { exact: false });
+    unmount();
+
+    // A rejected request resumes its normal course: the order goes back to completed
+    // and, since no certificate has been issued yet, remains eligible to a new request.
+    const rejectedOrder = {
+      ...pendingOrder,
+      state: OrderState.COMPLETED,
+      eligible_to_withdraw: true,
+    };
+    render(
+      <ProductCertificateFooter
+        product={product}
+        enrollment={EnrollmentFactory({ orders: [rejectedOrder] }).one()}
+        isWithdrawable={true}
+      />,
+    );
+
+    expect(screen.queryByText('and is being processed.', { exact: false })).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('You withdrew from this order', { exact: false }),
+    ).not.toBeInTheDocument();
+    screen.getByRole('button', { name: 'I wish to withdraw' });
+  });
 });

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Enrollment/ProductCertificateFooter/index.tsx
@@ -16,9 +16,10 @@ import { useCertificate } from 'hooks/useCertificates';
 import { isOpenedCourseRunCertificate } from 'utils/CourseRuns';
 import { OrderHelper } from 'utils/OrderHelper';
 import { OrderPaymentRetryModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderPaymentRetryModal';
+import { OrderWithdrawalModal } from 'widgets/Dashboard/components/DashboardItem/Order/OrderWithdrawalModal';
 import PaymentScheduleHelper from 'utils/PaymentScheduleHelper';
 import { useOrder } from 'hooks/useOrders';
-import useDateFormat from 'hooks/useDateFormat';
+import useDateFormat, { DATETIME_FORMAT } from 'hooks/useDateFormat';
 import CertificateStatus from '../../CertificateStatus';
 
 const messages = defineMessages({
@@ -58,6 +59,27 @@ const messages = defineMessages({
     description: 'Button label for the payment needed message',
     defaultMessage: 'Pay {amount}',
   },
+  withdrawalDescription: {
+    id: 'components.ProductCertificateFooter.withdrawalDescription',
+    description: 'Message displayed to offer the withdrawal of the certificate order',
+    defaultMessage:
+      "If you haven't accessed the exam yet, you can exercise your right of withdrawal until {date}.",
+  },
+  withdrawalButton: {
+    id: 'components.ProductCertificateFooter.withdrawalButton',
+    description: 'Button label to open the withdrawal request modal',
+    defaultMessage: 'I wish to withdraw',
+  },
+  pendingWithdrawalMessage: {
+    id: 'components.ProductCertificateFooter.pendingWithdrawalMessage',
+    description: 'Message displayed when a withdrawal request is being processed',
+    defaultMessage: 'Your withdrawal request has been recorded on {date} and is being processed.',
+  },
+  withdrawnMessage: {
+    id: 'components.ProductCertificateFooter.withdrawnMessage',
+    description: 'Message displayed once a withdrawal request has been confirmed',
+    defaultMessage: 'You withdrew from this order on {date}.',
+  },
 });
 
 export interface ProductCertificateFooterProps {
@@ -75,6 +97,8 @@ const ProductCertificateFooter = ({
     OrderHelper.getActiveEnrollmentOrder(enrollment.orders || [], product.id),
   );
   const isOrderActive = OrderHelper.isActive(order);
+  const isOrderWithdrawn = OrderHelper.isWithdrawn(order);
+  const isOrderVisible = isOrderActive || isOrderWithdrawn;
   const isPurchasable =
     OrderHelper.isPurchasable(order) && isOpenedCourseRunCertificate(enrollment.course_run.state);
   const isCertificateIssued = isOrderActive && Boolean(order!.certificate_id);
@@ -92,36 +116,46 @@ const ProductCertificateFooter = ({
   }
 
   return (
-    <div className="dashboard-item__course-enrolling__infos">
-      {!isOrderActive ? (
-        <ProductCertificateStatus />
-      ) : (
-        <OrderCertificateStatus order={order!} product={product} hasError={hasError} />
-      )}
-      {isCertificateIssued && (
-        <DownloadCertificateButton
+    <>
+      <div className="dashboard-item__course-enrolling__infos">
+        {!isOrderVisible ? (
+          <ProductCertificateStatus />
+        ) : (
+          <OrderCertificateStatus order={order!} product={product} hasError={hasError} />
+        )}
+        {isCertificateIssued && (
+          <DownloadCertificateButton
+            className="dashboard-item__button"
+            certificateId={order!.certificate_id!}
+          />
+        )}
+        <PurchaseButton
           className="dashboard-item__button"
-          certificateId={order!.certificate_id!}
+          product={product}
+          enrollment={enrollment}
+          isWithdrawable={isWithdrawable}
+          buttonProps={{ size: 'small' }}
+          disabled={!isPurchasable}
+          onFinish={(o) => {
+            /**
+             * As we do not refetch enrollments in DashboardCourses after SaleTunnel cache invalidation (to avoid
+             * scroll reset - and SaleTunnel modal unmounting too early caused by list reset) we need to manually
+             * update the active order in the enrollment in order to hide the buy button and display the download button.
+             */
+            setOrder(o);
+          }}
+        />
+        {hasError && <FailedInstallmentManager order={order!} updateOrder={setOrder} />}
+      </div>
+      {isOrderActive && order!.eligible_to_withdraw && (
+        <WithdrawalManager
+          order={order!}
+          product={product}
+          enrollment={enrollment}
+          updateOrder={setOrder}
         />
       )}
-      <PurchaseButton
-        className="dashboard-item__button"
-        product={product}
-        enrollment={enrollment}
-        isWithdrawable={isWithdrawable}
-        buttonProps={{ size: 'small' }}
-        disabled={!isPurchasable}
-        onFinish={(o) => {
-          /**
-           * As we do not refetch enrollments in DashboardCourses after SaleTunnel cache invalidation (to avoid
-           * scroll reset - and SaleTunnel modal unmounting too early caused by list reset) we need to manually
-           * update the active order in the enrollment in order to hide the buy button and display the download button.
-           */
-          setOrder(o);
-        }}
-      />
-      {hasError && <FailedInstallmentManager order={order!} updateOrder={setOrder} />}
-    </div>
+    </>
   );
 };
 
@@ -143,10 +177,20 @@ const OrderCertificateStatus = ({ order, product, hasError }: OrderCertificateSt
   const formatDate = useDateFormat();
   const nextInstallment = PaymentScheduleHelper.getPendingInstallment(order?.payment_schedule);
   const canAccessToExam = ![OrderState.PENDING, OrderState.NO_PAYMENT].includes(order.state);
+  const isPendingWithdrawal = order.state === OrderState.PENDING_WITHDRAW;
+  const isWithdrawn = OrderHelper.isWithdrawn(order);
+  let statusIcon = IconTypeEnum.CERTIFICATE;
+  if (hasError) {
+    statusIcon = IconTypeEnum.WARNING;
+  } else if (isPendingWithdrawal) {
+    statusIcon = IconTypeEnum.CLOCK;
+  } else if (isWithdrawn) {
+    statusIcon = IconTypeEnum.ROUND_CLOSE;
+  }
 
   return (
     <div className="dashboard-item__block__status">
-      <Icon name={hasError ? IconTypeEnum.WARNING : IconTypeEnum.CERTIFICATE} />
+      <Icon name={statusIcon} />
       <p>
         {hasError && (
           <>
@@ -156,12 +200,30 @@ const OrderCertificateStatus = ({ order, product, hasError }: OrderCertificateSt
             <br />
           </>
         )}
-        {canAccessToExam ? (
+        {isPendingWithdrawal && (
+          <>
+            <strong>
+              <FormattedMessage
+                {...messages.pendingWithdrawalMessage}
+                values={{ date: formatDate(order.withdrawn_requested_at) }}
+              />
+            </strong>
+            <br />
+          </>
+        )}
+        {isWithdrawn && (
+          <FormattedMessage
+            {...messages.withdrawnMessage}
+            values={{ date: formatDate(order.withdrawn_confirmation_at) }}
+          />
+        )}
+        {!isWithdrawn && !isPendingWithdrawal && canAccessToExam && (
           <>
             {product.certificate_definition.title + '. '}
             <CertificateStatus certificate={certificate} productType={product.type} />
           </>
-        ) : (
+        )}
+        {!isWithdrawn && !isPendingWithdrawal && !canAccessToExam && (
           <FormattedMessage {...messages.examAccessBlocked} />
         )}
         {!hasError && nextInstallment && (
@@ -229,6 +291,46 @@ const FailedInstallmentManager = ({ order, updateOrder }: FailedInstallmentManag
         onClose={orderQuery.methods.invalidate}
       />
     </>
+  );
+};
+
+type WithdrawalManagerProps = {
+  order: OrderEnrollment;
+  product: CertificateProduct;
+  enrollment: Enrollment;
+  updateOrder: (order: Order) => void;
+};
+const WithdrawalManager = ({ order, product, enrollment, updateOrder }: WithdrawalManagerProps) => {
+  const intl = useIntl();
+  const formatDate = useDateFormat(DATETIME_FORMAT);
+  const modal = useModal();
+
+  return (
+    <div className="dashboard-item__course-enrolling__infos">
+      <div className="dashboard-item__block__status">
+        <Icon name={IconTypeEnum.MONEY} />
+        <FormattedMessage
+          {...messages.withdrawalDescription}
+          values={{ date: formatDate(order.withdrawal_date_limit) }}
+        />
+      </div>
+      <Button
+        className="dashboard-item__course-enrolling__infos__withdrawal__button"
+        size="small"
+        color="brand"
+        variant="tertiary"
+        onClick={modal.open}
+      >
+        {intl.formatMessage(messages.withdrawalButton)}
+      </Button>
+      <OrderWithdrawalModal
+        {...modal}
+        order={order}
+        productTitle={product.title}
+        reference={enrollment.course_run.course.code}
+        onSuccess={updateOrder}
+      />
+    </div>
   );
 };
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.spec.tsx
@@ -195,6 +195,28 @@ describe('<DashboardItemOrder/>', () => {
     });
   });
 
+  it('renders a withdrawn order without its active-course content', async () => {
+    const order: CredentialOrder = CredentialOrderFactory({
+      state: OrderState.CANCELED,
+      withdrawn_confirmation_at: '2026-01-15T10:00:00.000Z',
+    }).one();
+    const { product } = mockCourseProductWithOrder(order);
+
+    render(<DashboardItemOrder order={order} />);
+
+    await screen.findByRole('heading', { level: 5, name: product.title });
+    const withdrawnOnDate = new Intl.DateTimeFormat('en', DEFAULT_DATE_FORMAT).format(
+      new Date(order.withdrawn_confirmation_at!),
+    );
+    await screen.findByText(`Withdrawn On ${withdrawnOnDate}.`, { exact: false });
+    expect(screen.queryByRole('link', { name: 'View details' })).not.toBeInTheDocument();
+    order.target_courses.forEach((course) => {
+      expect(
+        screen.queryByRole('heading', { level: 6, name: course.title }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it('renders a non-writable order with enrolled target course ', async () => {
     const order: CredentialOrder = CredentialOrderFactory({
       target_courses: TargetCourseFactory().many(1),

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrder.tsx
@@ -7,6 +7,7 @@ import { DashboardSubItem } from 'widgets/Dashboard/components/DashboardItem/Das
 import { RouterButton } from 'widgets/Dashboard/components/RouterButton';
 import { useCourseProduct } from 'hooks/useCourseProducts';
 import { OrderHelper } from 'utils/OrderHelper';
+import useDateFormat from 'hooks/useDateFormat';
 import { LearnerDashboardPaths } from 'widgets/Dashboard/utils/learnerRoutesPaths';
 import OrganizationBlock from 'widgets/Dashboard/components/DashboardItem/Order/OrganizationBlock';
 import CertificateItem from 'widgets/Dashboard/components/DashboardItem/Order/CertificateItem';
@@ -50,6 +51,11 @@ const messages = defineMessages({
     defaultMessage:
       'The subscription process cannot be resumed. The related training is no more purchasable.',
   },
+  withdrawnOn: {
+    id: 'components.DashboardItemOrder.withdrawnOn',
+    description: 'Date at which the withdrawal was confirmed',
+    defaultMessage: 'On {date}.',
+  },
 });
 
 interface DashboardItemOrderProps {
@@ -67,6 +73,7 @@ export const DashboardItemOrder = ({
 }: DashboardItemOrderProps) => {
   const { course } = order;
   const intl = useIntl();
+  const formatDate = useDateFormat();
   const { item: offering } = useCourseProduct({
     product_id: order.product_id,
     course_id: course.code,
@@ -75,8 +82,10 @@ export const DashboardItemOrder = ({
   const needsSignature = OrderHelper.orderNeedsSignature(order);
   const needsPaymentMethod = order.state === OrderState.TO_SAVE_PAYMENT_METHOD;
   const isActive = OrderHelper.isActive(order);
+  const isWithdrawn = OrderHelper.isWithdrawn(order);
   const isProductPurchasable = ProductHelper.isPurchasable(offering?.product);
   const isNotResumable = !isActive && !isProductPurchasable;
+  const hideResumableContent = isNotResumable || isWithdrawn;
   const canEnroll = OrderHelper.allowEnrollment(order);
   const isFreeFromBatchOrder = OrderHelper.isFreeFromBatchOrder(order);
 
@@ -107,12 +116,23 @@ export const DashboardItemOrder = ({
                   </>
                 ) : (
                   <>
-                    <Icon name={IconTypeEnum.SCHOOL} />
-                    <OrderStateLearnerMessage order={order} />
+                    <Icon name={isWithdrawn ? IconTypeEnum.ROUND_CLOSE : IconTypeEnum.SCHOOL} />
+                    <span>
+                      <OrderStateLearnerMessage order={order} />
+                      {isWithdrawn && order.withdrawn_confirmation_at && (
+                        <>
+                          {' '}
+                          <FormattedMessage
+                            {...messages.withdrawnOn}
+                            values={{ date: formatDate(order.withdrawn_confirmation_at) }}
+                          />
+                        </>
+                      )}
+                    </span>
                   </>
                 )}
               </div>
-              {!isNotResumable && showDetailsButton && !isFreeFromBatchOrder && (
+              {!hideResumableContent && showDetailsButton && !isFreeFromBatchOrder && (
                 <RouterButton
                   size="small"
                   className="dashboard-item__button"
@@ -170,7 +190,7 @@ export const DashboardItemOrder = ({
           </>
         }
       >
-        {!isNotResumable && (
+        {!hideResumableContent && (
           <DashboardSubItemsList
             subItems={order.target_courses?.map((targetCourse) => (
               <DashboardSubItem
@@ -195,15 +215,11 @@ export const DashboardItemOrder = ({
           />
         )}
       </DashboardItem>
-      {!isNotResumable && (
-        <>
-          {showCertificate && !!product?.certificate_definition && (
-            <CertificateItem order={order} product={product} />
-          )}
-          {writable && !isFreeFromBatchOrder && (
-            <OrganizationBlock order={order} product={product} />
-          )}
-        </>
+      {!hideResumableContent && showCertificate && !!product?.certificate_definition && (
+        <CertificateItem order={order} product={product} />
+      )}
+      {!isNotResumable && writable && !isFreeFromBatchOrder && (
+        <OrganizationBlock order={order} product={product} />
       )}
     </div>
   );

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.useUnionResource.cache.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/DashboardItemOrderContract.useUnionResource.cache.spec.tsx
@@ -88,7 +88,6 @@ describe('<DashboardItemOrder/> Contract', () => {
       fetchMock.get(
         'https://joanie.endpoint/api/v1.0/orders/' +
           '?product_type=credential' +
-          '&state_exclude=canceled' +
           '&state_exclude=refunding' +
           '&state_exclude=refunded' +
           '&page=1' +
@@ -267,7 +266,6 @@ describe('<DashboardItemOrder/> Contract', () => {
       fetchMock.get(
         'https://joanie.endpoint/api/v1.0/orders/' +
           '?product_type=credential' +
-          '&state_exclude=canceled' +
           '&state_exclude=refunding' +
           '&state_exclude=refunded' +
           '&page=1' +

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateLearnerMessage/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateLearnerMessage/index.spec.tsx
@@ -19,6 +19,7 @@ describe('<OrderStateLearnerMessage/>', () => {
     [OrderState.NO_PAYMENT, 'First direct debit has failed'],
     [OrderState.PENDING, 'Pending for the first direct debit'],
     [OrderState.PENDING_PAYMENT, 'On going'],
+    [OrderState.PENDING_WITHDRAW, 'Withdrawal in progress'],
     [OrderState.SIGNING, 'Signature required'],
     [OrderState.TO_SAVE_PAYMENT_METHOD, 'Payment method is missing'],
     [OrderState.TO_SIGN, 'Signature required'],
@@ -28,6 +29,17 @@ describe('<OrderStateLearnerMessage/>', () => {
       wrapper: ({ children }: PropsWithChildren) => <IntlWrapper>{children}</IntlWrapper>,
     });
     expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+  });
+
+  it('should display message for a withdrawn order', () => {
+    const order = CredentialOrderFactory({
+      state: OrderState.CANCELED,
+      withdrawn_confirmation_at: new Date().toISOString(),
+    }).one();
+    render(<OrderStateLearnerMessage order={order} />, {
+      wrapper: ({ children }: PropsWithChildren) => <IntlWrapper>{children}</IntlWrapper>,
+    });
+    expect(screen.getByText('Withdrawn')).toBeInTheDocument();
   });
 
   it('should display message for completed order that have a generated certificate', () => {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateLearnerMessage/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateLearnerMessage/index.tsx
@@ -71,6 +71,17 @@ export const messages = defineMessages<MessageKeys>({
     description: 'Status shown on the dashboard order item when order is refunded',
     defaultMessage: 'Refunded',
   },
+  statusPendingWithdrawal: {
+    id: 'components.DashboardItem.Order.OrderStateLearnerMessage.statusPendingWithdrawal',
+    description:
+      'Status shown on the dashboard order item when a withdrawal request is being processed',
+    defaultMessage: 'Withdrawal in progress',
+  },
+  statusWithdrawn: {
+    id: 'components.DashboardItem.Order.OrderStateLearnerMessage.statusWithdrawn',
+    description: 'Status shown on the dashboard order item when order has been withdrawn',
+    defaultMessage: 'Withdrawn',
+  },
 });
 
 const OrderStateLearnerMessage = (props: OrderStateMessageBaseProps) => {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateMessage/index.tsx
@@ -19,10 +19,12 @@ export type MessageKeys =
   | 'statusPassed'
   | 'statusPending'
   | 'statusPendingPayment'
+  | 'statusPendingWithdrawal'
   | 'statusRefunded'
   | 'statusWaitingCounterSignature'
   | 'statusWaitingPaymentMethod'
-  | 'statusWaitingSignature';
+  | 'statusWaitingSignature'
+  | 'statusWithdrawn';
 
 interface OrderStateMessageProps extends OrderStateMessageBaseProps {
   messages: Record<MessageKeys, MessageDescriptor>;
@@ -45,10 +47,12 @@ const OrderStateMessage = ({ order, messages }: OrderStateMessageProps) => {
     [OrderStatus.PASSED]: messages.statusPassed,
     [OrderStatus.PENDING]: messages.statusPending,
     [OrderStatus.PENDING_PAYMENT]: messages.statusPendingPayment,
+    [OrderStatus.PENDING_WITHDRAWAL]: messages.statusPendingWithdrawal,
     [OrderStatus.REFUNDED]: messages.statusRefunded,
     [OrderStatus.WAITING_COUNTER_SIGNATURE]: messages.statusWaitingCounterSignature,
     [OrderStatus.WAITING_PAYMENT_METHOD]: messages.statusWaitingPaymentMethod,
     [OrderStatus.WAITING_SIGNATURE]: messages.statusWaitingSignature,
+    [OrderStatus.WITHDRAWN]: messages.statusWithdrawn,
   };
   const status = OrderHelper.getState(order);
 

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateTeacherMessage/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateTeacherMessage/index.spec.tsx
@@ -19,6 +19,7 @@ describe('<OrderStateTeacherMessage/>', () => {
     [OrderState.NO_PAYMENT, 'First direct debit has failed'],
     [OrderState.PENDING, 'Pending for the first direct debit'],
     [OrderState.PENDING_PAYMENT, 'On going'],
+    [OrderState.PENDING_WITHDRAW, 'Withdrawal in progress'],
     [OrderState.SIGNING, "Pending for learner's signature"],
     [OrderState.TO_SAVE_PAYMENT_METHOD, 'Payment method is missing'],
     [OrderState.TO_SIGN, "Pending for learner's signature"],
@@ -28,6 +29,17 @@ describe('<OrderStateTeacherMessage/>', () => {
       wrapper: ({ children }: PropsWithChildren) => <IntlWrapper>{children}</IntlWrapper>,
     });
     expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+  });
+
+  it('should display message for a withdrawn order', () => {
+    const order = CredentialOrderFactory({
+      state: OrderState.CANCELED,
+      withdrawn_confirmation_at: new Date().toISOString(),
+    }).one();
+    render(<OrderStateTeacherMessage order={order} />, {
+      wrapper: ({ children }: PropsWithChildren) => <IntlWrapper>{children}</IntlWrapper>,
+    });
+    expect(screen.getByText('Withdrawn')).toBeInTheDocument();
   });
 
   it('should display message for validated order that need organization signature', () => {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateTeacherMessage/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderStateTeacherMessage/index.tsx
@@ -72,6 +72,17 @@ export const messages = defineMessages<MessageKeys>({
     description: 'Status shown on the dashboard order item when order is refunded',
     defaultMessage: 'Refunded',
   },
+  statusPendingWithdrawal: {
+    id: 'components.DashboardItem.Order.OrderStateTeacherMessage.statusPendingWithdrawal',
+    description:
+      'Status shown on the dashboard order item when a withdrawal request is being processed',
+    defaultMessage: 'Withdrawal in progress',
+  },
+  statusWithdrawn: {
+    id: 'components.DashboardItem.Order.OrderStateTeacherMessage.statusWithdrawn',
+    description: 'Status shown on the dashboard order item when order has been withdrawn',
+    defaultMessage: 'Withdrawn',
+  },
 });
 
 const OrderStateTeacherMessage = (props: OrderStateMessageBaseProps) => {

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderWithdrawalModal/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderWithdrawalModal/index.spec.tsx
@@ -1,0 +1,139 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'fetch-mock';
+import { OrderState } from 'types/Joanie';
+import {
+  UserFactory,
+  RichieContextFactory as mockRichieContextFactory,
+} from 'utils/test/factories/richie';
+import { CredentialOrderFactory, CertificateOrderFactory } from 'utils/test/factories/joanie';
+import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
+import { render } from 'utils/test/render';
+import { createTestQueryClient } from 'utils/test/createTestQueryClient';
+import { HttpStatusCode } from 'utils/errors/HttpError';
+import { OrderWithdrawalModal } from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.endpoint.test' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint' },
+  }).one(),
+}));
+
+const mockMessageModal = jest.fn();
+jest.mock('@openfun/cunningham-react', () => ({
+  ...jest.requireActual('@openfun/cunningham-react'),
+  useModals: () => ({
+    messageModal: mockMessageModal,
+  }),
+}));
+
+describe('<OrderWithdrawalModal/>', () => {
+  setupJoanieSession();
+  const user = UserFactory().one();
+  const renderModal = (props: Partial<React.ComponentProps<typeof OrderWithdrawalModal>>) =>
+    render(
+      <OrderWithdrawalModal
+        isOpen
+        onClose={jest.fn()}
+        order={CredentialOrderFactory().one()}
+        productTitle="Some product"
+        reference="COURSE-CODE"
+        {...props}
+      />,
+      { queryOptions: { client: createTestQueryClient({ user }) } },
+    );
+
+  it('should display order and user information, without the account update link for a non-keycloak backend', () => {
+    const order = CredentialOrderFactory().one();
+
+    renderModal({ order });
+
+    expect(
+      screen.getByText('You wish to cancel your subscription to', { exact: false }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(user.full_name!)).toBeInTheDocument();
+    expect(screen.getByText(user.email!)).toBeInTheDocument();
+    expect(screen.getByText(order.id)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'please update your account' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should confirm the withdrawal and display a confirmed message when the order is directly canceled', async () => {
+    const order = CredentialOrderFactory().one();
+    const updatedOrder = { ...order, state: OrderState.CANCELED };
+    fetchMock.post(`https://joanie.endpoint/api/v1.0/orders/${order.id}/withdraw/`, updatedOrder);
+    const onClose = jest.fn();
+
+    renderModal({ order, onClose });
+
+    const submitButton = screen.getByTestId('order-withdrawal-modal-submit-button');
+    await userEvent.click(submitButton);
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(mockMessageModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Withdrawal confirmed',
+        children: 'Your order has been canceled following your withdrawal request.',
+      }),
+    );
+  });
+
+  it('should confirm the withdrawal and display a pending message when the order needs manual review', async () => {
+    const order = CertificateOrderFactory().one();
+    const updatedOrder = { ...order, state: OrderState.PENDING_WITHDRAW };
+    fetchMock.post(`https://joanie.endpoint/api/v1.0/orders/${order.id}/withdraw/`, updatedOrder);
+    const onSuccess = jest.fn();
+
+    renderModal({ order, onSuccess });
+
+    const submitButton = screen.getByTestId('order-withdrawal-modal-submit-button');
+    await userEvent.click(submitButton);
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(updatedOrder));
+    expect(mockMessageModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Withdrawal request recorded',
+        children: 'Your withdrawal request has been recorded and is being processed.',
+      }),
+    );
+  });
+
+  it('should display a specific error message when the withdrawal delay has expired', async () => {
+    const order = CredentialOrderFactory().one();
+    fetchMock.post(
+      `https://joanie.endpoint/api/v1.0/orders/${order.id}/withdraw/`,
+      HttpStatusCode.UNPROCESSABLE_ENTITY,
+    );
+    const onClose = jest.fn();
+
+    renderModal({ order, onClose });
+
+    const submitButton = screen.getByTestId('order-withdrawal-modal-submit-button');
+    await userEvent.click(submitButton);
+
+    await screen.findByText('The withdrawal period for this order has expired.');
+    expect(onClose).not.toHaveBeenCalled();
+    expect(mockMessageModal).not.toHaveBeenCalled();
+  });
+
+  it('should display a generic error message for any other API error', async () => {
+    const order = CredentialOrderFactory().one();
+    fetchMock.post(
+      `https://joanie.endpoint/api/v1.0/orders/${order.id}/withdraw/`,
+      HttpStatusCode.INTERNAL_SERVER_ERROR,
+    );
+    const onClose = jest.fn();
+
+    renderModal({ order, onClose });
+
+    const submitButton = screen.getByTestId('order-withdrawal-modal-submit-button');
+    await userEvent.click(submitButton);
+
+    await screen.findByText('An error occurred, please contact our support team.');
+    expect(onClose).not.toHaveBeenCalled();
+    expect(mockMessageModal).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderWithdrawalModal/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderWithdrawalModal/index.tsx
@@ -1,0 +1,259 @@
+import {
+  Alert,
+  Button,
+  Modal,
+  ModalProps,
+  ModalSize,
+  useModals,
+  VariantType,
+} from '@openfun/cunningham-react';
+import { defineMessages, FormattedMessage, MessageDescriptor, useIntl } from 'react-intl';
+import { ReactNode, useState } from 'react';
+import { Order, OrderEnrollment, OrderState } from 'types/Joanie';
+import { useJoanieApi } from 'contexts/JoanieApiContext';
+import { useOrders } from 'hooks/useOrders';
+import { useSession } from 'contexts/SessionContext';
+import { UserHelper } from 'utils/UserHelper';
+import { AuthenticationApi } from 'api/authentication';
+import { APIBackend, KeycloakAccountApi } from 'types/api';
+import context from 'utils/context';
+import { Spinner } from 'components/Spinner';
+import { HttpStatusCode, isHttpError } from 'utils/errors/HttpError';
+
+const boldChunk = (chunks: ReactNode) => <strong>{chunks}</strong>;
+
+const InfoRow = ({ label, value }: { label: MessageDescriptor; value: ReactNode }) => (
+  <p className="mb-s">
+    <span className="fw-bold">
+      <FormattedMessage {...label} />
+    </span>{' '}
+    {value}
+  </p>
+);
+
+const messages = defineMessages({
+  title: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.title',
+    defaultMessage: 'Withdrawal request',
+    description: 'Title of the withdrawal request modal',
+  },
+  description: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.description',
+    defaultMessage:
+      'You wish to cancel your subscription to <bold>{productTitle} - Ref. {reference}</bold>.',
+    description: 'Message displayed in the withdrawal request modal',
+  },
+  informationTitle: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.informationTitle',
+    defaultMessage: 'Information',
+    description: 'Title of the information recap section in the withdrawal request modal',
+  },
+  informationDescription: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.informationDescription',
+    defaultMessage:
+      'This information will be included in the acknowledgement of receipt for your request.',
+    description: 'Description of the information recap section in the withdrawal request modal',
+  },
+  accountNameLabel: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.accountNameLabel',
+    defaultMessage: 'Account name',
+    description: 'Label for the account name in the withdrawal request modal',
+  },
+  accountEmailLabel: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.accountEmailLabel',
+    defaultMessage: 'Account email',
+    description: 'Label for the account email in the withdrawal request modal',
+  },
+  orderReferenceLabel: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.orderReferenceLabel',
+    defaultMessage: 'Order reference',
+    description: 'Label for the order reference in the withdrawal request modal',
+  },
+  accountLinkInfo: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.accountLinkInfo',
+    defaultMessage: 'If any of the information above is incorrect,',
+    description: 'Text before the account update link in the withdrawal request modal',
+  },
+  accountLinkLabel: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.accountLinkLabel',
+    defaultMessage: 'please update your account',
+    description: 'Label of the account update link in the withdrawal request modal',
+  },
+  submit: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.submit',
+    defaultMessage: 'I confirm my withdrawal request',
+    description: 'Submit button label of the withdrawal request modal',
+  },
+  submitInProgress: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.submitInProgress',
+    defaultMessage: 'Withdrawal request in progress',
+    description: 'Label for screen reader when a withdrawal request is in progress.',
+  },
+  successConfirmedTitle: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.successConfirmedTitle',
+    defaultMessage: 'Withdrawal confirmed',
+    description: 'Title of the success modal when the withdrawal is confirmed immediately',
+  },
+  successConfirmedDescription: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.successConfirmedDescription',
+    defaultMessage: 'Your order has been canceled following your withdrawal request.',
+    description: 'Description of the success modal when the withdrawal is confirmed immediately',
+  },
+  successPendingTitle: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.successPendingTitle',
+    defaultMessage: 'Withdrawal request recorded',
+    description: 'Title of the success modal when the withdrawal request needs manual review',
+  },
+  successPendingDescription: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.successPendingDescription',
+    defaultMessage: 'Your withdrawal request has been recorded and is being processed.',
+    description: 'Description of the success modal when the withdrawal request needs manual review',
+  },
+  errorDelayExpired: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.errorDelayExpired',
+    defaultMessage: 'The withdrawal period for this order has expired.',
+    description: 'Error message when the withdrawal delay has expired',
+  },
+  errorDefault: {
+    id: 'components.DashboardItemOrder.OrderWithdrawalModal.errorDefault',
+    defaultMessage: 'An error occurred, please contact our support team.',
+    description: 'Generic error message when the withdrawal request failed',
+  },
+});
+
+interface Props extends Pick<ModalProps, 'isOpen' | 'onClose'> {
+  order: Order | OrderEnrollment;
+  productTitle: string;
+  reference: string;
+  /**
+   * Called with the fresh order returned by the API once the withdrawal request succeeds.
+   * Callers relying on locally held order state (rather than a query that gets invalidated)
+   * must use this to update it, otherwise the UI keeps showing stale data until a full
+   * page refresh.
+   */
+  onSuccess?: (order: Order) => void;
+}
+
+enum ComponentStates {
+  IDLE = 'idle',
+  LOADING = 'loading',
+  ERROR = 'error',
+}
+
+export const OrderWithdrawalModal = ({
+  order,
+  productTitle,
+  reference,
+  onSuccess,
+  ...props
+}: Props) => {
+  const intl = useIntl();
+  const API = useJoanieApi();
+  const { user } = useSession();
+  const { methods: orderMethods } = useOrders(undefined, { enabled: false });
+  const modals = useModals();
+  const [state, setState] = useState<ComponentStates>(ComponentStates.IDLE);
+  const [error, setError] = useState<string>();
+
+  const isKeycloakBackend = [APIBackend.KEYCLOAK, APIBackend.FONZIE_KEYCLOAK].includes(
+    context?.authentication.backend as APIBackend,
+  );
+
+  const submit = async () => {
+    setState(ComponentStates.LOADING);
+    try {
+      const updatedOrder = await API.user.orders.withdraw(order.id);
+      await orderMethods.invalidate();
+      onSuccess?.(updatedOrder);
+      props.onClose();
+      await modals.messageModal({
+        messageType: VariantType.SUCCESS,
+        title: intl.formatMessage(
+          updatedOrder.state === OrderState.PENDING_WITHDRAW
+            ? messages.successPendingTitle
+            : messages.successConfirmedTitle,
+        ),
+        children: intl.formatMessage(
+          updatedOrder.state === OrderState.PENDING_WITHDRAW
+            ? messages.successPendingDescription
+            : messages.successConfirmedDescription,
+        ),
+      });
+    } catch (submitError) {
+      setState(ComponentStates.ERROR);
+      setError(
+        intl.formatMessage(
+          isHttpError(submitError) && submitError.code === HttpStatusCode.UNPROCESSABLE_ENTITY
+            ? messages.errorDelayExpired
+            : messages.errorDefault,
+        ),
+      );
+    }
+  };
+
+  return (
+    <Modal
+      {...props}
+      size={ModalSize.MEDIUM}
+      title={intl.formatMessage(messages.title)}
+      closeOnEsc={state !== ComponentStates.LOADING}
+      preventClose={state === ComponentStates.LOADING}
+      hideCloseButton={state === ComponentStates.LOADING}
+      actions={
+        <Button
+          color="error"
+          variant="primary"
+          size="small"
+          fullWidth={true}
+          onClick={submit}
+          disabled={state === ComponentStates.LOADING}
+          data-testid="order-withdrawal-modal-submit-button"
+        >
+          {state === ComponentStates.LOADING ? (
+            <Spinner theme="light" aria-labelledby="withdrawal-request-in-progress">
+              <span id="withdrawal-request-in-progress">
+                <FormattedMessage {...messages.submitInProgress} />
+              </span>
+            </Spinner>
+          ) : (
+            <FormattedMessage {...messages.submit} />
+          )}
+        </Button>
+      }
+    >
+      {error && (
+        <Alert type={VariantType.ERROR} className="mb-t">
+          {error}
+        </Alert>
+      )}
+      <p className="mb-b">
+        <FormattedMessage
+          {...messages.description}
+          values={{
+            productTitle,
+            reference,
+            bold: boldChunk,
+          }}
+        />
+      </p>
+      <h3 className="block-title mb-t">
+        <FormattedMessage {...messages.informationTitle} />
+      </h3>
+      <p className="mb-s">
+        <FormattedMessage {...messages.informationDescription} />
+      </p>
+      <InfoRow label={messages.accountNameLabel} value={user ? UserHelper.getName(user) : ''} />
+      <InfoRow label={messages.accountEmailLabel} value={user?.email} />
+      <InfoRow label={messages.orderReferenceLabel} value={order.id} />
+      {isKeycloakBackend && (
+        <p className="mb-b">
+          <FormattedMessage {...messages.accountLinkInfo} />{' '}
+          <a href={(AuthenticationApi!.account as KeycloakAccountApi).updateUrl()}>
+            <FormattedMessage {...messages.accountLinkLabel} />
+          </a>
+          .
+        </p>
+      )}
+    </Modal>
+  );
+};

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrganizationBlock/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrganizationBlock/index.spec.tsx
@@ -1,0 +1,102 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RichieContextFactory as mockRichieContextFactory } from 'utils/test/factories/richie';
+import { CredentialOrderFactory, CredentialProductFactory } from 'utils/test/factories/joanie';
+import { setupJoanieSession } from 'utils/test/wrappers/JoanieAppWrapper';
+import { render } from 'utils/test/render';
+import OrganizationBlock from '.';
+
+jest.mock('utils/context', () => ({
+  __esModule: true,
+  default: mockRichieContextFactory({
+    authentication: { backend: 'fonzie', endpoint: 'https://auth.endpoint.test' },
+    joanie_backend: { endpoint: 'https://joanie.endpoint' },
+  }).one(),
+}));
+
+jest.mock('../OrderWithdrawalModal', () => ({
+  __esModule: true,
+  OrderWithdrawalModal: ({
+    isOpen,
+    order,
+    productTitle,
+    reference,
+  }: {
+    isOpen: boolean;
+    order: { id: string };
+    productTitle: string;
+    reference: string;
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <div data-testid="OrderWithdrawalModalMock">
+        {order.id} - {productTitle} - {reference}
+      </div>
+    );
+  },
+}));
+
+describe('<OrganizationBlock/>', () => {
+  setupJoanieSession();
+  const product = CredentialProductFactory({ contract_definition: undefined }).one();
+
+  it('should display the withdrawal block with the withdraw button when the order is eligible', () => {
+    const order = CredentialOrderFactory({
+      total: 0,
+      eligible_to_withdraw: true,
+      withdrawal_date_limit: '2026-08-30T10:00:00.000Z',
+      withdrawn_confirmation_at: null,
+    }).one();
+
+    render(<OrganizationBlock order={order} product={product} />);
+
+    const block = screen.getByTestId('dashboard-item-withdrawal');
+    within(block).getByRole('button', { name: 'Withdraw' });
+    within(block).getByText('Aug 30, 2026', { exact: false });
+    expect(screen.queryByTestId('dashboard-item-withdrawn')).not.toBeInTheDocument();
+  });
+
+  it('should not display any withdrawal information when the order is not eligible and has not been withdrawn', () => {
+    const order = CredentialOrderFactory({
+      total: 0,
+      eligible_to_withdraw: false,
+      withdrawn_confirmation_at: null,
+    }).one();
+
+    render(<OrganizationBlock order={order} product={product} />);
+
+    expect(screen.queryByTestId('dashboard-item-withdrawal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dashboard-item-withdrawn')).not.toBeInTheDocument();
+  });
+
+  it('should display the withdrawn status instead of the withdrawal block once the order has been withdrawn', () => {
+    const order = CredentialOrderFactory({
+      total: 0,
+      eligible_to_withdraw: false,
+      withdrawn_confirmation_at: '2026-08-10T10:00:00.000Z',
+    }).one();
+
+    render(<OrganizationBlock order={order} product={product} />);
+
+    const block = screen.getByTestId('dashboard-item-withdrawn');
+    within(block).getByText('Aug 10, 2026', { exact: false });
+    expect(screen.queryByTestId('dashboard-item-withdrawal')).not.toBeInTheDocument();
+  });
+
+  it('should open the withdrawal modal with the order reference and product title when clicking the withdraw button', async () => {
+    const order = CredentialOrderFactory({
+      total: 0,
+      eligible_to_withdraw: true,
+      withdrawn_confirmation_at: null,
+    }).one();
+
+    render(<OrganizationBlock order={order} product={product} />);
+
+    expect(screen.queryByTestId('OrderWithdrawalModalMock')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Withdraw' }));
+
+    within(screen.getByTestId('OrderWithdrawalModalMock')).getByText(
+      `${order.id} - ${product.title} - ${order.course.code}`,
+    );
+  });
+});

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrganizationBlock/index.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrganizationBlock/index.tsx
@@ -1,10 +1,12 @@
-import { defineMessages, FormattedMessage } from 'react-intl';
-import { Button } from '@openfun/cunningham-react';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { Button, useModal } from '@openfun/cunningham-react';
 import { CredentialOrder, Product } from 'types/Joanie';
 import { AddressView } from 'components/Address';
 import { OrderHelper } from 'utils/OrderHelper';
+import useDateFormat, { DATETIME_FORMAT } from 'hooks/useDateFormat';
 import ContractItem from '../ContractItem';
 import Installment from '../Installment';
+import { OrderWithdrawalModal } from '../OrderWithdrawalModal';
 
 const messages = defineMessages({
   contactDescription: {
@@ -51,6 +53,31 @@ const messages = defineMessages({
     id: 'components.DashboardItemOrder.OrganizationBlock.organizationSubtitleContacts',
     description: 'Subtitle for the organization contacts section',
     defaultMessage: 'Contacts',
+  },
+  withdrawalTitle: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.withdrawalTitle',
+    description: 'Title of the withdrawal block',
+    defaultMessage: 'Withdrawal',
+  },
+  withdrawalDescription: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.withdrawalDescription',
+    description: 'Description of the withdrawal block',
+    defaultMessage: 'You can withdraw from your contract until {date}.',
+  },
+  withdrawalButton: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.withdrawalButton',
+    description: 'Button label of the withdrawal block',
+    defaultMessage: 'Withdraw',
+  },
+  withdrawnTitle: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.withdrawnTitle',
+    description: 'Title of the withdrawal block once the withdrawal is confirmed',
+    defaultMessage: 'Withdrawn',
+  },
+  withdrawnDescription: {
+    id: 'components.DashboardItemOrder.OrganizationBlock.withdrawnDescription',
+    description: 'Description shown once the withdrawal is confirmed',
+    defaultMessage: 'You withdrew from this order on {date}.',
   },
 });
 
@@ -148,7 +175,62 @@ const OrganizationBlock = ({ order, product }: Props) => {
           </div>
         )}
         {!hidePaymentBlock && <Installment order={order} />}
+        {order.eligible_to_withdraw && <Withdrawal order={order} product={product} />}
+        {OrderHelper.isWithdrawn(order) && <WithdrawnStatus order={order} />}
       </div>
+    </div>
+  );
+};
+
+const Withdrawal = ({ order, product }: Props) => {
+  const intl = useIntl();
+  const formatDate = useDateFormat(DATETIME_FORMAT);
+  const modal = useModal();
+
+  return (
+    <div data-testid="dashboard-item-withdrawal" className="dashboard-splitted-card__item">
+      <div className="dashboard-splitted-card__item__title">
+        <span>
+          <FormattedMessage {...messages.withdrawalTitle} />
+        </span>
+      </div>
+      <p className="dashboard-splitted-card__item__description">
+        <FormattedMessage
+          {...messages.withdrawalDescription}
+          values={{ date: formatDate(order.withdrawal_date_limit) }}
+        />
+      </p>
+      <div className="dashboard-splitted-card__item__actions">
+        <Button size="small" color="brand" variant="secondary" onClick={modal.open}>
+          {intl.formatMessage(messages.withdrawalButton)}
+        </Button>
+      </div>
+      <OrderWithdrawalModal
+        {...modal}
+        order={order}
+        productTitle={product.title}
+        reference={order.course.code}
+      />
+    </div>
+  );
+};
+
+const WithdrawnStatus = ({ order }: { order: CredentialOrder }) => {
+  const formatDate = useDateFormat(DATETIME_FORMAT);
+
+  return (
+    <div data-testid="dashboard-item-withdrawn" className="dashboard-splitted-card__item">
+      <div className="dashboard-splitted-card__item__title">
+        <span>
+          <FormattedMessage {...messages.withdrawnTitle} />
+        </span>
+      </div>
+      <p className="dashboard-splitted-card__item__description">
+        <FormattedMessage
+          {...messages.withdrawnDescription}
+          values={{ date: formatDate(order.withdrawn_confirmation_at) }}
+        />
+      </p>
     </div>
   );
 };

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/_styles.scss
@@ -56,7 +56,9 @@
 
     &__status {
       display: flex;
-      align-items: center;
+      // flex-start (not center) so the icon stays aligned with the first line
+      // of text when the text wraps onto several lines.
+      align-items: flex-start;
       gap: 0.5rem;
 
       @include media-breakpoint-down(sm) {
@@ -179,6 +181,7 @@
     justify-content: space-between;
     padding: 0.5rem 1rem;
     min-height: 3.75rem;
+    border-top: $onepixel solid r-theme-val(dashboard-item, base-border);
 
     &:first-child {
       border-top: 0;
@@ -200,6 +203,11 @@
 
     p {
       margin: 0;
+    }
+
+    &__withdrawal__button {
+      text-decoration: underline;
+      white-space: nowrap;
     }
   }
 

--- a/src/frontend/js/widgets/Dashboard/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/index.spec.tsx
@@ -52,7 +52,6 @@ describe('<Dashboard />', () => {
     fetchMock.get(
       'https://joanie.endpoint/api/v1.0/orders/' +
         '?product_type=credential' +
-        '&state_exclude=canceled' +
         '&state_exclude=refunding' +
         '&state_exclude=refunded' +
         '&page=1' +


### PR DESCRIPTION
This PR aims to implement withdrawal right for credential and certificates, linked issue is #2834.  Users will now be able to withdraw orders, via their dashboard. 

How to test : 

- [ ] Generate credential order without the withdrawal checkbox in sale tunnel, buy it, then try to withdraw it and rebuy it to see the full workflow.
- [ ] Generate certificate order without the withdrawal checkbox in sale tunnel, subscribe and buy the certificate then try to withdraw it and rebuy it.
- [ ] Generate certificate order with the withdrawal checkbox in sale tunnel, subscribe and buy the certificate then try to withdraw it, wait for the back-office OK or KO mail then refresh your browser.