### PR TITLE
Handle email data for user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Pin webpack version in dependent front build
+- Handle user data form the authentication method (especially for mail)
 
 ## [3.5.1] - 2026-08-18
 

--- a/src/frontend/js/api/lms/dummy.ts
+++ b/src/frontend/js/api/lms/dummy.ts
@@ -65,6 +65,7 @@ function getUserInfo(username: DevDemoUser): User {
     access_token: accessToken,
     username: JWTPayload.username,
     full_name: JWTPayload.full_name,
+    email: JWTPayload.email,
   };
 }
 

--- a/src/frontend/js/api/lms/openedx-fonzie-keycloak.spec.ts
+++ b/src/frontend/js/api/lms/openedx-fonzie-keycloak.spec.ts
@@ -31,19 +31,16 @@ describe('Fonzie Keycloak API', () => {
     jest.clearAllMocks();
   });
 
-  it('uses its own route to get user information and enriches with keycloak account', async () => {
+  it('reads the email and full name from the access token claims', async () => {
+    // JWT payload: { email: 'john.doe@example.com', full_name: 'John Doe' }
+    const accessToken =
+      'header.eyJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIiwiZnVsbF9uYW1lIjoiSm9obiBEb2UifQ.signature';
     const user = {
       username: 'test-richie-ncl',
-      full_name: 'n c',
-    };
-    const keycloakAccount = {
-      firstName: 'John',
-      lastName: 'Doe',
-      email: 'john.doe@example.com',
+      access_token: accessToken,
     };
 
     fetchMock.get('https://demo.endpoint.api/api/v1.0/user/me', user);
-    fetchMock.get('https://keycloak.test/auth/realms/richie-realm/account/', keycloakAccount);
 
     const api = FonzieKeycloakAPIInterface(configuration);
     await expect(api.user.me()).resolves.toEqual({
@@ -53,14 +50,14 @@ describe('Fonzie Keycloak API', () => {
     });
   });
 
-  it('falls back to fonzie data when keycloak account call fails', async () => {
+  it('does not fail when the access token has no usable claims', async () => {
     const user = {
       username: 'test-richie-ncl',
       full_name: 'n c',
+      access_token: 'not-a-jwt',
     };
 
     fetchMock.get('https://demo.endpoint.api/api/v1.0/user/me', user);
-    fetchMock.get('https://keycloak.test/auth/realms/richie-realm/account/', 500);
 
     const api = FonzieKeycloakAPIInterface(configuration);
     await expect(api.user.me()).resolves.toEqual(user);

--- a/src/frontend/js/api/lms/openedx-fonzie-keycloak.ts
+++ b/src/frontend/js/api/lms/openedx-fonzie-keycloak.ts
@@ -8,7 +8,24 @@ import { OpenEdxApiProfile } from 'types/openEdx';
 import { checkStatus } from 'api/utils';
 import { OpenEdxFullNameFormValues } from 'components/OpenEdxFullNameForm';
 import { location } from 'utils/indirection/window';
+import { base64Decode } from 'utils/base64Parser';
+import { Maybe } from 'types/utils';
 import OpenEdxHawthornApiInterface from './openedx-hawthorn';
+
+/**
+ * Extract claims from the JWT issued by Fonzie. The `user/me` route does not expose
+ * the email nor an up to date full name, but the token it returns always carries them.
+ */
+const getTokenClaims = (token: Maybe<string>): Maybe<{ email?: string; full_name?: string }> => {
+  if (!token) return undefined;
+
+  try {
+    const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(base64Decode(payload));
+  } catch {
+    return undefined;
+  }
+};
 
 /**
  *
@@ -46,27 +63,13 @@ const API = (APIConf: AuthenticationBackend): APILms => {
       me: async () => {
         const user = await ApiInterface.user.me();
         if (!user) return null;
-        try {
-          const keycloakAccount = await fetch(APIOptions.routes.user.account, {
-            credentials: 'include',
-            headers: {
-              Accept: 'application/json',
-              Authorization: `Bearer ${user.access_token}`,
-            },
-          }).then((res) => {
-            if (!res.ok) throw new Error(`Keycloak account fetch failed: ${res.status}`);
-            return res.json();
-          });
-          return {
-            ...user,
-            full_name:
-              [keycloakAccount.firstName, keycloakAccount.lastName].filter(Boolean).join(' ') ||
-              user.full_name,
-            email: keycloakAccount.email || user.email,
-          };
-        } catch {
-          return user;
-        }
+
+        const claims = getTokenClaims(user.access_token);
+        return {
+          ...user,
+          full_name: user.full_name || claims?.full_name,
+          email: user.email ?? claims?.email,
+        };
       },
       login: () => {
         const next = encodeURIComponent(location.href);

--- a/src/frontend/js/components/SaleTunnel/index.spec.tsx
+++ b/src/frontend/js/components/SaleTunnel/index.spec.tsx
@@ -706,6 +706,36 @@ describe.each([
     screen.getByTestId('walkthrough-banner');
   });
 
+  it('should render the account name and email from the OpenEdx profile', async () => {
+    const product = ProductFactory().one();
+    const paymentPlan = PaymentPlanFactory().one();
+    fetchMock
+      .get(
+        `https://joanie.endpoint/api/v1.0/orders/?${queryString.stringify(getFetchOrderQueryParams(product))}`,
+        [],
+      )
+      .get(
+        `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/payment-plan/`,
+        paymentPlan,
+      )
+      .get(
+        `https://joanie.endpoint/api/v1.0/courses/${course.code}/products/${product.id}/deep-link/`,
+        {},
+      );
+
+    render(<Wrapper product={product} isWithdrawable={true} paymentPlan={paymentPlan} />, {
+      queryOptions: { client: createTestQueryClient({ user: richieUser }) },
+    });
+
+    screen.getByRole('heading', { level: 4, name: 'Account email' });
+
+    await screen.findByText(openApiEdxProfile.email);
+
+    screen.getByText(
+      'This email will be used to send you confirmation mails, it is the one you created your account with.',
+    );
+  });
+
   it('should show a checkbox to waive withdrawal right if the product is not withdrawable', async () => {
     const product = ProductFactory().one();
     const paymentPlan = PaymentPlanFactory().one();

--- a/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderWithdrawalModal/index.spec.tsx
+++ b/src/frontend/js/widgets/Dashboard/components/DashboardItem/Order/OrderWithdrawalModal/index.spec.tsx
@@ -32,7 +32,10 @@ jest.mock('@openfun/cunningham-react', () => ({
 describe('<OrderWithdrawalModal/>', () => {
   setupJoanieSession();
   const user = UserFactory().one();
-  const renderModal = (props: Partial<React.ComponentProps<typeof OrderWithdrawalModal>>) =>
+  const renderModal = (
+    props: Partial<React.ComponentProps<typeof OrderWithdrawalModal>>,
+    sessionUser = user,
+  ) =>
     render(
       <OrderWithdrawalModal
         isOpen
@@ -42,7 +45,7 @@ describe('<OrderWithdrawalModal/>', () => {
         reference="COURSE-CODE"
         {...props}
       />,
-      { queryOptions: { client: createTestQueryClient({ user }) } },
+      { queryOptions: { client: createTestQueryClient({ user: sessionUser }) } },
     );
 
   it('should display order and user information, without the account update link for a non-keycloak backend', () => {
@@ -53,8 +56,11 @@ describe('<OrderWithdrawalModal/>', () => {
     expect(
       screen.getByText('You wish to cancel your subscription to', { exact: false }),
     ).toBeInTheDocument();
+    expect(screen.getByText('Account name')).toBeInTheDocument();
     expect(screen.getByText(user.full_name!)).toBeInTheDocument();
+    expect(screen.getByText('Account email')).toBeInTheDocument();
     expect(screen.getByText(user.email!)).toBeInTheDocument();
+    expect(screen.getByText('Order reference')).toBeInTheDocument();
     expect(screen.getByText(order.id)).toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'please update your account' }),


### PR DESCRIPTION
The keycloak account fetch in fonzie-keycloak's me() always failed with a 401 in production, so the withdrawal modal and sale tunnel showed an empty email. The JWT itself already carries the email and full name claims, so me() now reads them directly instead of making a request that has never worked. Also fills the email claim in the dummy backend.