### PR TITLE
Hotfix : string duplication in batch order seats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix crowdin duplication id for organization quotes seats count
+
 ## [3.5.0] - 2026-08-13
 
 ### Added

--- a/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.tsx
+++ b/src/frontend/js/pages/TeacherDashboardOrganizationQuotes/index.tsx
@@ -218,7 +218,7 @@ const messages = defineMessages({
     description: 'Label for the batch order reference (id)',
   },
   seatsCount: {
-    id: 'batchOrder.seatsCount',
+    id: 'components.OrganizationQuotesTable.batchOrder.seatsCount',
     defaultMessage: '{seats} {seats, plural, one {seat} other {seats}}',
     description: 'Text displayed for seats count with pluralization in batch order',
   },


### PR DESCRIPTION
Rename batchOrder.seatsCount used in TeacherDashboardOrganizationQuotes since it collided with the seatsCount id already used in the learner BatchOrder dashboard item, causing the French translation to silently fall back to English.
