### PR TITLE
🐛(ci) pin webpack version in dependent front build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,7 +687,8 @@ jobs:
           command: |
             yarn init -y
             cp ~/fun/src/frontend/yarn.lock .
-            yarn add webpack webpack-cli babel-loader source-map-loader file-loader ~/fun/src/frontend
+            # webpack is pinned to match src/frontend/package.json
+            yarn add webpack@5.109.2 webpack-cli babel-loader source-map-loader file-loader ~/fun/src/frontend
             echo '{"extends": "./node_modules/richie-education/tsconfig.json", "include": ["./**/*"]}' > tsconfig.json
       - run:
           name: Create an overridden React component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Withdrawing feature for certificate and credential orders
 
+### Fixed
+
+- Pin webpack version in dependent front build
+
 ## [3.5.1] - 2026-08-18
 
 ### Fixed


### PR DESCRIPTION
The build-dependent-front job installed webpack without pinning a version, letting yarn fetch whatever is latest on npm at build time.