### PR TITLE
📌(backend) pin django-formtools below 2.6 to fix CMS wizard crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix crowdin duplication id for organization quotes seats count
+- Pin django-form-tools python lib to avoid regression
 
 ## [3.5.0] - 2026-08-13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "djangorestframework<4",
     "django-autocomplete-light<4",
     "django-cms>=3.11.0,<4.0.0",
+    "django-formtools>=2.1,<2.6",
     "django-parler>=2.3,<3",
     "django-redis>=4.11.0,<6",
     "django-treebeard<5",


### PR DESCRIPTION
django-formtools 2.6.1 introduced a caching regression in get_form_list() that ignores form_list mutations. We need to pin the version, since we can't update to the latest release.